### PR TITLE
Throw when attempting to access original value when it is not being tracked.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Update/ModificationCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Update/ModificationCommand.cs
@@ -95,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                 foreach (var property in entityType.GetProperties())
                 {
                     var isKey = property.IsPrimaryKey();
-                    var isCondition = !adding && (isKey || property.IsConcurrencyToken);
+                    var isConcurrencyToken = property.IsConcurrencyToken;
+                    var isCondition = !adding && (isKey || isConcurrencyToken);
                     var readValue = entry.IsStoreGenerated(property);
                     var writeValue = !readValue && (adding || entry.IsModified(property));
 
@@ -121,7 +122,8 @@ namespace Microsoft.EntityFrameworkCore.Update
                             readValue,
                             writeValue,
                             isKey,
-                            isCondition));
+                            isCondition,
+                            isConcurrencyToken));
                     }
                 }
             }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             foreach (var columnModification in ModificationCommands.SelectMany(t => t.ColumnModifications))
             {
-                if (columnModification.ParameterName != null)
+                if (columnModification.UseCurrentValueParameter)
                 {
                     commandBuilder.AddParameter(
                         columnModification.ParameterName,
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                         columnModification.Value);
                 }
 
-                if (columnModification.OriginalParameterName != null)
+                if (columnModification.UseOriginalValueParameter)
                 {
                     commandBuilder.AddParameter(
                         columnModification.OriginalParameterName,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Update/UpdateSqlGenerator.cs
@@ -301,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 commandStringBuilder
                     .AppendLine()
                     .Append("WHERE ")
-                    .AppendJoin(operations, (sb, v) => AppendWhereCondition(sb, v, useOriginalValue: true), " AND ");
+                    .AppendJoin(operations, (sb, v) => AppendWhereCondition(sb, v, v.UseOriginalValueParameter), " AND ");
             }
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                                 }
                                 else
                                 {
-                                    AppendWhereCondition(sb, v, useOriginalValue: !v.IsWrite);
+                                    AppendWhereCondition(sb, v, v.UseOriginalValueParameter);
                                 }
                             }
                         }, " AND ");

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -90,12 +90,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             var parameterCount = 0;
             foreach (var columnModification in modificationCommand.ColumnModifications)
             {
-                if (columnModification.ParameterName != null)
+                if (columnModification.UseCurrentValueParameter)
                 {
                     parameterCount++;
                 }
 
-                if (columnModification.OriginalParameterName != null)
+                if (columnModification.UseOriginalValueParameter)
                 {
                     parameterCount++;
                 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -194,7 +194,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 MarkAsTemporary(property, isTemporary: false);
 
-                SetOriginalValue(property, this[property]);
+                var index = property.GetOriginalValueIndex();
+                if (index != -1)
+                {
+                    SetOriginalValue(property, this[property], index);
+                }
             }
 
             if (currentState != EntityState.Modified
@@ -346,10 +350,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public virtual void SetCurrentValue(IPropertyBase propertyBase, object value)
             => this[propertyBase] = value;
 
-        public virtual void SetOriginalValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value)
+        public virtual void SetOriginalValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value, int index = -1)
         {
             EnsureOriginalValues();
-            _originalValues.SetValue((IProperty)propertyBase, value);
+            _originalValues.SetValue((IProperty)propertyBase, value, index);
         }
 
         public virtual void SetRelationshipSnapshotValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -65,6 +65,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return (entityType as EntityType)?.UseEagerSnapshots ?? false;
         }
 
+        public static void UseEagerSnapshots([NotNull] this IEntityType entityType, bool useEagerSnapshots)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            var asEntityType = entityType as EntityType;
+            if (asEntityType != null)
+            {
+                asEntityType.UseEagerSnapshots = useEagerSnapshots;
+            }
+        }
+
         public static int StoreGeneratedCount([NotNull] this IEntityType entityType)
             => GetCounts(entityType).StoreGeneratedCount;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -85,15 +86,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             return Expression.Lambda<Func<InternalEntityEntry, TProperty>>(
                 originalValuesIndex >= 0
-                    ? Expression.Call(
+                    ? (Expression)Expression.Call(
                         entryParameter,
                         InternalEntityEntry.ReadOriginalValueMethod.MakeGenericMethod(typeof(TProperty)),
                         Expression.Constant(property),
                         Expression.Constant(originalValuesIndex))
-                    : Expression.Call(
-                        entryParameter,
-                        InternalEntityEntry.GetCurrentValueMethod.MakeGenericMethod(typeof(TProperty)),
-                        Expression.Constant(property)),
+                    : Expression.Block(
+                        Expression.Throw(Expression.Constant(
+                            new InvalidOperationException(
+                                CoreStrings.OriginalValueNotTracked(property.Name, property.DeclaringEntityType.DisplayName())))),
+                        Expression.Constant(default(TProperty), typeof(TProperty))),
                 entryParameter)
                 .Compile();
         }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. To access all original values set 'UseLazyOriginalValues' to false on the entity type.
+        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities that utilize the INotifyPropertyChanging interface. To access all original values set 'UseEagerSnapshots' to true on the EntityType during model building.
         /// </summary>
         public static string OriginalValueNotTracked([CanBeNull] object property, [CanBeNull] object entityType)
         {

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -169,7 +169,7 @@
     <value>Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.</value>
   </data>
   <data name="OriginalValueNotTracked" xml:space="preserve">
-    <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. To access all original values set 'UseLazyOriginalValues' to false on the entity type.</value>
+    <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities that utilize the INotifyPropertyChanging interface. To access all original values set 'UseEagerSnapshots' to true on the EntityType during model building.</value>
   </data>
   <data name="MissingBackingField" xml:space="preserve">
     <value>The property '{entityType}.{property}' is annotated with backing field '{field}' but that field cannot be found.</value>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ColumnModificationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ColumnModificationTest.cs
@@ -24,7 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 isRead: true,
                 isWrite: true,
                 isKey: true,
-                isCondition: true);
+                isCondition: true,
+                isConcurrencyToken: false);
 
             Assert.Null(columnModification.ColumnName);
             Assert.True(columnModification.IsRead);
@@ -33,7 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             Assert.True(columnModification.IsCondition);
             Assert.Equal("p0", columnModification.ParameterName);
             Assert.Equal("p1", columnModification.OriginalParameterName);
-            Assert.Equal("p2", columnModification.OutputParameterName);
         }
 
         [Fact]
@@ -48,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 isRead: false,
                 isWrite: false,
                 isKey: false,
-                isCondition: false);
+                isCondition: false,
+                isConcurrencyToken: false);
 
             var value = columnModification.Value;
 
@@ -68,7 +69,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 isRead: false,
                 isWrite: false,
                 isKey: false,
-                isCondition: false);
+                isCondition: false,
+                isConcurrencyToken: false);
             var value = new object();
 
             columnModification.Value = value;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -363,7 +363,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, false)
+                            false, true, false, false, false)
                     }));
 
             batch.AddCommand(
@@ -379,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             parameterNameGenerator.GenerateNext,
-                            false, true, false, false)
+                            false, true, false, false, false)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             new ParameterNameGenerator().GenerateNext,
-                            false, true, false, false)
+                            false, true, false, false, false)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -447,7 +447,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             new ParameterNameGenerator().GenerateNext,
-                            false, false, false, true)
+                            false, false, false, true, false)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
@@ -480,18 +480,16 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             new ParameterNameGenerator().GenerateNext,
-                            false, true, false, true)
+                            false, true, false, true, false)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();
 
-            Assert.Equal(2, storeCommand.RelationalCommand.Parameters.Count);
+            Assert.Equal(1, storeCommand.RelationalCommand.Parameters.Count);
             Assert.Equal("p0", storeCommand.RelationalCommand.Parameters[0].InvariantName);
-            Assert.Equal("p1", storeCommand.RelationalCommand.Parameters[1].InvariantName);
 
-            Assert.Equal(2, storeCommand.ParameterValues.Count);
+            Assert.Equal(1, storeCommand.ParameterValues.Count);
             Assert.Equal(1, storeCommand.ParameterValues["p0"]);
-            Assert.Equal(1, storeCommand.ParameterValues["p1"]);
         }
 
         [Fact]
@@ -515,7 +513,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                             property,
                             property.TestProvider(),
                             new ParameterNameGenerator().GenerateNext,
-                            true, false, false, false)
+                            true, false, false, false, false)
                     }));
 
             var storeCommand = batch.CreateStoreCommandBase();

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -316,15 +316,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, identityKey, !identityKey, true, false),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, identityKey, !identityKey, true, false, false),
                 new ColumnModification(
-                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false),
+                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
                 new ColumnModification(
-                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false),
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
                 new ColumnModification(
-                    entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false),
+                    entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false, true),
                 new ColumnModification(
-                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false, false)
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false)
             };
 
             if (defaultsOnly)
@@ -354,15 +354,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, false),
                 new ColumnModification(
-                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false),
+                    entry, nameProperty, nameProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
                 new ColumnModification(
-                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false),
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator.GenerateNext, false, true, false, false, false),
                 new ColumnModification(
-                    entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false),
+                    entry, computedProperty, computedProperty.TestProvider(), generator.GenerateNext, isComputed, false, false, false, false),
                 new ColumnModification(
-                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false, concurrencyToken)
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, true, false, concurrencyToken, concurrencyToken)
             };
 
             Func<IProperty, IRelationalPropertyAnnotations> func = p => p.TestProvider();
@@ -384,9 +384,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             var columnModifications = new[]
             {
                 new ColumnModification(
-                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true),
+                    entry, idProperty, idProperty.TestProvider(), generator.GenerateNext, false, false, true, true, concurrencyToken),
                 new ColumnModification(
-                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, false, false, concurrencyToken)
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator.GenerateNext, false, false, false, concurrencyToken, concurrencyToken)
             };
 
             Func<IProperty, IRelationalPropertyAnnotations> func = p => p.TestProvider();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -26,24 +26,24 @@ SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersi
 FROM [Sample] AS [r]
 WHERE [r].[UniqueNo] = 1
 
-@p0: 1
-@p1: ModifiedData
-@p2: 00000000-0000-0000-0003-000000000001
+@p2: 1
+@p0: ModifiedData
+@p1: 00000000-0000-0000-0003-000000000001
 @p3: 00000001-0000-0000-0000-000000000001
 
 SET NOCOUNT ON;
-UPDATE [Sample] SET [Name] = @p1, [RowVersion] = @p2
-WHERE [UniqueNo] = @p0 AND [RowVersion] = @p3;
+UPDATE [Sample] SET [Name] = @p0, [RowVersion] = @p1
+WHERE [UniqueNo] = @p2 AND [RowVersion] = @p3;
 SELECT @@ROWCOUNT;
 
-@p0: 1
-@p1: ChangedData
-@p2: 00000000-0000-0000-0002-000000000001
+@p2: 1
+@p0: ChangedData
+@p1: 00000000-0000-0000-0002-000000000001
 @p3: 00000001-0000-0000-0000-000000000001
 
 SET NOCOUNT ON;
-UPDATE [Sample] SET [Name] = @p1, [RowVersion] = @p2
-WHERE [UniqueNo] = @p0 AND [RowVersion] = @p3;
+UPDATE [Sample] SET [Name] = @p0, [RowVersion] = @p1
+WHERE [UniqueNo] = @p2 AND [RowVersion] = @p3;
 SELECT @@ROWCOUNT;",
                 Sql);
         }
@@ -170,28 +170,28 @@ SELECT TOP(1) [r].[Id], [r].[Data], [r].[Timestamp]
 FROM [Two] AS [r]
 WHERE [r].[Id] = 1
 
-@p0: 1
-@p1: ModifiedData
+@p1: 1
+@p0: ModifiedData
 @p2: System.Byte[]
 
 SET NOCOUNT ON;
 DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));
-UPDATE [Two] SET [Data] = @p1
+UPDATE [Two] SET [Data] = @p0
 OUTPUT INSERTED.[Timestamp]
 INTO @inserted0
-WHERE [Id] = @p0 AND [Timestamp] = @p2;
+WHERE [Id] = @p1 AND [Timestamp] = @p2;
 SELECT [Timestamp] FROM @inserted0;
 
-@p0: 1
-@p1: ChangedData
+@p1: 1
+@p0: ChangedData
 @p2: System.Byte[]
 
 SET NOCOUNT ON;
 DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));
-UPDATE [Two] SET [Data] = @p1
+UPDATE [Two] SET [Data] = @p0
 OUTPUT INSERTED.[Timestamp]
 INTO @inserted0
-WHERE [Id] = @p0 AND [Timestamp] = @p2;
+WHERE [Id] = @p1 AND [Timestamp] = @p2;
 SELECT [Timestamp] FROM @inserted0;",
                 Sql);
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -290,12 +290,12 @@ SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'
 
-@p0: Apteryx owenii
-@p1: Aquila chrysaetos canadensis
+@p1: Apteryx owenii
+@p0: Aquila chrysaetos canadensis
 
 SET NOCOUNT ON;
-UPDATE [Animal] SET [EagleId] = @p1
-WHERE [Species] = @p0;
+UPDATE [Animal] SET [EagleId] = @p0
+WHERE [Species] = @p1;
 SELECT @@ROWCOUNT;
 
 SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -25,8 +25,8 @@ FROM [Engines] AS [e]",
 
             Assert.Contains(
                 @"SET NOCOUNT ON;
-UPDATE [Engines] SET [Name] = @p2
-WHERE [Id] = @p0 AND [EngineSupplierId] = @p1 AND [Name] = @p3;
+UPDATE [Engines] SET [Name] = @p0
+WHERE [Id] = @p1 AND [EngineSupplierId] = @p2 AND [Name] = @p3;
 SELECT @@ROWCOUNT;",
                 Sql);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -78,13 +78,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 .PropertyChanging(entry, property);
 
             Assert.Equal("Cheese", entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal("Cheese", entry.GetOriginalValue(property));
             Assert.Equal("Cheese", entry.GetCurrentValue(property));
 
             entity.Name = "Pickle";
 
             Assert.Equal("Pickle", entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal("Pickle", entry.GetOriginalValue(property));
             Assert.Equal("Pickle", entry.GetCurrentValue(property));
         }
 
@@ -135,13 +133,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             Assert.True(entry.HasRelationshipSnapshot);
 
             Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal(77, entry.GetOriginalValue(property));
             Assert.Equal(77, entry.GetCurrentValue(property));
 
             entity.Id = 777;
 
             Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal(777, entry.GetOriginalValue(property));
             Assert.Equal(777, entry.GetCurrentValue(property));
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
+            simpleKeyProperty.IsConcurrencyToken = true; // So we get original values for it
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase).FullName);
             var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -1,7 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
 
@@ -13,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_get_name()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -24,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_get_current_value()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -37,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -52,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -67,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -83,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_set_original_value_to_null()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -98,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -117,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_get_name_generic()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -128,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_get_current_value_generic()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -141,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -156,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -171,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -187,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         public void Can_set_original_value_to_null_generic()
         {
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 new Wotty { Id = 1, Primate = "Monkey" });
 
@@ -202,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
             var entry = TestHelpers.Instance.CreateInternalEntry(
-                TestHelpers.Instance.BuildModelFor<Wotty>(),
+                BuildModel(),
                 EntityState.Unchanged,
                 entity);
 
@@ -217,10 +224,327 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             Assert.False(new PropertyEntry<Wotty, string>(entry, "Primate").IsModified);
         }
 
+        [Fact]
+        public void Can_set_and_get_original_value_notifying_entities()
+        {
+            var entity = new NotifyingWotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").OriginalValue);
+
+            new PropertyEntry(entry, "Primate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+            Assert.Equal("Monkey", entity.Primate);
+        }
+
+        [Fact]
+        public void Can_set_original_value_to_null_notifying_entities()
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                new NotifyingWotty { Id = 1, Primate = "Monkey" });
+
+            new PropertyEntry(entry, "Primate").OriginalValue = null;
+
+            Assert.Null(new PropertyEntry(entry, "Primate").OriginalValue);
+        }
+
+        [Fact]
+        public void Can_set_and_get_original_value_generic_notifying_entities()
+        {
+            var entity = new NotifyingWotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry<NotifyingWotty, string>(entry, "Primate").OriginalValue);
+
+            new PropertyEntry<NotifyingWotty, string>(entry, "Primate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry<NotifyingWotty, string>(entry, "Primate").OriginalValue);
+            Assert.Equal("Monkey", entity.Primate);
+        }
+
+        [Fact]
+        public void Can_set_original_value_to_null_generic_notifying_entities()
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                new NotifyingWotty { Id = 1, Primate = "Monkey" });
+
+            new PropertyEntry<NotifyingWotty, string>(entry, "Primate").OriginalValue = null;
+
+            Assert.Null(new PropertyEntry<NotifyingWotty, string>(entry, "Primate").OriginalValue);
+        }
+
+        [Fact]
+        public void Can_set_and_get_concurrency_token_original_value_full_notification_entities()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, ConcurrentPrimate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry(entry, "ConcurrentPrimate").OriginalValue);
+
+            new PropertyEntry(entry, "ConcurrentPrimate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry(entry, "ConcurrentPrimate").OriginalValue);
+            Assert.Equal("Monkey", entity.ConcurrentPrimate);
+        }
+
+        [Fact]
+        public void Can_set_concurrency_token_original_value_to_null_full_notification_entities()
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                new FullyNotifyingWotty { Id = 1, ConcurrentPrimate = "Monkey" });
+
+            new PropertyEntry(entry, "ConcurrentPrimate").OriginalValue = null;
+
+            Assert.Null(new PropertyEntry(entry, "ConcurrentPrimate").OriginalValue);
+        }
+
+        [Fact]
+        public void Can_set_and_get_concurrency_token_original_value_generic_full_notification_entities()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, ConcurrentPrimate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry<FullyNotifyingWotty, string>(entry, "ConcurrentPrimate").OriginalValue);
+
+            new PropertyEntry<FullyNotifyingWotty, string>(entry, "ConcurrentPrimate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry<FullyNotifyingWotty, string>(entry, "ConcurrentPrimate").OriginalValue);
+            Assert.Equal("Monkey", entity.ConcurrentPrimate);
+        }
+
+        [Fact]
+        public void Can_set_concurrency_token_original_value_to_null_generic_full_notification_entities()
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                new FullyNotifyingWotty { Id = 1, ConcurrentPrimate = "Monkey" });
+
+            new PropertyEntry<FullyNotifyingWotty, string>(entry, "ConcurrentPrimate").OriginalValue = null;
+
+            Assert.Null(new PropertyEntry<FullyNotifyingWotty, string>(entry, "ConcurrentPrimate").OriginalValue);
+        }
+
+        [Fact]
+        public void Cannot_set_or_get_original_value_when_not_tracked()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            var propertyEntry = new PropertyEntry(entry, "Primate");
+
+            Assert.Equal(
+                CoreStrings.OriginalValueNotTracked("Primate", "FullyNotifyingWotty"),
+                Assert.Throws<InvalidOperationException>(() => propertyEntry.OriginalValue).Message);
+
+            Assert.Equal(
+                CoreStrings.OriginalValueNotTracked("Primate", "FullyNotifyingWotty"),
+                Assert.Throws<InvalidOperationException>(() => propertyEntry.OriginalValue = "Chimp").Message);
+        }
+
+        [Fact]
+        public void Cannot_set_or_get_original_value_when_not_tracked_generic()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, ConcurrentPrimate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(),
+                EntityState.Unchanged,
+                entity);
+
+            var propertyEntry = new PropertyEntry<FullyNotifyingWotty, string>(entry, "Primate");
+
+            Assert.Equal(
+                CoreStrings.OriginalValueNotTracked("Primate", "FullyNotifyingWotty"),
+                Assert.Throws<InvalidOperationException>(() => propertyEntry.OriginalValue).Message);
+
+            Assert.Equal(
+                CoreStrings.OriginalValueNotTracked("Primate", "FullyNotifyingWotty"),
+                Assert.Throws<InvalidOperationException>(() => propertyEntry.OriginalValue = "Chimp").Message);
+        }
+
+        [Fact]
+        public void Can_set_or_get_original_value_when_property_explicitly_marked_to_be_tracked()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(useEagerSnapshots: true),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").OriginalValue);
+
+            new PropertyEntry(entry, "Primate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+            Assert.Equal("Monkey", entity.Primate);
+        }
+
+        [Fact]
+        public void Can_set_or_get_original_value_when_property_explicitly_marked_to_be_tracked_generic()
+        {
+            var entity = new FullyNotifyingWotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(
+                BuildModel(useEagerSnapshots: true),
+                EntityState.Unchanged,
+                entity);
+
+            Assert.Equal("Monkey", new PropertyEntry<FullyNotifyingWotty, string>(entry, "Primate").OriginalValue);
+
+            new PropertyEntry<FullyNotifyingWotty, string>(entry, "Primate").OriginalValue = "Chimp";
+
+            Assert.Equal("Chimp", new PropertyEntry<FullyNotifyingWotty, string>(entry, "Primate").OriginalValue);
+            Assert.Equal("Monkey", entity.Primate);
+        }
+
         private class Wotty
         {
             public int Id { get; set; }
             public string Primate { get; set; }
+        }
+
+        private class FullyNotifyingWotty : HasChangedAndChanging
+        {
+            private int _id;
+            private string _primate;
+            private string _concurrentprimate;
+
+            public int Id
+            {
+                get { return _id; }
+                set
+                {
+                    if (_id != value)
+                    {
+                        OnPropertyChanging();
+                        _id = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+
+            public string Primate
+            {
+                get { return _primate; }
+                set
+                {
+                    if (_primate != value)
+                    {
+                        OnPropertyChanging();
+                        _primate = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+
+            public string ConcurrentPrimate
+            {
+                get { return _concurrentprimate; }
+                set
+                {
+                    if (_concurrentprimate != value)
+                    {
+                        OnPropertyChanging();
+                        _concurrentprimate = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+        }
+
+        private class NotifyingWotty : HasChanged
+        {
+            private int _id;
+            private string _primate;
+
+            public int Id
+            {
+                get { return _id; }
+                set
+                {
+                    if (_id != value)
+                    {
+                        _id = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+
+            public string Primate
+            {
+                get { return _primate; }
+                set
+                {
+                    if (_primate != value)
+                    {
+                        _primate = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+        }
+
+        private abstract class HasChanged : INotifyPropertyChanged
+        {
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            protected void OnPropertyChanged([CallerMemberName]string propertyName = "") 
+                => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private abstract class HasChangedAndChanging : HasChanged, INotifyPropertyChanging
+        {
+            public event PropertyChangingEventHandler PropertyChanging;
+
+            protected void OnPropertyChanging([CallerMemberName]string propertyName = "") 
+                => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+        }
+
+        public IMutableModel BuildModel(bool useEagerSnapshots = false)
+        {
+            var builder = TestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<Wotty>();
+            builder.Entity<NotifyingWotty>();
+
+            var wottyBuilder = builder.Entity<FullyNotifyingWotty>();
+            wottyBuilder.Property(e => e.ConcurrentPrimate).IsConcurrencyToken();
+
+            if (useEagerSnapshots)
+            {
+                wottyBuilder.Metadata.UseEagerSnapshots(true);
+            }
+
+            return builder.Model;
         }
     }
 }

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -4,6 +4,7 @@
 <#@ assembly name="Microsoft.VisualStudio.Shell.Interop.8.0" #>
 <#@ assembly name="EnvDTE" #>
 <#@ assembly name="EnvDTE80" #>
+<#@ import namespace="System" #>
 <#@ import namespace="System.Collections" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="System.IO" #>
@@ -11,6 +12,9 @@
 <#@ import namespace="System.Resources" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Text.RegularExpressions" #>
+<#@ import namespace="Microsoft.VisualStudio.Shell.Interop" #>
+<#@ import namespace="EnvDTE" #>
+<#@ import namespace="EnvDTE80" #>
 <#
     var hostServiceProvider = (IServiceProvider)Host;
     var dte = (EnvDTE.DTE)hostServiceProvider.GetService(typeof(EnvDTE.DTE));
@@ -147,15 +151,18 @@ namespace {0}
     }
 
     private static void RenderProperty(StringBuilder builder, ResourceData resourceString)
-        => builder.AppendFormat("        public static string {0}", resourceString.Name)
+    {
+        builder.AppendFormat("        public static string {0}", resourceString.Name)
             .AppendLine()
             .AppendLine("        {")
             .AppendFormat(@"            get {{ return GetString(""{0}""); }}", resourceString.Name)
             .AppendLine()
             .AppendLine("        }");
+    }
 
     private static void RenderFormatMethod(StringBuilder builder, ResourceData resourceString)
-        => builder.AppendFormat("        public static string {0}({1})", resourceString.Name, resourceString.Parameters)
+    {
+        builder.AppendFormat("        public static string {0}({1})", resourceString.Name, resourceString.Parameters)
             .AppendLine()
             .AppendLine("        {")
             .AppendFormat(
@@ -165,6 +172,7 @@ namespace {0}
                 resourceString.ArgumentNames)
             .AppendLine()
             .AppendLine("        }");
+    }
 
     private class ResourceData
     {
@@ -174,12 +182,24 @@ namespace {0}
 
         public bool UsingNamedArgs { get; set; }
 
-        public string FormatArguments => string.Join(", ", Arguments.Select(a => "\"" + a + "\""));
+        public string FormatArguments
+        {
+            get { return string.Join(", ", Arguments.Select(a => "\"" + a + "\"")); }
+        }
 
-        public string ArgumentNames => string.Join(", ", Arguments.Select(GetArgName));
+        public string ArgumentNames
+        {
+            get { return string.Join(", ", Arguments.Select(GetArgName)); }
+        }
 
-        public string Parameters => string.Join(", ", Arguments.Select(a => "[CanBeNull] object " + GetArgName(a)));
+        public string Parameters
+        {
+            get { return string.Join(", ", Arguments.Select(a => "[CanBeNull] object " + GetArgName(a))); }
+        }
 
-        private string GetArgName(string name) => UsingNamedArgs ? name : 'p' + name;
+        public string GetArgName(string name)
+        {
+            return UsingNamedArgs ? name : 'p' + name;
+        }
     }
 #>


### PR DESCRIPTION
Issue #4375.

For entities that implement INotifyPropertyChanging, the original value is not needed by changing tracking and hence we do not store it or allocate space to store it. Previously if you asked for the original value in such cases we would give you back the current value. We now throw saying that the value is not available and directing you to the flag that will make it available. It's a pretty blunt flag right now, but we can make it more fine-grained if enough people want this behavior.

In fixing this, it turns out that the update pipeline was using the original value for primary key where clauses. This started to throw because the original value was not available. This has been changed to use the current value instead. This was complicated because the logic for choosing original or current was implemented twice and both needed to match, so this has been changed to use a common implementation.