### PR TITLE
Switch AddDbContext to use .Add instead of .TryAdd when adding DbContextOptions

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/DbContextOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/DbContextOperations.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             // Look for DbContext classes registered in the service provider
             var registeredContexts = _runtimeServices.GetServices<DbContextOptions>()
-                .Select(o => o.GetType().GenericTypeArguments[0]);
+                .Select(o => o.ContextType);
             foreach (var context in registeredContexts.Where(c => !contexts.ContainsKey(c)))
             {
                 contexts.Add(

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddLogging();
 
             serviceCollection.TryAddSingleton(p => DbContextOptionsFactory<TContext>(p, optionsAction));
-            serviceCollection.TryAddSingleton<DbContextOptions>(p => p.GetRequiredService<DbContextOptions<TContext>>());
+            serviceCollection.AddSingleton<DbContextOptions>(p => p.GetRequiredService<DbContextOptions<TContext>>());
 
             serviceCollection.TryAddScoped<TContext>();
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -4473,8 +4473,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
         public void Throws_when_adding_two_contexts_using_non_generic_options()
         {
             var appServiceProivder = new ServiceCollection()
-                .AddDbContext<NonGenericOptions1>(b => b.UseInMemoryDatabase())
                 .AddDbContext<NonGenericOptions2>(b => b.UseInMemoryDatabase())
+                .AddDbContext<NonGenericOptions1>(b => b.UseInMemoryDatabase())
                 .BuildServiceProvider();
 
             using (var serviceScope = appServiceProivder
@@ -4505,6 +4505,33 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 : base(options)
             {
             }
+        }
+
+        [Fact]
+        public void AddDbContext_adds_options_for_all_types()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<DbContextOptions>(_ => new DbContextOptions<NonGenericOptions1>())
+                .AddDbContext<NonGenericOptions1>()
+                .AddDbContext<NonGenericOptions2>()
+                .BuildServiceProvider();
+
+            Assert.Equal(3, services.GetServices<DbContextOptions>().Count());
+            Assert.Equal(2, services.GetServices<DbContextOptions>()
+                            .Select(o => o.ContextType)
+                            .Distinct()
+                            .Count());
+        }
+
+        [Fact]
+        public void Last_DbContextOptions_in_serviceCollection_selected()
+        {
+            var services = new ServiceCollection()
+                .AddDbContext<NonGenericOptions1>()
+                .AddDbContext<NonGenericOptions2>()
+                .BuildServiceProvider();
+
+            Assert.Equal(typeof(NonGenericOptions2), services.GetService<DbContextOptions>().ContextType);
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/aspnet/EntityFramework/issues/5156

~~This brings https://github.com/aspnet/EntityFramework/pull/5017 into release branch~~ 

cc @divega @ajcvickers 