### PR TITLE
Improve configurability of benchmark database 

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkConfig.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkConfig.cs
@@ -13,7 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
         private static readonly Lazy<BenchmarkConfig> _instance = new Lazy<BenchmarkConfig>(() =>
             {
                 var config = new ConfigurationBuilder()
-                    .SetBasePath(".")
                     .AddJsonFile("config.json")
                     .AddEnvironmentVariables()
                     .Build();

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkConfig.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkConfig.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
                 {
                     RunIterations = bool.Parse(config["benchmarks:runIterations"]),
                     ResultDatabases = resultDatabasesSection.GetChildren().Select(s => s.Value).ToArray(),
-                    BenchmarkDatabaseInstance = config["benchmarks:benchmarkDatabaseInstance"],
+                    BenchmarkDatabase = config["benchmarks:benchmarkDatabase"],
                     ProductReportingVersion = config["benchmarks:productReportingVersion"],
                     CustomData = config["benchmarks:customData"]
                 };
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
 
         public bool RunIterations { get; private set; }
         public IEnumerable<string> ResultDatabases { get; private set; }
-        public string BenchmarkDatabaseInstance { get; private set; }
+        public string BenchmarkDatabase { get; private set; }
         public string ProductReportingVersion { get; private set; }
         public string CustomData { get; private set; }
     }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/Models/AdventureWorks/TestHelpers/AdventureWorksDatabaseRequiredAttribute.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/Models/AdventureWorks/TestHelpers/AdventureWorksDatabaseRequiredAttribute.cs
@@ -28,6 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core.Models.AdventureWor
 
         public bool IsMet => _databaseExists.Value;
 
-        public string SkipReason => $"AdventureWorks2014 database does not exist on {BenchmarkConfig.Instance.BenchmarkDatabaseInstance}. Download the AdventureWorks backup from https://msftdbprodsamples.codeplex.com/downloads/get/880661 and restore it to {BenchmarkConfig.Instance.BenchmarkDatabaseInstance} to enable these tests.";
+        public string SkipReason => $"AdventureWorks2014 database does not exist. Download the AdventureWorks backup from https://msftdbprodsamples.codeplex.com/downloads/get/880661 and restore it to enable these tests.";
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/Models/AdventureWorks/TestHelpers/AdventureWorksFixtureBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/Models/AdventureWorks/TestHelpers/AdventureWorksFixtureBase.cs
@@ -5,6 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core.Models.AdventureWor
 {
     public class AdventureWorksFixtureBase
     {
-        public static string ConnectionString { get; } = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database=AdventureWorks2014;Integrated Security=True;MultipleActiveResultSets=true;";
+        public static string ConnectionString { get; } = $@"{BenchmarkConfig.Instance.BenchmarkDatabase}Database=AdventureWorks2014;";
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/SqlServerRequiredAttribute.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/SqlServerRequiredAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
     public class SqlServerRequiredAttribute : Attribute, ITestCondition
     {
         public bool IsMet => PlatformServices.Default.Runtime.OperatingSystem.Equals("Windows", StringComparison.OrdinalIgnoreCase)
-                             || !BenchmarkConfig.Instance.BenchmarkDatabaseInstance.StartsWith("(localdb)", StringComparison.OrdinalIgnoreCase);
+                             || !BenchmarkConfig.Instance.BenchmarkDatabase.Contains("(localdb)");
 
         public string SkipReason => "Must configured an external SQL Server to run the tests on this platform";
     }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.EF6.Models.Orders
 
         public OrdersFixture(string databaseName, int productCount, int customerCount, int ordersPerCustomer, int linesPerOrder)
         {
-            _connectionString = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database={databaseName};Integrated Security=True;MultipleActiveResultSets=true;";
+            _connectionString = $@"{BenchmarkConfig.Instance.BenchmarkDatabase}Database={databaseName};";
             _productCount = productCount;
             _customerCount = customerCount;
             _ordersPerCustomer = ordersPerCustomer;

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/config.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/config.json
@@ -4,7 +4,7 @@
     "resultDatabases": {
       "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
     },
-    "benchmarkDatabaseInstance": "(localdb)\\mssqllocaldb",
+    "benchmarkDatabase": "Server=(localdb)\\mssqllocaldb;Trusted_Connection=True;MultipleActiveResultSets=true;",
     "productReportingVersion": "EF6"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Models/Orders/OrdersFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Models/Orders/OrdersFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Models.Orders
 
         public OrdersFixture(string databaseName, int productCount, int customerCount, int ordersPerCustomer, int linesPerOrder)
         {
-            ConnectionString = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database={databaseName};Integrated Security=True;MultipleActiveResultSets=true;";
+            ConnectionString = $@"{BenchmarkConfig.Instance.BenchmarkDatabase}Database={databaseName};";
             _productCount = productCount;
             _customerCount = customerCount;
             _ordersPerCustomer = ordersPerCustomer;

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Query/Profile.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Query/Profile.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
         public Profile()
         {
             var connectionString
-                = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database=Perf_Query_Simple;Integrated Security=True;MultipleActiveResultSets=true;";
+                = $@"{BenchmarkConfig.Instance.BenchmarkDatabase}Database=Perf_Query_Simple;";
 
             _context = new OrdersContext(connectionString);
 

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/config.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/config.json
@@ -4,7 +4,7 @@
     "resultDatabases": {
       "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
     },
-    "benchmarkDatabaseInstance": "(localdb)\\mssqllocaldb",
+    "benchmarkDatabase": "Server=(localdb)\\mssqllocaldb;Trusted_Connection=True;MultipleActiveResultSets=true;",
     "productReportingVersion": "EF Core"
   }
 }


### PR DESCRIPTION
We used to just allow configuring the database instance name, and
assumed integrated security etc. Updating to allow the full connection
string to be specified, then we just append the database. This is
required because we are moving the benchmark CI to use a separate
database server.