### PR TITLE
[TINY] Increase work in fixup query tests

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark]
+        [Benchmark(Iterations = 1)]
         public void QueryChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -115,13 +115,13 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.EF6.ChangeTracker
                 var orders = context.Orders.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
+                Assert.Equal(5000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(10000, context.ChangeTracker.Entries<Order>().Count());
                 Assert.All(orders, o => Assert.NotNull(o.Customer));
             }
         }
 
-        [Benchmark]
+        [Benchmark(Iterations = 1)]
         public void QueryParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -132,8 +132,8 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.EF6.ChangeTracker
                 var customers = context.Customers.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
+                Assert.Equal(5000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(10000, context.ChangeTracker.Entries<Order>().Count());
                 Assert.All(customers, c => Assert.Equal(1, c.Orders.Count));
             }
         }
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.EF6.ChangeTracker
         public class FixupFixture : OrdersFixture
         {
             public FixupFixture()
-                : base("Perf_ChangeTracker_Fixup_EF6", 0, 1000, 1, 0)
+                : base("Perf_ChangeTracker_Fixup_EF6", 0, 5000, 2, 0)
             {
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/ChangeTracker/FixupTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/ChangeTracker/FixupTests.cs
@@ -138,8 +138,8 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.ChangeTracker
                 var orders = context.Orders.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
+                Assert.Equal(5000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(10000, context.ChangeTracker.Entries<Order>().Count());
                 Assert.All(orders, o => Assert.NotNull(o.Customer));
             }
         }
@@ -155,16 +155,16 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.ChangeTracker
                 var customers = context.Customers.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
-                Assert.All(customers, c => Assert.Equal(1, c.Orders.Count));
+                Assert.Equal(5000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(10000, context.ChangeTracker.Entries<Order>().Count());
+                Assert.All(customers, c => Assert.Equal(2, c.Orders.Count));
             }
         }
 
         public class FixupFixture : OrdersFixture
         {
             public FixupFixture()
-                : base("Perf_ChangeTracker_Fixup", 0, 1000, 1, 0)
+                : base("Perf_ChangeTracker_Fixup", 0, 5000, 2, 0)
             {
             }
         }


### PR DESCRIPTION
We recently updated the other fixup tests to work on 5,000 customers &
10,000 orders. Upping the tests that fixup with a query to work on the
same entity counts.