### PR TITLE
Re-enabling test that was disabled due to SQL Server bug

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        // [ConditionalFact] Currently disabled due to GitHub issue #266
+        [ConditionalFact]
         public async Task Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 var pegasuses = await context.Pegasuses.ToListAsync();
 
-                for (var i = 0; i < 50; i++)
+                for (var i = 0; i < 10; i++)
                 {
                     Assert.Equal(threadCount, pegasuses.Count(p => p.Name == "Rainbow Dash " + i));
                     Assert.Equal(threadCount, pegasuses.Count(p => p.Name == "Fluttershy " + i));


### PR DESCRIPTION
Bug is now fixed and pushed to releases/service packs. See #266.