### PR TITLE
Fix to #5043 - Query: Navigations: Using EF.Property with reference nav omits null compensation

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -464,6 +464,19 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return nullExpression;
             }
 
+            if (leftExpression.Type != rightExpression.Type
+                && leftExpression.Type.UnwrapNullableType() == rightExpression.Type.UnwrapNullableType())
+            {
+                if (leftExpression.Type.IsNullableType())
+                {
+                    rightExpression = Expression.Convert(rightExpression, leftExpression.Type);
+                }
+                else
+                {
+                    leftExpression = Expression.Convert(leftExpression, rightExpression.Type);
+                }
+            }
+
             return leftExpression.Type == rightExpression.Type
                 ? Expression.MakeBinary(binaryExpression.NodeType, leftExpression, rightExpression)
                 : null;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -629,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             handlerContext.SelectExpression.Limit = Expression.Constant(2);
 
-            return handlerContext.EvalOnClient(requiresClientResultOperator: false);
+            return handlerContext.EvalOnClient(requiresClientResultOperator: true);
         }
 
         private static Expression HandleSkip(HandlerContext handlerContext)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -2108,12 +2108,78 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Where_query_composition_entity_equality()
+        public virtual void Where_query_composition_entity_equality_one_element_SingleOrDefault()
         {
             AssertQuery<Employee>(
                 es =>
                     from e1 in es
                     where es.SingleOrDefault(e2 => e2.EmployeeID == e1.ReportsTo) == new Employee()
+                    select e1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_one_element_FirstOrDefault()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where es.FirstOrDefault(e2 => e2.EmployeeID == e1.ReportsTo) == new Employee()
+                    select e1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_no_elements_SingleOrDefault()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where es.SingleOrDefault(e2 => e2.EmployeeID == 42) == new Employee()
+                    select e1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_no_elements_Single()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = from e1 in ctx.Set<Employee>()
+                            where ctx.Set<Employee>().Single(e2 => e2.EmployeeID == 42) == new Employee()
+                            select e1;
+
+                Assert.Throws<InvalidOperationException>(() => query.ToList());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_no_elements_FirstOrDefault()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where es.FirstOrDefault(e2 => e2.EmployeeID == 42) == new Employee()
+                    select e1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_multiple_elements_SingleOrDefault()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = from e1 in ctx.Set<Employee>()
+                            where ctx.Set<Employee>().SingleOrDefault(e2 => e2.EmployeeID != e1.ReportsTo) == new Employee()
+                            select e1;
+
+                Assert.Throws<InvalidOperationException>(() => query.ToList());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition_entity_equality_multiple_elements_FirstOrDefault()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where es.FirstOrDefault(e2 => e2.EmployeeID != e1.ReportsTo) == new Employee()
                     select e1);
         }
 
@@ -5645,9 +5711,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
+                var expected = l2oQuery(NorthwindData.Set<TItem>()).ToArray();
+                var actual = efQuery(context.Set<TItem>()).ToArray();
+
                 TestHelpers.AssertResults(
-                    l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
-                    efQuery(context.Set<TItem>()).ToArray(),
+                    expected,
+                    actual,
                     assertOrder,
                     asserter);
 

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -38,11 +38,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Check.NotNull(binaryExpression, nameof(binaryExpression));
 
+             var newBinaryExpression = (BinaryExpression)base.VisitBinary(binaryExpression);
+
             if (binaryExpression.NodeType == ExpressionType.Equal
                 || binaryExpression.NodeType == ExpressionType.NotEqual)
             {
-                var newBinaryExpression = (BinaryExpression)base.VisitBinary(binaryExpression);
-
                 var constantExpression = newBinaryExpression.Left.RemoveConvert() as ConstantExpression;
 
                 if (constantExpression != null
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
             }
 
-            return binaryExpression;
+            return newBinaryExpression;
         }
 
         private static Expression CreateKeyAccessExpression(Expression target, IReadOnlyList<IProperty> properties)

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -349,57 +349,103 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             Check.NotNull(node, nameof(node));
 
             return
-                _queryModelVisitor.BindNavigationPathMemberExpression(
+                _queryModelVisitor.BindNavigationPathPropertyExpression(
                     node,
                     (ps, qs) =>
-                        {
-                            var properties = ps.ToList();
-                            var navigations = properties.OfType<INavigation>().ToList();
-
-                            if (navigations.Any())
-                            {
-                                var outerQuerySourceReferenceExpression = new QuerySourceReferenceExpression(qs);
-
-                                if (_navigationRewritingQueryModelVisitor.AdditionalFromClauseBeingProcessed != null
-                                    && navigations.Last().IsCollection())
-                                {
-                                    return RewriteSelectManyNavigationsIntoJoins(
-                                        outerQuerySourceReferenceExpression,
-                                        navigations,
-                                        _navigationRewritingQueryModelVisitor.AdditionalFromClauseBeingProcessed);
-                                }
-
-                                if (navigations.Count == 1
-                                    && navigations[0].IsDependentToPrincipal())
-                                {
-                                    var foreignKeyMemberAccess = CreateForeignKeyMemberAccess(node, navigations[0]);
-                                    if (foreignKeyMemberAccess != null)
-                                    {
-                                        return foreignKeyMemberAccess;
-                                    }
-                                }
-
-                                if (_navigationRewritingQueryModelVisitor.InsideInnerKeySelector)
-                                {
-                                    var translated = CreateSubqueryForNavigations(outerQuerySourceReferenceExpression, navigations, node);
-
-                                    return translated;
-                                }
-
-                                var navigationResultExpression = RewriteNavigationsIntoJoins(
-                                    outerQuerySourceReferenceExpression,
-                                    navigations,
-                                    properties.Count == navigations.Count ? null : (PropertyInfo)node.Member);
-
-                                return navigationResultExpression;
-                            }
-
-                            return default(Expression);
-                        })
+                    {
+                        return RewriteNavigationProperties(
+                            ps.ToList(), 
+                            qs, 
+                            node.Expression,
+                            node.Member.Name, 
+                            node.Type,
+                            e => Expression.MakeMemberAccess(e, node.Member));
+                    })
                 ?? base.VisitMember(node);
         }
 
-        private static Expression CreateForeignKeyMemberAccess(MemberExpression memberExpression, INavigation navigation)
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            Check.NotNull(node, nameof(node));
+
+            if (!EntityQueryModelVisitor.IsPropertyMethod(node.Method))
+            {
+                base.VisitMethodCall(node);
+            }
+
+            return
+                _queryModelVisitor.BindNavigationPathPropertyExpression(
+                    node,
+                    (ps, qs) =>
+                    {
+                        return RewriteNavigationProperties(
+                            ps.ToList(),
+                            qs,
+                            node.Arguments[0],
+                            (string)(node.Arguments[1] as ConstantExpression).Value,
+                            node.Type,
+                            e => Expression.Call(node.Method, e, node.Arguments[1]));
+                    })
+                ?? base.VisitMethodCall(node);
+        }
+
+        private Expression RewriteNavigationProperties(
+            List<IPropertyBase> properties, 
+            IQuerySource querySource,
+            Expression declaringExpression,
+            string propertyName,
+            Type propertyType,
+            Func<Expression, Expression> propertyCreator)
+        {
+            var navigations = properties.OfType<INavigation>().ToList();
+
+            if (navigations.Any())
+            {
+                var outerQuerySourceReferenceExpression = new QuerySourceReferenceExpression(querySource);
+
+                if (_navigationRewritingQueryModelVisitor.AdditionalFromClauseBeingProcessed != null
+                    && navigations.Last().IsCollection())
+                {
+                    return RewriteSelectManyNavigationsIntoJoins(
+                        outerQuerySourceReferenceExpression,
+                        navigations,
+                        _navigationRewritingQueryModelVisitor.AdditionalFromClauseBeingProcessed);
+                }
+
+                if (navigations.Count == 1
+                    && navigations[0].IsDependentToPrincipal())
+                {
+                    var foreignKeyMemberAccess = CreateForeignKeyMemberAccess(propertyName, declaringExpression, navigations[0]);
+                    if (foreignKeyMemberAccess != null)
+                    {
+                        return foreignKeyMemberAccess;
+                    }
+                }
+
+                if (_navigationRewritingQueryModelVisitor.InsideInnerKeySelector)
+                {
+                    var translated = CreateSubqueryForNavigations(
+                        outerQuerySourceReferenceExpression, 
+                        navigations,
+                        propertyCreator);
+
+                    return translated;
+                }
+
+                var navigationResultExpression = RewriteNavigationsIntoJoins(
+                    outerQuerySourceReferenceExpression,
+                    navigations,
+                    properties.Count == navigations.Count ? null : propertyType,
+                    propertyCreator);
+
+                return navigationResultExpression;
+            }
+
+            return default(Expression);
+        }
+
+
+        private static Expression CreateForeignKeyMemberAccess(string propertyName, Expression declaringExpression, INavigation navigation)
         {
             var principalKey = navigation.ForeignKey.PrincipalKey;
             if (principalKey.Properties.Count == 1)
@@ -407,13 +453,21 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 Debug.Assert(navigation.ForeignKey.Properties.Count == 1);
 
                 var principalKeyProperty = principalKey.Properties[0];
-                if (principalKeyProperty.Name == memberExpression.Member.Name
+                if (principalKeyProperty.Name == propertyName
                     && principalKeyProperty.ClrType == navigation.ForeignKey.Properties[0].ClrType)
                 {
-                    var declaringExpression = ((MemberExpression)memberExpression.Expression).Expression;
-                    var foreignKeyPropertyExpression = CreateKeyAccessExpression(declaringExpression, navigation.ForeignKey.Properties);
+                    var declaringMethodCallExpression = declaringExpression as MethodCallExpression;
+                    var parentDeclaringExpression = declaringMethodCallExpression != null
+                        && EntityQueryModelVisitor.IsPropertyMethod(declaringMethodCallExpression.Method)
+                        ? declaringMethodCallExpression.Arguments[0]
+                        : (declaringExpression as MemberExpression)?.Expression;
 
-                    return foreignKeyPropertyExpression;
+                    if (parentDeclaringExpression != null)
+                    {
+                        var foreignKeyPropertyExpression = CreateKeyAccessExpression(parentDeclaringExpression, navigation.ForeignKey.Properties);
+
+                        return foreignKeyPropertyExpression;
+                    }
                 }
             }
 
@@ -423,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private Expression CreateSubqueryForNavigations(
             Expression outerQuerySourceReferenceExpression,
             ICollection<INavigation> navigations,
-            MemberExpression memberExpression)
+            Func<Expression, Expression> propertyCreator)
         {
             var firstNavigation = navigations.First();
             var targetEntityType = firstNavigation.GetTargetType();
@@ -463,7 +517,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         selectClauseExpression,
                         (current, navigation) => Expression.Property(current, navigation.Name));
 
-            subQueryModel.SelectClause = new SelectClause(Expression.MakeMemberAccess(selectClauseExpression, memberExpression.Member));
+            subQueryModel.SelectClause = new SelectClause(propertyCreator(selectClauseExpression));
 
             if (navigations.Count > 1)
             {
@@ -504,7 +558,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private Expression RewriteNavigationsIntoJoins(
             QuerySourceReferenceExpression outerQuerySourceReferenceExpression,
             IEnumerable<INavigation> navigations,
-            PropertyInfo member)
+            Type propertyType,
+            Func<Expression, Expression> propertyCreator)
         {
             var querySourceReferenceExpression = outerQuerySourceReferenceExpression;
             var navigationJoins = _navigationJoins;
@@ -615,22 +670,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 navigationJoins = navigationJoin.NavigationJoins;
             }
 
-            if (member == null)
+            if (propertyType == null)
             {
                 return querySourceReferenceExpression;
             }
 
             if (optionalNavigationInChain)
             {
-                Expression memberAccessExpression = Expression.MakeMemberAccess(querySourceReferenceExpression, member);
-                if (!member.PropertyType.IsNullableType())
+                Expression memberAccessExpression = propertyCreator(querySourceReferenceExpression);
+                if (!propertyType.IsNullableType())
                 {
-                    memberAccessExpression = Expression.Convert(memberAccessExpression, member.PropertyType.MakeNullable());
+                    memberAccessExpression = Expression.Convert(memberAccessExpression, propertyType.MakeNullable());
                 }
 
-                var constantNullExpression = member.PropertyType.IsNullableType()
-                    ? Expression.Constant(null, member.PropertyType)
-                    : Expression.Constant(null, member.PropertyType.MakeNullable());
+                var constantNullExpression = propertyType.IsNullableType()
+                    ? Expression.Constant(null, propertyType)
+                    : Expression.Constant(null, propertyType.MakeNullable());
 
                 return Expression.Condition(
                     Expression.NotEqual(
@@ -639,7 +694,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     memberAccessExpression,
                     constantNullExpression);
             }
-            return Expression.MakeMemberAccess(querySourceReferenceExpression, member);
+
+            return propertyCreator(querySourceReferenceExpression);
         }
 
         private Expression RewriteSelectManyNavigationsIntoJoins(
@@ -913,7 +969,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     Check.NotNull(node, nameof(node));
 
                     return
-                        _queryModelVisitor.BindNavigationPathMemberExpression(
+                        _queryModelVisitor.BindNavigationPathPropertyExpression(
                             node,
                             (properties, querySource) =>
                                 {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -22,23 +22,98 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
-        // TODO #5043
         public override void Entity_equality_empty()
         {
             base.Entity_equality_empty();
 
             Assert.Equal(
-                @"", 
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId], [l.OneToOne_Optional_FK].[Id], [l.OneToOne_Optional_FK].[Level1_Optional_Id], [l.OneToOne_Optional_FK].[Level1_Required_Id], [l.OneToOne_Optional_FK].[Name], [l.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+LEFT JOIN [Level2] AS [l.OneToOne_Optional_FK] ON [l].[Id] = [l.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l].[Id]", 
                 Sql);
         }
 
-        // TODO #5043
         public override void Key_equality_when_sentinel_ef_property()
         {
             base.Key_equality_when_sentinel_ef_property();
 
             Assert.Equal(
-                @"", 
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId], [l.OneToOne_Optional_FK].[Id], [l.OneToOne_Optional_FK].[Level1_Optional_Id], [l.OneToOne_Optional_FK].[Level1_Required_Id], [l.OneToOne_Optional_FK].[Name], [l.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+LEFT JOIN [Level2] AS [l.OneToOne_Optional_FK] ON [l].[Id] = [l.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l].[Id]", 
+                Sql);
+        }
+
+        public override void Key_equality_using_property_method_required()
+        {
+            base.Key_equality_using_property_method_required();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN [Level2] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE [l.OneToOne_Required_FK].[Id] > 7",
+                Sql);
+        }
+
+        public override void Key_equality_using_property_method_nested()
+        {
+            base.Key_equality_using_property_method_nested();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN [Level2] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE [l.OneToOne_Required_FK].[Id] = 7",
+                Sql);
+        }
+
+        public override void Key_equality_using_property_method_and_member_expression1()
+        {
+            base.Key_equality_using_property_method_and_member_expression1();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN [Level2] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE [l.OneToOne_Required_FK].[Id] = 7",
+                Sql);
+        }
+
+        public override void Key_equality_using_property_method_and_member_expression2()
+        {
+            base.Key_equality_using_property_method_and_member_expression2();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN [Level2] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE [l.OneToOne_Required_FK].[Id] = 7",
+                Sql);
+        }
+
+        public override void Key_equality_navigation_converted_to_FK()
+        {
+            base.Key_equality_navigation_converted_to_FK();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l]
+WHERE [l].[Level1_Required_Id] = 1",
+                Sql);
+        }
+
+        public override void Key_equality_two_conditions_on_same_navigation()
+        {
+            base.Key_equality_two_conditions_on_same_navigation();
+
+            Assert.Equal(
+                @"SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN [Level2] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE ([l.OneToOne_Required_FK].[Id] = 1) OR ([l.OneToOne_Required_FK].[Id] = 2)",
                 Sql);
         }
 
@@ -202,6 +277,17 @@ ORDER BY [e2].[OneToOne_Optional_PK_InverseId]",
                 @"SELECT [e2].[Id]
 FROM [Level2] AS [e2]
 WHERE [e2].[Id] > 5", Sql);
+        }
+
+        public override void Navigation_inside_method_call_translated_to_join()
+        {
+            base.Navigation_inside_method_call_translated_to_join();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e1]
+INNER JOIN [Level2] AS [e1.OneToOne_Required_FK] ON [e1].[Id] = [e1.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%'", Sql);
         }
 
         public override void Join_navigation_in_outer_selector_translated_to_extra_join()
@@ -807,7 +893,7 @@ ORDER BY [l1.OneToOne_Required_FK].[Id]",
             base.Complex_navigations_with_predicate_projected_into_anonymous_type();
 
             Assert.Equal(
-                @"SELECT [e.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK].[Level1_Optional_Id], [e.OneToOne_Required_FK].[Level1_Required_Id], [e.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK.OneToOne_Required_FK].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToOne_Required_FK].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Name], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToOne_Optional_SelfId], [e].[Name]
+                @"SELECT [e.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK].[Level1_Optional_Id], [e.OneToOne_Required_FK].[Level1_Required_Id], [e.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[Name], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK.OneToOne_Required_FK].[Id], [e].[Name]
 FROM [Level1] AS [e]
 INNER JOIN [Level2] AS [e.OneToOne_Required_FK] ON [e].[Id] = [e.OneToOne_Required_FK].[Level1_Required_Id]
 INNER JOIN [Level3] AS [e.OneToOne_Required_FK.OneToOne_Required_FK] ON [e.OneToOne_Required_FK].[Id] = [e.OneToOne_Required_FK.OneToOne_Required_FK].[Level2_Required_Id]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -173,9 +173,9 @@ FROM [Employees] AS [e2]",
                 Sql);
         }
 
-        public override void Where_query_composition_entity_equality()
+        public override void Where_query_composition_entity_equality_one_element_SingleOrDefault()
         {
-            base.Where_query_composition_entity_equality();
+            base.Where_query_composition_entity_equality_one_element_SingleOrDefault();
 
             Assert.StartsWith(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
@@ -183,6 +183,64 @@ FROM [Employees] AS [e1]
 
 SELECT [e20].[EmployeeID]
 FROM [Employees] AS [e20]",
+                Sql);
+        }
+
+        public override void Where_query_composition_entity_equality_one_element_FirstOrDefault()
+        {
+            base.Where_query_composition_entity_equality_one_element_FirstOrDefault();
+
+            Assert.Equal(
+                @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+FROM [Employees] AS [e1]
+WHERE (
+    SELECT TOP(1) [e2].[EmployeeID]
+    FROM [Employees] AS [e2]
+    WHERE [e2].[EmployeeID] = [e1].[ReportsTo]
+) = 0",
+                Sql);
+        }
+
+        public override void Where_query_composition_entity_equality_no_elements_SingleOrDefault()
+        {
+            base.Where_query_composition_entity_equality_no_elements_SingleOrDefault();
+
+            Assert.StartsWith(
+                @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+FROM [Employees] AS [e1]
+
+SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] = 42", Sql);
+        }
+
+        public override void Where_query_composition_entity_equality_no_elements_FirstOrDefault()
+        {
+            base.Where_query_composition_entity_equality_no_elements_FirstOrDefault();
+
+            Assert.Equal(
+                @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+FROM [Employees] AS [e1]
+WHERE (
+    SELECT TOP(1) [e2].[EmployeeID]
+    FROM [Employees] AS [e2]
+    WHERE [e2].[EmployeeID] = 42
+) = 0",
+                Sql);
+        }
+
+        public override void Where_query_composition_entity_equality_multiple_elements_FirstOrDefault()
+        {
+            base.Where_query_composition_entity_equality_multiple_elements_FirstOrDefault();
+
+            Assert.Equal(
+                @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+FROM [Employees] AS [e1]
+WHERE (
+    SELECT TOP(1) [e2].[EmployeeID]
+    FROM [Employees] AS [e2]
+    WHERE ([e2].[EmployeeID] <> [e1].[ReportsTo]) OR [e1].[ReportsTo] IS NULL
+) = 0",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was that navigation expansion logic was only applied for MemberExpressions, but never for MethodCallExpression. Fix is to abstract that logic to work for both MemberExpressions and MethodCallExpression that happen to be EF.Property.
Also did some minor bugfixes and optimizations found along the way:
- compensating for nullability differences in SqlTranslatingExpressionVisitor, when processing comparison,
- preventing EntityEqualityRewritingVisitor to short-circuit on non-equality operations in case of nested binary expressions.