### PR TITLE
Reverse Engineer HasComputedColumnSql() as needed.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ColumnModel.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ColumnModel.cs
@@ -21,6 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         [CanBeNull]
         public virtual string DefaultValue { get; [param: CanBeNull] set; }
 
+        [CanBeNull]
+        public virtual string ComputedValue { get; [param: CanBeNull] set; }
         public virtual int? MaxLength { get; [param: CanBeNull] set; }
         public virtual int? Precision { get; [param: CanBeNull] set; }
         public virtual int? Scale { get; [param: CanBeNull] set; }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -310,6 +310,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                 property.HasDefaultValueSql(column.DefaultValue);
             }
 
+            if (column.ComputedValue != null)
+            {
+                property.HasComputedColumnSql(column.ComputedValue);
+            }
+
             if (!column.PrimaryKeyOrdinal.HasValue)
             {
                 property.IsRequired(!column.IsNullable);

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
@@ -13,6 +13,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Design.Properties.SqlServerDesignStrings", typeof(SqlServerDesignStrings).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// For column {columnId} unable to interpret computed value {computedValue}. Will not generate code setting a computed value for the property {propertyName} on entity type {entityTypeName}.
+        /// </summary>
+        public static string CannotInterpretComputedValue([CanBeNull] object columnId, [CanBeNull] object computedValue, [CanBeNull] object propertyName, [CanBeNull] object entityTypeName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotInterpretComputedValue", "columnId", "computedValue", "propertyName", "entityTypeName"), columnId, computedValue, propertyName, entityTypeName);
+        }
+
+        /// <summary>
         /// For column {columnId} unable to interpret default value {defaultValue}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.
         /// </summary>
         public static string CannotInterpretDefaultValue([CanBeNull] object columnId, [CanBeNull] object defaultValue, [CanBeNull] object propertyName, [CanBeNull] object entityTypeName)
@@ -77,11 +85,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.
+        /// Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.
         /// </summary>
-        public static string FoundColumn([CanBeNull] object schema, [CanBeNull] object tableName, [CanBeNull] object columnName, [CanBeNull] object dataType, [CanBeNull] object ordinal, [CanBeNull] object isNullable, [CanBeNull] object primaryKeyOrdinal, [CanBeNull] object defaultValue, [CanBeNull] object precision, [CanBeNull] object scale, [CanBeNull] object maxLength, [CanBeNull] object isIdentity, [CanBeNull] object isComputed)
+        public static string FoundColumn([CanBeNull] object schema, [CanBeNull] object tableName, [CanBeNull] object columnName, [CanBeNull] object dataType, [CanBeNull] object ordinal, [CanBeNull] object isNullable, [CanBeNull] object primaryKeyOrdinal, [CanBeNull] object defaultValue, [CanBeNull] object computedValue, [CanBeNull] object precision, [CanBeNull] object scale, [CanBeNull] object maxLength, [CanBeNull] object isIdentity, [CanBeNull] object isComputed)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("FoundColumn", "schema", "tableName", "columnName", "dataType", "ordinal", "isNullable", "primaryKeyOrdinal", "defaultValue", "precision", "scale", "maxLength", "isIdentity", "isComputed"), schema, tableName, columnName, dataType, ordinal, isNullable, primaryKeyOrdinal, defaultValue, precision, scale, maxLength, isIdentity, isComputed);
+            return string.Format(CultureInfo.CurrentCulture, GetString("FoundColumn", "schema", "tableName", "columnName", "dataType", "ordinal", "isNullable", "primaryKeyOrdinal", "defaultValue", "computedValue", "precision", "scale", "maxLength", "isIdentity", "isComputed"), schema, tableName, columnName, dataType, ordinal, isNullable, primaryKeyOrdinal, defaultValue, computedValue, precision, scale, maxLength, isIdentity, isComputed);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Properties/SqlServerDesignStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Properties/SqlServerDesignStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotInterpretComputedValue" xml:space="preserve">
+    <value>For column {columnId} unable to interpret computed value {computedValue}. Will not generate code setting a computed value for the property {propertyName} on entity type {entityTypeName}.</value>
+  </data>
   <data name="CannotInterpretDefaultValue" xml:space="preserve">
     <value>For column {columnId} unable to interpret default value {defaultValue}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.</value>
   </data>
@@ -142,7 +145,7 @@
     <value>Found a foreign key on table [{schemaName}].[{tableName}] with an empty or null name. Skipping foreign key.</value>
   </data>
   <data name="FoundColumn" xml:space="preserve">
-    <value>Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.</value>
+    <value>Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.</value>
   </data>
   <data name="FoundDefaultSchema" xml:space="preserve">
     <value>Found default schema {defaultSchema}.</value>

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerDatabaseModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerDatabaseModelFactory.cs
@@ -239,6 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
     c.is_nullable AS [nullable],
     CAST(ic.key_ordinal AS int) AS [primary_key_ordinal],
     object_definition(c.default_object_id) AS [default_sql],
+    cc.definition AS [computed_sql],
     CAST(CASE WHEN c.precision <> tp.precision
             THEN c.precision
             ELSE null
@@ -257,6 +258,7 @@ FROM sys.index_columns ic
     RIGHT JOIN (SELECT * FROM sys.indexes WHERE is_primary_key = 1) AS i ON i.object_id = ic.object_id AND i.index_id = ic.index_id
     RIGHT JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
     RIGHT JOIN sys.types tp ON tp.user_type_id = c.user_type_id
+    LEFT JOIN sys.computed_columns cc ON cc.object_id = c.object_id AND cc.column_id = c.column_id
     JOIN sys.tables AS t ON t.object_id = c.object_id
 WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'" +
                                   TemporalTableWhereClause;
@@ -273,6 +275,7 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'" +
                     var nullable = reader.GetValueOrDefault<bool>("nullable");
                     var primaryKeyOrdinal = reader.GetValueOrDefault<int?>("primary_key_ordinal");
                     var defaultValue = reader.GetValueOrDefault<string>("default_sql");
+                    var computedValue = reader.GetValueOrDefault<string>("computed_sql");
                     var precision = reader.GetValueOrDefault<int?>("precision");
                     var scale = reader.GetValueOrDefault<int?>("scale");
                     var maxLength = reader.GetValueOrDefault<int?>("max_length");
@@ -281,7 +284,7 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'" +
 
                     Logger.LogTrace(SqlServerDesignStrings.FoundColumn(
                         schemaName, tableName, columnName, dataTypeName, ordinal, nullable,
-                        primaryKeyOrdinal, defaultValue, precision, scale, maxLength, isIdentity, isComputed));
+                        primaryKeyOrdinal, defaultValue, computedValue, precision, scale, maxLength, isIdentity, isComputed));
 
                     if (!_tableSelectionSet.Allows(schemaName, tableName))
                     {
@@ -333,6 +336,7 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'" +
                         IsNullable = nullable,
                         PrimaryKeyOrdinal = primaryKeyOrdinal,
                         DefaultValue = defaultValue,
+                        ComputedValue = computedValue,
                         Precision = precision,
                         Scale = scale,
                         MaxLength = maxLength <= 0 ? default(int?) : maxLength,

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerScaffoldingModelFactory.cs
@@ -53,6 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
 
             VisitDefaultValue(propertyBuilder, column);
 
+            VisitComputedValue(propertyBuilder, column);
+
             return propertyBuilder;
         }
 
@@ -226,6 +228,34 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                         SqlServerDesignStrings.CannotInterpretDefaultValue(
                             column.DisplayName,
                             column.DefaultValue,
+                            propertyBuilder.Metadata.Name,
+                            propertyBuilder.Metadata.DeclaringEntityType.Name));
+                }
+            }
+        }
+
+        private void VisitComputedValue(PropertyBuilder propertyBuilder, ColumnModel column)
+        {
+            if (column.ComputedValue != null)
+            {
+                ((Property)propertyBuilder.Metadata).SetValueGenerated(null, ConfigurationSource.Explicit);
+                propertyBuilder.Metadata.Relational().ComputedValueSql = null;
+
+                var computedExpression = ConvertSqlServerDefaultValue(column.ComputedValue);
+                if (computedExpression != null)
+                {
+                    if (!(computedExpression == "NULL"
+                          && propertyBuilder.Metadata.ClrType.IsNullableType()))
+                    {
+                        propertyBuilder.HasComputedColumnSql(computedExpression);
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning(
+                        SqlServerDesignStrings.CannotInterpretComputedValue(
+                            column.DisplayName,
+                            column.ComputedValue,
                             propertyBuilder.Metadata.Name,
                             propertyBuilder.Metadata.DeclaringEntityType.Name));
                 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -108,6 +108,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
                                 Name = "created",
                                 DataType = "string",
                                 ValueGenerated = ValueGenerated.OnAdd
+                            },
+                            new ColumnModel
+                            {
+                                Name = "current",
+                                DataType = "string",
+                                ComputedValue = "compute_this()"
                             }
                         }
                     }
@@ -129,24 +135,30 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
                     },
                 col2 =>
                     {
-                        Assert.Equal("modified", col2.Relational().ColumnName);
-                        Assert.Equal(ValueGenerated.OnAddOrUpdate, col2.ValueGenerated);
+                        Assert.Equal("current", col2.Name);
+                        Assert.Equal(typeof(string), col2.ClrType);
+                        Assert.Equal("compute_this()", col2.Relational().ComputedValueSql);
                     },
                 col3 =>
                     {
-                        Assert.Equal("occupation", col3.Relational().ColumnName);
-                        Assert.Equal(typeof(string), col3.ClrType);
-                        Assert.False(col3.IsColumnNullable());
-                        Assert.Null(col3.GetMaxLength());
-                        Assert.Equal("\"dev\"", col3.Relational().DefaultValueSql);
+                        Assert.Equal("modified", col3.Relational().ColumnName);
+                        Assert.Equal(ValueGenerated.OnAddOrUpdate, col3.ValueGenerated);
                     },
                 col4 =>
                     {
-                        Assert.Equal("salary", col4.Name);
-                        Assert.Equal(typeof(long?), col4.ClrType);
-                        Assert.True(col4.IsColumnNullable());
-                        Assert.Equal(100, col4.GetMaxLength());
-                        Assert.Null(col4.Relational().DefaultValue);
+                        Assert.Equal("occupation", col4.Relational().ColumnName);
+                        Assert.Equal(typeof(string), col4.ClrType);
+                        Assert.False(col4.IsColumnNullable());
+                        Assert.Null(col4.GetMaxLength());
+                        Assert.Equal("\"dev\"", col4.Relational().DefaultValueSql);
+                    },
+                col5 =>
+                    {
+                        Assert.Equal("salary", col5.Name);
+                        Assert.Equal(typeof(long?), col5.ClrType);
+                        Assert.True(col5.IsColumnNullable());
+                        Assert.Equal(100, col5.GetMaxLength());
+                        Assert.Null(col5.Relational().DefaultValue);
                     });
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -204,7 +204,8 @@ CREATE TABLE "dbo"."PropertyConfiguration" (
 	"B" "int" NOT NULL,
 	"SumOfAAndB" AS A + B PERSISTED, -- tests StoreGeneratedPattern
 	"RowversionColumn" "rowversion" NOT NULL,
-	"PropertyConfiguration" "int" NULL -- tests column with same name as its table
+	"PropertyConfiguration" "int" NULL, -- tests column with same name as its table
+	"ComputedDateTimeColumn" AS GETDATE()
 )
 
 GO

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/PropertyConfiguration.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/PropertyConfiguration.expected
@@ -19,5 +19,6 @@ namespace E2ETest.Namespace
         public int? SumOfAAndB { get; set; }
         public byte[] RowversionColumn { get; set; }
         public int? PropertyConfiguration1 { get; set; }
+        public DateTime ComputedDateTimeColumn { get; set; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -271,6 +271,11 @@ namespace E2ETest.Namespace
                 entity.HasIndex(e => new { e.A, e.B })
                     .HasName("Test_PropertyConfiguration_Index");
 
+                entity.Property(e => e.ComputedDateTimeColumn)
+                    .HasColumnType("datetime")
+                    .HasComputedColumnSql("getdate()")
+                    .ValueGeneratedOnAddOrUpdate();
+
                 entity.Property(e => e.PropertyConfiguration1).HasColumnName("PropertyConfiguration");
 
                 entity.Property(e => e.RowversionColumn)
@@ -278,7 +283,9 @@ namespace E2ETest.Namespace
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
-                entity.Property(e => e.SumOfAAndB).ValueGeneratedOnAddOrUpdate();
+                entity.Property(e => e.SumOfAAndB)
+                    .HasComputedColumnSql("[A]+[B]")
+                    .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.WithDateDefaultExpression).HasDefaultValueSql("getdate()");
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
@@ -170,11 +170,18 @@ namespace E2ETest.Namespace
                 entity.HasIndex(e => new { e.A, e.B })
                     .HasName("Test_PropertyConfiguration_Index");
 
+                entity.Property(e => e.ComputedDateTimeColumn)
+                    .HasColumnType("datetime")
+                    .HasComputedColumnSql("getdate()")
+                    .ValueGeneratedOnAddOrUpdate();
+
                 entity.Property(e => e.RowversionColumn)
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
-                entity.Property(e => e.SumOfAAndB).ValueGeneratedOnAddOrUpdate();
+                entity.Property(e => e.SumOfAAndB)
+                    .HasComputedColumnSql("[A]+[B]")
+                    .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.WithDateDefaultExpression).HasDefaultValueSql("getdate()");
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PropertyConfiguration.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PropertyConfiguration.expected
@@ -23,5 +23,6 @@ namespace E2ETest.Namespace
         public byte[] RowversionColumn { get; set; }
         [Column("PropertyConfiguration")]
         public int? PropertyConfiguration1 { get; set; }
+        public DateTime ComputedDateTimeColumn { get; set; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -147,6 +147,7 @@ CREATE TABLE [dbo].[MountainsColumns] (
     Latitude decimal( 5, 2 ) DEFAULT 0.0,
     Created datetime2(6) DEFAULT('October 20, 2015 11am'),
     DiscoveredDate datetime2,
+    CurrentDate AS GETDATE(),
     Sum AS Latitude + 1.0,
     Modified rowversion,
     Primary Key (Name, Id)
@@ -205,6 +206,12 @@ CREATE TABLE [dbo].[MountainsColumns] (
                     {
                         Assert.Equal("DiscoveredDate", discovered.Name);
                         Assert.Equal(7, discovered.SqlServer().DateTimePrecision);
+                    },
+                current =>
+                    {
+                        Assert.Equal("CurrentDate", current.Name);
+                        Assert.Equal("datetime", current.DataType);
+                        Assert.Equal("(getdate())", current.ComputedValue);
                     },
                 sum =>
                     {


### PR DESCRIPTION
Fix for #4944. For computed columns used `HasComputedColumnSql()` instead of `HasDefaultValueSql()`.