### PR TITLE
Query: Fix #5179: Select Where Navigation returns wrong results on re…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
@@ -30,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         protected virtual IKey Key { get; }
         protected virtual Func<ValueBuffer, object> Materializer { get; }
         protected virtual bool AllowNullResult { get; private set; }
-        protected virtual int ValueBufferOffset { get; private set; }
+
+        public virtual int ValueBufferOffset { get; private set; }
 
         public abstract IShaper<TDerived> Cast<TDerived>() where TDerived : class;
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -2919,6 +2919,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task GroupJoin_simple3()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                select new { o.OrderID });
+        }
+
+        [ConditionalFact]
         public virtual async Task GroupJoin_projection()
         {
             await AssertQuery<Customer, Order>((cs, os) =>

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4331,6 +4331,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 from o in orders
                 select c);
         }
+        
+        [ConditionalFact]
+        public virtual void GroupJoin_simple3()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                select new { o.OrderID });
+        }
 
         [ConditionalFact]
         public virtual void GroupJoin_simple_ordering()
@@ -5355,10 +5365,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             bool assertOrder = false,
             int entryCount = 0,
             Action<IList<object>, IList<object>> asserter = null)
-            where TItem : class
-        {
-            AssertQuery(query, query, assertOrder, entryCount, asserter);
-        }
+            where TItem : class 
+                => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem>(
             Func<IQueryable<TItem>, object> query,

--- a/src/Microsoft.EntityFrameworkCore/Storage/ValueBuffer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/ValueBuffer.cs
@@ -89,5 +89,28 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         public bool IsEmpty => _values == null;
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            return obj is ValueBuffer
+                   && Equals((ValueBuffer)obj);
+        }
+
+        private bool Equals(ValueBuffer other)
+            => Equals(_values, other._values)
+               && _offset == other._offset;
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((_values?.GetHashCode() ?? 0) * 397) ^ _offset;
+            }
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2836,6 +2836,30 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
+        public override void GroupJoin_tracking_groups()
+        {
+            base.GroupJoin_tracking_groups();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+        
+        public override void GroupJoin_simple3()
+        {
+            base.GroupJoin_simple3();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
         public override void SelectMany_Joined_DefaultIfEmpty()
         {
             base.SelectMany_Joined_DefaultIfEmpty();


### PR DESCRIPTION
…lational providers

Fixed streaming relational GroupJoin operator to correctly re-group on outer element change.

Also fixed some places where we were failing to flow cancellation tokens.