### PR TITLE
Cleanup .NET Native workarounds

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
@@ -10,12 +11,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public abstract class ClrAccessorFactory<TAccessor>
         where TAccessor : class
     {
+        private static readonly MethodInfo _genericCreate
+             = typeof(ClrAccessorFactory<TAccessor>).GetTypeInfo().GetDeclaredMethods(nameof(CreateGeneric)).Single();
+
         public virtual TAccessor Create([NotNull] IPropertyBase property)
             => property as TAccessor ?? Create(property.DeclaringEntityType.ClrType.GetAnyProperty(property.Name));
 
-        // TODO revisit when .NET Native supports ImpliesMethodInstantiation
-        // original version used generics, which is much cleaner and performant but fails after ILC strips reflection info
-        // https://github.com/aspnet/EntityFramework/issues/3477
-        public abstract TAccessor Create([NotNull] PropertyInfo property);
+        public virtual TAccessor Create([NotNull] PropertyInfo property)
+        {
+            var boundMethod = _genericCreate.MakeGenericMethod(
+                property.DeclaringType,
+                property.PropertyType,
+                property.PropertyType.UnwrapNullableType());
+
+            try
+            {
+                return (TAccessor)boundMethod.Invoke(this, new object[] { property });
+            }
+            catch (TargetInvocationException e) when (e.InnerException != null)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        protected abstract TAccessor CreateGeneric<TEntity, TValue, TNonNullableEnumValue>([NotNull] PropertyInfo property)
+            where TEntity : class;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertyGetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertyGetterFactory.cs
@@ -8,12 +8,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public class ClrPropertyGetterFactory : ClrAccessorFactory<IClrPropertyGetter>
     {
-        public override IClrPropertyGetter Create(PropertyInfo property)
-        {
-            var types = new[] { property.DeclaringType, property.PropertyType };
-            var getterType = typeof(ClrPropertyGetter<,>).MakeGenericType(types);
-            var funcType = typeof(Func<,>).MakeGenericType(types);
-            return (IClrPropertyGetter)Activator.CreateInstance(getterType, property.GetMethod.CreateDelegate(funcType));
-        }
+        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(PropertyInfo property)
+            => new ClrPropertyGetter<TEntity, TValue>(
+                 (Func<TEntity, TValue>)property.GetMethod.CreateDelegate(typeof(Func<TEntity, TValue>)));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -4,20 +4,15 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public class ClrPropertySetterFactory : ClrAccessorFactory<IClrPropertySetter>
     {
-        public override IClrPropertySetter Create(PropertyInfo property)
+        protected override IClrPropertySetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>([NotNull] PropertyInfo property)
         {
-            var types = new[] { property.DeclaringType, property.PropertyType };
-
-            var type = property.PropertyType.IsNullableType() && property.PropertyType.UnwrapNullableType().GetTypeInfo().IsEnum
-                ? typeof(NullableEnumClrPropertySetter<,,>).MakeGenericType(property.DeclaringType, property.PropertyType, property.PropertyType.UnwrapNullableType())
-                : typeof(ClrPropertySetter<,>).MakeGenericType(types);
-
             var setterProperty = property;
             while (setterProperty.SetMethod == null)
             {
@@ -35,7 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            return (IClrPropertySetter)Activator.CreateInstance(type, setterProperty.SetMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(types)));
+            var setter = (Action<TEntity, TValue>)setterProperty.SetMethod.CreateDelegate(typeof(Action<TEntity, TValue>));
+
+            return property.PropertyType.IsNullableType() && property.PropertyType.UnwrapNullableType().GetTypeInfo().IsEnum
+                ? new NullableEnumClrPropertySetter<TEntity, TValue, TNonNullableEnumValue>(setter)
+                : (IClrPropertySetter)new ClrPropertySetter<TEntity, TValue>(setter);
         }
     }
 }


### PR DESCRIPTION
 Some changes were added in 3b693c7ee789f117c3e1a7f5f2cde8aeb298393c and c35ce4d3632331d14ff8a3ab8ac59c54a660a535 for .NET Native that are no longer necessary.

Fix #3477