### PR TITLE
Make the Metadata to .NET types mapping readonly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
@@ -35,17 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         protected virtual RelationalModelAnnotations GetAnnotations([NotNull] IModel model)
             => new RelationalModelAnnotations(model, ProviderFullAnnotationNames);
 
+        protected virtual RelationalEntityTypeAnnotations GetAnnotations([NotNull] IEntityType entityType)
+            => new RelationalEntityTypeAnnotations(entityType, ProviderFullAnnotationNames);
+
         public virtual string TableName
         {
             get
             {
-                var rootType = EntityType.RootType();
-                var rootAnnotations = new RelationalAnnotations(rootType);
+                if (EntityType.BaseType != null)
+                {
+                    var rootType = EntityType.RootType();
+                    return GetAnnotations(rootType).TableName;
+                }
 
-                return (string)rootAnnotations.GetAnnotation(
+                return (string)Annotations.GetAnnotation(
                     RelationalFullAnnotationNames.Instance.TableName,
                     ProviderFullAnnotationNames?.TableName)
-                       ?? rootType.DisplayName();
+                       ?? EntityType.DisplayName();
             }
             [param: CanBeNull] set { SetTableName(value); }
         }
@@ -60,8 +66,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             get
             {
-                var rootAnnotations = new RelationalAnnotations(EntityType.RootType());
-                return (string)rootAnnotations.GetAnnotation(
+                if (EntityType.BaseType != null)
+                {
+                    var rootType = EntityType.RootType();
+                    return GetAnnotations(rootType).Schema;
+                }
+
+                return (string)Annotations.GetAnnotation(
                     RelationalFullAnnotationNames.Instance.Schema,
                     ProviderFullAnnotationNames?.Schema)
                        ?? GetAnnotations((IMutableModel)EntityType.Model).DefaultSchema;
@@ -79,13 +90,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             get
             {
-                var rootType = EntityType.RootType();
-                var rootAnnotations = new RelationalAnnotations(rootType);
-                var propertyName = (string)rootAnnotations.GetAnnotation(
+                if (EntityType.BaseType != null)
+                {
+                    var rootType = EntityType.RootType();
+                    return GetAnnotations(rootType).DiscriminatorProperty;
+                }
+
+                var propertyName = (string)Annotations.GetAnnotation(
                     RelationalFullAnnotationNames.Instance.DiscriminatorProperty,
                     ProviderFullAnnotationNames?.DiscriminatorProperty);
 
-                return propertyName == null ? null : rootType.FindProperty(propertyName);
+                return propertyName == null ? null : EntityType.FindProperty(propertyName);
             }
             [param: CanBeNull] set { SetDiscriminatorProperty(value); }
         }
@@ -118,10 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             foreach (var derivedType in EntityType.GetDerivedTypes())
             {
-                new RelationalAnnotations(derivedType).SetAnnotation(
-                    RelationalFullAnnotationNames.Instance.DiscriminatorValue,
-                    ProviderFullAnnotationNames?.DiscriminatorValue,
-                    null);
+                GetAnnotations(derivedType).DiscriminatorValue = null;
             }
 
             return Annotations.SetAnnotation(
@@ -143,13 +155,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         protected virtual bool SetDiscriminatorValue([CanBeNull] object value)
         {
-            if (DiscriminatorProperty == null)
+            if (value != null
+                && DiscriminatorProperty == null)
             {
                 throw new InvalidOperationException(
                     RelationalStrings.NoDiscriminatorForValue(EntityType.DisplayName(), EntityType.RootType().DisplayName()));
             }
 
-            if ((value != null)
+            if (value != null
                 && !DiscriminatorProperty.ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
             {
                 throw new InvalidOperationException(RelationalStrings.DiscriminatorValueIncompatible(

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
@@ -26,10 +26,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(type, nameof(type));
 
-            var canFindEntityType = model as ICanFindEntityType;
+            var findClrEntityType = model as IModelFindClrType;
 
-            return canFindEntityType != null
-                ? canFindEntityType.FindEntityType(type)
+            return findClrEntityType != null
+                ? findClrEntityType.FindEntityType(type)
                 : model.FindEntityType(type.DisplayName());
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -32,31 +31,17 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The name of the entity type. </param>
         /// <returns> The existing or newly created entity type. </returns>
         public static IMutableEntityType GetOrAddEntityType([NotNull] this IMutableModel model, [NotNull] string name)
-        {
-            Check.NotNull(model, nameof(model));
+            => Check.NotNull(model, nameof(model)).FindEntityType(name) ?? model.AddEntityType(name);
 
-            return model.FindEntityType(name) ?? model.AddEntityType(name);
-        }
-
+        /// <summary>
+        ///     Gets the entity type with the given .NET type or adds a new entity type if none is found.
+        /// </summary>
+        /// <param name="model"> The model to find or add the entity type to. </param>
+        /// <param name="type"> The .NET type of the entity type. </param>
+        /// <returns> The existing or newly created entity type. </returns>
         public static IMutableEntityType GetOrAddEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
-            => model.FindEntityType(type) ?? model.AddEntityType(type);
-
-        public static IMutableEntityType AddEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
-        {
-            Check.NotNull(model, nameof(model));
-            Check.NotNull(type, nameof(type));
-
-            var canFindEntityType = model as ICanFindEntityType;
-
-            var entityType = canFindEntityType != null
-                ? canFindEntityType.AddEntityType(type.DisplayName(), type) :
-                model.AddEntityType(type.DisplayName());
-
-            entityType.ClrType = type;
-
-            return entityType;
-        }
-
+            => Check.NotNull(model, nameof(model)).FindEntityType(type) ?? model.AddEntityType(type);
+        
         public static IMutableEntityType RemoveEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
         {
             Check.NotNull(model, nameof(model));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -364,14 +364,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The newly created builder. </returns>
         protected virtual InternalPropertyBuilder PropertyBuilder(
             [NotNull] Type propertyType, [CanBeNull] string propertyName)
-        {
-            Check.NotNull(propertyType, nameof(propertyType));
-            Check.NotEmpty(propertyName, nameof(propertyName));
-
-            var builder = Builder.Property(propertyName, ConfigurationSource.Explicit);
-            var clrTypeSet = builder.HasClrType(propertyType, ConfigurationSource.Explicit);
-            Debug.Assert(clrTypeSet);
-            return builder;
-        }
+            => Builder.Property(
+                Check.NotEmpty(propertyName, nameof(propertyName)),
+                Check.NotNull(propertyType, nameof(propertyType)),
+                ConfigurationSource.Explicit);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IModel.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IModel.cs
@@ -15,16 +15,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IModel : IAnnotatable
     {
         /// <summary>
-        ///     Gets all entities types defined in the model.
+        ///     Gets all entity types defined in the model.
         /// </summary>
-        /// <returns> All entities types defined in the model. </returns>
+        /// <returns> All entity types defined in the model. </returns>
         IEnumerable<IEntityType> GetEntityTypes();
 
         /// <summary>
-        ///     Gets the entity with the given name. Returns null if no entity with the given name is found.
+        ///     Gets the entity type with the given name. Returns null if no entity type with the given name is found.
         /// </summary>
-        /// <param name="name"> The name of the entity to find. </param>
-        /// <returns> The entity type, or null if none if found. </returns>
+        /// <param name="name"> The name of the entity type to find. </param>
+        /// <returns> The entity type, or null if none are found. </returns>
         IEntityType FindEntityType([NotNull] string name);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
@@ -19,18 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IMutableEntityType : IEntityType, IMutableAnnotatable
     {
         /// <summary>
-        ///     <para>
-        ///         Gets or sets the CLR class that is used to represent instances of this entity. Returns null if the entity does not
-        ///         have a corresponding CLR class (known as a shadow entity).
-        ///     </para>
-        ///     <para>
-        ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
-        ///         Therefore, shadow entities will only exist in migration model snapshots, etc.
-        ///     </para>
-        /// </summary>
-        new Type ClrType { get; [param: CanBeNull] set; }
-
-        /// <summary>
         ///     Gets the model this entity belongs to.
         /// </summary>
         new IMutableModel Model { get; }
@@ -173,8 +161,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Adds a property to this entity.
         /// </summary>
         /// <param name="name"> The name of the property to add. </param>
+        /// <param name="propertyType"> The type of value the property will hold. </param>
+        /// <param name="shadow"> Whether the property is in shadow-state. </param>
         /// <returns> The newly created property. </returns>
-        IMutableProperty AddProperty([NotNull] string name);
+        IMutableProperty AddProperty([NotNull] string name, [NotNull] Type propertyType, bool shadow);
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableModel.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -20,30 +21,43 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IMutableModel : IModel, IMutableAnnotatable
     {
         /// <summary>
-        ///     Adds an entity from the model.
+        ///     <para>
+        ///         Adds a shadow state entity type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
+        ///         Therefore, shadow state entity types will only exist in migration model snapshots, etc.
+        ///     </para>
         /// </summary>
         /// <param name="name"> The name of the entity to be added. </param>
-        /// <returns> The new created entity. </returns>
+        /// <returns> The new entity type. </returns>
         IMutableEntityType AddEntityType([NotNull] string name);
 
         /// <summary>
-        ///     Gets the entity with the given name. Returns null if no navigation property with the given name is found.
+        ///     Adds an entity type to the model.
         /// </summary>
-        /// <param name="name"> The name of the entity to find. </param>
-        /// <returns> The entity type, or null if none if found. </returns>
+        /// <param name="clrType"> The CLR class that is used to represent instances of this entity type. </param>
+        /// <returns> The new entity type. </returns>
+        IMutableEntityType AddEntityType([CanBeNull] Type clrType);
+
+        /// <summary>
+        ///     Gets the entity with the given name. Returns null if no entity type with the given name is found.
+        /// </summary>
+        /// <param name="name"> The name of the entity type to find. </param>
+        /// <returns> The entity type, or null if none are found. </returns>
         new IMutableEntityType FindEntityType([NotNull] string name);
 
         /// <summary>
-        ///     Removes an entity from the model.
+        ///     Removes an entity type from the model.
         /// </summary>
-        /// <param name="name"> The name of the entity to be removed. </param>
-        /// <returns> The entity that was removed. </returns>
+        /// <param name="name"> The name of the entity type to be removed. </param>
+        /// <returns> The entity type that was removed. </returns>
         IMutableEntityType RemoveEntityType([NotNull] string name);
 
         /// <summary>
-        ///     Gets all entities types defined in the model.
+        ///     Gets all entity types defined in the model.
         /// </summary>
-        /// <returns> All entities types defined in the model. </returns>
+        /// <returns> All entity types defined in the model. </returns>
         new IEnumerable<IMutableEntityType> GetEntityTypes();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableProperty.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -23,11 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the type that this property belongs to.
         /// </summary>
         new IMutableEntityType DeclaringEntityType { get; }
-
-        /// <summary>
-        ///     Gets or sets the type of value that this property holds.
-        /// </summary>
-        new Type ClrType { get; [param: NotNull] set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether this property can contain null.
@@ -61,13 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     values when new entities are added to the context.
         /// </summary>
         new bool RequiresValueGenerator { get; set; }
-
-        /// <summary>
-        ///     Gets or sets a value indicating whether this is a shadow property. A shadow property is one that does not have a
-        ///     corresponding property in the entity class. The current value for the property is stored in
-        ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
-        /// </summary>
-        new bool IsShadowProperty { get; set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether this property is used as a concurrency token. When a property is configured

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -29,7 +29,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return accessor;
             }
 
-            var property = navigation.DeclaringEntityType.ClrType.GetAnyProperty(navigation.Name);
+            var propertyInfoAccessor = navigation as IPropertyPropertyInfoAccessor;
+            var property = propertyInfoAccessor != null
+                ? propertyInfoAccessor.PropertyInfo
+                : navigation.DeclaringEntityType.ClrType.GetAnyProperty(navigation.Name);
             var elementType = property.PropertyType.TryGetElementType(typeof(ICollection<>));
 
             // TODO: Only ICollections supported; add support for enumerables with add/remove methods

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IModelFindClrType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IModelFindClrType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public interface IModelFindClrType
+    {
+        IEntityType FindEntityType([NotNull] Type type);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IMutableEntityTypeAddPropertyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IMutableEntityTypeAddPropertyInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public interface IMutableEntityTypeAddPropertyInfo
+    {
+        /// <summary>
+        ///     Adds a property to this entity.
+        /// </summary>
+        /// <param name="propertyInfo"> The corresponding property in the entity class. </param>
+        /// <returns> The newly created property. </returns>
+        IMutableProperty AddProperty([NotNull] PropertyInfo propertyInfo);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IPropertyPropertyInfoAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IPropertyPropertyInfoAccessor.cs
@@ -1,14 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using JetBrains.Annotations;
+using System.Reflection;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
-    public interface ICanFindEntityType
+    public interface IPropertyPropertyInfoAccessor
     {
-        IEntityType FindEntityType([NotNull] Type type);
-        IMutableEntityType AddEntityType([NotNull] string name, [CanBeNull] Type type);
+        PropertyInfo PropertyInfo { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
+    [DebuggerDisplay("{Metadata,nq}")]
     public class InternalEntityTypeBuilder : InternalMetadataItemBuilder<EntityType>
     {
         public InternalEntityTypeBuilder([NotNull] EntityType metadata, [NotNull] InternalModelBuilder modelBuilder)
@@ -161,18 +162,89 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return currentConfigurationSource;
         }
 
+        private class KeyBuildersSnapshot
+        {
+            public KeyBuildersSnapshot(
+                IReadOnlyList<Tuple<InternalKeyBuilder, ConfigurationSource>> keys,
+                Tuple<InternalKeyBuilder, ConfigurationSource> primaryKey)
+            {
+                Keys = keys;
+                PrimaryKey = primaryKey;
+            }
+
+            private IReadOnlyList<Tuple<InternalKeyBuilder, ConfigurationSource>> Keys { get; }
+            private Tuple<InternalKeyBuilder, ConfigurationSource> PrimaryKey { get; }
+
+            public void Attach()
+            {
+                foreach (var keyTuple in Keys)
+                {
+                    var detachedKeyBuilder = keyTuple.Item1;
+                    var detachedConfigurationSource = keyTuple.Item2;
+                    if (detachedKeyBuilder.Attach(detachedConfigurationSource) == null)
+                    {
+                        detachedKeyBuilder.ModelBuilder.Metadata.ConventionDispatcher
+                            .OnKeyRemoved(detachedKeyBuilder.Metadata.DeclaringEntityType.Builder, detachedKeyBuilder.Metadata);
+                    }
+                    else if (PrimaryKey != null
+                             && PrimaryKey.Item1 == detachedKeyBuilder)
+                    {
+                        var rootType = detachedKeyBuilder.Metadata.DeclaringEntityType.RootType();
+                        var primaryKeyConfigurationSource = rootType.GetPrimaryKeyConfigurationSource();
+                        if (primaryKeyConfigurationSource == null
+                            || !primaryKeyConfigurationSource.Value.Overrides(PrimaryKey.Item2))
+                        {
+                            rootType.Builder.PrimaryKey(detachedKeyBuilder.Metadata.Properties, PrimaryKey.Item2);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static KeyBuildersSnapshot DetachKeys(IEnumerable<Key> keysToDetach)
+        {
+            var keysToDetachList = keysToDetach.ToList();
+            if (keysToDetachList.Count == 0)
+            {
+                return null;
+            }
+
+            var detachedKeys = new List<Tuple<InternalKeyBuilder, ConfigurationSource>>();
+            Tuple<InternalKeyBuilder, ConfigurationSource> primaryKey = null;
+            foreach (var keyToDetach in keysToDetachList)
+            {
+                var entityTypeBuilder = keyToDetach.DeclaringEntityType.Builder;
+                var keyBuilder = keyToDetach.Builder;
+                if (keyToDetach.IsPrimaryKey())
+                {
+                    var primaryKeyConfigurationSource = entityTypeBuilder.Metadata.GetPrimaryKeyConfigurationSource();
+                    Debug.Assert(primaryKeyConfigurationSource.HasValue);
+                    primaryKey = Tuple.Create(keyBuilder, primaryKeyConfigurationSource.Value);
+                }
+                var removedConfigurationSource = entityTypeBuilder.RemoveKey(keyToDetach, ConfigurationSource.Explicit, runConventions: false);
+                Debug.Assert(removedConfigurationSource != null);
+
+                detachedKeys.Add(Tuple.Create(keyBuilder, removedConfigurationSource.Value));
+            }
+
+            return new KeyBuildersSnapshot(detachedKeys, primaryKey);
+        }
+
         public virtual InternalPropertyBuilder Property(
             [NotNull] string propertyName, [NotNull] Type propertyType, ConfigurationSource configurationSource)
-            => Property(propertyName, propertyType, /*shadowProperty:*/ null, configurationSource);
+            => Property(propertyName, propertyType, clrProperty: null, configurationSource: configurationSource);
 
         public virtual InternalPropertyBuilder Property([NotNull] string propertyName, ConfigurationSource configurationSource)
-            => Property(propertyName, null, /*shadowProperty:*/ null, configurationSource);
+            => Property(propertyName, null, clrProperty: null, configurationSource: configurationSource);
 
         public virtual InternalPropertyBuilder Property([NotNull] PropertyInfo clrProperty, ConfigurationSource configurationSource)
-            => Property(clrProperty.Name, clrProperty.PropertyType, /*shadowProperty:*/ false, configurationSource);
+            => Property(clrProperty.Name, clrProperty.PropertyType, clrProperty: clrProperty, configurationSource: configurationSource);
 
         private InternalPropertyBuilder Property(
-            string propertyName, Type propertyType, bool? shadowProperty, ConfigurationSource? configurationSource)
+            [NotNull] string propertyName,
+            [CanBeNull] Type propertyType,
+            [CanBeNull] PropertyInfo clrProperty,
+            [CanBeNull] ConfigurationSource? configurationSource)
         {
             if (IsIgnored(propertyName, configurationSource))
             {
@@ -189,10 +261,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else if (existingProperty.DeclaringEntityType != Metadata)
             {
                 return existingProperty.DeclaringEntityType.Builder
-                    .Property(existingProperty, propertyName, propertyType, shadowProperty, configurationSource);
+                    .Property(existingProperty, propertyName, propertyType, clrProperty, configurationSource);
             }
 
-            var builder = Property(existingProperty, propertyName, propertyType, shadowProperty, configurationSource);
+            var builder = Property(existingProperty, propertyName, propertyType, clrProperty, configurationSource);
 
             detachedProperties?.Attach(this);
 
@@ -200,56 +272,64 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private InternalPropertyBuilder Property(
-            Property existingProperty,
-            string propertyName,
-            Type propertyType,
-            bool? shadowProperty,
-            ConfigurationSource? configurationSource)
+            [CanBeNull] Property existingProperty,
+            [NotNull] string propertyName,
+            [CanBeNull] Type propertyType,
+            [CanBeNull] PropertyInfo clrProperty,
+            [CanBeNull] ConfigurationSource? configurationSource)
         {
             var property = existingProperty;
-            if (existingProperty == null
-                && configurationSource.HasValue)
-            {
-                Unignore(propertyName);
-
-                property = Metadata.AddProperty(propertyName, configurationSource.Value, runConventions: false);
-            }
-            else if (configurationSource.HasValue)
-            {
-                property.UpdateConfigurationSource(configurationSource.Value);
-            }
-
-            var builder = ConfigureProperty(property.Builder, propertyType, shadowProperty, configurationSource);
-
             if (existingProperty == null)
             {
-                builder = Metadata.Model.ConventionDispatcher.OnPropertyAdded(property.Builder);
+                if (!configurationSource.HasValue)
+                {
+                    return null;
+                }
+
+                Unignore(propertyName);
+
+                if (clrProperty != null)
+                {
+                    property = Metadata.AddProperty(clrProperty, configurationSource.Value);
+                }
+                else
+                {
+                    property = Metadata.AddProperty(propertyName, propertyType, configurationSource: configurationSource.Value);
+                }
             }
-
-            return builder;
-        }
-
-        private static InternalPropertyBuilder ConfigureProperty(
-            InternalPropertyBuilder builder, Type propertyType, bool? shadowProperty, ConfigurationSource? configurationSource)
-        {
-            if (builder == null)
+            else
             {
-                return null;
+                if ((propertyType != null
+                     && propertyType != existingProperty.ClrType)
+                    || (clrProperty != null
+                        && existingProperty.IsShadowProperty))
+                {
+                    if (!configurationSource.HasValue
+                        || !configurationSource.Value.Overrides(existingProperty.GetConfigurationSource()))
+                    {
+                        return null;
+                    }
+
+                    var detachedProperties = DetachProperties(new[] { existingProperty });
+
+                    if (clrProperty != null)
+                    {
+                        property = Metadata.AddProperty(clrProperty, configurationSource.Value);
+                    }
+                    else
+                    {
+                        property = Metadata.AddProperty(propertyName, propertyType, configurationSource: configurationSource.Value);
+                    }
+
+                    detachedProperties.Attach(this);
+                }
+                else if (configurationSource.HasValue)
+                {
+                    property.UpdateConfigurationSource(configurationSource.Value);
+                }
             }
 
-            if ((propertyType != null)
-                && !builder.HasClrType(propertyType, configurationSource))
-            {
-                return null;
-            }
-
-            if (shadowProperty.HasValue
-                && !builder.IsShadow(shadowProperty.Value, configurationSource))
-            {
-                return null;
-            }
-
-            return builder;
+            return property?.Builder;
         }
 
         private bool CanRemoveProperty(
@@ -398,7 +478,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var detachedRelationships = new HashSet<RelationshipBuilderSnapshot>();
             PropertyBuildersSnapshot detachedProperties = null;
-            var removedKeys = new List<Key>();
+            KeyBuildersSnapshot detachedKeys = null;
             var changedRelationships = new List<InternalRelationshipBuilder>();
             IReadOnlyList<RelationshipSnapshot> relationshipsToBeRemoved = new List<RelationshipSnapshot>();
             if (baseEntityType != null)
@@ -443,20 +523,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                // TODO: Detach and reattach keys
-                // Issue #2611
-                removedKeys = Metadata.GetDeclaredKeys().ToList();
-                foreach (var key in removedKeys)
-                {
-                    var removedConfigurationSource = RemoveKey(key, configurationSource, runConventions: false);
-                    Debug.Assert(removedConfigurationSource.HasValue);
-                }
+                detachedKeys = DetachKeys(Metadata.GetDeclaredKeys());
 
                 var duplicatedProperties = baseEntityType.GetProperties()
                     .Select(p => Metadata.FindDeclaredProperty(p.Name))
                     .Where(p => p != null);
 
-                // TODO: Detach base property if shadow and derived non-shadow
                 detachedProperties = DetachProperties(duplicatedProperties);
 
                 baseEntityType.UpdateConfigurationSource(configurationSource);
@@ -466,6 +538,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Metadata.HasBaseType(baseEntityType, configurationSource, runConventions: false);
 
             detachedProperties?.Attach(this);
+
+            detachedKeys?.Attach();
 
             foreach (var detachedRelationship in detachedRelationships)
             {
@@ -496,17 +570,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyRemoved(dependentEntityType, relationshipToBeRemoved.ForeignKey);
             }
 
-            foreach (var removedKey in removedKeys)
-            {
-                ModelBuilder.Metadata.ConventionDispatcher.OnKeyRemoved(this, removedKey);
-            }
-
             ModelBuilder.Metadata.ConventionDispatcher.OnBaseEntityTypeSet(this, originalBaseType);
 
             return this;
         }
 
-        private PropertyBuildersSnapshot DetachProperties(IEnumerable<Property> propertiesToDetach)
+        private static PropertyBuildersSnapshot DetachProperties(IEnumerable<Property> propertiesToDetach)
         {
             var propertiesToDetachList = propertiesToDetach.ToList();
             if (propertiesToDetachList.Count == 0)
@@ -523,18 +592,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            // TODO: Detach and reattach keys and the referencing FKs
-            // Issue #2611
+            var detachedIndexes = DetachIndexes(propertiesToDetachList.SelectMany(p => p.FindContainingIndexes()).Distinct());
 
-            var detachedIndexes = new List<IndexBuildersSnapshot>();
-            foreach (var propertyToDetach in propertiesToDetachList)
-            {
-                var indexesToDetach = propertyToDetach.FindContainingIndexes().ToList();
-                if (indexesToDetach.Count > 0)
-                {
-                    detachedIndexes.Add(DetachIndexes(indexesToDetach));
-                }
-            }
+            var detachedKeys = DetachKeys(propertiesToDetachList.SelectMany(p => p.FindContainingKeys()).Distinct());
 
             var detachedProperties = new List<Tuple<InternalPropertyBuilder, ConfigurationSource>>();
             foreach (var propertyToDetach in propertiesToDetachList)
@@ -551,24 +611,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            return new PropertyBuildersSnapshot(detachedProperties, detachedIndexes, detachedRelationships);
+            return new PropertyBuildersSnapshot(detachedProperties, detachedIndexes, detachedKeys, detachedRelationships);
         }
 
         private class PropertyBuildersSnapshot
         {
             public PropertyBuildersSnapshot(
                 IReadOnlyList<Tuple<InternalPropertyBuilder, ConfigurationSource>> properties,
-                IReadOnlyList<IndexBuildersSnapshot> indexes,
+                IndexBuildersSnapshot indexes,
+                KeyBuildersSnapshot keys,
                 IReadOnlyList<RelationshipBuilderSnapshot> relationships)
             {
                 Properties = properties;
                 Indexes = indexes;
+                Keys = keys;
                 Relationships = relationships;
             }
 
             private IReadOnlyList<Tuple<InternalPropertyBuilder, ConfigurationSource>> Properties { get; }
             private IReadOnlyList<RelationshipBuilderSnapshot> Relationships { get; }
-            private IReadOnlyList<IndexBuildersSnapshot> Indexes { get; }
+            private IndexBuildersSnapshot Indexes { get; }
+            private KeyBuildersSnapshot Keys { get; }
 
             public void Attach(InternalEntityTypeBuilder entityTypeBuilder)
             {
@@ -577,10 +640,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     propertyTuple.Item1.Attach(entityTypeBuilder, propertyTuple.Item2);
                 }
 
-                foreach (var detachedIndexes in Indexes)
-                {
-                    detachedIndexes.Attach();
-                }
+                Indexes?.Attach();
+
+                Keys?.Attach();
 
                 foreach (var detachedRelationship in Relationships)
                 {
@@ -697,7 +759,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return currentConfigurationSource;
         }
 
-        private RelationshipBuilderSnapshot DetachRelationship([NotNull] ForeignKey foreignKey)
+        private static RelationshipBuilderSnapshot DetachRelationship([NotNull] ForeignKey foreignKey)
         {
             var relationshipBuilder = foreignKey.Builder;
             var relationshipConfigurationSource = foreignKey.DeclaringEntityType.Builder
@@ -886,7 +948,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var indexToDetach in indexesToDetachList)
             {
                 var entityTypeBuilder = indexToDetach.DeclaringEntityType.Builder;
-                var indexBuilder = entityTypeBuilder.HasIndex(indexToDetach.Properties, ConfigurationSource.Convention);
+                var indexBuilder = indexToDetach.Builder;
                 var removedConfigurationSource = entityTypeBuilder.RemoveIndex(indexToDetach, ConfigurationSource.Explicit);
                 Debug.Assert(removedConfigurationSource != null);
 
@@ -1443,7 +1505,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                     else
                     {
-                        throw new InvalidOperationException(CoreStrings.NoClrProperty(propertyName, Metadata.Name));
+                        throw new InvalidOperationException(CoreStrings.NoPropertyType(propertyName, Metadata.DisplayName()));
                     }
 
                     if (propertyBuilder == null)
@@ -1499,7 +1561,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var property in properties)
             {
                 var builder = property.Builder
-                              ?? Property(property.Name, propertyType: null, shadowProperty: null, configurationSource: configurationSource);
+                              ?? Property(property.Name, propertyType: null, clrProperty: null, configurationSource: configurationSource);
                 if (builder == null)
                 {
                     return null;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalIndexBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalIndexBuilder.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
+    [DebuggerDisplay("{Metadata,nq}")]
     public class InternalIndexBuilder : InternalMetadataItemBuilder<Index>
     {
         public InternalIndexBuilder([NotNull] Index index, [NotNull] InternalModelBuilder modelBuilder)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalKeyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalKeyBuilder.cs
@@ -1,15 +1,40 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
+    [DebuggerDisplay("{Metadata,nq}")]
     public class InternalKeyBuilder : InternalMetadataItemBuilder<Key>
     {
         public InternalKeyBuilder([NotNull] Key key, [NotNull] InternalModelBuilder modelBuilder)
             : base(key, modelBuilder)
         {
+        }
+
+        public virtual InternalKeyBuilder Attach(ConfigurationSource configurationSource)
+        {
+            // TODO: attach to same entity type
+            // Issue #2611
+            var entityTypeBuilder = Metadata.DeclaringEntityType.RootType().Builder;
+
+            var propertyNames = Metadata.Properties.Select(p => p.Name).ToList();
+            foreach (var propertyName in propertyNames)
+            {
+                if (entityTypeBuilder.Metadata.FindProperty(propertyName) == null)
+                {
+                    return null;
+                }
+            }
+
+            var newKeyBuilder = entityTypeBuilder.HasKey(propertyNames, configurationSource);
+
+            newKeyBuilder?.MergeAnnotationsFrom(this);
+
+            return newKeyBuilder;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 Metadata.Unignore(name);
 
-                entityType = Metadata.AddEntityType(name, null, configurationSource);
+                entityType = Metadata.AddEntityType(name, configurationSource);
             }
             else
             {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
+    [DebuggerDisplay("{Metadata,nq}")]
     public class InternalPropertyBuilder : InternalMetadataItemBuilder<Property>
     {
         public InternalPropertyBuilder([NotNull] Property property, [NotNull] InternalModelBuilder modelBuilder)
@@ -82,38 +83,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return false;
         }
 
-        public virtual bool IsShadow(bool isShadowProperty, ConfigurationSource? configurationSource)
-        {
-            if ((Metadata.IsShadowProperty == isShadowProperty)
-                || (configurationSource.HasValue
-                    && configurationSource.Value.Overrides(Metadata.GetIsShadowPropertyConfigurationSource())))
-            {
-                if (configurationSource.HasValue)
-                {
-                    Metadata.SetIsShadowProperty(isShadowProperty, configurationSource.Value);
-                }
-                return true;
-            }
-
-            return false;
-        }
-
-        public virtual bool HasClrType([NotNull] Type propertyType, ConfigurationSource? configurationSource)
-        {
-            if ((Metadata.ClrType == propertyType)
-                || (configurationSource.HasValue
-                    && configurationSource.Value.Overrides(Metadata.GetClrTypeConfigurationSource())))
-            {
-                if (configurationSource.HasValue)
-                {
-                    Metadata.HasClrType(propertyType, configurationSource.Value);
-                }
-                return true;
-            }
-
-            return false;
-        }
-
         public virtual bool RequiresValueGenerator(bool generateValue, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetRequiresValueGeneratorConfigurationSource())
@@ -159,11 +128,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             newPropertyBuilder.MergeAnnotationsFrom(this);
 
-            var oldClrTypeConfigurationSource = Metadata.GetClrTypeConfigurationSource();
-            if (oldClrTypeConfigurationSource.HasValue)
-            {
-                newPropertyBuilder.HasClrType(Metadata.ClrType, oldClrTypeConfigurationSource.Value);
-            }
             var oldIsReadOnlyAfterSaveConfigurationSource = Metadata.GetIsReadOnlyAfterSaveConfigurationSource();
             if (oldIsReadOnlyAfterSaveConfigurationSource.HasValue)
             {
@@ -186,11 +150,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 newPropertyBuilder.IsConcurrencyToken(Metadata.IsConcurrencyToken,
                     oldIsConcurrencyTokenConfigurationSource.Value);
-            }
-            var oldIsShadowPropertyConfigurationSource = Metadata.GetIsShadowPropertyConfigurationSource();
-            if (oldIsShadowPropertyConfigurationSource.HasValue)
-            {
-                newPropertyBuilder.IsShadow(Metadata.IsShadowProperty, oldIsShadowPropertyConfigurationSource.Value);
             }
             var oldRequiresValueGeneratorConfigurationSource = Metadata.GetRequiresValueGeneratorConfigurationSource();
             if (oldRequiresValueGeneratorConfigurationSource.HasValue)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
+    [DebuggerDisplay("{Metadata,nq}")]
     public class InternalRelationshipBuilder : InternalMetadataItemBuilder<ForeignKey>
     {
         public InternalRelationshipBuilder(

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
-    public class Model : ConventionalAnnotatable, IMutableModel, ICanFindEntityType
+    public class Model : ConventionalAnnotatable, IMutableModel, IModelFindClrType
     {
         private readonly SortedDictionary<string, EntityType> _entityTypes
             = new SortedDictionary<string, EntityType>();
@@ -44,36 +44,39 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual EntityType AddEntityType(
             [NotNull] string name,
             // ReSharper disable once MethodOverloadWithOptionalParameter
-            [CanBeNull] Type type = null,
-            // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit)
         {
             Check.NotEmpty(name, nameof(name));
 
             var entityType = new EntityType(name, this, configurationSource);
 
+            return AddEntityType(entityType);
+        }
+
+        public virtual EntityType AddEntityType(
+            [NotNull] Type type,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            ConfigurationSource configurationSource = ConfigurationSource.Explicit)
+        {
+            Check.NotNull(type, nameof(type));
+
+            var entityType = new EntityType(type, this, configurationSource);
+
+            _clrTypeMap[type] = entityType;
+            return AddEntityType(entityType);
+        }
+
+        private EntityType AddEntityType(EntityType entityType)
+        {
             var previousLength = _entityTypes.Count;
-            _entityTypes[name] = entityType;
+            _entityTypes[entityType.Name] = entityType;
             if (previousLength == _entityTypes.Count)
             {
                 throw new InvalidOperationException(CoreStrings.DuplicateEntityType(entityType.Name));
             }
 
-            if (type != null)
-            {
-                entityType.ClrType = type;
-                _clrTypeMap[type] = entityType;
-            }
-
             return ConventionDispatcher.OnEntityTypeAdded(entityType.Builder)?.Metadata;
         }
-
-        IMutableEntityType ICanFindEntityType.AddEntityType(string name, Type type)
-            => AddEntityType(name, type);
-
-        public virtual EntityType AddEntityType(
-            [NotNull] Type type, ConfigurationSource configurationSource = ConfigurationSource.Explicit)
-            => AddEntityType(type.DisplayName(), type, configurationSource);
 
         public virtual EntityType GetOrAddEntityType([NotNull] Type type)
             => FindEntityType(type) ?? AddEntityType(type);
@@ -82,9 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => FindEntityType(name) ?? AddEntityType(name);
 
         public virtual EntityType FindEntityType([NotNull] Type type)
-            => (EntityType)((ICanFindEntityType)this).FindEntityType(type);
+            => (EntityType)((IModelFindClrType)this).FindEntityType(type);
 
-        IEntityType ICanFindEntityType.FindEntityType(Type type)
+        IEntityType IModelFindClrType.FindEntityType(Type type)
         {
             Check.NotNull(type, nameof(type));
 
@@ -212,6 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         IEnumerable<IEntityType> IModel.GetEntityTypes() => GetEntityTypes();
 
         IMutableEntityType IMutableModel.AddEntityType(string name) => AddEntityType(name);
+        IMutableEntityType IMutableModel.AddEntityType(Type type) => AddEntityType(type);
         IEnumerable<IMutableEntityType> IMutableModel.GetEntityTypes() => GetEntityTypes();
         IMutableEntityType IMutableModel.FindEntityType(string name) => FindEntityType(name);
         IMutableEntityType IMutableModel.RemoveEntityType(string name) => RemoveEntityType(name);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -20,8 +20,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var accessors = propertyBase as IPropertyBaseAccessors;
 
-            return accessors != null
-                ? accessors.Getter
+            if (accessors != null)
+            {
+                return accessors.Getter;
+            }
+
+            var propertyInfoAccessor = propertyBase as IPropertyPropertyInfoAccessor;
+            return propertyInfoAccessor != null
+                ? new ClrPropertyGetterFactory().Create(propertyInfoAccessor.PropertyInfo)
                 : new ClrPropertyGetterFactory().Create(propertyBase);
         }
 
@@ -29,8 +35,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var accessors = propertyBase as IPropertyBaseAccessors;
 
-            return accessors != null
-                ? accessors.Setter
+            if (accessors != null)
+            {
+                return accessors.Setter;
+            }
+
+            var propertyInfoAccessor = propertyBase as IPropertyPropertyInfoAccessor;
+            return propertyInfoAccessor != null
+                ? new ClrPropertySetterFactory().Create(propertyInfoAccessor.PropertyInfo)
                 : new ClrPropertySetterFactory().Create(propertyBase);
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -321,9 +321,10 @@
     <Compile Include="Metadata\Internal\IEntityMaterializer.cs" />
     <Compile Include="Metadata\Internal\IEntityMaterializerSource.cs" />
     <Compile Include="Metadata\Internal\IFieldMatcher.cs" />
-    <Compile Include="Metadata\Internal\ICanFindEntityType.cs" />
+    <Compile Include="Metadata\Internal\IModelFindClrType.cs" />
     <Compile Include="Metadata\Internal\IIdentityMapFactorySource.cs" />
     <Compile Include="Metadata\Internal\IMemberMapper.cs" />
+    <Compile Include="Metadata\Internal\IMutableEntityTypeAddPropertyInfo.cs" />
     <Compile Include="Metadata\Internal\INavigationAccessors.cs" />
     <Compile Include="Metadata\Internal\Index.cs" />
     <Compile Include="Metadata\Internal\InternalEntityTypeBuilder.cs" />
@@ -341,6 +342,7 @@
     <Compile Include="Metadata\Internal\IPropertyIndexesAccessor.cs" />
     <Compile Include="Metadata\Internal\IPropertyIndexMetadata.cs" />
     <Compile Include="Metadata\Internal\IPropertyKeyMetadata.cs" />
+    <Compile Include="Metadata\Internal\IPropertyPropertyInfoAccessor.cs" />
     <Compile Include="Metadata\Internal\IReferencingForeignKeyMetadata.cs" />
     <Compile Include="Metadata\Internal\ISnapshotFactorySource.cs" />
     <Compile Include="Metadata\Internal\Key.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The CLR entity materializer cannot be used for entity type '{entityType}' because it is a shadow-state entity type.  Materialization to a CLR type is only possible for entity types that have a corresponding CLR type.
+        /// The CLR entity materializer cannot be used for entity type '{entityType}' because it is a shadow state entity type.  Materialization to a CLR type is only possible for entity types that have a corresponding CLR type.
         /// </summary>
         public static string NoClrType([CanBeNull] object entityType)
         {
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.
+        /// The property '{property}' cannot be added to entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.
         /// </summary>
         public static string NoClrProperty([CanBeNull] object property, [CanBeNull] object entityType)
         {
@@ -277,11 +277,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and the type of the corresponding CLR property does not match the type specified in the property.
+        /// The property '{property}' cannot be added to entity type '{entityType}' because the property is not in shadow state and the type of the corresponding CLR property '{clrType}' does not match the specified type '{propertyType}'.
         /// </summary>
-        public static string PropertyWrongClrType([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string PropertyWrongClrType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyWrongClrType", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyWrongClrType", "property", "entityType", "clrType", "propertyType"), property, entityType, clrType, propertyType);
         }
 
         /// <summary>
@@ -637,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show aditional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.
+        /// An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.
         /// </summary>
         public static string ExpressionParameterizationException
         {
@@ -829,14 +829,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The CLR type for property '{property}' cannot be changed because it is referenced by the foreign key {foreignKey} from entity type '{entityType}'.
-        /// </summary>
-        public static string PropertyClrTypeCannotBeChangedWhenReferenced([CanBeNull] object property, [CanBeNull] object foreignKey, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyClrTypeCannotBeChangedWhenReferenced", "property", "foreignKey", "entityType"), property, foreignKey, entityType);
-        }
-
-        /// <summary>
         /// The InversePropertyAttribute on property '{property}' on type '{entityType}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.
         /// </summary>
         public static string InvalidNavigationWithInverseProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referencedProperty, [CanBeNull] object referencedEntityType)
@@ -978,22 +970,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static string NavigationForWrongForeignKey([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetFk, [CanBeNull] object actualFk)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("NavigationForWrongForeignKey", "navigation", "entityType", "targetFk", "actualFk"), navigation, entityType, targetFk, actualFk);
-        }
-
-        /// <summary>
-        /// The specified CLR type '{clrType}' does not match the entity type name '{entity}'.
-        /// </summary>
-        public static string ClrTypeWrongName([CanBeNull] object clrType, [CanBeNull] object entity)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ClrTypeWrongName", "clrType", "entity"), clrType, entity);
-        }
-
-        /// <summary>
-        /// The CLR type cannot be set on the entity type '{entityType}' because it has members, base entity type or derived entity types.
-        /// </summary>
-        public static string EntityTypeInUse([CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeInUse", "entityType"), entityType);
         }
 
         /// <summary>
@@ -1162,6 +1138,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static string NoClrSetter([CanBeNull] object property)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("NoClrSetter", "property"), property);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because there was no property type specified and there is no corresponding CLR property. To add a shadow state property the property type needs to be specified.
+        /// </summary>
+        public static string NoPropertyType([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoPropertyType", "property", "entityType"), property, entityType);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -181,7 +181,7 @@
     <value>The property '{entityType}.{property}' does not have a setter and no backing field was found by convention. Either remove the property from the model, add a property setter, or configure a backing field (see http://go.microsoft.com/fwlink/?LinkId=723277).</value>
   </data>
   <data name="NoClrType" xml:space="preserve">
-    <value>The CLR entity materializer cannot be used for entity type '{entityType}' because it is a shadow-state entity type.  Materialization to a CLR type is only possible for entity types that have a corresponding CLR type.</value>
+    <value>The CLR entity materializer cannot be used for entity type '{entityType}' because it is a shadow state entity type.  Materialization to a CLR type is only possible for entity types that have a corresponding CLR type.</value>
   </data>
   <data name="MultipleProvidersConfigured" xml:space="preserve">
     <value>The database providers {storeNames}are configured. A context can only be configured to use a single database provider.</value>
@@ -214,10 +214,10 @@
     <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="NoClrProperty" xml:space="preserve">
-    <value>The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.</value>
+    <value>The property '{property}' cannot be added to entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.</value>
   </data>
   <data name="PropertyWrongClrType" xml:space="preserve">
-    <value>The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and the type of the corresponding CLR property does not match the type specified in the property.</value>
+    <value>The property '{property}' cannot be added to entity type '{entityType}' because the property is not in shadow state and the type of the corresponding CLR property '{clrType}' does not match the specified type '{propertyType}'.</value>
   </data>
   <data name="ClrPropertyOnShadowEntity" xml:space="preserve">
     <value>The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.</value>
@@ -423,9 +423,6 @@
   <data name="PropertyWrongEntityClrType" xml:space="preserve">
     <value>CLR property '{property}' cannot be added to entity type '{entityType}' because it is declared on the CLR type '{clrType}'.</value>
   </data>
-  <data name="PropertyClrTypeCannotBeChangedWhenReferenced" xml:space="preserve">
-    <value>The CLR type for property '{property}' cannot be changed because it is referenced by the foreign key {foreignKey} from entity type '{entityType}'.</value>
-  </data>
   <data name="InvalidNavigationWithInverseProperty" xml:space="preserve">
     <value>The InversePropertyAttribute on property '{property}' on type '{entityType}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.</value>
   </data>
@@ -479,12 +476,6 @@
   </data>
   <data name="NavigationForWrongForeignKey" xml:space="preserve">
     <value>The navigation property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>
-  </data>
-  <data name="ClrTypeWrongName" xml:space="preserve">
-    <value>The specified CLR type '{clrType}' does not match the entity type name '{entity}'.</value>
-  </data>
-  <data name="EntityTypeInUse" xml:space="preserve">
-    <value>The CLR type cannot be set on the entity type '{entityType}' because it has members, base entity type or derived entity types.</value>
   </data>
   <data name="EntityTypeNotFound" xml:space="preserve">
     <value>The entity type '{entityType}' was not found. Ensure that the entity type has been added to the model.</value>
@@ -548,5 +539,8 @@
   </data>
   <data name="NoClrSetter" xml:space="preserve">
     <value>Could not find setter for property {property}</value>
+  </data>
+  <data name="NoPropertyType" xml:space="preserve">
+    <value>The property '{property}' cannot be added to the entity type '{entityType}' because there was no property type specified and there is no corresponding CLR property. To add a shadow state property the property type needs to be specified.</value>
   </data>
 </root>

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestUtilities/Extensions.cs
@@ -78,9 +78,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         {
             foreach (var property in sourceEntityType.GetDeclaredProperties())
             {
-                var clonedProperty = targetEntityType.AddProperty(property.Name);
-                clonedProperty.ClrType = property.ClrType;
-                clonedProperty.IsShadowProperty = property.IsShadowProperty;
+                var clonedProperty = targetEntityType.AddProperty(property.Name, property.ClrType, property.IsShadowProperty);
                 clonedProperty.IsNullable = property.IsNullable;
                 clonedProperty.IsConcurrencyToken = property.IsConcurrencyToken;
                 clonedProperty.RequiresValueGenerator = property.RequiresValueGenerator;

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -17,8 +17,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = model.AddEntityType(typeof(Customer));
-            var property1 = customerType.AddProperty("Id", typeof(int));
-            property1.IsShadowProperty = false;
+            var property1 = customerType.AddProperty("Id", typeof(int), shadow: false);
             customerType.GetOrSetPrimaryKey(property1);
             customerType.AddProperty("Name", typeof(string));
 

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
             builder.Entity<AnEntity>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random)).IsShadowProperty = false;
+            entityType.AddProperty("Random", typeof(Random), shadow: false);
 
             foreach (var property in entityType.GetProperties())
             {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -17,10 +17,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention);
+            entityTypeBuilder.Property("LongProperty", typeof(long), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "Property", typeof(long).DisplayName(fullName: false)),
+                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "LongProperty", typeof(long).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -29,10 +29,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
+            entityTypeBuilder.Property("LongProperty", typeof(long), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "Property", typeof(long).DisplayName(fullName: false)),
+                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "LongProperty", typeof(long).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var idProperty = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Relational(ConfigurationSource.Convention).HasName("Splew"));
@@ -202,8 +202,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
             Assert.Equal(typeof(int?), typeBuilder.Metadata.Relational().DiscriminatorProperty.ClrType);
 
             Assert.NotNull(typeBuilder.Relational(ConfigurationSource.DataAnnotation).HasDiscriminator(typeof(int)));
-            Assert.Null(typeBuilder.Relational(ConfigurationSource.Convention).HasDiscriminator(typeof(int?)));
-            Assert.Equal(Splot.SplowedProperty.Name, typeBuilder.Metadata.Relational().DiscriminatorProperty.Name);
+            Assert.Null(typeBuilder.Relational(ConfigurationSource.Convention).HasDiscriminator(typeof(long)));
+            Assert.Equal("Discriminator", typeBuilder.Metadata.Relational().DiscriminatorProperty.Name);
             Assert.Equal(typeof(int), typeBuilder.Metadata.Relational().DiscriminatorProperty.ClrType);
 
             Assert.Null(typeBuilder.Relational(ConfigurationSource.Convention).HasDiscriminator((PropertyInfo)null));

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             Assert.Null(entityType.Relational().DiscriminatorProperty);
 
-            var property = entityType.AddProperty("D");
+            var property = entityType.AddProperty("D", typeof(string), shadow: true);
 
             entityType.Relational().DiscriminatorProperty = property;
 
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
             var entityType = modelBuilder
                 .Entity<Customer>()
                 .Metadata;
-            var property = entityType.AddProperty("D");
+            var property = entityType.AddProperty("D", typeof(string), shadow: true);
 
             var derivedType = modelBuilder
                 .Entity<SpecialCustomer>()
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<SpecialCustomer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D");
+            var property = entityType.AddProperty("D", typeof(string), shadow: true);
 
             Assert.Equal(RelationalStrings.DiscriminatorPropertyNotFound("D", typeof(SpecialCustomer).FullName),
                 Assert.Throws<InvalidOperationException>(() => otherType.Relational().DiscriminatorProperty = property).Message);
@@ -358,8 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<Customer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D");
-            property.ClrType = typeof(string);
+            var property = entityType.AddProperty("D", typeof(string), shadow: true);
             entityType.Relational().DiscriminatorProperty = property;
 
             Assert.Null(entityType.Relational().DiscriminatorValue);
@@ -396,8 +395,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<Customer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D");
-            property.ClrType = typeof(int);
+            var property = entityType.AddProperty("D", typeof(int), true);
             entityType.Relational().DiscriminatorProperty = property;
 
             Assert.Equal(RelationalStrings.DiscriminatorValueIncompatible("V", "D", typeof(int)),

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         {
             base.SetBaseType(entityType, baseEntityType);
 
-            var discriminatorProperty = baseEntityType.GetOrAddProperty("Discriminator", typeof(string));
+            var discriminatorProperty = baseEntityType.GetOrAddProperty("Discriminator", typeof(string), shadow: true);
             baseEntityType.Relational().DiscriminatorProperty = discriminatorProperty;
             baseEntityType.Relational().DiscriminatorValue = baseEntityType.Name;
             entityType.Relational().DiscriminatorValue = entityType.Name;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ModificationCommandTest.cs
@@ -372,14 +372,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             var model = new Model();
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int));
-            key.IsShadowProperty = false;
+            var key = entityType.AddProperty("Id", typeof(int), shadow: false);
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name", typeof(string));
-            nonKey.IsShadowProperty = false;
+            var nonKey = entityType.AddProperty("Name", typeof(string), shadow: false);
             nonKey.IsConcurrencyToken = computeNonKeyValue;
 
             nonKey.Relational().ColumnName = "Col2";

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -535,14 +535,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
 
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int));
-            key.IsShadowProperty = false;
+            var key = entityType.AddProperty("Id", typeof(int), shadow: false);
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name", typeof(string));
-            nonKey.IsShadowProperty = false;
+            var nonKey = entityType.AddProperty("Name", typeof(string), shadow: false);
             nonKey.Relational().ColumnName = "Col2";
             nonKey.ValueGenerated = computeNonKeyValue ? ValueGenerated.OnAddOrUpdate : ValueGenerated.Never;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var idProperty = entityTypeBuilder.Property("Id", typeof(string), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.SqlServer(ConfigurationSource.Convention).IsClustered(true));

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -117,8 +117,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             var model = builder.Model;
             model.SqlServer().GetOrAddSequence(SqlServerModelAnnotations.DefaultHiLoSequenceName);
             var entityType = model.FindEntityType(typeof(AnEntity));
-            var property1 = entityType.AddProperty("Random", typeof(Random));
-            property1.IsShadowProperty = false;
+            entityType.AddProperty("Random", typeof(Random), shadow: false);
 
             foreach (var property in entityType.GetProperties())
             {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata.Internal
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var idProperty = entityTypeBuilder.Property("Id", typeof(string), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Sqlite(ConfigurationSource.Convention).HasName("Splew"));

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -38,10 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            var property = entityType.AddProperty("Long", typeof(int));
-            property.IsShadowProperty = false;
-            var property1 = entityType.AddProperty("Hammer", typeof(string));
-            property1.IsShadowProperty = false;
+            entityType.AddProperty("Long", typeof(int), shadow: false);
+            entityType.AddProperty("Hammer", typeof(string), shadow: false);
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -62,9 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            var property1 = entityType.AddProperty("Long", typeof(int));
-            property1.IsShadowProperty = false;
-            entityType.AddProperty("Hammer", typeof(string));
+            entityType.AddProperty("Long", typeof(int), shadow: false);
+            entityType.AddProperty("Hammer", typeof(string), shadow: true);
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -1182,56 +1182,44 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase));
-            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
-            simpleKeyProperty.IsShadowProperty = false;
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int), shadow: false);
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase));
-            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
-            compositeKeyProperty1.IsShadowProperty = false;
-            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string));
-            compositeKeyProperty2.IsShadowProperty = false;
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int), shadow: false);
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string), shadow: false);
             compositeKeyProperty2.IsNullable = false;
             someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             entityType1.HasBaseType(someSimpleEntityType);
-            var property3 = entityType1.AddProperty("Name", typeof(string));
-            property3.IsShadowProperty = false;
+            var property3 = entityType1.AddProperty("Name", typeof(string), shadow: false);
             property3.IsConcurrencyToken = true;
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
             entityType2.HasBaseType(someCompositeEntityType);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
-            fk.IsShadowProperty = false;
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadow: false);
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.FindPrimaryKey(), entityType1);
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
-            justAProperty.IsShadowProperty = false;
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadow: false);
             justAProperty.RequiresValueGenerator = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            var property6 = entityType3.AddProperty("Id", typeof(int));
-            property6.IsShadowProperty = false;
+            var property6 = entityType3.AddProperty("Id", typeof(int), shadow: false);
             entityType3.GetOrSetPrimaryKey(property6);
-            var property7 = entityType3.AddProperty("Name", typeof(string));
-            property7.IsShadowProperty = false;
+            var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
             property7.IsConcurrencyToken = true;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            var property8 = entityType4.AddProperty("Id", typeof(int));
-            property8.IsShadowProperty = false;
+            var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
             entityType4.GetOrSetPrimaryKey(property8);
-            var property9 = entityType4.AddProperty("Name", typeof(string));
-            property9.IsShadowProperty = false;
+            var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
             property9.IsConcurrencyToken = true;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.HasBaseType(someSimpleEntityType);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
-            fk5a.IsShadowProperty = false;
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
-            fk5b.IsShadowProperty = false;
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadow: false);
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadow: false);
             entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.FindPrimaryKey(), entityType2);
 
             return model;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -95,11 +95,48 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
         protected override Model BuildModel()
         {
-            var model = base.BuildModel();
+            var model = new Model();
 
-            model.FindEntityType(typeof(SomeSimpleEntityBase)).FindProperty("Id").IsShadowProperty = true;
-            model.FindEntityType(typeof(SomeEntity)).FindProperty("Name").IsConcurrencyToken = false;
-            model.FindEntityType(typeof(SomeDependentEntity)).FindProperty("SomeEntityId").IsShadowProperty = true;
+            var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase));
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int), shadow: true);
+            simpleKeyProperty.RequiresValueGenerator = true;
+            someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
+
+            var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase));
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int), shadow: false);
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string), shadow: false);
+            compositeKeyProperty2.IsNullable = false;
+            someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
+
+            var entityType1 = model.AddEntityType(typeof(SomeEntity));
+            entityType1.HasBaseType(someSimpleEntityType);
+            var property3 = entityType1.AddProperty("Name", typeof(string), shadow: false);
+            property3.IsConcurrencyToken = false;
+
+            var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
+            entityType2.HasBaseType(someCompositeEntityType);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadow: true);
+            entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.FindPrimaryKey(), entityType1);
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadow: false);
+            justAProperty.RequiresValueGenerator = true;
+
+            var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
+            var property6 = entityType3.AddProperty("Id", typeof(int), shadow: false);
+            entityType3.GetOrSetPrimaryKey(property6);
+            var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
+            property7.IsConcurrencyToken = true;
+
+            var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
+            var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
+            entityType4.GetOrSetPrimaryKey(property8);
+            var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
+            property9.IsConcurrencyToken = true;
+
+            var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
+            entityType5.HasBaseType(someSimpleEntityType);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadow: false);
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadow: false);
+            entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.FindPrimaryKey(), entityType2);
 
             return model;
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -202,9 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
             var keyProperties = new Property[propertyCount];
             for (var i = 0; i < propertyCount; i++)
             {
-                var property = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i));
-                property.ClrType = typeof(int?);
-                property.IsShadowProperty = false;
+                var property = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i), typeof(int?), shadow: false);
                 keyProperties[i] = property;
                 keyProperties[i].RequiresValueGenerator = true;
                 keyProperties[i].IsNullable = false;
@@ -214,8 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
 
         public void SetPrimaryKey(EntityType entityType)
         {
-            var property = entityType.AddProperty("Id", typeof(int));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Id", typeof(int), shadow: false);
             entityType.SetPrimaryKey(property);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
@@ -405,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
             entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.ShadowKey("{'Foo'}", typeof(SampleEntity).Name, "{'Foo'}"),
@@ -417,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
             entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.DataAnnotation);
 
             Assert.Same(modelBuilder, new KeyConvention().Apply(modelBuilder));
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", ConfigurationSource.DataAnnotation);
+            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
             entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.Convention);
 
             Assert.Same(modelBuilder, new KeyConvention().Apply(modelBuilder));
@@ -441,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
             var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
-            referencedEntityBuilder.Property("Foo", ConfigurationSource.Convention);
+            referencedEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
             var properties = new List<string> { "Foo" };
             referencedEntityBuilder.HasForeignKey(
                 principalEntityBuilder,
@@ -463,8 +463,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
             var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
-            principalEntityBuilder.Property("Foo", ConfigurationSource.DataAnnotation);
-            referencedEntityBuilder.Property("Foo", ConfigurationSource.DataAnnotation);
+            principalEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
+            referencedEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
             var properties = new List<string> { "Foo" };
             referencedEntityBuilder.HasForeignKey(
                 principalEntityBuilder,

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -143,17 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         public virtual void Does_not_throw_when_non_candidate_property_is_not_added()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
-
-            CreateConvention().Apply(modelBuilder);
-        }
-
-        [Fact]
-        public virtual void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationAsProperty), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("ShadowPropertyOfNullType", ConfigurationSource.Convention);
+            modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
 
             CreateConvention().Apply(modelBuilder);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -26,8 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Delegate_getter_is_returned_for_IProperty_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
-            idProperty.IsShadowProperty = false;
+            var idProperty = entityType.AddProperty("Id", typeof(int), shadow: false);
 
             Assert.Equal(7, new ClrPropertyGetterFactory().Create(idProperty).GetClrValue(new Customer { Id = 7 }));
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/FieldMatcherTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/FieldMatcherTest.cs
@@ -44,14 +44,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             => FieldMatchTest("BrainDamage", "m_BrainDamage");
 
         [Fact]
-        public void M_underscpre_matching_field_is_used_as_fifth_preference() 
+        public void M_underscore_matching_field_is_used_as_fifth_preference() 
             => FieldMatchTest("Eclipse", "m_Eclipse");
 
         private static void FieldMatchTest(string propertyName, string fieldName)
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.AddProperty(propertyName, typeof(int));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty(propertyName, typeof(int), shadow: false);
             var propertyInfo = entityType.ClrType.GetAnyProperty(propertyName);
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 
@@ -64,8 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void M_underscore_matching_field_is_not_used_if_type_is_not_compatible()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.AddProperty("SpeakToMe", typeof(int));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("SpeakToMe", typeof(int), shadow: false);
             var propertyInfo = entityType.ClrType.GetAnyProperty("SpeakToMe");
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.Property("CustomerId", ConfigurationSource.Explicit);
+            principalEntityBuilder.Property("CustomerId", typeof(string), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new [] { "CustomerId"}, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.Property("CustomerId", ConfigurationSource.Explicit);
+            principalEntityBuilder.Property("CustomerId", typeof(string), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { "CustomerId" }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.Ignore("CustomerId", ConfigurationSource.Explicit);
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             Assert.Equal(
-                CoreStrings.NoClrProperty("ShadowCustomerId", typeof(Order)),
+                CoreStrings.NoPropertyType("ShadowCustomerId", nameof(Order)),
                 Assert.Throws<InvalidOperationException>(
                     () => orderEntityBuilder.HasForeignKey(
                         customerEntityBuilder.Metadata.Name,
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             Assert.Equal(
-                CoreStrings.NoClrProperty("ShadowCustomerId", typeof(Order)),
+                CoreStrings.NoPropertyType("ShadowCustomerId", nameof(Order)),
                 Assert.Throws<InvalidOperationException>(
                     () => orderEntityBuilder.HasForeignKey(
                         customerEntityBuilder.Metadata.Name,
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             Assert.Equal(
-                CoreStrings.NoClrProperty("ShadowCustomerId", typeof(Order)),
+                CoreStrings.NoPropertyType("ShadowCustomerId", nameof(Order)),
                 Assert.Throws<InvalidOperationException>(
                     () => orderEntityBuilder.HasForeignKey(
                         customerEntityBuilder.Metadata.Name,
@@ -833,7 +833,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            Assert.Equal(CoreStrings.NoClrProperty(Customer.UniqueProperty.Name, typeof(Order).FullName),
+            Assert.Equal(CoreStrings.NoPropertyType(Customer.UniqueProperty.Name, nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() =>
                     entityBuilder.HasKey(new[] { Customer.UniqueProperty.Name }, ConfigurationSource.Convention)).Message);
         }
@@ -874,7 +874,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Null(dependentEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(
-                CoreStrings.KeyPropertyInForeignKey(Order.IdProperty.Name, typeof(Order).Name),
+                CoreStrings.KeyPropertyInForeignKey(Order.IdProperty.Name, nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => dependentEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.Explicit)).Message);
         }
 
@@ -884,7 +884,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order).Name, ConfigurationSource.Explicit);
 
-            Assert.Equal(CoreStrings.NoClrProperty(Order.IdProperty.Name, typeof(Order).Name),
+            Assert.Equal(CoreStrings.NoPropertyType(Order.IdProperty.Name, nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() =>
                     entityBuilder.HasKey(new[] { Order.IdProperty.Name }, ConfigurationSource.Convention)).Message);
         }
@@ -1056,7 +1056,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            Assert.Equal(CoreStrings.NoClrProperty(Customer.UniqueProperty.Name, typeof(Order).FullName),
+            Assert.Equal(CoreStrings.NoPropertyType(Customer.UniqueProperty.Name, nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() =>
                     entityBuilder.PrimaryKey(new[] { Customer.UniqueProperty.Name }, ConfigurationSource.Convention)).Message);
         }
@@ -1067,7 +1067,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order).Name, ConfigurationSource.Explicit);
 
-            Assert.Equal(CoreStrings.NoClrProperty(Order.IdProperty.Name, typeof(Order).Name),
+            Assert.Equal(CoreStrings.NoPropertyType(Order.IdProperty.Name, nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() =>
                     entityBuilder.PrimaryKey(new[] { Order.IdProperty.Name }, ConfigurationSource.Convention)).Message);
         }
@@ -1234,7 +1234,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit);
 
             Assert.NotNull(propertyBuilder);
-            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit));
+            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit));
         }
 
         [Fact]
@@ -1243,10 +1243,20 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation);
+            var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(propertyBuilder);
             Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation));
+        }
+
+        [Fact]
+        public void Cannot_add_shadow_property_without_type()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+
+            Assert.Equal(CoreStrings.NoPropertyType("Shadow", nameof(Order)),
+                Assert.Throws<InvalidOperationException>(() => entityBuilder.Property("Shadow", ConfigurationSource.DataAnnotation)).Message);
         }
 
         [Fact]
@@ -1256,21 +1266,21 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
-            var derivedProperty = derivedEntityBuilder.Property(Order.IdProperty.Name, typeof(string), ConfigurationSource.DataAnnotation);
+            var derivedProperty = derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), ConfigurationSource.DataAnnotation);
             derivedProperty.IsConcurrencyToken(true, ConfigurationSource.Convention);
             derivedProperty.HasMaxLength(1, ConfigurationSource.DataAnnotation);
             var derivedEntityBuilder2 = modelBuilder.Entity(typeof(BackOrder), ConfigurationSource.Convention);
             derivedEntityBuilder2.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
-            var derivedProperty2 = derivedEntityBuilder2.Property(Order.IdProperty.Name, typeof(string), ConfigurationSource.Convention);
+            var derivedProperty2 = derivedEntityBuilder2.Property(nameof(SpecialOrder.Specialty), typeof(byte), ConfigurationSource.Convention);
             derivedProperty2.RequiresValueGenerator(true, ConfigurationSource.Convention);
             derivedProperty2.HasMaxLength(2, ConfigurationSource.Convention);
 
-            var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Convention);
-            Assert.Same(propertyBuilder.Metadata, entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
-            Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
+            var propertyBuilder = entityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(int), ConfigurationSource.Convention);
+            Assert.Same(propertyBuilder.Metadata, entityBuilder.Metadata.FindProperty(nameof(SpecialOrder.Specialty)));
+            Assert.False(entityBuilder.Ignore(nameof(SpecialOrder.Specialty), ConfigurationSource.Convention));
             Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredProperties());
             Assert.Empty(derivedEntityBuilder2.Metadata.GetDeclaredProperties());
-            Assert.Equal(typeof(string), propertyBuilder.Metadata.ClrType);
+            Assert.Equal(typeof(int), propertyBuilder.Metadata.ClrType);
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
             Assert.True(propertyBuilder.Metadata.RequiresValueGenerator);
             Assert.Equal(1, propertyBuilder.Metadata.GetMaxLength());
@@ -1281,18 +1291,28 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit)
+            entityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(int), ConfigurationSource.Explicit)
                 .IsConcurrencyToken(false, ConfigurationSource.Convention);
 
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-            var propertyBuilder = derivedEntityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation);
+            var propertyBuilder = derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(int), ConfigurationSource.DataAnnotation);
 
-            Assert.Same(entityBuilder.Metadata.FindProperty(Order.IdProperty.Name), propertyBuilder.Metadata);
+            Assert.Same(entityBuilder.Metadata.FindProperty(nameof(SpecialOrder.Specialty)), propertyBuilder.Metadata);
             Assert.True(propertyBuilder.IsConcurrencyToken(true, ConfigurationSource.Convention));
             Assert.True(propertyBuilder.Metadata.IsConcurrencyToken);
-            Assert.False(propertyBuilder.HasClrType(typeof(string), ConfigurationSource.DataAnnotation));
+            Assert.Same(typeof(int), propertyBuilder.Metadata.ClrType);
+
+            Assert.Null(derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(string), ConfigurationSource.DataAnnotation));
+
+            Assert.Null(entityBuilder.Metadata.FindPrimaryKey());
+            Assert.NotNull(entityBuilder.PrimaryKey(new [] { propertyBuilder.Metadata.Name}, ConfigurationSource.Explicit));
+            propertyBuilder = derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(string), ConfigurationSource.Explicit);
+
+            Assert.Same(typeof(string), propertyBuilder.Metadata.ClrType);
+            Assert.Same(entityBuilder.Metadata, propertyBuilder.Metadata.DeclaringEntityType);
+            Assert.NotNull(entityBuilder.Metadata.FindPrimaryKey());
         }
 
         [Fact]
@@ -1306,9 +1326,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation));
+            Assert.Null(entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation));
 
-            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit));
         }
 
         [Fact]
@@ -1318,14 +1338,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var entityType = entityBuilder.Metadata;
 
-            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
 
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
 
-            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
             Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
@@ -1340,8 +1360,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var entityType = entityBuilder.Metadata;
-            var property = entityType.AddProperty(Order.IdProperty.Name, typeof(int));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty(Order.IdProperty.Name, typeof(int), shadow: false);
 
             Assert.Same(property, entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.Convention).Metadata);
 
@@ -1357,7 +1376,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(typeof(Order), ConfigurationSource.DataAnnotation);
 
-            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation));
             Assert.False(derivedEntityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.NotNull(entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
 
@@ -1623,9 +1642,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int));
-            property1.IsShadowProperty = false;
-            var property2 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid));
+            var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int), shadow: false);
+            var property2 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid?));
             var foreignKey = dependentEntityBuilder.Metadata.AddForeignKey(
                 new[]
                 {

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -13,50 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
     public class InternalPropertyBuilderTest
     {
         [Fact]
-        public void Can_only_override_lower_or_equal_source_ClrType()
-        {
-            var builder = CreateInternalPropertyBuilder();
-            var metadata = builder.Metadata;
-
-            Assert.True(builder.HasClrType(typeof(int), ConfigurationSource.DataAnnotation));
-
-            Assert.Equal(typeof(int), metadata.ClrType);
-
-            Assert.True(builder.HasClrType(typeof(string), ConfigurationSource.DataAnnotation));
-
-            Assert.Equal(typeof(string), metadata.ClrType);
-
-            Assert.False(builder.HasClrType(typeof(int), ConfigurationSource.Convention));
-
-            Assert.Equal(typeof(string), metadata.ClrType);
-
-            Assert.True(builder.HasClrType(typeof(string), ConfigurationSource.Convention));
-        }
-
-        [Fact]
-        public void Can_only_override_existing_ClrType_value_explicitly()
-        {
-            var model = new Model();
-            model.AddEntityType(typeof(Customer)).AddProperty(Customer.NameProperty.Name);
-            var modelBuilder = new InternalModelBuilder(model);
-            var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var builder = entityBuilder.Property(Customer.NameProperty.Name, ConfigurationSource.Convention);
-            Assert.Null(builder.Metadata.GetClrTypeConfigurationSource());
-
-            builder.Metadata.ClrType = typeof(string);
-
-            Assert.Equal(ConfigurationSource.Explicit, builder.Metadata.GetClrTypeConfigurationSource());
-            Assert.True(builder.HasClrType(typeof(string), ConfigurationSource.DataAnnotation));
-            Assert.False(builder.HasClrType(typeof(int), ConfigurationSource.DataAnnotation));
-
-            Assert.Equal(typeof(string), builder.Metadata.ClrType);
-
-            Assert.True(builder.HasClrType(typeof(int), ConfigurationSource.Explicit));
-            Assert.Equal(typeof(int), builder.Metadata.ClrType);
-        }
-
-        [Fact]
-        public void Property_added_by_name_is_shadow_even_if_matches_Clr_type()
+        public void Property_added_by_name_is_non_shadow_if_matches_Clr_property()
         {
             var model = new Model();
             var modelBuilder = new InternalModelBuilder(model);
@@ -65,9 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = builder.Metadata;
 
             Assert.Equal(typeof(string), property.ClrType);
-            Assert.True(property.IsShadowProperty);
-            Assert.Null(property.GetClrTypeConfigurationSource());
-            Assert.Null(property.GetIsShadowPropertyConfigurationSource());
+            Assert.False(property.IsShadowProperty);
         }
 
         [Fact]
@@ -238,8 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
-            var builder = entityBuilder.Property(nameof(Customer.Id), ConfigurationSource.Convention);
-            builder.HasClrType(typeof(int), ConfigurationSource.Convention);
+            var builder = entityBuilder.Property(nameof(Customer.Id), typeof(int), ConfigurationSource.Convention);
 
             Assert.False(builder.IsRequired(false, ConfigurationSource.DataAnnotation));
 
@@ -311,40 +265,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.True(builder.ReadOnlyBeforeSave(false, ConfigurationSource.Explicit));
             Assert.False(metadata.IsReadOnlyBeforeSave);
-        }
-
-        [Fact]
-        public void Can_only_override_lower_or_equal_source_Shadow()
-        {
-            var builder = CreateInternalPropertyBuilder();
-            var metadata = builder.Metadata;
-
-            Assert.True(builder.IsShadow(true, ConfigurationSource.DataAnnotation));
-            Assert.True(builder.IsShadow(false, ConfigurationSource.DataAnnotation));
-
-            Assert.False(metadata.IsShadowProperty);
-
-            Assert.False(builder.IsShadow(true, ConfigurationSource.Convention));
-            Assert.False(metadata.IsShadowProperty);
-        }
-
-        [Fact]
-        public void Can_only_override_existing_Shadow_value_explicitly()
-        {
-            var model = new Model();
-            var metadata = model.AddEntityType(typeof(Customer)).AddProperty(Customer.NameProperty.Name);
-            Assert.Null(metadata.GetIsShadowPropertyConfigurationSource());
-            metadata.IsShadowProperty = false;
-            var builder = CreateInternalPropertyBuilder(metadata);
-
-            Assert.Equal(ConfigurationSource.Explicit, metadata.GetIsShadowPropertyConfigurationSource());
-            Assert.True(builder.IsShadow(false, ConfigurationSource.DataAnnotation));
-            Assert.False(builder.IsShadow(true, ConfigurationSource.DataAnnotation));
-
-            Assert.False(builder.Metadata.IsShadowProperty);
-
-            Assert.True(builder.IsShadow(true, ConfigurationSource.Explicit));
-            Assert.True(builder.Metadata.IsShadowProperty);
         }
 
         private InternalPropertyBuilder CreateInternalPropertyBuilder()

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.NoClrProperty("ShadowCustomerId", typeof(Order)),
+                CoreStrings.NoPropertyType("ShadowCustomerId", nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => relationshipBuilder.HasForeignKey(new[] { "ShadowCustomerId", "ShadowCustomerUnique" }, ConfigurationSource.Convention)).Message);
         }
 
@@ -251,7 +251,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.NoClrProperty("ShadowCustomerId", typeof(Order)),
+                CoreStrings.NoPropertyType("ShadowCustomerId", nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => relationshipBuilder.HasForeignKey(new[] { "ShadowCustomerId" }, ConfigurationSource.Convention)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityType1 = model.AddEntityType(typeof(Customer));
             var entityType2 = model.AddEntityType(typeof(Order));
             var keyProperty = entityType1.AddProperty("Id", typeof(int));
-            var fkProperty = entityType2.AddProperty("CustomerId", typeof(int?));
+            var fkProperty = entityType2.AddProperty("CustomerId", typeof(int));
             var foreignKey = entityType2.GetOrAddForeignKey(fkProperty, entityType1.AddKey(keyProperty), entityType1);
 
             var referencingForeignKeys = entityType1.GetReferencingForeignKeys();

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -15,28 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_set_ClrType()
         {
             var entityType = new Model().AddEntityType(typeof(object));
-            var property = entityType.AddProperty("Kake");
+            var property = entityType.AddProperty("Kake", typeof(string));
 
             Assert.Equal(typeof(string), property.ClrType);
-
-            property.ClrType = typeof(int);
-            Assert.Equal(typeof(int), property.ClrType);
-        }
-
-        [Fact]
-        public void Setting_ClrType_throws_when_referenced()
-        {
-            var entityType = new Model().AddEntityType(typeof(object));
-            var principalProperty = entityType.AddProperty("Kake");
-            principalProperty.IsNullable = false;
-            var key = entityType.AddKey(principalProperty);
-            var dependentProperty = entityType.AddProperty("Alaska");
-            entityType.AddForeignKey(dependentProperty, key, entityType);
-
-            Assert.Equal(CoreStrings.PropertyClrTypeCannotBeChangedWhenReferenced("Kake", "{'Alaska'}", "object"),
-                Assert.Throws<InvalidOperationException>(() =>
-                    principalProperty.ClrType = typeof(int)).Message);
-            Assert.Equal(typeof(string), ((IProperty)principalProperty).ClrType);
         }
 
         [Fact]
@@ -111,66 +92,24 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void UnderlyingType_returns_correct_underlying_type()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property1 = entityType.AddProperty("Id", typeof(int?));
-            property1.IsShadowProperty = false;
+            var property1 = entityType.AddProperty("Id", typeof(int?), shadow: false);
             Assert.Equal(typeof(int), property1.ClrType.UnwrapNullableType());
         }
 
         [Fact]
-        public void IsShadowProperty_is_set_appropriately()
+        public void IsShadowProperty_is_set()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty(nameof(Entity.Name));
+            var property = entityType.AddProperty(nameof(Entity.Name), typeof(string), shadow: false);
 
-            Assert.True(property.IsShadowProperty);
-
-            property.ClrType = typeof(string);
-            property.IsShadowProperty = false;
             Assert.False(property.IsShadowProperty);
-
-            property.IsShadowProperty = true;
-            Assert.True(property.IsShadowProperty);
-        }
-
-        [Fact]
-        public void IsShadowProperty_throws_if_shadow_entity_type()
-        {
-            var entityType = new Model().AddEntityType("Entity");
-            var property = entityType.AddProperty(nameof(Entity.Name));
-
-            property.ClrType = typeof(int);
-            Assert.Equal(CoreStrings.ClrPropertyOnShadowEntity(nameof(Entity.Name), "Entity"),
-                Assert.Throws<InvalidOperationException>(() => property.IsShadowProperty = false).Message);
-        }
-
-        [Fact]
-        public void IsShadowProperty_throws_if_no_clr_property()
-        {
-            var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Random");
-
-            property.ClrType = typeof(int);
-            Assert.Equal(CoreStrings.NoClrProperty("Random", nameof(Entity)),
-                Assert.Throws<InvalidOperationException>(() => property.IsShadowProperty = false).Message);
-        }
-
-        [Fact]
-        public void IsShadowProperty_throws_if_clr_type_does_not_match()
-        {
-            var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty(nameof(Entity.Name));
-
-            property.ClrType = typeof(int);
-            Assert.Equal(CoreStrings.PropertyWrongClrType(nameof(Entity.Name), nameof(Entity)),
-                Assert.Throws<InvalidOperationException>(() => property.IsShadowProperty = false).Message);
         }
 
         [Fact]
         public void Property_does_not_use_ValueGenerated_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
@@ -179,8 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_as_using_ValueGenerated()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
@@ -193,8 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_is_not_concurrency_token_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.False(property.IsConcurrencyToken);
         }
@@ -203,9 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_as_concurrency_token()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name");
-            property.ClrType = typeof(string);
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             property.IsConcurrencyToken = true;
             Assert.True(property.IsConcurrencyToken);
@@ -218,8 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_to_always_use_store_generated_values()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.False(property.IsStoreGeneratedAlways);
 
@@ -234,8 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Store_generated_concurrency_tokens_always_use_store_values_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.False(((IProperty)property).IsStoreGeneratedAlways);
 
@@ -259,8 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_is_read_write_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.False(property.IsReadOnlyAfterSave);
             Assert.False(property.IsReadOnlyBeforeSave);
@@ -270,8 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_before_save()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
             property.IsReadOnlyBeforeSave = true;
 
             Assert.True(property.IsReadOnlyBeforeSave);
@@ -284,8 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_after_save()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
             property.IsReadOnlyAfterSave = true;
 
             Assert.True(property.IsReadOnlyAfterSave);
@@ -298,8 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_always()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
+            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
 
             Assert.False(property.IsReadOnlyBeforeSave);
             Assert.False(property.IsReadOnlyAfterSave);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -1593,7 +1593,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var relationship = entityA.HasMany<Beta>().WithOne(e => e.FirstNav);
 
                 Assert.Equal(
-                    CoreStrings.NoClrProperty("ShadowId", typeof(Beta)),
+                    CoreStrings.NoPropertyType("ShadowId", nameof(Beta)),
                     Assert.Throws<InvalidOperationException>(() => relationship.HasForeignKey("ShadowId")).Message);
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -17,43 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
     {
         public class NonGenericOneToManyType : OneToManyTestBase
         {
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOneType : ManyToOneTestBase
         {
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -36,45 +36,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         public class NonGenericOneToMany : OneToManyTestBase
         {
-            [Fact]
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOne : ManyToOneTestBase
         {
-            [Fact]
-            public override void Can_set_foreign_key_property_when_matching_property_added()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
-                modelBuilder.Entity<PrincipalEntity>();
-
-                var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", foreignKey.Properties.Single().Name);
-
-                modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
-
-                // Does not set foreign key property for added shadow property
-                var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
-                Assert.Equal("NavId", newForeignKey.Properties.Single().Name);
-            }
-
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -716,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 var modelBuilder = CreateModelBuilder();
                 var entityType = (EntityType)modelBuilder.Entity<SelfRef>().Metadata;
-                var shadowProperty = entityType.AddProperty("ShadowProperty", ConfigurationSource.Convention);
+                var shadowProperty = entityType.AddProperty("ShadowProperty", typeof(string), configurationSource: ConfigurationSource.Convention);
                 shadowProperty.IsNullable = false;
                 entityType.AddKey(shadowProperty);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1726,7 +1726,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var relationship = entityB.HasOne(e => e.FirstNav).WithMany();
 
                 Assert.Equal(
-                    CoreStrings.NoClrProperty("ShadowId", typeof(Beta)),
+                    CoreStrings.NoPropertyType("ShadowId", nameof(Beta)),
                     Assert.Throws<InvalidOperationException>(() => relationship.HasForeignKey("ShadowId")).Message);
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2897,7 +2897,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var relationship = entityB.HasOne(e => e.FirstNav).WithOne();
 
                 Assert.Equal(
-                    CoreStrings.NoClrProperty("ShadowId", typeof(Beta)),
+                    CoreStrings.NoPropertyType("ShadowId", nameof(Beta)),
                     Assert.Throws<InvalidOperationException>(() => relationship.HasForeignKey(typeof(Beta), "ShadowId")).Message);
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             builder.Entity<AnEntity>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random)).IsShadowProperty = false;
+            entityType.AddProperty("Random", typeof(Random), shadow: false);
 
             foreach (var property in entityType.GetProperties())
             {


### PR DESCRIPTION
Make IMutableEntityType.ClrType, IMutableProperty.ClrType and IMutableProperty.IsShadowProperty readonly

Properties added using EntityTypeBuilder will always be non-shadow if the name matches a CLR property.
Properties added using EntityType can be shadow even if the name matches a CLR property.

Fixes #4934
Fixes #4714