### PR TITLE
Query: Async: Reduce allocations during async query.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
@@ -30,11 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryContext queryContext,
             ShaperCommandContext shaperCommandContext,
             IShaper<T> shaper)
-            => new AsyncQueryingEnumerable(
-                (RelationalQueryContext)queryContext,
-                shaperCommandContext,
-                queryIndex: null)
-                .Select(vb => shaper.Shape(queryContext, vb)); // TODO: Pass shaper to underlying enumerable
+            => AsyncLinqOperatorProvider.
+                _Select(new AsyncQueryingEnumerable(
+                    (RelationalQueryContext)queryContext,
+                    shaperCommandContext,
+                    queryIndex: null),
+                    vb => shaper.Shape(queryContext, vb)); // TODO: Pass shaper to underlying enumerable
 
         public virtual MethodInfo DefaultIfEmptyShapedQueryMethod => _defaultIfEmptyShapedQueryMethodInfo;
 
@@ -48,12 +49,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryContext queryContext,
             ShaperCommandContext shaperCommandContext,
             IShaper<T> shaper)
-            => new DefaultIfEmptyAsyncEnumerable(
-                new AsyncQueryingEnumerable(
-                    (RelationalQueryContext)queryContext,
-                    shaperCommandContext,
-                    queryIndex: null))
-                .Select(vb => shaper.Shape(queryContext, vb));
+            => AsyncLinqOperatorProvider.
+                _Select(
+                    new DefaultIfEmptyAsyncEnumerable(
+                        new AsyncQueryingEnumerable(
+                            (RelationalQueryContext)queryContext,
+                            shaperCommandContext,
+                            queryIndex: null)),
+                    vb => shaper.Shape(queryContext, vb));
 
         private sealed class DefaultIfEmptyAsyncEnumerable : IAsyncEnumerable<ValueBuffer>
         {
@@ -169,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<TSource, TElement> elementSelector)
             => new GroupByAsyncEnumerable<TSource, TKey, TElement>(source, keySelector, elementSelector);
 
-        private class GroupByAsyncEnumerable<TSource, TKey, TElement> : IAsyncEnumerable<IGrouping<TKey, TElement>>
+        private sealed class GroupByAsyncEnumerable<TSource, TKey, TElement> : IAsyncEnumerable<IGrouping<TKey, TElement>>
         {
             private readonly IAsyncEnumerable<TSource> _source;
             private readonly Func<TSource, TKey> _keySelector;
@@ -187,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public IAsyncEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => new GroupByAsyncEnumerator(this);
 
-            private class GroupByAsyncEnumerator : IAsyncEnumerator<IGrouping<TKey, TElement>>
+            private sealed class GroupByAsyncEnumerator : IAsyncEnumerator<IGrouping<TKey, TElement>>
             {
                 private readonly GroupByAsyncEnumerable<TSource, TKey, TElement> _groupByAsyncEnumerable;
                 private readonly IEqualityComparer<TKey> _comparer;
@@ -303,7 +306,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 outerGroupJoinInclude,
                 innerGroupJoinInclude);
 
-        private class GroupJoinAsyncEnumerable<TOuter, TInner, TKey, TResult> : IAsyncEnumerable<TResult>
+        private sealed class GroupJoinAsyncEnumerable<TOuter, TInner, TKey, TResult> : IAsyncEnumerable<TResult>
         {
             private readonly RelationalQueryContext _queryContext;
             private readonly IAsyncEnumerable<ValueBuffer> _source;
@@ -336,7 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public IAsyncEnumerator<TResult> GetEnumerator() => new GroupJoinAsyncEnumerator(this);
 
-            private class GroupJoinAsyncEnumerator : IAsyncEnumerator<TResult>
+            private sealed class GroupJoinAsyncEnumerator : IAsyncEnumerator<TResult>
             {
                 private readonly GroupJoinAsyncEnumerable<TOuter, TInner, TKey, TResult> _groupJoinAsyncEnumerable;
                 private readonly IEqualityComparer<TKey> _comparer;
@@ -520,7 +523,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<ValueBuffer, object> materializer)
             => new ReferenceRelatedEntitiesLoader(valueBufferOffset, queryIndex, materializer);
 
-        private class ReferenceRelatedEntitiesLoader : IAsyncRelatedEntitiesLoader
+        private sealed class ReferenceRelatedEntitiesLoader : IAsyncRelatedEntitiesLoader
         {
             private readonly int _valueBufferOffset;
             private readonly int _queryIndex;
@@ -546,7 +549,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     new EntityLoadInfo(valueBuffer, _materializer));
             }
 
-            private class AsyncEnumerableAdapter<T> : IAsyncEnumerable<T>
+            private sealed class AsyncEnumerableAdapter<T> : IAsyncEnumerable<T>
             {
                 private readonly T _value;
 
@@ -557,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 public IAsyncEnumerator<T> GetEnumerator() => new AsyncEnumeratorAdapter(_value);
 
-                private class AsyncEnumeratorAdapter : IAsyncEnumerator<T>
+                private sealed class AsyncEnumeratorAdapter : IAsyncEnumerator<T>
                 {
                     private readonly T _value;
                     private bool _hasNext = true;
@@ -633,9 +636,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             public IAsyncEnumerable<EntityLoadInfo> Load(QueryContext queryContext, IIncludeKeyComparer keyComparer)
             {
                 return
-                    _includeCollectionIterator
-                        .GetRelatedValues(keyComparer)
-                        .Select(vr => new EntityLoadInfo(vr, _materializer));
+                    AsyncLinqOperatorProvider
+                        ._Select(
+                            _includeCollectionIterator.GetRelatedValues(keyComparer),
+                            vr => new EntityLoadInfo(vr, _materializer));
             }
 
             public void Dispose() => _includeCollectionIterator?.Dispose();

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -593,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                await Assert.ThrowsAsync<AggregateException>(async () =>
+                await Assert.ThrowsAsync<NotImplementedException>(async () =>
                     await context.Set<Customer>()
                         .Where(c => c.City == city.Throw().InstanceFieldValue)
                         .ToListAsync());
@@ -3161,12 +3161,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 ((IInfrastructure<IServiceProvider>)context).Instance.GetService<IConcurrencyDetector>().EnterCriticalSection();
 
-                var ex = await Assert.ThrowsAsync<AggregateException>(
-                    async () => await context.Customers.ToListAsync());
-
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    ex.InnerException.Message);
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => await context.Customers.ToListAsync())).Message);
             }
         }
 
@@ -3177,12 +3175,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 ((IInfrastructure<IServiceProvider>)context).Instance.GetService<IConcurrencyDetector>().EnterCriticalSection();
 
-                var ex = await Assert.ThrowsAsync<AggregateException>(
-                    async () => await context.Customers.FirstAsync());
-
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    ex.InnerException.Message);
+                    (await Assert.ThrowsAsync<AggregateException>(
+                        async () => await context.Customers.FirstAsync())).InnerException.Message);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1156,6 +1156,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("TempValue", "property", "entityType"), property, entityType);
         }
 
+        /// <summary>
+        /// Sequence contains more than one element
+        /// </summary>
+        public static string MoreThanOneElement
+        {
+            get { return GetString("MoreThanOneElement"); }
+        }
+
+        /// <summary>
+        /// Sequence contains no elements
+        /// </summary>
+        public static string NoElements
+        {
+            get { return GetString("NoElements"); }
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -546,4 +546,10 @@
   <data name="TempValue" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has a temporary value. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.</value>
   </data>
+  <data name="MoreThanOneElement" xml:space="preserve">
+    <value>Sequence contains more than one element</value>
+  </data>
+  <data name="NoElements" xml:space="preserve">
+    <value>Sequence contains no elements</value>
+  </data>
 </root>

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -170,7 +170,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             queryContext.BeginTrackingQuery();
 
-            return results.Select(result =>
+            return _Select(
+                results,
+                result =>
                 {
                     if (result != null)
                     {
@@ -216,13 +218,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             IList<Func<TIn, object>> entityAccessors)
             where TIn : class
         {
-            return groupings
-                .Select(g =>
-                    new TrackingGrouping<TKey, TOut, TIn>(
-                        g,
-                        queryContext,
-                        entityTrackingInfos,
-                        entityAccessors));
+            return _Select(
+                groupings,
+                g => new TrackingGrouping<TKey, TOut, TIn>(
+                    g,
+                    queryContext,
+                    entityTrackingInfos,
+                    entityAccessors));
         }
 
         public virtual MethodInfo TrackGroupedEntities => _trackGroupedEntities;
@@ -373,11 +375,47 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             = typeof(AsyncLinqOperatorProvider)
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Select));
 
-        [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IAsyncEnumerable<TResult> _Select<TSource, TResult>(
-            IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
-            => source.Select(selector);
+        public static IAsyncEnumerable<TResult> _Select<TSource, TResult>(
+            [NotNull] IAsyncEnumerable<TSource> source, [NotNull] Func<TSource, TResult> selector)
+            => new SelectAsyncEnumerable<TSource, TResult>(source, selector);
+
+        private sealed class SelectAsyncEnumerable<TSource, TResult> : IAsyncEnumerable<TResult>
+        {
+            private readonly IAsyncEnumerable<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+
+            public SelectAsyncEnumerable(
+                IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
+            {
+                _source = source;
+                _selector = selector;
+            }
+
+            public IAsyncEnumerator<TResult> GetEnumerator()
+                => new SelectAsyncEnumerator(_source.GetEnumerator(), _selector);
+
+            private sealed class SelectAsyncEnumerator : IAsyncEnumerator<TResult>
+            {
+                private readonly IAsyncEnumerator<TSource> _source;
+                private readonly Func<TSource, TResult> _selector;
+
+                public SelectAsyncEnumerator(
+                    IAsyncEnumerator<TSource> asyncEnumerator,
+                    Func<TSource, TResult> selector)
+                {
+                    _source = asyncEnumerator;
+                    _selector = selector;
+                }
+
+                public void Dispose() => _source.Dispose();
+
+                public Task<bool> MoveNext(CancellationToken cancellationToken)
+                    => _source.MoveNext(cancellationToken);
+
+                public TResult Current => _selector(_source.Current);
+            }
+        }
 
         public virtual MethodInfo Select => _select;
 
@@ -430,8 +468,50 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static readonly MethodInfo _defaultIfEmpty = GetMethod("DefaultIfEmpty");
         private static readonly MethodInfo _defaultIfEmptyArg = GetMethod("DefaultIfEmpty", 1);
         private static readonly MethodInfo _distinct = GetMethod("Distinct");
-        private static readonly MethodInfo _first = GetMethod("First");
-        private static readonly MethodInfo _firstOrDefault = GetMethod("FirstOrDefault");
+
+        private static readonly MethodInfo _first 
+            = typeof(AsyncLinqOperatorProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_First));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static async Task<TSource> _First<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                if (await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    return asyncEnumerator.Current;
+                }
+            }
+
+            throw new InvalidOperationException(CoreStrings.NoElements);
+        }
+
+        public virtual MethodInfo First => _first;
+
+        private static readonly MethodInfo _firstOrDefault
+            = typeof(AsyncLinqOperatorProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_FirstOrDefault));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static async Task<TSource> _FirstOrDefault<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                if (await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    return asyncEnumerator.Current;
+                }
+            }
+
+            return default(TSource);
+        }
+
+        public virtual MethodInfo FirstOrDefault => _firstOrDefault;
 
         public virtual MethodInfo Any => _any;
         public virtual MethodInfo All => _all;
@@ -441,10 +521,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public virtual MethodInfo DefaultIfEmpty => _defaultIfEmpty;
         public virtual MethodInfo DefaultIfEmptyArg => _defaultIfEmptyArg;
         public virtual MethodInfo Distinct => _distinct;
-
-        public virtual MethodInfo First => _first;
-        public virtual MethodInfo FirstOrDefault => _firstOrDefault;
-
+        
         private static readonly MethodInfo _groupBy
             = typeof(AsyncLinqOperatorProvider).GetTypeInfo().GetDeclaredMethod(nameof(_GroupBy));
 
@@ -456,7 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Func<TSource, TElement> elementSelector)
             => new GroupByAsyncEnumerable<TSource, TKey, TElement>(source, keySelector, elementSelector);
 
-        internal class GroupByAsyncEnumerable<TSource, TKey, TElement> : IAsyncEnumerable<IGrouping<TKey, TElement>>
+        internal sealed class GroupByAsyncEnumerable<TSource, TKey, TElement> : IAsyncEnumerable<IGrouping<TKey, TElement>>
         {
             private readonly IAsyncEnumerable<TSource> _source;
             private readonly Func<TSource, TKey> _keySelector;
@@ -475,7 +552,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public IAsyncEnumerator<IGrouping<TKey, TElement>> GetEnumerator()
                 => new GroupByEnumerator(this);
 
-            private class GroupByEnumerator : IAsyncEnumerator<IGrouping<TKey, TElement>>
+            private sealed class GroupByEnumerator : IAsyncEnumerator<IGrouping<TKey, TElement>>
             {
                 private readonly GroupByAsyncEnumerable<TSource, TKey, TElement> _groupByAsyncEnumerable;
 
@@ -529,8 +606,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static readonly MethodInfo _lastOrDefault = GetMethod("LastOrDefault");
         private static readonly MethodInfo _longCount = GetMethod("LongCount");
         private static readonly MethodInfo _ofType = GetMethod("OfType");
-        private static readonly MethodInfo _single = GetMethod("Single");
-        private static readonly MethodInfo _singleOrDefault = GetMethod("SingleOrDefault");
         private static readonly MethodInfo _skip = GetMethod("Skip", 1);
         private static readonly MethodInfo _take = GetMethod("Take", 1);
 
@@ -538,8 +613,65 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public virtual MethodInfo LastOrDefault => _lastOrDefault;
         public virtual MethodInfo LongCount => _longCount;
         public virtual MethodInfo OfType => _ofType;
+
+        private static readonly MethodInfo _single 
+            = typeof(AsyncLinqOperatorProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_Single));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static async Task<TSource> _Single<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                if (!await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    throw new InvalidOperationException(CoreStrings.NoElements);
+                }
+
+                var item = asyncEnumerator.Current;
+
+                if (!await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    return item;
+                }
+            }
+
+            throw new InvalidOperationException(CoreStrings.MoreThanOneElement);
+        }
+
         public virtual MethodInfo Single => _single;
+
+        private static readonly MethodInfo _singleOrDefault
+            = typeof(AsyncLinqOperatorProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_SingleOrDefault));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static async Task<TSource> _SingleOrDefault<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                if (!await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    return default(TSource);
+                }
+
+                var item = asyncEnumerator.Current;
+
+                if (!await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    return item;
+                }
+            }
+
+            throw new InvalidOperationException(CoreStrings.MoreThanOneElement);
+        }
+
         public virtual MethodInfo SingleOrDefault => _singleOrDefault;
+
         public virtual MethodInfo Skip => _skip;
         public virtual MethodInfo Take => _take;
 
@@ -577,7 +709,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return new AsyncEnumerableAdapter<T>(source);
         }
 
-        private class AsyncEnumerableAdapter<T> : IAsyncEnumerable<T>
+        private sealed class AsyncEnumerableAdapter<T> : IAsyncEnumerable<T>
         {
             private readonly IEnumerable<T> _source;
 
@@ -589,7 +721,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public IAsyncEnumerator<T> GetEnumerator()
                 => new AsyncEnumeratorAdapter(_source.GetEnumerator());
 
-            private class AsyncEnumeratorAdapter : IAsyncEnumerator<T>
+            private sealed class AsyncEnumeratorAdapter : IAsyncEnumerator<T>
             {
                 private readonly IEnumerator<T> _enumerator;
 


### PR DESCRIPTION
Replaced most commonly used IX-Async operators with async methods (await), which are more efficient.

In one async query microbenchmark we see allocations go from 1,893,939,770 bytes/34,771,015 objects to 312,770,445 bytes/5,421,289 objects.