### PR TITLE
Temporary workaround for Newtonsoft.Json issues with AssemblyLoadContext

### DIFF
--- a/TestAssets/TestProjects/PortableAppWithTools/TestContext.cs
+++ b/TestAssets/TestProjects/PortableAppWithTools/TestContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 
 namespace ConsoleApplication
 {
@@ -13,6 +14,8 @@ namespace ConsoleApplication
     {
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
+            var o = new object();
+            JsonConvert.SerializeObject(o);
             options.UseSqlite("Filename=./test.db");
         }
         

--- a/TestAssets/TestProjects/PortableAppWithTools/project.json.ignore
+++ b/TestAssets/TestProjects/PortableAppWithTools/project.json.ignore
@@ -17,7 +17,8 @@
     },
     "Microsoft.EntityFrameworkCore.Sqlite": {
       "target": "project"
-    }
+    },
+    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/dotnet-ef/project.json
+++ b/src/dotnet-ef/project.json
@@ -15,7 +15,8 @@
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
-    "Microsoft.Extensions.DependencyModel": "1.0.0-*"
+    "Microsoft.Extensions.DependencyModel": "1.0.0-*",
+    "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {
     "netstandard1.5": {


### PR DESCRIPTION
This is to unblock other teams.

Temporary workaround for https://github.com/dotnet/cli/issues/2514. 

We may need to change dotnet-ef's execution strategy to permanently fix version issues with using `AssemblyLoadContext` from a tool. Until that lands, we can fix most issues by just pulling higher version of Newtonsoft.Json.