### PR TITLE
Query: Funcletize method calls

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -593,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                await Assert.ThrowsAsync<NotImplementedException>(async () =>
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                     await context.Set<Customer>()
                         .Where(c => c.City == city.Throw().InstanceFieldValue)
                         .ToListAsync());

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -758,7 +758,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                Assert.Throws<NotImplementedException>(() =>
+                Assert.Throws<InvalidOperationException>(() =>
                     context.Set<Customer>()
                         .Where(c => c.City == city.Throw().InstanceFieldValue)
                         .ToList());
@@ -3496,13 +3496,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [ConditionalFact]
         public virtual void OrderBy_Count_with_predicate_client_eval_mixed()
         {
-            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => ClientEvalPredicateStateless()));
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => ClientEvalPredicate(o)));
         }
 
         [ConditionalFact]
         public virtual void OrderBy_Where_Count_with_predicate_client_eval()
         {
-            AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).Count(o => ClientEvalPredicate(o)));
+            AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)).Count(o => ClientEvalPredicate(o)));
         }
 
         [ConditionalFact]
@@ -3511,7 +3511,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).Count(o => o.CustomerID != "ALFKI"));
         }
 
-        [ConditionalFact]
+        //TODO: The function translated to SQL and due to being integer represent the column number
+        //[ConditionalFact]
         public virtual void OrderBy_client_Take()
         {
             AssertQuery<Employee>(es => es.OrderBy(o => ClientEvalSelectorStateless()).Take(10), entryCount: 9);
@@ -5161,6 +5162,90 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .ToList();
 
                 Assert.Equal(19, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTime_parse_is_funcletized()
+        {
+            AssertQuery<Order>(
+                os => os.Where(o => o.OrderDate > DateTime.Parse("1/1/1998 12:00:00 PM")),
+                entryCount: 267);
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_1()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random().Next())
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_2()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random().Next(5))
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_3()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random().Next(0, 10))
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_4()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random(15).Next())
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_5()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random(15).Next(5))
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Random_next_is_not_funcletized_6()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                    .Where(o => o.OrderID > new Random(15).Next(0, 10))
+                    .ToList();
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Environment_newline_is_funcletized()
+        {
+            using (var context = CreateContext())
+            {
+                AssertQuery<Customer>(
+                    cs => cs.Where(c => c.CustomerID.Contains(Environment.NewLine)));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
@@ -219,8 +219,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private static readonly PropertyInfo _dateTimeUtcNow
                 = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.UtcNow));
 
+            private static readonly MethodInfo _guidNewGuid
+                = typeof(Guid).GetTypeInfo().GetDeclaredMethod("NewGuid");
+
+            private static readonly List<MethodInfo> _randomNext
+                = typeof(Random).GetTypeInfo().GetDeclaredMethods("Next").ToList();
+
             public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression)
-                => typeof(IQueryable).GetTypeInfo().IsAssignableFrom(methodCallExpression.Type.GetTypeInfo());
+            {
+                if ((methodCallExpression.Method == _guidNewGuid)
+                    || _randomNext.Contains(methodCallExpression.Method))
+                {
+                    return false;
+                }
+                return base.IsEvaluatableMethodCall(methodCallExpression);
+            }
 
             public override bool IsEvaluatableMember(MemberExpression memberExpression)
                 => memberExpression.Member != _dateTimeNow && memberExpression.Member != _dateTimeUtcNow;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -46,8 +46,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public override async Task String_Contains_MethodCall()
         {
             await AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())),
-                entryCount: 19);
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                entryCount: 34);
         }
 
         public async Task Skip_when_no_order_by()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3672,7 +3672,8 @@ WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE N'M' + N'%'",
                 Sql);
         }
 
@@ -3715,7 +3716,8 @@ WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE N'%' + N'm'",
                 Sql);
         }
 
@@ -3758,12 +3760,14 @@ WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
         public override void String_Contains_MethodCall()
         {
             AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())),
-                entryCount: 19);
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                entryCount: 34);
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
                 Sql);
         }
 
@@ -3860,7 +3864,7 @@ WHERE [c].[CustomerID] <> UPPER([c].[CustomerID])
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] > REPLACE(N'ALFKI', UPPER(N'ALF'), [c].[CustomerID])
+WHERE [c].[CustomerID] > REPLACE(N'ALFKI', N'ALF', [c].[CustomerID])
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -3872,7 +3876,7 @@ WHERE [c].[CustomerID] > UPPER([c].[CustomerID])
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] < REPLACE(N'ALFKI', UPPER(N'ALF'), [c].[CustomerID])",
+WHERE [c].[CustomerID] < REPLACE(N'ALFKI', N'ALF', [c].[CustomerID])",
                 Sql);
         }
 
@@ -3931,7 +3935,7 @@ WHERE ABS([od].[UnitPrice]) > 10.0",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE ABS(-10) < [od].[ProductID]",
+WHERE 10 < [od].[ProductID]",
                 Sql);
         }
 
@@ -4910,6 +4914,91 @@ WHERE [e].[ContactTitle] = N'Owner'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void DateTime_parse_is_funcletized()
+        {
+            base.DateTime_parse_is_funcletized();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] > '1998-01-01T12:00:00.000'",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_1()
+        {
+            base.Random_next_is_not_funcletized_1();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_2()
+        {
+            base.Random_next_is_not_funcletized_2();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_3()
+        {
+            base.Random_next_is_not_funcletized_3();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_4()
+        {
+            base.Random_next_is_not_funcletized_4();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_5()
+        {
+            base.Random_next_is_not_funcletized_5();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Random_next_is_not_funcletized_6()
+        {
+            base.Random_next_is_not_funcletized_6();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Environment_newline_is_funcletized()
+        {
+            base.Environment_newline_is_funcletized();
+
+            Assert.Equal(
+                @"@__NewLine_0: 
+
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE (N'%' + @__NewLine_0) + N'%'",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -199,8 +201,30 @@ WHERE [t0].[__RowNumber__] > @__p_1",
 
         public override void String_Contains_Literal()
         {
-            // skip. This is covered in QuerySqlServerTest
-            // base.String_Contains_Literal()
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains("M") || c.ContactName.Contains("m")), // case-sensitive
+                entryCount: 34);
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
+                Sql);
+        }
+
+        public override void String_Contains_MethodCall()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                entryCount: 34);
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
+                Sql);
         }
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
@@ -45,8 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         public override async Task String_Contains_MethodCall()
         {
             await AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())),
-                entryCount: 19);
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                entryCount: 34);
         }
 
         public async Task Skip_when_no_order_by()

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -25,6 +25,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                 entryCount: 34);
         }
 
+        public override void String_Contains_MethodCall()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                entryCount: 34);
+        }
+
         public override void Take_Skip()
         {
             base.Take_Skip();


### PR DESCRIPTION
fixes #5035 
Funcletize method calls in query.
`Guid.NextGuid()` & `Random().Next()` are not funcletized