### PR TITLE
Update identity map after SaveChanges fails

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -728,6 +728,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        protected class Darwin
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
         protected class Gumball
         {
             public int Id { get; set; }
@@ -758,6 +764,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
 
             public DbSet<Gumball> Gumballs { get; set; }
+            public DbSet<Darwin> Darwins { get; set; }
         }
 
         protected StoreGeneratedContext CreateContext()

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StoreGeneratedValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StoreGeneratedValues.cs
@@ -69,8 +69,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             public bool CanStoreValue(IPropertyBase propertyBase)
-                => (_values != null)
-                   && (propertyBase.GetStoreGeneratedIndex() != -1);
+                => _values != null
+                   && propertyBase.GetStoreGeneratedIndex() != -1;
 
             public void SetValue(IPropertyBase propertyBase, object value)
             {


### PR DESCRIPTION
Issue #448

Store-generated values are discarded, but the identity maps from key value to entry were not being updated. The fix is to send a changed notification for any property that had been assigned a store generated value.