### PR TITLE
Make notification change tracking opt-in and implement collection notifications

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -6,8 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
@@ -109,12 +110,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             => Can_build_monster_model_and_seed_data_using_principal_navigations_test(
                 p => CreateSnapshotMonsterContext(p, SnapshotDatabaseName + "_PrincipalNavs"));
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_principal_navigations()
             => Can_build_monster_model_and_seed_data_using_principal_navigations_test(
                 p => CreateChangedChangingMonsterContext(p, FullNotifyDatabaseName + "_PrincipalNavs"));
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_principal_navigations()
             => Can_build_monster_model_and_seed_data_using_principal_navigations_test(
                 p => CreateChangedOnlyMonsterContext(p, ChangedOnlyDatabaseName + "_PrincipalNavs"));
@@ -414,11 +415,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void One_to_many_fixup_happens_when_collection_changes_for_snapshot_entities()
             => One_to_many_fixup_happens_when_collection_changes_test(p => CreateSnapshotMonsterContext(p), SnapshotDatabaseName, useDetectChanges: true);
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void One_to_many_fixup_happens_when_collection_changes_for_full_notification_entities()
             => One_to_many_fixup_happens_when_collection_changes_test(p => CreateChangedChangingMonsterContext(p), FullNotifyDatabaseName, useDetectChanges: false);
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void One_to_many_fixup_happens_when_collection_changes_for_changed_only_notification_entities()
             => One_to_many_fixup_happens_when_collection_changes_test(p => CreateChangedOnlyMonsterContext(p), ChangedOnlyDatabaseName, useDetectChanges: false);
 
@@ -811,11 +812,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_for_snapshot_entities()
             => Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateSnapshotMonsterContext(p), SnapshotDatabaseName, useDetectChanges: true);
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_for_full_notification_entities()
             => Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateChangedChangingMonsterContext(p), FullNotifyDatabaseName, useDetectChanges: false);
 
-        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
+        [Fact]
         public virtual void Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_for_changed_only_notification_entities()
             => Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateChangedOnlyMonsterContext(p), ChangedOnlyDatabaseName, useDetectChanges: false);
 
@@ -943,7 +944,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 incorrectScan2.ExpectedBarcode = barcode1;
                 incorrectScan1.ActualBarcode = barcode3;
                 incorrectScan2.ActualBarcode = barcode3;
-                barcode2.BadScans.Add(incorrectScan2);
 
                 if (useDetectChanges)
                 {
@@ -1366,7 +1366,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Same(barcode1, incorrectScan2.ExpectedBarcode);
                 Assert.Same(incorrectScan2, barcode1.BadScans.Single());
 
-                Assert.Null(barcode3.BadScans);
+                Assert.True(barcode3.BadScans == null || !barcode3.BadScans.Any());
 
                 var complaint1 = context.Complaints.Single(e => e.Details.StartsWith("Don't"));
                 var complaint2 = context.Complaints.Single(e => e.Details.StartsWith("Really"));
@@ -1394,7 +1394,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Same(customer3, login3.Customer);
                 Assert.Same(login3, customer3.Logins.Single());
 
-                Assert.Null(customer0.Logins);
+                Assert.True(customer0.Logins == null || !customer0.Logins.Any());
 
                 var rsaToken1 = context.RsaTokens.Single(e => e.Serial == "1234");
                 var rsaToken2 = context.RsaTokens.Single(e => e.Serial == "2234");
@@ -1514,7 +1514,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Same(product2, productReview3.Product);
                 Assert.Same(productReview3, product2.Reviews.Single());
 
-                Assert.Null(product3.Reviews);
+                Assert.True(product3.Reviews == null || !product3.Reviews.Any());
 
                 var productPhoto1 = context.ProductPhotos.Single(e => e.Photo[0] == 101);
                 var productPhoto2 = context.ProductPhotos.Single(e => e.Photo[0] == 103);
@@ -1525,7 +1525,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     product1.Photos.OrderBy(r => r.Photo.First()).ToArray());
 
                 Assert.Same(productPhoto3, product3.Photos.Single());
-                Assert.Null(product2.Photos);
+                Assert.True(product2.Photos == null || !product2.Photos.Any());
 
                 var productWebFeature1 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("Waffle"));
                 var productWebFeature2 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("What"));
@@ -1537,13 +1537,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Same(productWebFeature1, productReview1.Features.Single());
 
                 Assert.Null(productWebFeature2.Photo);
-                Assert.Null(productPhoto2.Features);
+                Assert.True(productPhoto2.Features == null || !productPhoto2.Features.Any());
 
                 Assert.Same(productReview3, productWebFeature2.Review);
                 Assert.Same(productWebFeature2, productReview3.Features.Single());
 
-                Assert.Null(productPhoto3.Features);
-                Assert.Null(productReview2.Features);
+                Assert.True(productPhoto3.Features == null || !productPhoto3.Features.Any());
+                Assert.True(productReview2.Features == null || !productReview2.Features.Any());
 
                 var supplier1 = context.Suppliers.Single(e => e.Name.StartsWith("Trading"));
                 var supplier2 = context.Suppliers.Single(e => e.Name.StartsWith("Ants"));
@@ -1602,15 +1602,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         private SnapshotMonsterContext CreateSnapshotMonsterContext(IServiceProvider serviceProvider, string databaseName = SnapshotDatabaseName)
             => new SnapshotMonsterContext(new DbContextOptionsBuilder(CreateOptions(databaseName)).UseInternalServiceProvider(serviceProvider).Options,
-                OnModelCreating<SnapshotMonsterContext.Message, SnapshotMonsterContext.ProductPhoto, SnapshotMonsterContext.ProductReview>);
+                b =>
+                    {
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+                        OnModelCreating<SnapshotMonsterContext.Message, SnapshotMonsterContext.ProductPhoto, SnapshotMonsterContext.ProductReview>(b);
+                    });
 
         private ChangedChangingMonsterContext CreateChangedChangingMonsterContext(IServiceProvider serviceProvider, string databaseName = FullNotifyDatabaseName)
             => new ChangedChangingMonsterContext(new DbContextOptionsBuilder(CreateOptions(databaseName)).UseInternalServiceProvider(serviceProvider).Options,
-                OnModelCreating<ChangedChangingMonsterContext.Message, ChangedChangingMonsterContext.ProductPhoto, ChangedChangingMonsterContext.ProductReview>);
+                b =>
+                    {
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+                        OnModelCreating<ChangedChangingMonsterContext.Message, ChangedChangingMonsterContext.ProductPhoto, ChangedChangingMonsterContext.ProductReview>(b);
+                    });
 
         private ChangedOnlyMonsterContext CreateChangedOnlyMonsterContext(IServiceProvider serviceProvider, string databaseName = ChangedOnlyDatabaseName)
             => new ChangedOnlyMonsterContext(new DbContextOptionsBuilder(CreateOptions(databaseName)).UseInternalServiceProvider(serviceProvider).Options,
-                OnModelCreating<ChangedOnlyMonsterContext.Message, ChangedOnlyMonsterContext.ProductPhoto, ChangedOnlyMonsterContext.ProductReview>);
+                b =>
+                    {
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
+                        OnModelCreating<ChangedOnlyMonsterContext.Message, ChangedOnlyMonsterContext.ProductPhoto, ChangedOnlyMonsterContext.ProductReview>(b);
+                    });
 
         public virtual void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
             where TMessage : class, IMessage

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -91,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                BadScans = BadScans ?? new HashSet<IIncorrectScan>();
+                BadScans = BadScans ?? new ObservableCollection<IIncorrectScan>();
             }
 
             public byte[] Code
@@ -613,8 +614,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                OrderLines = OrderLines ?? new HashSet<IOrderLine>();
-                Notes = Notes ?? new HashSet<IOrderNote>();
+                OrderLines = OrderLines ?? new ObservableCollection<IOrderLine>();
+                Notes = Notes ?? new ObservableCollection<IOrderNote>();
             }
 
             public int AnOrderId
@@ -862,11 +863,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Suppliers = Suppliers ?? new HashSet<ISupplier>();
-                //Replaces = new HashSet<DiscontinuedProduct>();
-                Reviews = Reviews ?? new HashSet<IProductReview>();
-                Photos = Photos ?? new HashSet<IProductPhoto>();
-                Barcodes = Barcodes ?? new HashSet<IBarcode>();
+                Suppliers = Suppliers ?? new ObservableCollection<ISupplier>();
+                //Replaces = new ObservableCollection<DiscontinuedProduct>();
+                Reviews = Reviews ?? new ObservableCollection<IProductReview>();
+                Photos = Photos ?? new ObservableCollection<IProductPhoto>();
+                Barcodes = Barcodes ?? new ObservableCollection<IBarcode>();
             }
 
             public int ProductId
@@ -955,7 +956,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Features = Features ?? new HashSet<IProductWebFeature>();
+                Features = Features ?? new ObservableCollection<IProductWebFeature>();
             }
 
             public int ProductId
@@ -993,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Features = Features ?? new HashSet<IProductWebFeature>();
+                Features = Features ?? new ObservableCollection<IProductWebFeature>();
             }
 
             public int ProductId
@@ -1235,8 +1236,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Products = Products ?? new HashSet<IProduct>();
-                //BackOrderLines = new HashSet<BackOrderLine>();
+                Products = Products ?? new ObservableCollection<IProduct>();
+                //BackOrderLines = new ObservableCollection<BackOrderLine>();
             }
 
             public int SupplierId
@@ -1312,8 +1313,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Orders = Orders ?? new HashSet<IAnOrder>();
-                Logins = Logins ?? new HashSet<ILogin>();
+                Orders = Orders ?? new ObservableCollection<IAnOrder>();
+                Logins = Logins ?? new ObservableCollection<ILogin>();
             }
 
             public int CustomerId
@@ -1390,9 +1391,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                SentMessages = SentMessages ?? new HashSet<IMessage>();
-                ReceivedMessages = ReceivedMessages ?? new HashSet<IMessage>();
-                Orders = Orders ?? new HashSet<IAnOrder>();
+                SentMessages = SentMessages ?? new ObservableCollection<IMessage>();
+                ReceivedMessages = ReceivedMessages ?? new ObservableCollection<IMessage>();
+                Orders = Orders ?? new ObservableCollection<IAnOrder>();
             }
 
             public string Username

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -86,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                BadScans = BadScans ?? new HashSet<IIncorrectScan>();
+                BadScans = BadScans ?? new ObservableCollection<IIncorrectScan>();
             }
 
             public byte[] Code
@@ -608,8 +609,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                OrderLines = OrderLines ?? new HashSet<IOrderLine>();
-                Notes = Notes ?? new HashSet<IOrderNote>();
+                OrderLines = OrderLines ?? new ObservableCollection<IOrderLine>();
+                Notes = Notes ?? new ObservableCollection<IOrderNote>();
             }
 
             public int AnOrderId
@@ -856,11 +857,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Suppliers = Suppliers ?? new HashSet<ISupplier>();
-                //Replaces = new HashSet<DiscontinuedProduct>();
-                Reviews = Reviews ?? new HashSet<IProductReview>();
-                Photos = Photos ?? new HashSet<IProductPhoto>();
-                Barcodes = Barcodes ?? new HashSet<IBarcode>();
+                Suppliers = Suppliers ?? new ObservableCollection<ISupplier>();
+                //Replaces = new ObservableCollection<DiscontinuedProduct>();
+                Reviews = Reviews ?? new ObservableCollection<IProductReview>();
+                Photos = Photos ?? new ObservableCollection<IProductPhoto>();
+                Barcodes = Barcodes ?? new ObservableCollection<IBarcode>();
                 Dimensions = Dimensions ?? new Dimensions();
             }
 
@@ -950,7 +951,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Features = Features ?? new HashSet<IProductWebFeature>();
+                Features = Features ?? new ObservableCollection<IProductWebFeature>();
             }
 
             public int ProductId
@@ -988,7 +989,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Features = Features ?? new HashSet<IProductWebFeature>();
+                Features = Features ?? new ObservableCollection<IProductWebFeature>();
             }
 
             public int ProductId
@@ -1230,8 +1231,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Products = Products ?? new HashSet<IProduct>();
-                //BackOrderLines = new HashSet<BackOrderLine>();
+                Products = Products ?? new ObservableCollection<IProduct>();
+                //BackOrderLines = new ObservableCollection<BackOrderLine>();
             }
 
             public int SupplierId
@@ -1307,8 +1308,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                Orders = Orders ?? new HashSet<IAnOrder>();
-                Logins = Logins ?? new HashSet<ILogin>();
+                Orders = Orders ?? new ObservableCollection<IAnOrder>();
+                Logins = Logins ?? new ObservableCollection<ILogin>();
             }
 
             public int CustomerId
@@ -1385,9 +1386,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
             public void InitializeCollections()
             {
-                SentMessages = SentMessages ?? new HashSet<IMessage>();
-                ReceivedMessages = ReceivedMessages ?? new HashSet<IMessage>();
-                Orders = Orders ?? new HashSet<IAnOrder>();
+                SentMessages = SentMessages ?? new ObservableCollection<IMessage>();
+                ReceivedMessages = ReceivedMessages ?? new ObservableCollection<IMessage>();
+                Orders = Orders ?? new ObservableCollection<IAnOrder>();
             }
 
             public string Username

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -12,6 +12,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class ChangeDetector : IChangeDetector
     {
+        public const string SkipDetectChangesAnnotation = "ChangeDetector.SkipDetectChanges";
+
         private bool _suspended;
 
         public virtual void Suspend() => _suspended = true;
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         public virtual void PropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase, bool setModified)
         {
-            if (_suspended)
+            if (_suspended || entry.EntityState == EntityState.Detached)
             {
                 return;
             }
@@ -37,24 +39,32 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
             else
             {
-                var navigation = propertyBase as INavigation;
-                if (navigation != null)
+                if (propertyBase.GetRelationshipIndex() != -1)
                 {
-                    DetectNavigationChange(entry, navigation);
+                    var navigation = propertyBase as INavigation;
+                    if (navigation != null)
+                    {
+                        DetectNavigationChange(entry, navigation);
+                    }
                 }
             }
         }
 
         public virtual void PropertyChanging(InternalEntityEntry entry, IPropertyBase propertyBase)
         {
-            if (_suspended)
+            if (_suspended || entry.EntityState == EntityState.Detached)
             {
                 return;
             }
 
             if (!entry.EntityType.UseEagerSnapshots())
             {
-                entry.EnsureOriginalValues();
+                var asProperty = propertyBase as IProperty;
+                if (asProperty != null
+                    && asProperty.GetOriginalValueIndex() != -1)
+                {
+                    entry.EnsureOriginalValues();
+                }
 
                 if (propertyBase.GetRelationshipIndex() != -1)
                 {
@@ -65,26 +75,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         public virtual void DetectChanges(IStateManager stateManager)
         {
-            foreach (var entry in stateManager.Entries.Where(e => e.EntityState != EntityState.Detached).ToList())
+            if (stateManager.Context.Model[SkipDetectChangesAnnotation] == null)
             {
-                DetectChanges(entry);
+                foreach (var entry in stateManager.Entries.Where(
+                    e => e.EntityState != EntityState.Detached
+                         && e.EntityType.GetChangeTrackingStrategy() == ChangeTrackingStrategy.Snapshot).ToList())
+                {
+                    DetectChanges(entry);
+                }
             }
         }
 
         public virtual void DetectChanges(InternalEntityEntry entry)
         {
-            DetectPropertyChanges(entry);
-            DetectRelationshipChanges(entry);
-        }
-
-        private static void DetectPropertyChanges(InternalEntityEntry entry)
-        {
             var entityType = entry.EntityType;
-
-            if (entityType.HasPropertyChangedNotifications())
-            {
-                return;
-            }
 
             foreach (var property in entityType.GetProperties())
             {
@@ -94,42 +98,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     entry.SetPropertyModified(property);
                 }
             }
-        }
 
-        private void DetectRelationshipChanges(InternalEntityEntry entry)
-        {
-            var entityType = entry.EntityType;
-
-            if (!entityType.HasPropertyChangedNotifications())
+            foreach (var property in entityType.GetProperties())
             {
-                DetectKeyChanges(entry);
+                DetectKeyChange(entry, property);
             }
 
             if (entry.HasRelationshipSnapshot)
-            {
-                DetectNavigationChanges(entry);
-            }
-        }
-
-        private void DetectKeyChanges(InternalEntityEntry entry)
-        {
-            var entityType = entry.EntityType;
-
-            if (!entityType.HasPropertyChangedNotifications())
-            {
-                foreach (var property in entityType.GetProperties())
-                {
-                    DetectKeyChange(entry, property);
-                }
-            }
-        }
-
-        private void DetectNavigationChanges(InternalEntityEntry entry)
-        {
-            var entityType = entry.EntityType;
-
-            if (!entityType.HasPropertyChangedNotifications()
-                || entityType.GetNavigations().Any(n => n.IsNonNotifyingCollection(entry)))
             {
                 foreach (var navigation in entityType.GetNavigations())
                 {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
@@ -22,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         void NavigationCollectionChanged(
             [NotNull] InternalEntityEntry entry,
             [NotNull] INavigation navigation,
-            [NotNull] ISet<object> added,
-            [NotNull] ISet<object> removed);
+            [NotNull] IEnumerable<object> added,
+            [NotNull] IEnumerable<object> removed);
 
         void KeyPropertyChanged(
             [NotNull] InternalEntityEntry entry,

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/INavigationListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/INavigationListener.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         void NavigationCollectionChanged(
             [NotNull] InternalEntityEntry entry,
             [NotNull] INavigation navigation,
-            [NotNull] ISet<object> added,
-            [NotNull] ISet<object> removed);
+            [NotNull] IEnumerable<object> added,
+            [NotNull] IEnumerable<object> removed);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
@@ -72,7 +72,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
-        public virtual void NavigationReferenceChanged(InternalEntityEntry entry, INavigation navigation, object oldValue, object newValue)
+        public virtual void NavigationReferenceChanged(
+            InternalEntityEntry entry,
+            INavigation navigation,
+            object oldValue,
+            object newValue)
         {
             if (_navigationListeners == null)
             {
@@ -85,7 +89,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
-        public virtual void NavigationCollectionChanged(InternalEntityEntry entry, INavigation navigation, ISet<object> added, ISet<object> removed)
+        public virtual void NavigationCollectionChanged(
+            InternalEntityEntry entry,
+            INavigation navigation,
+            IEnumerable<object> added,
+            IEnumerable<object> removed)
         {
             if (_navigationListeners == null)
             {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -28,26 +31,88 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 entry.EnsureOriginalValues();
                 entry.EnsureRelationshipSnapshot();
             }
-            else if (entityType.GetNavigations().Any(n => n.IsNonNotifyingCollection(entry)))
-            {
-                entry.EnsureRelationshipSnapshot();
-            }
 
-            var changing = entry.Entity as INotifyPropertyChanging;
-            if (changing != null)
+            var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
+            if (changeTrackingStrategy != ChangeTrackingStrategy.Snapshot)
             {
-                changing.PropertyChanging += (s, e) =>
+                foreach (var navigation in entityType.GetNavigations().Where(n => n.IsCollection()))
+                {
+                    var notifyingCollection = navigation.GetCollectionAccessor().GetOrCreate(entry.Entity) as INotifyCollectionChanged;
+                    if (notifyingCollection == null)
                     {
-                        foreach (var propertyBase in GetNotificationProperties(entityType, e.PropertyName))
-                        {
-                            _notifier.PropertyChanging(entry, propertyBase);
-                        }
-                    };
-            }
+                        throw new InvalidOperationException(
+                            CoreStrings.NonNotifyingCollection(navigation.Name, entityType.DisplayName(), changeTrackingStrategy));
+                    }
 
-            var changed = entry.Entity as INotifyPropertyChanged;
-            if (changed != null)
-            {
+                    notifyingCollection.CollectionChanged += (s, e) =>
+                        {
+                            switch (e.Action)
+                            {
+                                case NotifyCollectionChangedAction.Add:
+                                    _notifier.NavigationCollectionChanged(
+                                        entry,
+                                        navigation,
+                                        e.NewItems.OfType<object>(),
+                                        Enumerable.Empty<object>());
+                                    break;
+                                case NotifyCollectionChangedAction.Remove:
+                                    _notifier.NavigationCollectionChanged(
+                                        entry,
+                                        navigation,
+                                        Enumerable.Empty<object>(),
+                                        e.OldItems.OfType<object>());
+                                    break;
+                                case NotifyCollectionChangedAction.Replace:
+                                    _notifier.NavigationCollectionChanged(
+                                        entry,
+                                        navigation,
+                                        e.NewItems.OfType<object>(),
+                                        e.OldItems.OfType<object>());
+                                    break;
+                                case NotifyCollectionChangedAction.Reset:
+                                    if (e.OldItems == null)
+                                    {
+                                        throw new InvalidOperationException(CoreStrings.ResetNotSupported);
+                                    }
+
+                                    _notifier.NavigationCollectionChanged(
+                                        entry,
+                                        navigation,
+                                        Enumerable.Empty<object>(),
+                                        e.OldItems.OfType<object>());
+                                    break;
+                                // Note: ignoring Move since index not important
+                            }
+                        };
+                }
+
+                if (changeTrackingStrategy != ChangeTrackingStrategy.ChangedNotifications)
+                {
+                    var changing = entry.Entity as INotifyPropertyChanging;
+                    if (changing == null)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.ChangeTrackingInterfaceMissing(
+                                entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanging).Name));
+                    }
+
+                    changing.PropertyChanging += (s, e) =>
+                        {
+                            foreach (var propertyBase in GetNotificationProperties(entityType, e.PropertyName))
+                            {
+                                _notifier.PropertyChanging(entry, propertyBase);
+                            }
+                        };
+                }
+
+                var changed = entry.Entity as INotifyPropertyChanged;
+                if (changed == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ChangeTrackingInterfaceMissing(
+                            entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanged).Name));
+                }
+
                 changed.PropertyChanged += (s, e) =>
                     {
                         foreach (var propertyBase in GetNotificationProperties(entityType, e.PropertyName))
@@ -85,7 +150,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         private static IPropertyBase TryGetPropertyBase(IEntityType entityType, string propertyName)
-            => (IPropertyBase)entityType.FindProperty(propertyName)
-               ?? entityType.FindNavigation(propertyName);
+            => (IPropertyBase)entityType.FindProperty(propertyName) ?? entityType.FindNavigation(propertyName);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -163,8 +164,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public virtual void NavigationCollectionChanged(
             InternalEntityEntry entry,
             INavigation navigation,
-            ISet<object> added,
-            ISet<object> removed)
+            IEnumerable<object> added,
+            IEnumerable<object> removed)
         {
             if (_inFixup)
             {
@@ -578,12 +579,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 foreach (var danglerEntry in stateManager.GetRecordedReferers(entry.Entity))
                 {
                     DelayedFixup(danglerEntry.Item2, danglerEntry.Item1, entry);
-                }
-
-                // Ensure current value is snapshotted for all keys and FKs
-                foreach (var property in entityType.GetProperties().Where(p => p.GetRelationshipIndex() >= 0))
-                {
-                    entry.SetRelationshipSnapshotValue(property, entry[property]);
                 }
             }
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 if (value == null)
                 {
                     var property = propertyBase as IProperty;
-                    if ((property != null)
+                    if (property != null
                         && !property.IsNullable)
                     {
                         return;
@@ -47,29 +47,43 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             public void RemoveFromCollection(IPropertyBase propertyBase, object removedEntity)
-                => ((HashSet<object>)_values[propertyBase.GetRelationshipIndex()]).Remove(removedEntity);
+            {
+                var index = propertyBase.GetRelationshipIndex();
+                if (index != -1)
+                {
+                    ((HashSet<object>)_values[index]).Remove(removedEntity);
+                }
+            }
 
             public void AddToCollection(IPropertyBase propertyBase, object addedEntity)
             {
-                var snapshot = GetOrCreateCollection(propertyBase);
+                var index = propertyBase.GetRelationshipIndex();
 
-                snapshot.Add(addedEntity);
-            }
-
-            public void AddRangeToCollection(IPropertyBase propertyBase, IEnumerable<object> addedEntities)
-            {
-                var snapshot = GetOrCreateCollection(propertyBase);
-
-                foreach (var addedEntity in addedEntities)
+                if (index != -1)
                 {
+                    var snapshot = GetOrCreateCollection(index);
+
                     snapshot.Add(addedEntity);
                 }
             }
 
-            private HashSet<object> GetOrCreateCollection(IPropertyBase propertyBase)
+            public void AddRangeToCollection(IPropertyBase propertyBase, IEnumerable<object> addedEntities)
             {
                 var index = propertyBase.GetRelationshipIndex();
 
+                if (index != -1)
+                {
+                    var snapshot = GetOrCreateCollection(index);
+
+                    foreach (var addedEntity in addedEntities)
+                    {
+                        snapshot.Add(addedEntity);
+                    }
+                }
+            }
+
+            private HashSet<object> GetOrCreateCollection(int index)
+            {
                 var snapshot = (HashSet<object>)_values[index];
                 if (snapshot == null)
                 {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -102,8 +102,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     : _model.FindEntityType(clrType),
                 entity, valueBuffer);
 
-            _subscriber.SnapshotAndSubscribe(newEntry);
-
             foreach (var key in baseEntityType.GetKeys())
             {
                 GetOrCreateIdentityMap(key).AddOrUpdate(newEntry);
@@ -112,6 +110,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _entityReferenceMap[entity] = newEntry;
 
             newEntry.MarkUnchangedFromQuery();
+
+            _subscriber.SnapshotAndSubscribe(newEntry);
 
             return newEntry;
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableCollectionWithClear.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableCollectionWithClear.cs
@@ -1,0 +1,164 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    public class ObservableCollectionWithClear<T>
+        : Collection<T>, INotifyCollectionChanged, INotifyPropertyChanged
+    {
+        public ObservableCollectionWithClear()
+        {
+        }
+
+        public ObservableCollectionWithClear([NotNull] IEnumerable<T> collection)
+            : base(new List<T>(Check.NotNull(collection, nameof(collection))))
+        {
+        }
+
+        public virtual void Move(int oldIndex, int newIndex)
+            => MoveItem(oldIndex, newIndex);
+
+        public virtual event PropertyChangedEventHandler PropertyChanged;
+
+        public virtual event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        protected override void ClearItems()
+        {
+            CheckReentrancy();
+            var items = this.ToList();
+            base.ClearItems();
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
+            OnCollectionReset(items);
+        }
+
+        protected override void RemoveItem(int index)
+        {
+            CheckReentrancy();
+            var removedItem = this[index];
+
+            base.RemoveItem(index);
+
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
+            OnCollectionChanged(NotifyCollectionChangedAction.Remove, removedItem, index);
+        }
+
+        protected override void InsertItem(int index, [CanBeNull] T item)
+        {
+            CheckReentrancy();
+            base.InsertItem(index, item);
+
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
+            OnCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
+        }
+
+        protected override void SetItem(int index, [CanBeNull] T item)
+        {
+            CheckReentrancy();
+            var originalItem = this[index];
+            base.SetItem(index, item);
+
+            OnIndexerPropertyChanged();
+            OnCollectionChanged(NotifyCollectionChangedAction.Replace, originalItem, item, index);
+        }
+
+        protected virtual void MoveItem(int oldIndex, int newIndex)
+        {
+            CheckReentrancy();
+
+            var removedItem = this[oldIndex];
+
+            base.RemoveItem(oldIndex);
+            base.InsertItem(newIndex, removedItem);
+
+            OnIndexerPropertyChanged();
+            OnCollectionChanged(NotifyCollectionChangedAction.Move, removedItem, newIndex, oldIndex);
+        }
+
+        protected virtual void OnPropertyChanged([NotNull] PropertyChangedEventArgs e)
+            => PropertyChanged?.Invoke(this, e);
+
+        protected virtual void OnCollectionChanged([NotNull] NotifyCollectionChangedEventArgs e)
+        {
+            if (CollectionChanged != null)
+            {
+                using (BlockReentrancy())
+                {
+                    CollectionChanged(this, e);
+                }
+            }
+        }
+
+        protected virtual IDisposable BlockReentrancy()
+            => _monitor.Enter();
+
+        protected virtual void CheckReentrancy()
+        {
+            if (_monitor.Busy
+                && CollectionChanged != null
+                && CollectionChanged.GetInvocationList().Length > 1)
+            {
+                throw new InvalidOperationException(CoreStrings.ObservableCollectionReentrancy);
+            }
+        }
+
+        private void OnCountPropertyChanged()
+            => OnPropertyChanged(EventArgsCache.CountPropertyChanged);
+
+        private void OnIndexerPropertyChanged()
+            => OnPropertyChanged(EventArgsCache.IndexerPropertyChanged);
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, object item, int index)
+            => OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, item, index));
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, object item, int index, int oldIndex)
+            => OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, item, index, oldIndex));
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, object oldItem, object newItem, int index)
+            => OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, newItem, oldItem, index));
+
+        // Can't actually use Reset because event args constructor will throw!
+        private void OnCollectionReset(IList oldItems)
+            => OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, new object[0], oldItems));
+
+        private class SimpleMonitor : IDisposable
+        {
+            public SimpleMonitor Enter()
+            {
+                ++_busyCount;
+
+                return this;
+            }
+
+            public void Dispose()
+            {
+                --_busyCount;
+            }
+
+            public bool Busy => _busyCount > 0;
+
+            private int _busyCount;
+        }
+
+        private readonly SimpleMonitor _monitor = new SimpleMonitor();
+
+        private static class EventArgsCache
+        {
+            internal static readonly PropertyChangedEventArgs CountPropertyChanged = new PropertyChangedEventArgs("Count");
+            internal static readonly PropertyChangedEventArgs IndexerPropertyChanged = new PropertyChangedEventArgs("Item[]");
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -241,5 +241,9 @@ namespace Microsoft.EntityFrameworkCore
 
             return entityType.FindIndex(new[] { property });
         }
+
+        public static ChangeTrackingStrategy GetChangeTrackingStrategy(
+            [NotNull] this IEntityType entityType)
+            => Check.NotNull(entityType, nameof(entityType)).AsEntityType().ChangeTrackingStrategy;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
@@ -23,5 +23,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The entity type, or null if none if found. </returns>
         public static IEntityType FindEntityType([NotNull] this IModel model, [NotNull] Type type)
             => Check.NotNull(model, nameof(model)).AsModel().FindEntityType(Check.NotNull(type, nameof(type)));
+
+        public static ChangeTrackingStrategy GetChangeTrackingStrategy(
+            [NotNull] this IModel model)
+            => Check.NotNull(model, nameof(model)).AsModel().ChangeTrackingStrategy;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -368,5 +368,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 Check.NotEmpty(propertyName, nameof(propertyName)),
                 Check.NotNull(propertyType, nameof(propertyType)),
                 ConfigurationSource.Explicit);
+
+        public virtual EntityTypeBuilder HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            Builder.Metadata.ChangeTrackingStrategy = changeTrackingStrategy;
+
+            return this;
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -265,6 +265,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 CollectionBuilder(relatedEntityType, navigationName));
         }
 
+        public new virtual EntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
+            => (EntityTypeBuilder<TEntity>)base.HasChangeTrackingStrategy(changeTrackingStrategy);
+
         private InternalEntityTypeBuilder Builder => this.GetInfrastructure<InternalEntityTypeBuilder>();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/ChangeTrackingStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/ChangeTrackingStrategy.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    public enum ChangeTrackingStrategy
+    {
+        Snapshot,
+        ChangedNotifications,
+        ChangingAndChangedNotifications,
+        ChangingAndChangedNotificationsWithOriginalValues
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 setterDelegate = (Action<TEntity, TCollection>)setter.CreateDelegate(typeof(Action<TEntity, TCollection>));
 
-                var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(TCollection));
+                var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(TEntity), typeof(TCollection));
 
                 if (concreteType != null)
                 {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -77,6 +77,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return collection;
         }
 
+        public virtual object GetOrCreate(object instance) => GetOrCreateCollection(instance);
+
         private TCollection GetOrCreateCollection(object instance)
         {
             var collection = _getCollection((TEntity)instance);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CollectionTypeFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CollectionTypeFactory.cs
@@ -3,16 +3,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public class CollectionTypeFactory : ICollectionTypeFactory
     {
-        public virtual Type TryFindTypeToInstantiate(Type collectionType)
+        public virtual Type TryFindTypeToInstantiate(Type entityType, Type collectionType)
         {
             // Code taken from EF6. The rules are:
             // If the collection is defined as a concrete type with a public parameterless constructor, then create an instance of that type
+            // Else, if entity type is notifying and ObservableCollectionWithClear{T} can be assigned to the type, then use ObservableCollectionWithClear{T}
+            // Else, if entity type is notifying and ObservableCollection{T} can be assigned to the type, then use ObservableCollection{T}
             // Else, if HashSet{T} can be assigned to the type, then use HashSet{T}
             // Else, if List{T} can be assigned to the type, then use List{T}
             // Else, return null.
@@ -27,10 +33,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!collectionType.GetTypeInfo().IsAbstract)
             {
                 var constructor = collectionType.GetDeclaredConstructor(null);
-                if ((constructor != null)
+                if (constructor != null
                     && constructor.IsPublic)
                 {
                     return collectionType;
+                }
+            }
+
+            if (typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.GetTypeInfo()))
+            {
+                var observableCollectionWithClearOfT = typeof(ObservableCollectionWithClear<>).MakeGenericType(elementType);
+                if (collectionType.GetTypeInfo().IsAssignableFrom(observableCollectionWithClearOfT.GetTypeInfo()))
+                {
+                    return observableCollectionWithClearOfT;
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IClrCollectionAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IClrCollectionAccessor.cs
@@ -14,6 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         bool Contains([NotNull] object instance, [NotNull] object value);
         void Remove([NotNull] object instance, [NotNull] object value);
         object Create([NotNull] IEnumerable<object> values);
+        object GetOrCreate([NotNull] object instance);
         Type CollectionType { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ICollectionTypeFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ICollectionTypeFactory.cs
@@ -8,6 +8,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public interface ICollectionTypeFactory
     {
-        Type TryFindTypeToInstantiate([NotNull] Type collectionType);
+        Type TryFindTypeToInstantiate([NotNull] Type entityType, [NotNull] Type collectionType);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
@@ -36,6 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConventionDispatcher.OnModelInitialized(Builder);
         }
 
+        public virtual ChangeTrackingStrategy ChangeTrackingStrategy { get; set; } 
+            = ChangeTrackingStrategy.Snapshot;
+
         public virtual ConventionDispatcher ConventionDispatcher { get; }
         public virtual InternalModelBuilder Builder { get; }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/NavigationExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -11,26 +10,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         public static IClrCollectionAccessor GetCollectionAccessor([NotNull] this INavigation navigation)
             => navigation.AsNavigation().CollectionAccessor;
-
-        public static bool IsNonNotifyingCollection([NotNull] this INavigation navigation, [NotNull] InternalEntityEntry entry)
-        {
-            if (!navigation.IsCollection())
-            {
-                return false;
-            }
-
-            // TODO: Returning true until INotifyCollectionChanged (Issue #445) is supported.
-            return true;
-
-            //if (typeof(INotifyCollectionChanged).GetTypeInfo().IsAssignableFrom(navigation.GetType().GetTypeInfo()))
-            //{
-            //    return false;
-            //}
-
-            //var collectionInstance = entry[navigation];
-
-            //return collectionInstance != null && !(collectionInstance is INotifyCollectionChanged);
-        }
 
         public static Navigation AsNavigation([NotNull] this INavigation navigation, [NotNull] [CallerMemberName] string methodName = "")
             => navigation.AsConcreteMetadataType<INavigation, Navigation>(methodName);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
@@ -55,9 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static int GetOriginalValueIndex([NotNull] this IProperty property)
             => property.GetPropertyIndexes().OriginalValueIndex;
 
-        public static int GetIndex([NotNull] this IProperty property)
-            => property.GetPropertyIndexes().Index;
-
         public static bool MayBeStoreGenerated([NotNull] this IProperty property)
         {
             if (property.ValueGenerated != ValueGenerated.Never)
@@ -76,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         public static bool RequiresOriginalValue([NotNull] this IProperty property)
-            => property.DeclaringEntityType.UseEagerSnapshots()
+            => property.DeclaringEntityType.GetChangeTrackingStrategy() != ChangeTrackingStrategy.ChangingAndChangedNotifications
                || property.IsConcurrencyToken
                || property.IsForeignKey();
 

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -127,6 +127,7 @@
     <Compile Include="ChangeTracking\Internal\StateManager.cs" />
     <Compile Include="ChangeTracking\Internal\StoreGeneratedValues.cs" />
     <Compile Include="ChangeTracking\Internal\ValueGenerationManager.cs" />
+    <Compile Include="ChangeTracking\ObservableCollectionWithClear.cs" />
     <Compile Include="ChangeTracking\PropertyEntry.cs" />
     <Compile Include="ChangeTracking\PropertyEntry`.cs" />
     <Compile Include="DbContext.cs" />
@@ -228,6 +229,7 @@
     <Compile Include="Metadata\Builders\ReferenceNavigationBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
+    <Compile Include="Metadata\ChangeTrackingStrategy.cs" />
     <Compile Include="Metadata\Conventions\ConventionSet.cs" />
     <Compile Include="Metadata\Conventions\Internal\BaseTypeDiscoveryConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\CascadeDeleteConvention.cs" />
@@ -495,7 +497,9 @@
     <Compile Include="ValueGeneration\ValueGenerator`.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Properties\CoreStrings.resx" />
+    <EmbeddedResource Include="Properties\CoreStrings.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\tools\Resources.tt">

--- a/src/Microsoft.EntityFrameworkCore/ModelBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/ModelBuilder.cs
@@ -208,6 +208,13 @@ namespace Microsoft.EntityFrameworkCore
             return this;
         }
 
+        public virtual ModelBuilder HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            Builder.Metadata.ChangeTrackingStrategy = changeTrackingStrategy;
+
+            return this;
+        }
+
         private InternalModelBuilder Builder => this.GetInfrastructure();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -141,19 +141,43 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.
+        /// The entity type '{entityType}' is configured to use the '{changeTrackingStrategy}' change tracking strategy but does not implement the required '{notificationInterface}' interface.
         /// </summary>
-        public static string EagerOriginalValuesRequired([CanBeNull] object entityType)
+        public static string ChangeTrackingInterfaceMissing([CanBeNull] object entityType, [CanBeNull] object changeTrackingStrategy, [CanBeNull] object notificationInterface)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("EagerOriginalValuesRequired", "entityType"), entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("ChangeTrackingInterfaceMissing", "entityType", "changeTrackingStrategy", "notificationInterface"), entityType, changeTrackingStrategy, notificationInterface);
         }
 
         /// <summary>
-        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities that utilize the INotifyPropertyChanging interface. To access all original values set 'UseEagerSnapshots' to true on the EntityType during model building.
+        /// The collection type being used for navigation property '{navigation}' on entity type '{entityType}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.
+        /// </summary>
+        public static string NonNotifyingCollection([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object changeTrackingStrategy)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NonNotifyingCollection", "navigation", "entityType", "changeTrackingStrategy"), navigation, entityType, changeTrackingStrategy);
+        }
+
+        /// <summary>
+        /// 'ObservableCollection&lt;T&gt;.Clear()' is not supported because it uses the 'INotifyCollectionChanged' 'Reset' operation, which does not supply the items removed. Either use multiple calls to 'Remove' or use a notifying collection that supports 'Clear', such as 'Microsoft.EntityFrameworkCore.ChangeTracking.ObservableCollectionWithClear&lt;T&gt;'.
+        /// </summary>
+        public static string ResetNotSupported
+        {
+            get { return GetString("ResetNotSupported"); }
+        }
+
+        /// <summary>
+        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities when the 'ChangingAndChangedNotifications' strategy is used. To access all original values use a different change tracking strategy such as 'ChangingAndChangedNotificationsWithOriginalValues'.
         /// </summary>
         public static string OriginalValueNotTracked([CanBeNull] object property, [CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("OriginalValueNotTracked", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// Cannot change ObservableCollectionWithClear during a CollectionChanged event.
+        /// </summary>
+        public static string ObservableCollectionReentrancy
+        {
+            get { return GetString("ObservableCollectionReentrancy"); }
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -165,11 +165,20 @@
   <data name="IQueryableProviderNotAsync" xml:space="preserve">
     <value>The provider for the source IQueryable doesn't implement IAsyncQueryProvider. Only providers that implement IEntityQueryProvider can be used for Entity Framework asynchronous operations.</value>
   </data>
-  <data name="EagerOriginalValuesRequired" xml:space="preserve">
-    <value>Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.</value>
+  <data name="ChangeTrackingInterfaceMissing" xml:space="preserve">
+    <value>The entity type '{entityType}' is configured to use the '{changeTrackingStrategy}' change tracking strategy but does not implement the required '{notificationInterface}' interface.</value>
+  </data>
+  <data name="NonNotifyingCollection" xml:space="preserve">
+    <value>The collection type being used for navigation property '{navigation}' on entity type '{entityType}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
+  </data>
+  <data name="ResetNotSupported" xml:space="preserve">
+    <value>'ObservableCollection&lt;T&gt;.Clear()' is not supported because it uses the 'INotifyCollectionChanged' 'Reset' operation, which does not supply the items removed. Either use multiple calls to 'Remove' or use a notifying collection that supports 'Clear', such as 'Microsoft.EntityFrameworkCore.ChangeTracking.ObservableCollectionWithClear&lt;T&gt;'.</value>
   </data>
   <data name="OriginalValueNotTracked" xml:space="preserve">
-    <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities that utilize the INotifyPropertyChanging interface. To access all original values set 'UseEagerSnapshots' to true on the EntityType during model building.</value>
+    <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities when the 'ChangingAndChangedNotifications' strategy is used. To access all original values use a different change tracking strategy such as 'ChangingAndChangedNotificationsWithOriginalValues'.</value>
+  </data>
+  <data name="ObservableCollectionReentrancy" xml:space="preserve">
+    <value>Cannot change ObservableCollectionWithClear during a CollectionChanged event.</value>
   </data>
   <data name="MissingBackingField" xml:space="preserve">
     <value>The property '{entityType}.{property}' is annotated with backing field '{field}' but that field cannot be found.</value>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -6,9 +6,12 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.Common;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.TestModels;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
@@ -560,7 +563,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<TBlog>().ToTable("Blog", "dbo");
+            {
+                if (typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(typeof(TBlog).GetTypeInfo()))
+                {
+                    modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+                }
+                else if(typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(typeof(TBlog).GetTypeInfo()))
+                {
+                    modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
+                }
+                modelBuilder.Entity<TBlog>().ToTable("Blog", "dbo");
+            }
 
             public DbSet<TBlog> Blogs { get; set; }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
@@ -36,9 +38,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         [Fact]
         public void PropertyChanging_snapshots_original_and_FK_value_if_lazy_snapshots_are_in_use()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(BuildModelWithChanging());
-            var entity = new ProductWithChanging { DependentId = 77 };
+            var contextServices = TestHelpers.Instance.CreateContextServices(BuildNotifyingModel());
+            var entity = new NotifyingProduct { DependentId = 77 };
             var entry = CreateInternalEntry(contextServices, entity);
+            entry.SetEntityState(EntityState.Unchanged);
 
             Assert.False(entry.EntityType.UseEagerSnapshots());
             Assert.False(entry.HasRelationshipSnapshot);
@@ -57,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             entity.DependentId = 777;
 
-            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(777, entry.GetRelationshipSnapshotValue(property)); // Because is now changed
             Assert.Equal(77, entry.GetOriginalValue(property));
             Assert.Equal(777, entry.GetCurrentValue(property));
         }
@@ -65,8 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         [Fact]
         public void PropertyChanging_does_not_snapshot_original_values_for_properties_with_no_original_value_tracking()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(BuildModelWithChanging());
-            var entity = new ProductWithChanging { Name = "Cheese" };
+            var contextServices = TestHelpers.Instance.CreateContextServices(BuildNotifyingModel());
+            var entity = new NotifyingProduct { Name = "Cheese" };
             var entry = CreateInternalEntry(contextServices, entity);
 
             Assert.False(entry.EntityType.UseEagerSnapshots());
@@ -89,10 +92,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         [Fact]
         public void PropertyChanging_snapshots_reference_navigations_if_lazy_snapshots_are_in_use()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(BuildModelWithChanging());
-            var category = new CategoryWithChanging();
-            var entity = new ProductWithChanging { Category = category };
+            var contextServices = TestHelpers.Instance.CreateContextServices(BuildNotifyingModel());
+            var category = new NotifyingCategory();
+            var entity = new NotifyingProduct { Category = category };
             var entry = CreateInternalEntry(contextServices, entity);
+            entry.SetEntityState(EntityState.Added);
 
             Assert.False(entry.EntityType.UseEagerSnapshots());
             Assert.False(entry.HasRelationshipSnapshot);
@@ -108,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             Assert.Same(category, entry.GetRelationshipSnapshotValue(navigation));
             Assert.Same(category, entry.GetCurrentValue(navigation));
 
-            entity.Category = new CategoryWithChanging();
+            entity.Category = new NotifyingCategory { Id = 7, PrincipalId = 11 };
 
             Assert.Same(category, entry.GetRelationshipSnapshotValue(navigation));
             Assert.NotSame(category, entry.GetCurrentValue(navigation));
@@ -117,9 +121,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         [Fact]
         public void PropertyChanging_snapshots_PK_for_relationships_if_lazy_snapshots_are_in_use()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(BuildModelWithChanging());
-            var entity = new ProductWithChanging { Id = 77 };
+            var contextServices = TestHelpers.Instance.CreateContextServices(BuildNotifyingModel());
+            var id = Guid.NewGuid();
+            var entity = new NotifyingProduct { Id = id };
             var entry = CreateInternalEntry(contextServices, entity);
+            entry.SetEntityState(EntityState.Added);
 
             Assert.False(entry.EntityType.UseEagerSnapshots());
             Assert.False(entry.HasRelationshipSnapshot);
@@ -132,13 +138,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             Assert.True(entry.HasRelationshipSnapshot);
 
-            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal(77, entry.GetCurrentValue(property));
+            Assert.Equal(id, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(id, entry.GetCurrentValue(property));
 
-            entity.Id = 777;
+            var newId = Guid.NewGuid();
+            entity.Id = newId;
 
-            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
-            Assert.Equal(777, entry.GetCurrentValue(property));
+            Assert.Equal(newId, entry.GetRelationshipSnapshotValue(property)); // Because now changed.
+            Assert.Equal(newId, entry.GetCurrentValue(property));
         }
 
         [Fact]
@@ -165,6 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var contextServices = TestHelpers.Instance.CreateContextServices(BuildModelWithChanged());
 
+            var stateManager = contextServices.GetRequiredService<IStateManager>();
             var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
 
             var product = new ProductWithChanged { Id = 1, Name = "Oculus Rift" };
@@ -173,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             product.Name = "Gear VR";
 
-            changeDetector.DetectChanges(entry);
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.False(entry.IsModified(entry.EntityType.FindProperty("Name")));
@@ -715,7 +723,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             product.Id = 78;
 
-            changeDetector.DetectChanges(entry);
+            changeDetector.DetectChanges(stateManager);
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -738,7 +746,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             product.DependentId = 78;
 
-            changeDetector.DetectChanges(entry);
+            changeDetector.DetectChanges(stateManager);
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -762,7 +770,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             product.Category = new CategoryWithChanged { Id = 2 };
 
-            changeDetector.DetectChanges(entry);
+            changeDetector.DetectChanges(stateManager);
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -791,49 +799,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             var product3 = new ProductWithChanged { Id = 3, DependentId = 77 };
             category.Products.Add(product3);
-
-            changeDetector.DetectChanges(entry);
-
-            // TODO: DetectChanges is actually used here until INotifyCollectionChanged is supported (Issue #445)
-
-            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
-
-            Assert.Same(entry, testListener.CollectionChange.Item1);
-            Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
-            Assert.Equal(new[] { product3 }, testListener.CollectionChange.Item3);
-            Assert.Empty(testListener.CollectionChange.Item4);
-
-            Assert.Null(testListener.KeyChange);
-            Assert.Null(testListener.ReferenceChange);
-        }
-
-        [Fact]
-        public void Change_detection_still_happens_for_non_notifying_collections_on_notifying_entities()
-        {
-            var contextServices = CreateContextServices(BuildModelWithChanged());
-
-            var changeDetector = contextServices.GetRequiredService<IChangeDetector>();
-            var stateManager = contextServices.GetRequiredService<IStateManager>();
-
-            var product1 = new ProductWithChanged { Id = 1, DependentId = 77 };
-            var product2 = new ProductWithChanged { Id = 2, DependentId = 77 };
-            var category = new CategoryWithChanged
-            {
-                Id = 77,
-                Products = new List<ProductWithChanged> { product1, product2 }
-            };
-            var entry = stateManager.GetOrCreateEntry(category);
-            entry.SetEntityState(EntityState.Unchanged);
-
-            var product3 = new ProductWithChanged { Id = 3, DependentId = 77 };
-            category.Products.Add(product3);
-
-            changeDetector.DetectChanges(entry);
-
-            var testAttacher = (TestAttacher)contextServices.GetRequiredService<IEntityGraphAttacher>();
-
-            Assert.Same(product3, testAttacher.Attached.Item1.Entity);
-            Assert.Equal(EntityState.Added, testAttacher.Attached.Item2);
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1254,9 +1219,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var product3 = new NotifyingProduct { Id = Guid.NewGuid(), DependentId = 77 };
             category.Products.Add(product3);
 
-            // DetectChanges still needed here because INotifyCollectionChanged not supported (Issue #445)
-            changeDetector.DetectChanges(entry);
-
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
@@ -1286,9 +1248,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             product2.Category = category;
 
             category.Products.Remove(product1);
-
-            // DetectChanges still needed here because INotifyCollectionChanged not supported (Issue #445)
-            changeDetector.DetectChanges(entry);
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1378,9 +1337,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             var product3 = new NotifyingProduct { Tag = new NotifyingProductTag() };
             category.Products.Add(product3);
-
-            // DetectChanges still needed here because INotifyCollectionChanged not supported (Issue #445)
-            changeDetector.DetectChanges(entry);
 
             var testAttacher = (TestAttacher)contextServices.GetRequiredService<IEntityGraphAttacher>();
 
@@ -1704,7 +1660,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
         private static IModel BuildNotifyingModel()
         {
-            var builder = TestHelpers.Instance.CreateConventionBuilder();
+            var builder = TestHelpers.Instance.CreateConventionBuilder()
+                .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
 
             builder.Entity<NotifyingProduct>(b =>
                 {
@@ -1730,45 +1687,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             builder.Entity<NotifyingPerson>()
                 .HasOne(e => e.Husband).WithOne(e => e.Wife)
                 .HasForeignKey<NotifyingPerson>(e => e.HusbandId);
-
-            return builder.Model;
-        }
-
-        private class CategoryWithChanging : INotifyPropertyChanging
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-
-            public virtual ICollection<ProductWithChanging> Products { get; } = new ObservableCollection<ProductWithChanging>();
-
-            // Actual implementation not needed for tests
-#pragma warning disable 67
-            public event PropertyChangingEventHandler PropertyChanging;
-#pragma warning restore 67
-        }
-
-        private class ProductWithChanging : INotifyPropertyChanging
-        {
-            public int Id { get; set; }
-            public int? DependentId { get; set; }
-            public string Name { get; set; }
-
-            public virtual CategoryWithChanging Category { get; set; }
-
-            // Actual implementation not needed for tests
-#pragma warning disable 67
-            public event PropertyChangingEventHandler PropertyChanging;
-#pragma warning restore 67
-        }
-
-        private static IModel BuildModelWithChanging()
-        {
-            var builder = TestHelpers.Instance.CreateConventionBuilder();
-
-            builder.Entity<ProductWithChanging>();
-            builder.Entity<CategoryWithChanging>()
-                .HasMany(e => e.Products).WithOne(e => e.Category)
-                .HasForeignKey(e => e.DependentId);
 
             return builder.Model;
         }
@@ -1799,10 +1717,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             public event PropertyChangedEventHandler PropertyChanged;
 #pragma warning restore 67
         }
-
         private static IModel BuildModelWithChanged()
         {
-            var builder = TestHelpers.Instance.CreateConventionBuilder();
+            var builder = TestHelpers.Instance.CreateConventionBuilder()
+                .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
 
             builder.Entity<ProductWithChanged>();
             builder.Entity<CategoryWithChanged>()
@@ -1844,14 +1762,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             public Tuple<InternalEntityEntry, IProperty, IReadOnlyList<IKey>, IReadOnlyList<IForeignKey>, object, object> KeyChange { get; set; }
             public Tuple<InternalEntityEntry, INavigation, object, object> ReferenceChange { get; set; }
-            public Tuple<InternalEntityEntry, INavigation, ISet<object>, ISet<object>> CollectionChange { get; set; }
+            public Tuple<InternalEntityEntry, INavigation, IEnumerable<object>, IEnumerable<object>> CollectionChange { get; set; }
 
             public void NavigationReferenceChanged(InternalEntityEntry entry, INavigation navigation, object oldValue, object newValue)
             {
                 ReferenceChange = Tuple.Create(entry, navigation, oldValue, newValue);
             }
 
-            public void NavigationCollectionChanged(InternalEntityEntry entry, INavigation navigation, ISet<object> added, ISet<object> removed)
+            public void NavigationCollectionChanged(InternalEntityEntry entry, INavigation navigation, IEnumerable<object> added, IEnumerable<object> removed)
             {
                 CollectionChange = Tuple.Create(entry, navigation, added, removed);
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -315,9 +315,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entry.SetEntityState(EntityState.Added);
             entry.MarkAsTemporary(keyProperty);
 
+            Assert.True(entry.HasTemporaryValue(keyProperty));
+
             entry.SetEntityState(EntityState.Detached);
 
-            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.True(entry.HasTemporaryValue(keyProperty));
 
             entry[keyProperty] = 1;
             entry.SetEntityState(EntityState.Unchanged);
@@ -594,7 +596,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = BuildModel();
             var entityType = model.FindEntityType(typeof(FullNotificationEntity).FullName);
-            entityType.UseEagerSnapshots = true;
+            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.Snapshot;
 
             AllOriginalValuesTest(model, entityType, new FullNotificationEntity { Id = 1, Name = "Kool" });
         }
@@ -1209,12 +1211,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entityType3.GetOrSetPrimaryKey(property6);
             var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
             property7.IsConcurrencyToken = true;
+            entityType3.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
             var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
             entityType4.GetOrSetPrimaryKey(property8);
             var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
             property9.IsConcurrencyToken = true;
+            entityType4.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.HasBaseType(someSimpleEntityType);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -1,15 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -17,55 +21,230 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 {
     public class InternalEntryEntrySubscriberTest
     {
-        [Fact]
-        public void Snapshots_are_created_for_entities_without_changing_notifications()
+        [Theory]
+        [InlineData(ChangeTrackingStrategy.Snapshot)]
+        [InlineData(ChangeTrackingStrategy.ChangedNotifications)]
+        public void Original_and_relationship_values_recorded_when_no_changing_notifications(
+            ChangeTrackingStrategy changeTrackingStrategy)
         {
-            var entity = new ChangedOnlyNotificationEntity { Name = "Palmer", Id = 1 };
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(changeTrackingStrategy));
 
-            Assert.True(entry.HasRelationshipSnapshot);
-
-            Assert.Equal("Palmer", entry.GetOriginalValue(entry.EntityType.FindProperty("Name")));
-
-            entity.Name = "Luckey";
-
-            Assert.Equal("Palmer", entry.GetOriginalValue(entry.EntityType.FindProperty("Name")));
-        }
-
-        [Fact]
-        public void Snapshots_are_not_created_for_full_notification_entities()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(BuildModel());
             entry.SetEntityState(EntityState.Unchanged);
 
-            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
+            Assert.True(entry.HasOriginalValuesSnapshot);
             Assert.True(entry.HasRelationshipSnapshot);
         }
 
-        [Fact]
-        public void Relationship_snapshot_is_created_when_entity_has_non_notifying_collection_instance()
+        [Theory]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotifications)]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)]
+        public void Original_and_relationship_values_not_recorded_when_full_notifications(
+            ChangeTrackingStrategy changeTrackingStrategy)
         {
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                new FullNotificationEntity { Name = "Palmer", Id = 1, RelatedCollection = new List<ChangedOnlyNotificationEntity>() });
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(changeTrackingStrategy));
 
-            Assert.True(entry.HasRelationshipSnapshot);
+            entry.SetEntityState(EntityState.Unchanged);
+
+            Assert.False(entry.HasOriginalValuesSnapshot);
+            Assert.False(entry.HasRelationshipSnapshot);
         }
 
         [Fact]
-        public void Relationship_snapshot_is_not_created_when_entity_has_notifying_collection()
+        public void Notifying_collections_are_not_created_when_snapshot_tracking()
         {
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                new FullNotificationEntity { Id = -1, Name = "Palmer", RelatedCollection = new ObservableCollection<ChangedOnlyNotificationEntity>() });
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(ChangeTrackingStrategy.Snapshot));
 
-            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
-            Assert.True(entry.HasRelationshipSnapshot);
+            entry.SetEntityState(EntityState.Unchanged);
+
+            Assert.Null(((FullNotificationEntity)entry.Entity).RelatedCollection);
+        }
+
+        [Theory]
+        [InlineData(ChangeTrackingStrategy.ChangedNotifications)]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotifications)]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)]
+        public void Notifying_collections_are_created_when_notification_tracking(
+            ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(changeTrackingStrategy));
+
+            entry.SetEntityState(EntityState.Unchanged);
+
+            Assert.IsType<ObservableCollectionWithClear<ChangedOnlyNotificationEntity>>(
+                ((FullNotificationEntity)entry.Entity).RelatedCollection);
+        }
+
+        [Fact]
+        public void Non_notifying_collection_acceptable_when_snapshot_tracking()
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(ChangeTrackingStrategy.Snapshot));
+
+            var collection = new List<ChangedOnlyNotificationEntity>();
+            ((FullNotificationEntity)entry.Entity).RelatedCollection = collection;
+
+            entry.SetEntityState(EntityState.Unchanged);
+
+            Assert.Same(collection, ((FullNotificationEntity)entry.Entity).RelatedCollection);
+        }
+
+        [Theory]
+        [InlineData(ChangeTrackingStrategy.ChangedNotifications)]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotifications)]
+        [InlineData(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)]
+        public void Non_notifying_collections_not_acceotable_when_noitification_tracking(
+            ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            var entry = TestHelpers.Instance.CreateInternalEntry<FullNotificationEntity>(
+                BuildModel(changeTrackingStrategy));
+
+            ((FullNotificationEntity)entry.Entity).RelatedCollection = new List<ChangedOnlyNotificationEntity>();
+
+            Assert.Equal(
+                CoreStrings.NonNotifyingCollection("RelatedCollection", "FullNotificationEntity", changeTrackingStrategy),
+                Assert.Throws<InvalidOperationException>(
+                    () => entry.SetEntityState(EntityState.Unchanged)).Message);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Entry_subscribes_to_INotifyCollectionChanged_for_Add(bool ourCollection)
+        {
+            var collection = CreateCollection(ourCollection);
+            var testListener = SetupTestCollectionListener(collection);
+
+            var item = new ChangedOnlyNotificationEntity();
+            collection.Add(item);
+
+            Assert.Equal("RelatedCollection", testListener.CollectionChanged.Single().Item1.Name);
+            Assert.Same(item, testListener.CollectionChanged.Single().Item2.Single());
+            Assert.Empty(testListener.CollectionChanged.Single().Item3);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Entry_subscribes_to_INotifyCollectionChanged_for_Remove(bool ourCollection)
+        {
+            var item = new ChangedOnlyNotificationEntity();
+            var collection = CreateCollection(ourCollection, item);
+            var testListener = SetupTestCollectionListener(collection);
+
+            collection.Remove(item);
+
+            Assert.Equal("RelatedCollection", testListener.CollectionChanged.Single().Item1.Name);
+            Assert.Empty(testListener.CollectionChanged.Single().Item2);
+            Assert.Same(item, testListener.CollectionChanged.Single().Item3.Single());
+        }
+
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Entry_subscribes_to_INotifyCollectionChanged_for_Replace(bool ourCollection)
+        {
+            var item1 = new ChangedOnlyNotificationEntity();
+            var collection = CreateCollection(ourCollection, item1);
+            var testListener = SetupTestCollectionListener(collection);
+
+            var item2 = new ChangedOnlyNotificationEntity();
+            if (ourCollection)
+            {
+                ((ObservableCollectionWithClear<ChangedOnlyNotificationEntity>)collection)[0] = item2;
+            }
+            else
+            {
+                ((ObservableCollection<ChangedOnlyNotificationEntity>)collection)[0] = item2;
+            }
+
+            Assert.Equal("RelatedCollection", testListener.CollectionChanged.Single().Item1.Name);
+            Assert.Same(item2, testListener.CollectionChanged.Single().Item2.Single());
+            Assert.Same(item1, testListener.CollectionChanged.Single().Item3.Single());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Entry_ignores_INotifyCollectionChanged_for_Move(bool ourCollection)
+        {
+            var item1 = new ChangedOnlyNotificationEntity();
+            var item2 = new ChangedOnlyNotificationEntity();
+            var collection = CreateCollection(ourCollection, item1, item2);
+            var testListener = SetupTestCollectionListener(collection);
+
+            if (ourCollection)
+            {
+                ((ObservableCollectionWithClear<ChangedOnlyNotificationEntity>)collection).Move(0, 1);
+            }
+            else
+            {
+                ((ObservableCollection<ChangedOnlyNotificationEntity>)collection).Move(0, 1);
+            }
+
+            Assert.Empty(testListener.CollectionChanged);
+        }
+
+        [Fact]
+        public void Entry_throws_for_INotifyCollectionChanged_Reset()
+        {
+            var item1 = new ChangedOnlyNotificationEntity();
+            var item2 = new ChangedOnlyNotificationEntity();
+            var collection = new ObservableCollection<ChangedOnlyNotificationEntity> { item1, item2 };
+            var testListener = SetupTestCollectionListener(collection);
+
+            Assert.Equal(
+                CoreStrings.ResetNotSupported,
+                Assert.Throws<InvalidOperationException>(() => collection.Clear()).Message);
+
+            Assert.Empty(testListener.CollectionChanged);
+        }
+
+        [Fact]
+        public void Entry_handles_clear_as_replace_with_ObservableCollectionWithClear()
+        {
+            var item1 = new ChangedOnlyNotificationEntity();
+            var item2 = new ChangedOnlyNotificationEntity();
+            var collection = new ObservableCollectionWithClear<ChangedOnlyNotificationEntity> { item1, item2 };
+            var testListener = SetupTestCollectionListener(collection);
+
+            collection.Clear();
+
+            Assert.Empty(collection);
+
+            Assert.Equal("RelatedCollection", testListener.CollectionChanged.Single().Item1.Name);
+            Assert.Empty(testListener.CollectionChanged.Single().Item2);
+            Assert.Same(item1, testListener.CollectionChanged.Single().Item3.First());
+            Assert.Same(item2, testListener.CollectionChanged.Single().Item3.Skip(1).Single());
+        }
+
+        private static ICollection<ChangedOnlyNotificationEntity> CreateCollection(
+            bool ourCollection, params ChangedOnlyNotificationEntity[] items)
+            => ourCollection
+            ? (ICollection<ChangedOnlyNotificationEntity>)new ObservableCollectionWithClear<ChangedOnlyNotificationEntity>(items)
+            : new ObservableCollection<ChangedOnlyNotificationEntity>(items);
+
+        private static TestNavigationListener SetupTestCollectionListener(
+            ICollection<ChangedOnlyNotificationEntity> collection)
+        {
+            var contextServices = TestHelpers.Instance.CreateContextServices(
+                new ServiceCollection().AddScoped<INavigationListener, TestNavigationListener>(),
+                BuildModel());
+
+            var testListener = contextServices
+                .GetRequiredService<IEnumerable<INavigationListener>>()
+                .OfType<TestNavigationListener>()
+                .Single();
+
+            var entity = new FullNotificationEntity { RelatedCollection = collection };
+            var entry = contextServices.GetRequiredService<IStateManager>().GetOrCreateEntry(entity);
+            entry.SetEntityState(EntityState.Unchanged);
+
+            return testListener;
         }
 
         [Fact]
@@ -110,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entity.NotifyChanging(null);
 
             Assert.Equal(
-                new[] { "Name", "RelatedCollection" }, 
+                new[] { "Name", "RelatedCollection" },
                 testListener.Changing.Select(e => e.Name).OrderBy(e => e).ToArray());
 
             Assert.Empty(testListener.Changed);
@@ -171,14 +350,30 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             public List<IPropertyBase> Changing { get; } = new List<IPropertyBase>();
             public List<IPropertyBase> Changed { get; } = new List<IPropertyBase>();
 
-            public void PropertyChanged(InternalEntityEntry entry, IPropertyBase property, bool setModified) 
+            public void PropertyChanged(InternalEntityEntry entry, IPropertyBase property, bool setModified)
                 => Changed.Add(property);
 
-            public void PropertyChanging(InternalEntityEntry entry, IPropertyBase property) 
+            public void PropertyChanging(InternalEntityEntry entry, IPropertyBase property)
                 => Changing.Add(property);
         }
 
-        private static IModel BuildModel()
+        private class TestNavigationListener : INavigationListener
+        {
+            public List<Tuple<INavigation, IEnumerable<object>, IEnumerable<object>>> CollectionChanged { get; }
+                = new List<Tuple<INavigation, IEnumerable<object>, IEnumerable<object>>>();
+
+            public void NavigationReferenceChanged(
+                InternalEntityEntry entry, INavigation navigation, object oldValue, object newValue)
+            {
+            }
+
+            public void NavigationCollectionChanged(
+                InternalEntityEntry entry, INavigation navigation, IEnumerable<object> added, IEnumerable<object> removed) 
+                => CollectionChanged.Add(Tuple.Create(navigation, added, removed));
+        }
+
+        private static IModel BuildModel(
+            ChangeTrackingStrategy changeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications)
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
@@ -186,6 +381,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 {
                     b.Ignore(e => e.NotMapped);
                     b.HasMany(e => e.RelatedCollection).WithOne(e => e.Related).HasForeignKey(e => e.Fk);
+                    b.HasChangeTrackingStrategy(changeTrackingStrategy);
                 });
 
             return builder.Model;
@@ -287,5 +483,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             private void NotifyChanged(string propertyName)
                 => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-    }
+
+}
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -76,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = BuildModel();
             var entityType = model.FindEntityType(typeof(ChangedOnlyEntity).FullName);
-            entityType.UseEagerSnapshots = true;
+            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.Snapshot;
 
             AllOriginalValuesTest(model, entityType, new ChangedOnlyEntity { Id = 1, Name = "Kool" });
         }
@@ -125,12 +126,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entityType3.GetOrSetPrimaryKey(property6);
             var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
             property7.IsConcurrencyToken = true;
+            entityType3.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
             var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
             entityType4.GetOrSetPrimaryKey(property8);
             var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
             property9.IsConcurrencyToken = true;
+            entityType4.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.HasBaseType(someSimpleEntityType);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -33,7 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
-            simpleKeyProperty.IsConcurrencyToken = true; // So we get original values for it
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase).FullName);
             var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
@@ -57,11 +57,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entityType3.GetOrSetPrimaryKey(entityType3.AddProperty("Id", typeof(int)));
             var property6 = entityType3.AddProperty("Name", typeof(string));
             property6.IsConcurrencyToken = true;
+            entityType3.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
             entityType4.GetOrSetPrimaryKey(entityType4.AddProperty("Id", typeof(int)));
             var property8 = entityType4.AddProperty("Name", typeof(string));
             property8.IsConcurrencyToken = true;
+            entityType4.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity).FullName);
             entityType5.HasBaseType(someSimpleEntityType);

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -213,26 +213,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
         }
 
-        [Fact]
-        public void Entry_methods_delegate_to_underlying_state_manager()
-        {
-            var entity = new Random();
-            var stateManagerMock = new Mock<IStateManager>();
-            var entry = CreateInternalEntryMock().Object;
-            stateManagerMock.Setup(m => m.GetOrCreateEntry(entity)).Returns(entry);
-
-            var services = new ServiceCollection()
-                .AddScoped(_ => stateManagerMock.Object);
-
-            var serviceProvider = TestHelpers.Instance.CreateServiceProvider(services);
-
-            using (var context = new EarlyLearningCenter(serviceProvider))
-            {
-                Assert.Same(entry, context.Entry(entity).GetInfrastructure());
-                Assert.Same(entry, context.Entry((object)entity).GetInfrastructure());
-            }
-        }
-
         private class FakeStateManager : IStateManager
         {
             public IEnumerable<InternalEntityEntry> InternalEntries { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/CollectionTypeFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/CollectionTypeFactoryTest.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
@@ -16,11 +19,18 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var factory = new CollectionTypeFactory();
 
-            Assert.Same(typeof(CustomHashSet), factory.TryFindTypeToInstantiate(typeof(CustomHashSet)));
-            Assert.Same(typeof(CustomList), factory.TryFindTypeToInstantiate(typeof(CustomList)));
-            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(HashSet<Random>)));
-            Assert.Same(typeof(List<Random>), factory.TryFindTypeToInstantiate(typeof(List<Random>)));
-            Assert.Same(typeof(ObservableCollection<Random>), factory.TryFindTypeToInstantiate(typeof(ObservableCollection<Random>)));
+            Assert.Same(typeof(CustomHashSet), factory.TryFindTypeToInstantiate(typeof(object), typeof(CustomHashSet)));
+            Assert.Same(typeof(CustomList), factory.TryFindTypeToInstantiate(typeof(object), typeof(CustomList)));
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(HashSet<Random>)));
+            Assert.Same(typeof(List<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(List<Random>)));
+            Assert.Same(typeof(ObservableCollection<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(ObservableCollection<Random>)));
+            Assert.Same(typeof(ObservableCollectionWithClear<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(ObservableCollectionWithClear<Random>)));
+        }
+
+        [Fact]
+        public void Returns_ObservableCollectionWithClear_if_notifying_and_assignable()
+        {
+            Assert.Same(typeof(ObservableCollectionWithClear<Random>), new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(DummyNotifying), typeof(ICollection<Random>)));
         }
 
         [Fact]
@@ -28,15 +38,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var factory = new CollectionTypeFactory();
 
-            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ICollection<Random>)));
-
-            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ISet<Random>)));
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(ICollection<Random>)));
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(object), typeof(ISet<Random>)));
         }
 
         [Fact]
         public void Returns_List_if_assignable()
         {
-            Assert.Same(typeof(List<Random>), new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(IList<Random>)));
+            Assert.Same(typeof(List<Random>), new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(object), typeof(IList<Random>)));
         }
 
         [Fact]
@@ -44,14 +53,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var factory = new CollectionTypeFactory();
 
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(PrivateConstructor)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(InternalConstructor)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(ProtectedConstructor)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(NoParameterlessConstructor)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Abstract)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Random)));
-            Assert.Null(factory.TryFindTypeToInstantiate(typeof(IEnumerable<Random>)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(PrivateConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(InternalConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(ProtectedConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(NoParameterlessConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(Abstract)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(object)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(Random)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object), typeof(IEnumerable<Random>)));
         }
 
         private class CustomHashSet : HashSet<Random>
@@ -93,6 +102,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private abstract class Abstract : List<Random>
         {
+        }
+
+        private class DummyNotifying : INotifyPropertyChanged
+        {
+#pragma warning disable 67
+            public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore 67
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
@@ -23,6 +23,23 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
+        public void Snapshot_change_tracking_is_used_by_default()
+        {
+            Assert.Equal(ChangeTrackingStrategy.Snapshot, new Model().ChangeTrackingStrategy);
+            Assert.Equal(ChangeTrackingStrategy.Snapshot, new Model().GetChangeTrackingStrategy());
+        }
+
+        [Fact]
+        public void Change_tracking_strategy_can_be_changed()
+        {
+            var model = new Model { ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications };
+            Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, model.ChangeTrackingStrategy);
+
+            model.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
+            Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, model.GetChangeTrackingStrategy());
+        }
+
+        [Fact]
         public void Can_add_and_remove_entity_by_type()
         {
             var model = new Model();

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tests.Metadata
@@ -136,81 +134,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
             }
 
             return model;
-        }
-
-        [Fact]
-        public void IsNonNotifyingCollection_returns_false_for_reference_avigations()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry<Dependent>(BuildCollectionsModel());
-
-            Assert.False(entry.EntityType.FindNavigation("Principal1").IsNonNotifyingCollection(entry));
-        }
-
-        [Fact]
-        public void IsNonNotifyingCollection_returns_false_for_collections_typed_for_notifications()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry<Principal>(BuildCollectionsModel());
-
-            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
-            Assert.True(entry.EntityType.FindNavigation("Dependents2").IsNonNotifyingCollection(entry));
-        }
-
-        [Fact]
-        public void IsNonNotifyingCollection_returns_false_for_null_collections()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry<Principal>(BuildCollectionsModel());
-
-            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
-            Assert.True(entry.EntityType.FindNavigation("Dependents1").IsNonNotifyingCollection(entry));
-        }
-
-        [Fact]
-        public void IsNonNotifyingCollection_returns_false_for_notifying_instances()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildCollectionsModel(),
-                EntityState.Detached,
-                new Principal { Dependents1 = new ObservableCollection<Dependent>() });
-
-            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
-            Assert.True(entry.EntityType.FindNavigation("Dependents1").IsNonNotifyingCollection(entry));
-        }
-
-        [Fact]
-        public void IsNonNotifyingCollection_returns_true_for_non_notifying_instances()
-        {
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildCollectionsModel(),
-                EntityState.Detached,
-                new Principal { Dependents1 = new List<Dependent>() });
-
-            Assert.True(entry.EntityType.FindNavigation("Dependents1").IsNonNotifyingCollection(entry));
-        }
-
-        private static IModel BuildCollectionsModel()
-        {
-            var builder = TestHelpers.Instance.CreateConventionBuilder();
-
-            builder.Entity<Principal>().HasMany(e => e.Dependents1).WithOne(e => e.Principal1);
-            builder.Entity<Principal>().HasMany(e => e.Dependents2).WithOne(e => e.Principal2);
-
-            return builder.Model;
-        }
-
-        private class Principal
-        {
-            public int Id { get; set; }
-
-            public ICollection<Dependent> Dependents1 { get; set; }
-            public ObservableCollection<Dependent> Dependents2 { get; set; }
-        }
-
-        private class Dependent
-        {
-            public int Id { get; set; }
-
-            public Principal Principal1 { get; set; }
-            public Principal Principal2 { get; set; }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -179,6 +179,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
                 => new GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(collection));
+
+            public override TestEntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
+                => Wrap(EntityTypeBuilder.HasChangeTrackingStrategy(changeTrackingStrategy));
         }
 
         protected class GenericTestPropertyBuilder<TProperty> : TestPropertyBuilder<TProperty>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -131,6 +131,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(typeof(TRelatedEntity), collection?.GetPropertyAccess().Name));
+
+            public override TestEntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
+                => Wrap(EntityTypeBuilder.HasChangeTrackingStrategy(changeTrackingStrategy));
         }
 
         protected class NonGenericTestPropertyBuilder<TProperty> : TestPropertyBuilder<TProperty>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -166,6 +166,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public abstract TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
                 where TRelatedEntity : class;
+
+            public abstract TestEntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy);
         }
 
         public class TestKeyBuilder

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -511,6 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                         b.Property<string>("Strange").IsConcurrencyToken(false);
                         b.Property<int>("Top").IsConcurrencyToken();
                         b.Property<string>("Bottom").IsConcurrencyToken(false);
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
                     });
 
                 var entityType = (IEntityType)model.FindEntityType(typeof(Quarks));


### PR DESCRIPTION
Issue #5075
Issue #445
Also, updates options for PR #5118

Use of INotifyProperyChanged and INotifyPropertyChanging is now opt-in. If you opt-in, then you must also start using INotifyCollectionChanged on your collection nav props, which is now implemented. We check these things in various places, including model validation and when we start tracking entities to try to make sure that you won't think that change tracking is happening when it isn't.

Doing a Clear on ObservableCollection does not work because the event does not tell us which items were removed. This has always been a problem for EF. An implementation of ObservableCollection where Clear does work is provided, and is used by default when we initialize collections on notification entities.

/cc @rowanmiller for API changes and exception messages