### PR TITLE
Query: Convert order by condition to case blocks

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -769,6 +769,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                         break;
                     }
 
+                    if (sqlOrderingExpression.IsComparisonOperation()
+                        || sqlOrderingExpression.IsLogicalOperation())
+                    {
+                        sqlOrderingExpression = Expression.Condition(
+                            sqlOrderingExpression,
+                            Expression.Constant(true, typeof(bool)),
+                            Expression.Constant(false, typeof(bool)));
+                    }
+
                     orderings.Add(
                         new Ordering(
                             sqlOrderingExpression,

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -3494,6 +3494,35 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 9);
         }
 
+        [ConditionalFact]
+        public virtual void OrderBy_condition_comparison()
+        {
+            AssertQuery<Product>(
+                ps => ps.OrderBy(p => p.UnitsInStock > 0).ThenBy(p => p.ProductID),
+                assertOrder: true,
+                entryCount: 77);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_ternary_conditions()
+        {
+            AssertQuery<Product>(
+                ps => ps.OrderBy(p => p.UnitsInStock > 10 ? p.ProductID > 40 : p.ProductID <= 40).ThenBy(p => p.ProductID),
+                assertOrder: true,
+                entryCount: 77);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_any()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.OrderBy(p => p.Orders.Any(o => o.OrderID > 11000)).ThenBy(p => p.CustomerID).ToList();
+
+                Assert.Equal(91, query.Count);
+            }
+        }
+
         public static bool ClientEvalPredicateStateless() => true;
 
         protected static bool ClientEvalPredicate(Order order) => order.OrderID > 10000;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -812,6 +812,53 @@ ORDER BY [e].[EmployeeID] - [e].[EmployeeID]",
                 Sql);
         }
 
+        public override void OrderBy_condition_comparison()
+        {
+            base.OrderBy_condition_comparison();
+
+            Assert.Equal(
+               @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+ORDER BY CASE
+    WHEN [p].[UnitsInStock] > 0
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [p].[ProductID]",
+               Sql);
+        }
+
+        public override void OrderBy_ternary_conditions()
+        {
+            base.OrderBy_ternary_conditions();
+
+            Assert.Equal(
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+ORDER BY CASE
+    WHEN (([p].[UnitsInStock] > 10) AND ([p].[ProductID] > 40)) OR (([p].[UnitsInStock] <= 10) AND ([p].[ProductID] <= 40))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [p].[ProductID]",
+                Sql);
+        }
+
+        public override void OrderBy_any()
+        {
+            base.OrderBy_any();
+
+            Assert.Equal(
+                @"SELECT [p].[CustomerID], [p].[Address], [p].[City], [p].[CompanyName], [p].[ContactName], [p].[ContactTitle], [p].[Country], [p].[Fax], [p].[Phone], [p].[PostalCode], [p].[Region]
+FROM [Customers] AS [p]
+ORDER BY (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE ([o].[OrderID] > 11000) AND ([p].[CustomerID] = [o].[CustomerID]))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+), [p].[CustomerID]",
+                Sql);
+        }
+
         public override void Sum_with_no_arg()
         {
             base.Sum_with_no_arg();


### PR DESCRIPTION
Issue is Order By requires value type for ordering. Having condition in order by expression is incorrect sql.
Fix is convert comparison or logical expressions in case blocks when they appear in order by expression

Fixes #5095 