### PR TITLE
Fix for NullRef when adding graph with shadow keys

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 for (var i = 0; i < x.Length; i++)
                 {
-                    if (!x[i].Equals(y[i]))
+                    if (!Equals(x[i], y[i]))
                     {
                         return false;
                     }


### PR DESCRIPTION
Issue #4854

Switch to using Equals(x, y) instead of x.Equals(y).