### PR TITLE
[rc2] Throw when using multiple context types with non-generic DbContextOptions

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(options, nameof(options));
 
-            if (!options.ContextType.GetTypeInfo().IsAssignableFrom(GetType()))
+            if (!options.ContextType.IsAssignableFrom(GetType()))
             {
                 throw new InvalidOperationException(CoreStrings.NonGenericOptions(GetType().DisplayName()));
             }

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -82,6 +83,11 @@ namespace Microsoft.EntityFrameworkCore
         public DbContext([NotNull] DbContextOptions options)
         {
             Check.NotNull(options, nameof(options));
+
+            if (!options.ContextType.GetTypeInfo().IsAssignableFrom(GetType()))
+            {
+                throw new InvalidOperationException(CoreStrings.NonGenericOptions(GetType().DisplayName()));
+            }
 
             _options = options;
 

--- a/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
@@ -74,5 +74,7 @@ namespace Microsoft.EntityFrameworkCore
             where TExtension : class, IDbContextOptionsExtension;
 
         private readonly IReadOnlyDictionary<Type, IDbContextOptionsExtension> _extensions;
+
+        public abstract Type ContextType { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/DbContextOptions`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptions`.cs
@@ -56,5 +56,7 @@ namespace Microsoft.EntityFrameworkCore
 
             return new DbContextOptions<TContext>(extensions);
         }
+
+        public override Type ContextType => typeof(TContext);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -709,11 +709,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The DbContextOptions object registered in the service provider must be a DbContextOptions&lt;TContext&gt; where TContext is the type of the DbContext being used.
+        /// The DbContextOptions passed to the {contextType} constructor must be a DbContextOptions&lt;{contextType}&gt;. When registering multiple DbContext types make sure that the constructor for each context type has a DbContextOptions&lt;TContext&gt; parameter rather than a non-generic DbContextOptions parameter.
         /// </summary>
-        public static string NonGenericOptions
+        public static string NonGenericOptions([CanBeNull] object contextType)
         {
-            get { return GetString("NonGenericOptions"); }
+            return string.Format(CultureInfo.CurrentCulture, GetString("NonGenericOptions", "contextType"), contextType);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -379,7 +379,7 @@
     <value>Property '{property}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.</value>
   </data>
   <data name="NonGenericOptions" xml:space="preserve">
-    <value>The DbContextOptions object registered in the service provider must be a DbContextOptions&lt;TContext&gt; where TContext is the type of the DbContext being used.</value>
+    <value>The DbContextOptions passed to the {contextType} constructor must be a DbContextOptions&lt;{contextType}&gt;. When registering multiple DbContext types make sure that the constructor for each context type has a DbContextOptions&lt;TContext&gt; parameter rather than a non-generic DbContextOptions parameter.</value>
   </data>
   <data name="OptionsExtensionNotFound" xml:space="preserve">
     <value>Options extension of type '{optionsExtension}' not found.</value>


### PR DESCRIPTION
Add #5017 to RC2. 
Fixes https://github.com/aspnet/EntityFramework/issues/4994

cc @ajcvickers @divega 