### PR TITLE
Upgrade version of dotnet-test-xunit to RC2

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Commands.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Commands.FunctionalTests/project.json
@@ -21,7 +21,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {}

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
@@ -25,7 +25,7 @@
           "type": "platform"
         },
         "Microsoft.CSharp": "4.0.1-*",
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
@@ -18,7 +18,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {}

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
@@ -19,7 +19,7 @@
           "type": "platform"
         },
         "System.Data.SqlClient": "4.1.0-*",
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
@@ -25,7 +25,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
@@ -27,7 +27,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
@@ -21,7 +21,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     },
     "net451": {}

--- a/test/Microsoft.EntityFrameworkCore.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tests/project.json
@@ -18,7 +18,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*",
+        "dotnet-test-xunit": "1.0.0-*",
         "moq.netcore": "4.4.0-*",
         "System.Diagnostics.TraceSource": "4.0.0-*"
       }

--- a/test/dotnet-ef.FunctionalTests/project.json
+++ b/test/dotnet-ef.FunctionalTests/project.json
@@ -18,7 +18,7 @@
           "version": "1.0.0-*",
           "type": "platform"
         },
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-*"
       }
     }
   },


### PR DESCRIPTION
Also removes unnecessary dependency on Ms.NETCore.Platforms.

cc @pakrym @smitpatel 