### PR TITLE
Ensure properties matching CLR properties are always marked as non-shadow

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -212,6 +212,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 Unignore(propertyName);
 
+                if (shadowProperty != false)
+                {
+                    var clrProperty = Metadata.ClrType?.GetPropertiesInHierarchy(propertyName).FirstOrDefault();
+                    if (clrProperty != null)
+                    {
+                        propertyType = clrProperty.PropertyType;
+                        shadowProperty = false;
+                    }
+                    else
+                    {
+                        shadowProperty = true;
+                    }
+                }
+
                 property = Metadata.AddProperty(propertyName, configurationSource.Value, runConventions: false);
             }
             else if (configurationSource.HasValue)

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1270,7 +1270,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredProperties());
             Assert.Empty(derivedEntityBuilder2.Metadata.GetDeclaredProperties());
-            Assert.Equal(typeof(string), propertyBuilder.Metadata.ClrType);
+            Assert.Equal(typeof(int), propertyBuilder.Metadata.ClrType);
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
             Assert.True(propertyBuilder.Metadata.RequiresValueGenerator);
             Assert.Equal(1, propertyBuilder.Metadata.GetMaxLength());

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
-        public void Property_added_by_name_is_shadow_even_if_matches_Clr_type()
+        public void Property_added_by_name_is_non_shadow_if_matches_Clr_property()
         {
             var model = new Model();
             var modelBuilder = new InternalModelBuilder(model);
@@ -65,9 +65,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = builder.Metadata;
 
             Assert.Equal(typeof(string), property.ClrType);
-            Assert.True(property.IsShadowProperty);
-            Assert.Null(property.GetClrTypeConfigurationSource());
-            Assert.Null(property.GetIsShadowPropertyConfigurationSource());
+            Assert.False(property.IsShadowProperty);
+            Assert.Equal(ConfigurationSource.Convention, property.GetClrTypeConfigurationSource());
+            Assert.Equal(ConfigurationSource.Convention, property.GetIsShadowPropertyConfigurationSource());
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -17,43 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
     {
         public class NonGenericOneToManyType : OneToManyTestBase
         {
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOneType : ManyToOneTestBase
         {
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -36,45 +36,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         public class NonGenericOneToMany : OneToManyTestBase
         {
-            [Fact]
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOne : ManyToOneTestBase
         {
-            [Fact]
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 


### PR DESCRIPTION
Fixes #4714