### PR TITLE
Improve navigation building perf

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
@@ -141,8 +141,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         p => targetPrincipalEntityType.FindProperty(p.Name)).ToList()),
                     targetPrincipalEntityType);
                 var clonedNavigation = navigation.IsDependentToPrincipal()
-                    ? targetForeignKey.HasDependentToPrincipal(navigation.Name)
-                    : targetForeignKey.HasPrincipalToDependent(navigation.Name);
+                    ? (navigation.GetPropertyInfo() != null
+                        ? targetForeignKey.HasDependentToPrincipal(navigation.GetPropertyInfo())
+                        : targetForeignKey.HasDependentToPrincipal(navigation.Name))
+                    : (navigation.GetPropertyInfo() != null
+                        ? targetForeignKey.HasPrincipalToDependent(navigation.GetPropertyInfo())
+                        : targetForeignKey.HasPrincipalToDependent(navigation.Name));
                 navigation.GetAnnotations().ForEach(annotation => clonedNavigation[annotation.Name] = annotation.Value);
             }
         }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -53,23 +54,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures this as a one-to-many relationship.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationName">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder WithOne([CanBeNull] string reference = null)
-            => new ReferenceCollectionBuilder(WithOneBuilder(Check.NullButNotEmpty(reference, nameof(reference))));
+        public virtual ReferenceCollectionBuilder WithOne([CanBeNull] string navigationName = null)
+            => new ReferenceCollectionBuilder(WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
 
         /// <summary>
         ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationName">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> The internal builder to further configure the relationship. </returns>
-        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string reference)
-            => Builder.DependentToPrincipal(reference, ConfigurationSource.Explicit);
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string navigationName)
+            => Builder.DependentToPrincipal(navigationName, ConfigurationSource.Explicit);
+
+        /// <summary>
+        ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
+        /// </summary>
+        /// <param name="navigationProperty">
+        ///     The reference navigation property on the other end of this relationship.
+        ///     If null, there is no navigation property on the other end of the relationship.
+        /// </param>
+        /// <returns> The internal builder to further configure the relationship. </returns>
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] PropertyInfo navigationProperty)
+            => Builder.DependentToPrincipal(navigationProperty, ConfigurationSource.Explicit);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -45,25 +45,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures this as a one-to-many relationship.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on the other end of this
         ///     relationship (<c>post => post.Blog</c>). If no property is specified, the relationship will be
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
-            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference?.GetPropertyAccess().Name));
+        public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
+            [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression)
+            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
+                WithOneBuilder(navigationExpression?.GetPropertyAccess()));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationName">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string reference = null)
+        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(Check.NullButNotEmpty(reference, nameof(reference))));
+                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -99,11 +99,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the primary key. </returns>
         public virtual KeyBuilder HasKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
-        {
-            Check.NotNull(keyExpression, nameof(keyExpression));
-
-            return new KeyBuilder(Builder.PrimaryKey(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
-        }
+            => new KeyBuilder(Builder.PrimaryKey(
+                Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Creates a new unique constraint for this entity type if one does not already exist over the specified
@@ -120,11 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the unique constraint. </returns>
         public virtual KeyBuilder HasAlternateKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
-        {
-            Check.NotNull(keyExpression, nameof(keyExpression));
-
-            return new KeyBuilder(Builder.HasKey(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
-        }
+            => new KeyBuilder(Builder.HasKey(
+                Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Returns an object that can be used to configure a property of the entity type.
@@ -136,12 +130,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
-        {
-            Check.NotNull(propertyExpression, nameof(propertyExpression));
-
-            var propertyInfo = propertyExpression.GetPropertyAccess();
-            return new PropertyBuilder<TProperty>(Builder.Property(propertyInfo, ConfigurationSource.Explicit));
-        }
+            => new PropertyBuilder<TProperty>(Builder.Property(
+                Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -191,11 +181,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the index. </returns>
         public virtual IndexBuilder HasIndex([NotNull] Expression<Func<TEntity, object>> indexExpression)
-        {
-            Check.NotNull(indexExpression, nameof(indexExpression));
-
-            return new IndexBuilder(Builder.HasIndex(indexExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
-        }
+            => new IndexBuilder(Builder.HasIndex(
+                Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     <para>
@@ -214,24 +201,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </summary>
         /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-        /// <param name="reference">
+        /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>post => post.Blog</c>). If no property is specified, the relationship will be
         ///     configured without a navigation property on this end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> reference = null)
+            [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
             where TRelatedEntity : class
         {
             var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
-            var navigationName = reference?.GetPropertyAccess().Name;
+            var navigation = navigationExpression?.GetPropertyAccess();
 
             return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                 Builder.Metadata,
                 relatedEntityType,
-                navigationName,
-                ReferenceBuilder(relatedEntityType, navigationName));
+                navigation?.Name,
+                HasOneBuilder(relatedEntityType, navigation));
         }
 
         /// <summary>
@@ -248,22 +235,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </summary>
         /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-        /// <param name="collection">
+        /// <param name="navigationExpression">
         ///     A lambda expression representing the collection navigation property on this entity type that represents
         ///     the relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
         ///     configured without a navigation property on this end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
             where TRelatedEntity : class
-        {
-            var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
-            var navigationName = collection?.GetPropertyAccess().Name;
-
-            return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(
-                CollectionBuilder(relatedEntityType, navigationName));
-        }
+            => new CollectionNavigationBuilder<TEntity, TRelatedEntity>(HasManyBuilder(
+                Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata,
+                navigationExpression?.GetPropertyAccess()));
 
         public new virtual EntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy)
             => (EntityTypeBuilder<TEntity>)base.HasChangeTrackingStrategy(changeTrackingStrategy);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -82,8 +82,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 ForeignKey.AreCompatible(
                     foreignKey.PrincipalEntityType,
                     foreignKey.DeclaringEntityType,
-                    foreignKey.DependentToPrincipal?.Name,
-                    foreignKey.PrincipalToDependent?.Name,
+                    foreignKey.DependentToPrincipal?.PropertyInfo,
+                    foreignKey.PrincipalToDependent?.PropertyInfo,
                     _foreignKeyProperties,
                     _principalKeyProperties,
                     foreignKey.IsUnique,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -55,54 +55,56 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures this as a one-to-many relationship.
         /// </summary>
-        /// <param name="collection">
+        /// <param name="navigationExpression">
         ///     A lambda expression representing the collection navigation property on the other end of this
         ///     relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
-            [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection)
-            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(WithManyBuilder(collection?.GetPropertyAccess().Name));
+            [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
+            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
+                WithManyBuilder(navigationExpression?.GetPropertyAccess()));
 
         /// <summary>
         ///     Configures this as a one-to-one relationship.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on the other end of this
         ///     relationship (<c>blog => blog.BlogInfo</c>). If no property is specified, the relationship will be
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
+            [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(reference?.GetPropertyAccess().Name),
+                WithOneBuilder(navigationExpression?.GetPropertyAccess()),
                 DeclaringEntityType,
                 RelatedEntityType);
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
         /// </summary>
-        /// <param name="collection">
+        /// <param name="navigationName">
         ///     The name of the collection navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string collection = null)
+        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string navigationName = null)
             => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
-                WithManyBuilder(Check.NullButNotEmpty(collection, nameof(collection))));
+                WithManyBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
 
         /// <summary>
         ///     Configures this as a one-to-one relationship.
         /// </summary>
-        /// <param name="reference">
+        /// <param name="navigationName">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string reference = null)
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(Check.NullButNotEmpty(reference, nameof(reference))),
+                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))),
                 DeclaringEntityType,
                 RelatedEntityType);
     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -113,16 +113,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(
             [NotNull] Type dependentEntityType,
             [NotNull] params string[] foreignKeyPropertyNames)
-        {
-            Check.NotNull(dependentEntityType, nameof(dependentEntityType));
-            Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetDependentEntityType(dependentEntityType).HasForeignKey(foreignKeyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                SetDependentEntityType(Check.NotNull(dependentEntityType, nameof(dependentEntityType)))
+                    .HasForeignKey(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.ClrType != dependentEntityType,
                 foreignKeySet: true);
-        }
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -139,16 +135,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
             [NotNull] Type principalEntityType,
             [NotNull] params string[] keyPropertyNames)
-        {
-            Check.NotNull(principalEntityType, nameof(principalEntityType));
-            Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetPrincipalEntityType(principalEntityType).HasPrincipalKey(keyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                SetPrincipalEntityType(Check.NotNull(principalEntityType, nameof(principalEntityType)))
+                    .HasPrincipalKey(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames)), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != principalEntityType,
                 principalKeySet: true);
-        }
 
         /// <summary>
         ///     <para>
@@ -179,16 +171,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(
             [NotNull] string dependentEntityTypeName,
             [NotNull] params string[] foreignKeyPropertyNames)
-        {
-            Check.NotEmpty(dependentEntityTypeName, nameof(dependentEntityTypeName));
-            Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetDependentEntityType(dependentEntityTypeName).HasForeignKey(foreignKeyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                SetDependentEntityType(Check.NotEmpty(dependentEntityTypeName, nameof(dependentEntityTypeName)))
+                    .HasForeignKey(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.Name != dependentEntityTypeName,
                 foreignKeySet: true);
-        }
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -206,16 +194,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
             [NotNull] string principalEntityTypeName,
             [NotNull] params string[] keyPropertyNames)
-        {
-            Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName));
-            Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetPrincipalEntityType(principalEntityTypeName).HasPrincipalKey(keyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                SetPrincipalEntityType(Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName)))
+                    .HasPrincipalKey(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames)), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.Name != principalEntityTypeName,
                 principalKeySet: true);
-        }
 
         /// <summary>
         ///     <para>
@@ -249,16 +233,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
-        {
-            Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 SetDependentEntityType(typeof(TDependentEntity))
-                    .HasForeignKey(foreignKeyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit),
+                    .HasForeignKey(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.ClrType != typeof(TDependentEntity),
                 foreignKeySet: true);
-        }
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -282,16 +262,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
             [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
-        {
-            Check.NotNull(keyExpression, nameof(keyExpression));
-
-            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 SetPrincipalEntityType(typeof(TPrincipalEntity))
-                    .HasPrincipalKey(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit),
+                    .HasPrincipalKey(Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != typeof(TPrincipalEntity),
                 principalKeySet: true);
-        }
 
         /// <summary>
         ///     Configures whether this is a required relationship (i.e. whether the foreign key property(s) can

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -257,9 +258,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             foreach (var relationshipCandidate in relationshipCandidates)
             {
-                if (((relationshipCandidate.NavigationProperties.Count > 1)
-                     && (relationshipCandidate.InverseProperties.Count > 0))
-                    || (relationshipCandidate.InverseProperties.Count > 1))
+                Debug.Assert(relationshipCandidate.NavigationProperties.Count > 0);
+                if ((relationshipCandidate.NavigationProperties.Count > 1
+                     && relationshipCandidate.InverseProperties.Count > 0)
+                    || relationshipCandidate.InverseProperties.Count > 1)
                 {
                     foreach (var navigationProperty in relationshipCandidate.NavigationProperties)
                     {
@@ -282,11 +284,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 foreach (var navigation in relationshipCandidate.NavigationProperties)
                 {
                     var inverse = relationshipCandidate.InverseProperties.SingleOrDefault();
-                    entityTypeBuilder.Relationship(
-                        relationshipCandidate.TargetTypeBuilder,
-                        navigation,
-                        inverse,
-                        ConfigurationSource.Convention);
+                    if (inverse == null)
+                    {
+                        entityTypeBuilder.Navigation(
+                            relationshipCandidate.TargetTypeBuilder,
+                            navigation,
+                            ConfigurationSource.Convention);
+                    }
+                    else
+                    {
+                        entityTypeBuilder.Relationship(
+                            relationshipCandidate.TargetTypeBuilder,
+                            navigation,
+                            inverse,
+                            ConfigurationSource.Convention);
+                    }
                 }
             }
         }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableForeignKey.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableForeignKey.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -63,6 +64,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IMutableNavigation HasDependentToPrincipal([CanBeNull] string name);
 
         /// <summary>
+        ///     Sets the navigation property on the dependent entity type that points to the principal entity.
+        /// </summary>
+        /// <param name="property">
+        ///     The navigation property on the dependent type. Passing null will result in there being
+        ///     no navigation property defined.
+        /// </param>
+        /// <returns> The newly created navigation property. </returns>
+        IMutableNavigation HasDependentToPrincipal([CanBeNull] PropertyInfo property);
+
+        /// <summary>
         ///     Sets the navigation property on the principal entity type that points to the dependent entity.
         /// </summary>
         /// <param name="name">
@@ -71,6 +82,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <returns> The newly created navigation property. </returns>
         IMutableNavigation HasPrincipalToDependent([CanBeNull] string name);
+
+        /// <summary>
+        ///     Sets the navigation property on the principal entity type that points to the dependent entity.
+        /// </summary>
+        /// <param name="property">
+        ///     The name of the navigation property on the principal type. Passing null will result in there being
+        ///     no navigation property defined.
+        /// </param>
+        /// <returns> The newly created navigation property. </returns>
+        IMutableNavigation HasPrincipalToDependent([CanBeNull] PropertyInfo property);
 
         /// <summary>
         ///     Gets or sets a value indicating whether the values assigned to the foreign key properties are unique.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
@@ -37,6 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return true;
         }
 
+        public static bool OverridesStrictly(this ConfigurationSource newConfigurationSource, ConfigurationSource? oldConfigurationSource)
+            => newConfigurationSource.Overrides(oldConfigurationSource) && newConfigurationSource != oldConfigurationSource;
+
         [ContractAnnotation("left:notnull => notnull;right:notnull => notnull")]
         public static ConfigurationSource? Max(this ConfigurationSource? left, ConfigurationSource? right)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -12,8 +13,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
-    public class ForeignKey
-        : ConventionalAnnotatable, IMutableForeignKey
+    public class ForeignKey : ConventionalAnnotatable, IMutableForeignKey
     {
         private DeleteBehavior? _deleteBehavior;
         private bool? _isUnique;
@@ -109,53 +109,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             bool runConventions = true)
-        {
-            var oldNavigation = DependentToPrincipal;
-            if (name == oldNavigation?.Name)
-            {
-                UpdateDependentToPrincipalConfigurationSource(configurationSource);
-                return oldNavigation;
-            }
+            => Navigation(PropertyIdentity.Create(name), configurationSource, runConventions, pointsToPrincipal: true);
 
-            if (oldNavigation != null)
-            {
-                Debug.Assert(oldNavigation.Name != null);
-                DeclaringEntityType.RemoveNavigation(oldNavigation.Name);
-            }
-
-            Navigation navigation = null;
-            if (name != null)
-            {
-                navigation = DeclaringEntityType.AddNavigation(name, this, pointsToPrincipal: true);
-            }
-
-            DependentToPrincipal = navigation;
-            UpdateDependentToPrincipalConfigurationSource(configurationSource);
-
-            if (runConventions)
-            {
-                if (oldNavigation != null)
-                {
-                    Debug.Assert(oldNavigation.Name != null);
-                    DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
-                        DeclaringEntityType.Builder,
-                        PrincipalEntityType.Builder,
-                        oldNavigation.Name);
-                }
-
-                if (navigation != null)
-                {
-                    navigation = DeclaringEntityType.Model.ConventionDispatcher.OnNavigationAdded(Builder, navigation)
-                        ?.Metadata.DependentToPrincipal;
-                }
-            }
-
-            return navigation ?? oldNavigation;
-        }
+        public virtual Navigation HasDependentToPrincipal(
+            [CanBeNull] PropertyInfo property,
+            ConfigurationSource configurationSource = ConfigurationSource.Explicit,
+            bool runConventions = true)
+            => Navigation(PropertyIdentity.Create(property), configurationSource, runConventions, pointsToPrincipal: true);
 
         public virtual ConfigurationSource? GetDependentToPrincipalConfigurationSource() => _dependentToPrincipalConfigurationSource;
 
-        private void UpdateDependentToPrincipalConfigurationSource(ConfigurationSource configurationSource)
+        public virtual void UpdateDependentToPrincipalConfigurationSource(ConfigurationSource? configurationSource)
             => _dependentToPrincipalConfigurationSource = configurationSource.Max(_dependentToPrincipalConfigurationSource);
 
         public virtual Navigation PrincipalToDependent { get; private set; }
@@ -165,54 +129,110 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             bool runConventions = true)
+            => Navigation(PropertyIdentity.Create(name), configurationSource, runConventions, pointsToPrincipal: false);
+
+        public virtual Navigation HasPrincipalToDependent(
+            [CanBeNull] PropertyInfo property,
+            ConfigurationSource configurationSource = ConfigurationSource.Explicit,
+            bool runConventions = true)
+            => Navigation(PropertyIdentity.Create(property), configurationSource, runConventions, pointsToPrincipal: false);
+
+        public virtual ConfigurationSource? GetPrincipalToDependentConfigurationSource() => _principalToDependentConfigurationSource;
+
+        public virtual void UpdatePrincipalToDependentConfigurationSource(ConfigurationSource? configurationSource)
+            => _principalToDependentConfigurationSource = configurationSource.Max(_principalToDependentConfigurationSource);
+
+        private Navigation Navigation(
+            PropertyIdentity? propertyIdentity,
+            ConfigurationSource configurationSource,
+            bool runConventions,
+            bool pointsToPrincipal)
         {
-            var oldNavigation = PrincipalToDependent;
+            var name = propertyIdentity?.Name;
+            var oldNavigation = pointsToPrincipal ? DependentToPrincipal : PrincipalToDependent;
             if (name == oldNavigation?.Name)
             {
-                UpdatePrincipalToDependentConfigurationSource(configurationSource);
+                if (pointsToPrincipal)
+                {
+                    UpdateDependentToPrincipalConfigurationSource(configurationSource);
+                }
+                else
+                {
+                    UpdatePrincipalToDependentConfigurationSource(configurationSource);
+                }
                 return oldNavigation;
             }
 
             if (oldNavigation != null)
             {
                 Debug.Assert(oldNavigation.Name != null);
-                PrincipalEntityType.RemoveNavigation(oldNavigation.Name);
+                if (pointsToPrincipal)
+                {
+                    DeclaringEntityType.RemoveNavigation(oldNavigation.Name);
+                }
+                else
+                {
+                    PrincipalEntityType.RemoveNavigation(oldNavigation.Name);
+                }
             }
 
             Navigation navigation = null;
-            if (name != null)
+            var property = propertyIdentity?.Property;
+            if (property != null)
             {
-                navigation = PrincipalEntityType.AddNavigation(name, this, pointsToPrincipal: false);
+                navigation = pointsToPrincipal
+                    ? DeclaringEntityType.AddNavigation(property, this, pointsToPrincipal: true)
+                    : PrincipalEntityType.AddNavigation(property, this, pointsToPrincipal: false);
+            }
+            else if (name != null)
+            {
+                navigation = pointsToPrincipal
+                    ? DeclaringEntityType.AddNavigation(name, this, pointsToPrincipal: true)
+                    : PrincipalEntityType.AddNavigation(name, this, pointsToPrincipal: false);
             }
 
-            PrincipalToDependent = navigation;
-            UpdatePrincipalToDependentConfigurationSource(configurationSource);
+            if (pointsToPrincipal)
+            {
+                DependentToPrincipal = navigation;
+                UpdateDependentToPrincipalConfigurationSource(configurationSource);
+            }
+            else
+            {
+                PrincipalToDependent = navigation;
+                UpdatePrincipalToDependentConfigurationSource(configurationSource);
+            }
 
             if (runConventions)
             {
                 if (oldNavigation != null)
                 {
                     Debug.Assert(oldNavigation.Name != null);
-                    DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
-                        PrincipalEntityType.Builder,
-                        DeclaringEntityType.Builder,
-                        oldNavigation.Name);
+
+                    if (pointsToPrincipal)
+                    {
+                        DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
+                            DeclaringEntityType.Builder,
+                            PrincipalEntityType.Builder,
+                            oldNavigation.Name);
+                    }
+                    else
+                    {
+                        DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
+                            PrincipalEntityType.Builder,
+                            DeclaringEntityType.Builder,
+                            oldNavigation.Name);
+                    }
                 }
 
                 if (navigation != null)
                 {
-                    navigation = DeclaringEntityType.Model.ConventionDispatcher.OnNavigationAdded(Builder, navigation)
-                        ?.Metadata.PrincipalToDependent;
+                    var builder = DeclaringEntityType.Model.ConventionDispatcher.OnNavigationAdded(Builder, navigation);
+                    navigation = pointsToPrincipal ? builder?.Metadata.DependentToPrincipal : builder?.Metadata.PrincipalToDependent;
                 }
             }
 
             return navigation ?? oldNavigation;
         }
-
-        public virtual ConfigurationSource? GetPrincipalToDependentConfigurationSource() => _principalToDependentConfigurationSource;
-
-        private void UpdatePrincipalToDependentConfigurationSource(ConfigurationSource configurationSource)
-            => _principalToDependentConfigurationSource = configurationSource.Max(_principalToDependentConfigurationSource);
 
         public virtual bool IsUnique
         {
@@ -324,10 +344,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         INavigation IForeignKey.DependentToPrincipal => DependentToPrincipal;
         IMutableNavigation IMutableForeignKey.DependentToPrincipal => DependentToPrincipal;
         IMutableNavigation IMutableForeignKey.HasDependentToPrincipal(string name) => HasDependentToPrincipal(name);
+        IMutableNavigation IMutableForeignKey.HasDependentToPrincipal(PropertyInfo property) => HasDependentToPrincipal(property);
 
         INavigation IForeignKey.PrincipalToDependent => PrincipalToDependent;
         IMutableNavigation IMutableForeignKey.PrincipalToDependent => PrincipalToDependent;
         IMutableNavigation IMutableForeignKey.HasPrincipalToDependent(string name) => HasPrincipalToDependent(name);
+        IMutableNavigation IMutableForeignKey.HasPrincipalToDependent(PropertyInfo property) => HasPrincipalToDependent(property);
 
         public override string ToString()
             => $"'{DeclaringEntityType.DisplayName()}' {Property.Format(Properties)} -> '{PrincipalEntityType.DisplayName()}' {Property.Format(PrincipalKey.Properties)}";
@@ -335,8 +357,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static bool AreCompatible(
             [NotNull] EntityType principalEntityType,
             [NotNull] EntityType dependentEntityType,
-            [CanBeNull] string navigationToPrincipalName,
-            [CanBeNull] string navigationToDependentName,
+            [CanBeNull] PropertyInfo navigationToPrincipal,
+            [CanBeNull] PropertyInfo navigationToDependent,
             [CanBeNull] IReadOnlyList<Property> dependentProperties,
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             bool? unique,
@@ -346,36 +368,36 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(principalEntityType, nameof(principalEntityType));
             Check.NotNull(dependentEntityType, nameof(dependentEntityType));
 
-            if (!string.IsNullOrEmpty(navigationToDependentName)
-                && !Navigation.IsCompatible(
-                    navigationToDependentName,
-                    principalEntityType,
-                    dependentEntityType,
-                    !unique,
-                    shouldThrow))
+            if (navigationToPrincipal != null
+                && !Internal.Navigation.IsCompatible(
+                    navigationToPrincipal,
+                    dependentEntityType.ClrType,
+                    principalEntityType.ClrType,
+                    shouldBeCollection: false,
+                    shouldThrow: shouldThrow))
             {
                 return false;
             }
 
-            if (!string.IsNullOrEmpty(navigationToPrincipalName)
-                && !Navigation.IsCompatible(
-                    navigationToPrincipalName,
-                    dependentEntityType,
-                    principalEntityType,
-                    false,
-                    shouldThrow))
+            if (navigationToDependent != null
+                && !Internal.Navigation.IsCompatible(
+                    navigationToDependent,
+                    principalEntityType.ClrType,
+                    dependentEntityType.ClrType,
+                    shouldBeCollection: !unique,
+                    shouldThrow: shouldThrow))
             {
                 return false;
             }
 
-            if ((dependentProperties != null)
+            if (dependentProperties != null
                 && !CanPropertiesBeRequired(dependentProperties, required, dependentEntityType, true))
             {
                 return false;
             }
 
-            if ((principalProperties != null)
-                && (dependentProperties != null)
+            if (principalProperties != null
+                && dependentProperties != null
                 && !AreCompatible(
                     principalProperties,
                     dependentProperties,
@@ -387,16 +409,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return true;
-        }
-
-        public virtual bool IsCompatible([NotNull] EntityType principalType, [NotNull] EntityType dependentType, bool? unique)
-        {
-            Check.NotNull(principalType, nameof(principalType));
-            Check.NotNull(dependentType, nameof(dependentType));
-
-            return ((unique == null) || (IsUnique == unique))
-                   && (PrincipalEntityType == principalType)
-                   && (DeclaringEntityType == dependentType);
         }
 
         public static bool CanPropertiesBeRequired(

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -23,132 +23,212 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         public virtual InternalRelationshipBuilder DependentToPrincipal(
-            [CanBeNull] string navigationToPrincipalName,
+            [CanBeNull] string name,
             ConfigurationSource configurationSource)
-            => Navigation(
-                navigationToPrincipalName,
-                pointsToPrincipal: true,
-                configurationSource: configurationSource,
-                runConventions: true);
+            => Navigations(
+                PropertyIdentity.Create(name),
+                null,
+                configurationSource);
+
+        public virtual InternalRelationshipBuilder DependentToPrincipal(
+            [CanBeNull] PropertyInfo property,
+            ConfigurationSource configurationSource)
+            => Navigations(
+                PropertyIdentity.Create(property),
+                null,
+                configurationSource);
 
         public virtual InternalRelationshipBuilder PrincipalToDependent(
-            [CanBeNull] string navigationToDependentName,
+            [CanBeNull] string name,
             ConfigurationSource configurationSource)
-            => Navigation(
-                navigationToDependentName,
-                pointsToPrincipal: false,
-                configurationSource: configurationSource,
-                runConventions: true);
+            => Navigations(
+                null,
+                PropertyIdentity.Create(name),
+                configurationSource);
+
+        public virtual InternalRelationshipBuilder PrincipalToDependent(
+            [CanBeNull] PropertyInfo property,
+            ConfigurationSource configurationSource)
+            => Navigations(
+                null,
+                PropertyIdentity.Create(property),
+                configurationSource);
 
         public virtual InternalRelationshipBuilder Navigations(
             [CanBeNull] string navigationToPrincipalName,
             [CanBeNull] string navigationToDependentName,
             ConfigurationSource configurationSource)
+            => Navigations(
+                PropertyIdentity.Create(navigationToPrincipalName),
+                PropertyIdentity.Create(navigationToDependentName),
+                configurationSource);
+
+        public virtual InternalRelationshipBuilder Navigations(
+            [CanBeNull] PropertyInfo navigationToPrincipalProperty,
+            [CanBeNull] PropertyInfo navigationToDependentProperty,
+            ConfigurationSource configurationSource)
+            => Navigations(
+                PropertyIdentity.Create(navigationToPrincipalProperty),
+                PropertyIdentity.Create(navigationToDependentProperty),
+                configurationSource);
+
+        private InternalRelationshipBuilder Navigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
+            ConfigurationSource? configurationSource)
         {
-            navigationToPrincipalName = navigationToPrincipalName ?? "";
-            navigationToDependentName = navigationToDependentName ?? "";
-            bool _;
-            if (!CanSetRelatedTypes(Metadata.PrincipalEntityType,
-                Metadata.DeclaringEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
-                configurationSource,
-                false,
-                configurationSource == ConfigurationSource.Explicit,
-                out _,
-                out _,
-                out _,
-                out _))
+            var principalEntityType = Metadata.PrincipalEntityType;
+            var dependentEntityType = Metadata.DeclaringEntityType;
+            var shouldThrow = configurationSource == ConfigurationSource.Explicit;
+
+            var navigationToPrincipalName = navigationToPrincipal?.Name;
+            if (navigationToPrincipalName != null
+                && navigationToPrincipal.Value.Property == null
+                && dependentEntityType.HasClrType())
             {
-                return null;
+                var navigationProperty = Navigation.GetClrProperty(navigationToPrincipalName, dependentEntityType, principalEntityType, shouldThrow);
+                if (navigationProperty == null)
+                {
+                    return null;
+                }
+                navigationToPrincipal = PropertyIdentity.Create(navigationProperty);
             }
 
-            var newRelationshipBuilder = ReplaceForeignKey(configurationSource,
-                navigationToPrincipalName: navigationToPrincipalName,
-                navigationToDependentName: navigationToDependentName);
-
-            if (newRelationshipBuilder != null
-                && newRelationshipBuilder.Metadata.Builder == null)
+            var navigationToDependentName = navigationToDependent?.Name;
+            if (navigationToDependentName != null
+                && navigationToDependent.Value.Property == null
+                && principalEntityType.HasClrType())
             {
-                newRelationshipBuilder = FindCurrentRelationshipBuilder(
-                    Metadata.PrincipalEntityType,
-                    Metadata.DeclaringEntityType,
-                    navigationToPrincipalName,
-                    navigationToDependentName)
-                                         ?? FindCurrentRelationshipBuilder(
-                                             Metadata.DeclaringEntityType,
-                                             Metadata.PrincipalEntityType,
-                                             navigationToDependentName,
-                                             navigationToPrincipalName);
+                var navigationProperty = Navigation.GetClrProperty(navigationToDependentName, principalEntityType, dependentEntityType, shouldThrow);
+                if (navigationProperty == null)
+                {
+                    return null;
+                }
+                navigationToDependent = PropertyIdentity.Create(navigationProperty);
             }
 
-            if (newRelationshipBuilder == null
-                || ((navigationToPrincipalName != (newRelationshipBuilder.Metadata.DependentToPrincipal?.Name ?? "")
-                     || navigationToDependentName != (newRelationshipBuilder.Metadata.PrincipalToDependent?.Name ?? ""))
-                    && (navigationToDependentName != (newRelationshipBuilder.Metadata.DependentToPrincipal?.Name ?? "")
-                        || navigationToPrincipalName != (newRelationshipBuilder.Metadata.PrincipalToDependent?.Name ?? ""))))
-            {
-                return null;
-            }
-
-            return newRelationshipBuilder;
+            return Navigations(navigationToPrincipal, navigationToDependent, configurationSource.Value, runConventions: true);
         }
 
-        private InternalRelationshipBuilder Navigation(
-            [CanBeNull] string navigationName,
-            bool pointsToPrincipal,
+        private InternalRelationshipBuilder Navigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             ConfigurationSource? configurationSource,
             bool runConventions)
         {
-            var oldNavigation = pointsToPrincipal ? Metadata.DependentToPrincipal : Metadata.PrincipalToDependent;
-            if (navigationName == oldNavigation?.Name)
+            if ((navigationToPrincipal == null
+                 || navigationToPrincipal.Value.Name == Metadata.DependentToPrincipal?.Name)
+                && (navigationToDependent == null
+                    || navigationToDependent.Value.Name == Metadata.PrincipalToDependent?.Name))
             {
                 if (configurationSource.HasValue)
                 {
                     Metadata.UpdateConfigurationSource(configurationSource.Value);
-
-                    if (pointsToPrincipal)
+                    if (navigationToPrincipal != null)
                     {
-                        Metadata.HasDependentToPrincipal(navigationName, configurationSource.Value, runConventions);
+                        Metadata.UpdateDependentToPrincipalConfigurationSource(configurationSource);
                     }
-                    else
+
+                    if (navigationToDependent != null)
                     {
-                        Metadata.HasPrincipalToDependent(navigationName, configurationSource.Value, runConventions);
+                        Metadata.UpdatePrincipalToDependentConfigurationSource(configurationSource);
                     }
                 }
                 return this;
             }
 
-            bool removeOppositeNavigation;
+            var shouldThrow = configurationSource == ConfigurationSource.Explicit;
+            bool? shouldInvert;
             bool? shouldBeUnique;
-            if (!CanSetNavigation(
-                navigationName,
-                pointsToPrincipal,
+            bool removeOppositeNavigation;
+            if (!CanSetNavigations(
+                navigationToPrincipal,
+                navigationToDependent,
                 configurationSource,
-                shouldThrow: configurationSource == ConfigurationSource.Explicit,
-                overrideSameSource: true,
-                shouldBeUnique: out shouldBeUnique,
-                removeOppositeNavigation: out removeOppositeNavigation))
+                shouldThrow,
+                true,
+                out shouldInvert,
+                out shouldBeUnique,
+                out removeOppositeNavigation))
             {
                 return null;
             }
 
-            Debug.Assert(configurationSource.HasValue);
-
-            var builder = this;
             if (removeOppositeNavigation)
             {
-                builder = builder.Navigation(null, !pointsToPrincipal, configurationSource, runConventions);
+                if (navigationToPrincipal == null)
+                {
+                    navigationToPrincipal = PropertyIdentity.None;
+                }
+
+                if (navigationToDependent == null)
+                {
+                    navigationToDependent = PropertyIdentity.None;
+                }
             }
 
-            if (runConventions)
+            Debug.Assert(configurationSource.HasValue);
+
+            var principalEntityType = Metadata.PrincipalEntityType;
+            var dependentEntityType = Metadata.DeclaringEntityType;
+            IReadOnlyList<Property> dependentProperties = null;
+            IReadOnlyList<Property> principalProperties = null;
+            if (shouldInvert == true)
             {
-                navigationName = navigationName ?? "";
-                return builder.ReplaceForeignKey(
-                    configurationSource,
-                    navigationToPrincipalName: pointsToPrincipal ? navigationName : null,
-                    navigationToDependentName: pointsToPrincipal ? null : navigationName,
-                    isUnique: shouldBeUnique);
+                Debug.Assert(configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()));
+                Debug.Assert(configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
+
+                var entityType = principalEntityType;
+                principalEntityType = dependentEntityType;
+                dependentEntityType = entityType;
+
+                var navigation = navigationToPrincipal;
+                navigationToPrincipal = navigationToDependent;
+                navigationToDependent = navigation;
+
+                if (Metadata.GetForeignKeyPropertiesConfigurationSource() == configurationSource.Value)
+                {
+                    dependentProperties = new Property[0];
+                }
+
+                if (Metadata.GetPrincipalKeyConfigurationSource() == configurationSource.Value)
+                {
+                    principalProperties = new Property[0];
+                }
+            }
+
+            var builder = this;
+            if (runConventions
+                || shouldInvert == true)
+            {
+                builder = builder.ReplaceForeignKey(configurationSource,
+                    principalEntityTypeBuilder: principalEntityType.Builder,
+                    dependentEntityTypeBuilder: dependentEntityType.Builder,
+                    navigationToPrincipal: navigationToPrincipal,
+                    navigationToDependent: navigationToDependent,
+                    dependentProperties: dependentProperties,
+                    principalProperties: principalProperties,
+                    isUnique: shouldBeUnique,
+                    principalEndConfigurationSource: shouldInvert != null ? configurationSource : null,
+                    oldRelationshipInverted: shouldInvert == true,
+                    runConventions: runConventions);
+
+                Debug.Assert(builder == null
+                             || builder.Metadata.Builder != null);
+                if (builder != null
+                    && ((navigationToPrincipal != null
+                         && builder.Metadata.DependentToPrincipal?.Name != navigationToPrincipal.Value.Name)
+                        || (navigationToDependent != null
+                            && builder.Metadata.PrincipalToDependent?.Name != navigationToDependent.Value.Name))
+                    && ((navigationToDependent != null
+                         && builder.Metadata.DependentToPrincipal?.Name != navigationToDependent.Value.Name)
+                        || (navigationToPrincipal != null
+                            && builder.Metadata.PrincipalToDependent?.Name != navigationToPrincipal.Value.Name)))
+                {
+                    return null;
+                }
+
+                return builder;
             }
 
             if (shouldBeUnique.HasValue)
@@ -156,21 +236,48 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder = builder.IsUnique(shouldBeUnique.Value, configurationSource.Value, false);
             }
 
-            if (navigationName != null)
+            if (navigationToPrincipal != null)
             {
-                var entityTypeBuilder = pointsToPrincipal
-                    ? Metadata.DeclaringEntityType.Builder
-                    : Metadata.PrincipalEntityType.Builder;
-                entityTypeBuilder.Unignore(navigationName);
+                if (navigationToDependent != null)
+                {
+                    // Remove the other navigation in case it's conflicting
+                    builder.Metadata.HasPrincipalToDependent((string)null, configurationSource.Value, runConventions: false);
+                }
+
+                var navigationToPrincipalName = navigationToPrincipal.Value.Name;
+                if (navigationToPrincipalName != null)
+                {
+                    Metadata.DeclaringEntityType.Builder.Unignore(navigationToPrincipalName);
+                }
+
+                var navigationProperty = navigationToPrincipal.Value.Property;
+                if (navigationProperty != null)
+                {
+                    builder.Metadata.HasDependentToPrincipal(navigationProperty, configurationSource.Value, runConventions: false);
+                }
+                else
+                {
+                    builder.Metadata.HasDependentToPrincipal(navigationToPrincipalName, configurationSource.Value, runConventions: false);
+                }
             }
 
-            if (pointsToPrincipal)
+            if (navigationToDependent != null)
             {
-                builder.Metadata.HasDependentToPrincipal(navigationName, configurationSource.Value, runConventions: false);
-            }
-            else
-            {
-                builder.Metadata.HasPrincipalToDependent(navigationName, configurationSource.Value, runConventions: false);
+                var navigationToDependentName = navigationToDependent.Value.Name;
+                if (navigationToDependentName != null)
+                {
+                    Metadata.PrincipalEntityType.Builder.Unignore(navigationToDependentName);
+                }
+
+                var navigationProperty = navigationToDependent.Value.Property;
+                if (navigationProperty != null)
+                {
+                    builder.Metadata.HasPrincipalToDependent(navigationProperty, configurationSource.Value, runConventions: false);
+                }
+                else
+                {
+                    builder.Metadata.HasPrincipalToDependent(navigationToDependentName, configurationSource.Value, runConventions: false);
+                }
             }
 
             return builder;
@@ -182,10 +289,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource? configurationSource,
             bool overrideSameSource = true)
         {
+            PropertyIdentity navigation;
+            var sourceType = pointsToPrincipal ? Metadata.DeclaringEntityType : Metadata.PrincipalEntityType;
+            if (navigationName == null
+                || !sourceType.HasClrType())
+            {
+                navigation = PropertyIdentity.Create(navigationName);
+            }
+            else
+            {
+                var navigationProperty = Navigation.GetClrProperty(
+                    navigationName,
+                    sourceType,
+                    pointsToPrincipal ? Metadata.PrincipalEntityType : Metadata.DeclaringEntityType,
+                    shouldThrow: configurationSource == ConfigurationSource.Explicit);
+                if (navigationProperty == null)
+                {
+                    return false;
+                }
+                navigation = PropertyIdentity.Create(navigationProperty);
+            }
+
             bool? _;
             bool __;
             return CanSetNavigation(
-                navigationName,
+                navigation,
+                pointsToPrincipal,
+                configurationSource,
+                false,
+                overrideSameSource,
+                out _,
+                out __);
+        }
+
+        public virtual bool CanSetNavigation(
+            [CanBeNull] PropertyInfo navigationProperty,
+            bool pointsToPrincipal,
+            ConfigurationSource? configurationSource,
+            bool overrideSameSource = true)
+        {
+            bool? _;
+            bool __;
+            return CanSetNavigation(
+                PropertyIdentity.Create(navigationProperty),
                 pointsToPrincipal,
                 configurationSource,
                 false,
@@ -195,7 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private bool CanSetNavigation(
-            string navigationName,
+            PropertyIdentity navigation,
             bool pointsToPrincipal,
             ConfigurationSource? configurationSource,
             bool shouldThrow,
@@ -203,11 +349,46 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             out bool? shouldBeUnique,
             out bool removeOppositeNavigation)
         {
+            bool? _;
+            return pointsToPrincipal
+                ? CanSetNavigations(
+                    navigation,
+                    null,
+                    configurationSource,
+                    shouldThrow,
+                    overrideSameSource,
+                    out _,
+                    out shouldBeUnique,
+                    out removeOppositeNavigation)
+                : CanSetNavigations(
+                    null,
+                    navigation,
+                    configurationSource,
+                    shouldThrow,
+                    overrideSameSource,
+                    out _,
+                    out shouldBeUnique,
+                    out removeOppositeNavigation);
+        }
+
+        private bool CanSetNavigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
+            ConfigurationSource? configurationSource,
+            bool shouldThrow,
+            bool overrideSameSource,
+            out bool? shouldInvert,
+            out bool? shouldBeUnique,
+            out bool removeOppositeNavigation)
+        {
+            shouldInvert = null;
             shouldBeUnique = null;
             removeOppositeNavigation = false;
 
-            var existingNavigation = pointsToPrincipal ? Metadata.DependentToPrincipal : Metadata.PrincipalToDependent;
-            if (navigationName == existingNavigation?.Name)
+            if ((navigationToPrincipal == null
+                 || navigationToPrincipal.Value.Name == Metadata.DependentToPrincipal?.Name)
+                && (navigationToDependent == null
+                    || navigationToDependent.Value.Name == Metadata.PrincipalToDependent?.Name))
             {
                 return true;
             }
@@ -217,74 +398,205 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            if (pointsToPrincipal
-                && (!configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
-                    || (!overrideSameSource && configurationSource.Value == Metadata.GetDependentToPrincipalConfigurationSource())))
+            var navigationToPrincipalName = navigationToPrincipal?.Name;
+            if (navigationToPrincipal != null
+                && navigationToPrincipalName != Metadata.DependentToPrincipal?.Name)
             {
-                return false;
+                if (!configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
+                    || (!overrideSameSource && configurationSource == Metadata.GetDependentToPrincipalConfigurationSource()))
+                {
+                    return false;
+                }
+
+                if (navigationToPrincipalName != null)
+                {
+                    if (Metadata.DeclaringEntityType.Builder.IsIgnored(navigationToPrincipalName, configurationSource))
+                    {
+                        return false;
+                    }
+
+                    if (navigationToDependent == null
+                        && navigationToPrincipalName == Metadata.PrincipalToDependent?.Name
+                        && Metadata.IsIntraHierarchical())
+                    {
+                        if (!configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                            || (!overrideSameSource && configurationSource == Metadata.GetPrincipalToDependentConfigurationSource()))
+                        {
+                            return false;
+                        }
+
+                        removeOppositeNavigation = true;
+                    }
+                }
             }
 
-            if (!pointsToPrincipal
-                && (!configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
-                    || (!overrideSameSource && configurationSource.Value == Metadata.GetPrincipalToDependentConfigurationSource())))
+            var navigationToDependentName = navigationToDependent?.Name;
+            if (navigationToDependent != null
+                && navigationToDependentName != Metadata.PrincipalToDependent?.Name)
             {
-                return false;
+                if (!configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                    || (!overrideSameSource && configurationSource == Metadata.GetPrincipalToDependentConfigurationSource()))
+                {
+                    return false;
+                }
+
+                if (navigationToDependentName != null)
+                {
+                    if (Metadata.PrincipalEntityType.Builder.IsIgnored(navigationToDependentName, configurationSource))
+                    {
+                        return false;
+                    }
+
+                    if (navigationToPrincipal == null
+                        && navigationToDependentName == Metadata.DependentToPrincipal?.Name
+                        && Metadata.IsIntraHierarchical())
+                    {
+                        if (!configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
+                            || (!overrideSameSource && configurationSource == Metadata.GetDependentToPrincipalConfigurationSource()))
+                        {
+                            return false;
+                        }
+
+                        removeOppositeNavigation = true;
+                    }
+                }
             }
 
-            var entityTypeBuilder = pointsToPrincipal
-                ? Metadata.DeclaringEntityType.Builder
-                : Metadata.PrincipalEntityType.Builder;
+            var navigationToPrincipalProperty = navigationToPrincipal?.Property;
+            var navigationToDependentProperty = navigationToDependent?.Property;
 
-            if (navigationName == null)
+            bool? invertedShouldBeUnique = null;
+            if (navigationToPrincipalProperty != null
+                && !IsCompatible(
+                    navigationToPrincipalProperty,
+                    false,
+                    Metadata.PrincipalEntityType.ClrType,
+                    Metadata.DeclaringEntityType.ClrType,
+                    false,
+                    out invertedShouldBeUnique))
             {
-                return true;
+                shouldInvert = false;
             }
 
-            if (entityTypeBuilder.IsIgnored(navigationName, configurationSource.Value))
+            bool? _;
+            if (navigationToDependentProperty != null
+                && !IsCompatible(
+                    navigationToDependentProperty,
+                    true,
+                    Metadata.PrincipalEntityType.ClrType,
+                    Metadata.DeclaringEntityType.ClrType,
+                    false,
+                    out _))
             {
-                return false;
+                shouldInvert = false;
             }
 
-            if (!Internal.Navigation.IsCompatible(
-                navigationName,
-                pointsToPrincipal,
-                Metadata.DeclaringEntityType,
-                Metadata.PrincipalEntityType,
-                shouldThrow,
-                out shouldBeUnique))
+            if (navigationToPrincipalProperty != null
+                && !IsCompatible(
+                    navigationToPrincipalProperty,
+                    true,
+                    Metadata.DeclaringEntityType.ClrType,
+                    Metadata.PrincipalEntityType.ClrType,
+                    shouldThrow && shouldInvert != null,
+                    out _))
             {
-                return false;
+                if (shouldInvert != null)
+                {
+                    return false;
+                }
+                shouldInvert = true;
+            }
+
+            if (navigationToDependentProperty != null
+                && !IsCompatible(
+                    navigationToDependentProperty,
+                    false,
+                    Metadata.DeclaringEntityType.ClrType,
+                    Metadata.PrincipalEntityType.ClrType,
+                    shouldThrow && shouldInvert != null,
+                    out shouldBeUnique))
+            {
+                if (shouldInvert != null)
+                {
+                    return false;
+                }
+                shouldInvert = true;
+            }
+
+            if (shouldInvert == true)
+            {
+                shouldBeUnique = invertedShouldBeUnique;
             }
 
             if (shouldBeUnique.HasValue
-                && (Metadata.IsUnique != shouldBeUnique)
+                && Metadata.IsUnique != shouldBeUnique
                 && !configurationSource.Value.Overrides(Metadata.GetIsUniqueConfigurationSource()))
             {
                 return false;
             }
-
-            foreach (var conflictingNavigation in entityTypeBuilder.Metadata.FindNavigationsInHierarchy(navigationName))
+            else if(shouldBeUnique == null
+                && (Metadata.IsUnique || configurationSource.Value.OverridesStrictly(Metadata.GetIsUniqueConfigurationSource()))
+                && ((navigationToDependentProperty != null && shouldInvert != true)
+                || (navigationToPrincipalProperty != null && shouldInvert == true)))
             {
-                if (conflictingNavigation.ForeignKey == Metadata)
+                // if new dependent can be both assume single
+                shouldBeUnique = true;
+            }
+
+            return true;
+        }
+
+        private static bool IsCompatible(
+            [NotNull] PropertyInfo navigationProperty,
+            bool pointsToPrincipal,
+            [NotNull] Type dependentType,
+            [NotNull] Type principalType,
+            bool shouldThrow,
+            out bool? shouldBeUnique)
+        {
+            shouldBeUnique = null;
+            if (!pointsToPrincipal)
+            {
+                var canBeUnique = Navigation.IsCompatible(
+                    navigationProperty,
+                    principalType,
+                    dependentType,
+                    shouldBeCollection: false,
+                    shouldThrow: false);
+                var canBeNonUnique = Navigation.IsCompatible(
+                    navigationProperty,
+                    principalType,
+                    dependentType,
+                    shouldBeCollection: true,
+                    shouldThrow: false);
+
+                if (canBeUnique != canBeNonUnique)
                 {
-                    Debug.Assert(conflictingNavigation.IsDependentToPrincipal() != pointsToPrincipal);
-
-                    if (!pointsToPrincipal
-                        && !configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
-                        || (!overrideSameSource && configurationSource.Value == Metadata.GetDependentToPrincipalConfigurationSource()))
-                    {
-                        return false;
-                    }
-
-                    if (pointsToPrincipal
-                        && !configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
-                        || (!overrideSameSource && configurationSource.Value == Metadata.GetPrincipalToDependentConfigurationSource()))
-                    {
-                        return false;
-                    }
-
-                    removeOppositeNavigation = true;
+                    shouldBeUnique = canBeUnique;
                 }
+                else if (!canBeUnique)
+                {
+                    if (shouldThrow)
+                    {
+                        Navigation.IsCompatible(
+                            navigationProperty,
+                            principalType,
+                            dependentType,
+                            shouldBeCollection: false,
+                            shouldThrow: true);
+                    }
+
+                    return false;
+                }
+            }
+            else if (!Navigation.IsCompatible(
+                navigationProperty,
+                dependentType,
+                principalType,
+                shouldBeCollection: false,
+                shouldThrow: shouldThrow))
+            {
+                return false;
             }
 
             return true;
@@ -440,9 +752,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (resetToDependent)
             {
-                builder = builder.Navigation(
+                builder = builder.Navigations(
                     null,
-                    pointsToPrincipal: false,
+                    PropertyIdentity.None,
                     configurationSource: configurationSource,
                     runConventions: runConventions);
 
@@ -471,10 +783,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if ((Metadata.PrincipalToDependent != null)
-                && !Internal.Navigation.IsCompatible(
-                    Metadata.PrincipalToDependent.Name,
-                    Metadata.PrincipalEntityType,
-                    Metadata.DeclaringEntityType,
+                && !Navigation.IsCompatible(
+                    Metadata.PrincipalToDependent.PropertyInfo,
+                    Metadata.PrincipalEntityType.ClrType,
+                    Metadata.DeclaringEntityType.ClrType,
                     !unique,
                     shouldThrow: false))
             {
@@ -589,12 +901,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] EntityType dependentEntityType,
             ConfigurationSource? configurationSource,
             bool runConventions = true)
+            => RelatedEntityTypes(principalEntityType, dependentEntityType, configurationSource, configurationSource, runConventions);
+
+        private InternalRelationshipBuilder RelatedEntityTypes(
+            [NotNull] EntityType principalEntityType,
+            [NotNull] EntityType dependentEntityType,
+            ConfigurationSource? principalEndConfigurationSource,
+            ConfigurationSource? configurationSource,
+            bool runConventions)
         {
             bool shouldInvert;
             bool shouldResetToPrincipal;
             bool shouldResetToDependent;
             bool shouldResetPrincipalProperties;
             bool shouldResetDependentProperties;
+            bool? shouldBeUnique;
             if (!CanSetRelatedTypes(
                 principalEntityType,
                 dependentEntityType,
@@ -607,7 +928,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 out shouldResetToPrincipal,
                 out shouldResetToDependent,
                 out shouldResetPrincipalProperties,
-                out shouldResetDependentProperties)
+                out shouldResetDependentProperties,
+                out shouldBeUnique)
                 && configurationSource != ConfigurationSource.Explicit)
             {
                 return null;
@@ -616,10 +938,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (shouldInvert)
             {
-                Debug.Assert(!configurationSource.HasValue
-                             || configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()));
-                Debug.Assert(!configurationSource.HasValue
-                             || configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
+                Debug.Assert(configurationSource.HasValue
+                             && configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()));
+                Debug.Assert(configurationSource.HasValue
+                             && configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
 
                 principalEntityType = principalEntityType.LeastDerivedType(Metadata.DeclaringEntityType);
                 dependentEntityType = dependentEntityType.LeastDerivedType(Metadata.PrincipalEntityType);
@@ -637,10 +959,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                  && !shouldResetPrincipalProperties
                                  && !shouldResetDependentProperties);
 
-                    if (configurationSource.HasValue
-                        && Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
+                    if (principalEndConfigurationSource.HasValue
+                        && Metadata.GetPrincipalEndConfigurationSource()?.Overrides(principalEndConfigurationSource) != true)
                     {
-                        builder.Metadata.UpdatePrincipalEndConfigurationSource(configurationSource.Value);
+                        builder.Metadata.UpdatePrincipalEndConfigurationSource(principalEndConfigurationSource.Value);
                         if (runConventions)
                         {
                             builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
@@ -655,11 +977,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource,
                 principalEntityTypeBuilder: principalEntityType.Builder,
                 dependentEntityTypeBuilder: dependentEntityType.Builder,
-                navigationToPrincipalName: shouldResetToPrincipal ? "" : null,
-                navigationToDependentName: shouldResetToDependent ? "" : null,
+                navigationToPrincipal: shouldResetToPrincipal ? PropertyIdentity.None : (PropertyIdentity?)null,
+                navigationToDependent: shouldResetToDependent ? PropertyIdentity.None : (PropertyIdentity?)null,
                 dependentProperties: shouldResetDependentProperties ? new Property[0] : null,
                 principalProperties: shouldResetPrincipalProperties ? new Property[0] : null,
-                strictPrincipal: true,
+                isUnique: shouldBeUnique,
+                principalEndConfigurationSource: principalEndConfigurationSource,
                 oldRelationshipInverted: shouldInvert,
                 runConventions: runConventions);
         }
@@ -930,11 +1253,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!ForeignKey.AreCompatible(
-                    properties,
-                    Metadata.Properties,
-                    Metadata.PrincipalEntityType,
-                    Metadata.DeclaringEntityType,
-                    shouldThrow: false))
+                properties,
+                Metadata.Properties,
+                Metadata.PrincipalEntityType,
+                Metadata.DeclaringEntityType,
+                shouldThrow: false))
             {
                 if (!configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
                 {
@@ -951,14 +1274,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource? configurationSource,
             InternalEntityTypeBuilder principalEntityTypeBuilder = null,
             InternalEntityTypeBuilder dependentEntityTypeBuilder = null,
-            string navigationToPrincipalName = null,
-            string navigationToDependentName = null,
+            PropertyIdentity? navigationToPrincipal = null,
+            PropertyIdentity? navigationToDependent = null,
             IReadOnlyList<Property> dependentProperties = null,
             IReadOnlyList<Property> principalProperties = null,
             bool? isUnique = null,
             bool? isRequired = null,
             DeleteBehavior? deleteBehavior = null,
-            bool strictPrincipal = false,
+            ConfigurationSource? principalEndConfigurationSource = null,
             bool oldRelationshipInverted = false,
             bool runConventions = true)
         {
@@ -971,39 +1294,39 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                              ? Metadata.PrincipalEntityType.Builder
                                              : Metadata.DeclaringEntityType.Builder);
 
-            if (navigationToPrincipalName == null)
+            if (navigationToPrincipal == null)
             {
                 if (oldRelationshipInverted)
                 {
-                    navigationToPrincipalName = Metadata.GetPrincipalToDependentConfigurationSource()?.Overrides(configurationSource)
-                                                ?? false
-                        ? Metadata.PrincipalToDependent?.Name ?? ""
-                        : null;
+                    navigationToPrincipal = Metadata.GetPrincipalToDependentConfigurationSource()?.Overrides(configurationSource)
+                                            ?? false
+                        ? PropertyIdentity.Create(Metadata.PrincipalToDependent)
+                        : navigationToPrincipal;
                 }
                 else
                 {
-                    navigationToPrincipalName = Metadata.GetDependentToPrincipalConfigurationSource()?.Overrides(configurationSource)
-                                                ?? false
-                        ? Metadata.DependentToPrincipal?.Name ?? ""
-                        : null;
+                    navigationToPrincipal = Metadata.GetDependentToPrincipalConfigurationSource()?.Overrides(configurationSource)
+                                            ?? false
+                        ? PropertyIdentity.Create(Metadata.DependentToPrincipal)
+                        : navigationToPrincipal;
                 }
             }
 
-            if (navigationToDependentName == null)
+            if (navigationToDependent == null)
             {
                 if (oldRelationshipInverted)
                 {
-                    navigationToDependentName = Metadata.GetDependentToPrincipalConfigurationSource()?.Overrides(configurationSource)
-                                                ?? false
-                        ? Metadata.DependentToPrincipal?.Name ?? ""
-                        : null;
+                    navigationToDependent = Metadata.GetDependentToPrincipalConfigurationSource()?.Overrides(configurationSource)
+                                            ?? false
+                        ? PropertyIdentity.Create(Metadata.DependentToPrincipal)
+                        : navigationToDependent;
                 }
                 else
                 {
-                    navigationToDependentName = Metadata.GetPrincipalToDependentConfigurationSource()?.Overrides(configurationSource)
-                                                ?? false
-                        ? Metadata.PrincipalToDependent?.Name ?? ""
-                        : null;
+                    navigationToDependent = Metadata.GetPrincipalToDependentConfigurationSource()?.Overrides(configurationSource)
+                                            ?? false
+                        ? PropertyIdentity.Create(Metadata.PrincipalToDependent)
+                        : navigationToDependent;
                 }
             }
 
@@ -1034,21 +1357,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                  ? Metadata.DeleteBehavior
                                  : (DeleteBehavior?)null);
 
-            var principalEndConfigurationSource =
-                strictPrincipal
-                || (principalEntityTypeBuilder.Metadata != dependentEntityTypeBuilder.Metadata
-                    && (principalProperties != null
-                        || dependentProperties != null
-                        || (navigationToDependentName != null && isUnique == false)))
-                    ? configurationSource
-                    : null;
+            principalEndConfigurationSource = principalEndConfigurationSource ??
+                                              (principalEntityTypeBuilder.Metadata != dependentEntityTypeBuilder.Metadata
+                                               && (principalProperties != null
+                                                   || dependentProperties != null
+                                                   || (navigationToDependent != null && isUnique == false))
+                                                  ? configurationSource
+                                                  : null);
             principalEndConfigurationSource = principalEndConfigurationSource.Max(Metadata.GetPrincipalEndConfigurationSource());
 
             return ReplaceForeignKey(
                 principalEntityTypeBuilder,
                 dependentEntityTypeBuilder,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties,
                 principalProperties,
                 isUnique,
@@ -1063,8 +1385,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private InternalRelationshipBuilder ReplaceForeignKey(
             [NotNull] InternalEntityTypeBuilder principalEntityTypeBuilder,
             [NotNull] InternalEntityTypeBuilder dependentEntityTypeBuilder,
-            [CanBeNull] string navigationToPrincipalName,
-            [CanBeNull] string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             [CanBeNull] IReadOnlyList<Property> dependentProperties,
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             bool? isUnique,
@@ -1077,11 +1399,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Check.NotNull(principalEntityTypeBuilder, nameof(principalEntityTypeBuilder));
             Check.NotNull(dependentEntityTypeBuilder, nameof(dependentEntityTypeBuilder));
+            Debug.Assert(navigationToPrincipal?.Name == null
+                         || navigationToPrincipal.Value.Property != null
+                         || !dependentEntityTypeBuilder.Metadata.HasClrType());
+            Debug.Assert(navigationToDependent?.Name == null
+                         || navigationToDependent.Value.Property != null
+                         || !principalEntityTypeBuilder.Metadata.HasClrType());
             Debug.Assert(AreCompatible(
                 principalEntityTypeBuilder.Metadata,
                 dependentEntityTypeBuilder.Metadata,
-                navigationToPrincipalName == "" ? null : navigationToPrincipalName,
-                navigationToDependentName == "" ? null : navigationToDependentName,
+                navigationToPrincipal?.Property,
+                navigationToDependent?.Property,
                 dependentProperties != null && dependentProperties.Any() ? dependentProperties : null,
                 principalProperties != null && principalProperties.Any() ? principalProperties : null,
                 isUnique,
@@ -1090,23 +1418,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var newRelationshipConfigurationSource = Metadata.GetConfigurationSource();
             if ((dependentProperties != null && dependentProperties.Any())
-                || !string.IsNullOrEmpty(navigationToPrincipalName)
-                || !string.IsNullOrEmpty(navigationToDependentName))
+                || navigationToPrincipal?.Name != null
+                || navigationToDependent?.Name != null)
             {
                 newRelationshipConfigurationSource = newRelationshipConfigurationSource.Max(configurationSource);
             }
 
             var dependentEntityType = dependentEntityTypeBuilder.Metadata;
             var principalEntityType = principalEntityTypeBuilder.Metadata;
-            var removedNavigations = new Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>>();
+            var removedNavigations = new List<Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string, PropertyInfo>>();
             var removedForeignKeys = new List<Tuple<InternalEntityTypeBuilder, ForeignKey>>();
             var addedForeignKeys = new List<InternalRelationshipBuilder>();
             bool existingRelationshipInverted;
             var newRelationshipBuilder = GetOrCreateRelationshipBuilder(
                 principalEntityType,
                 dependentEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties != null && dependentProperties.Any() ? dependentProperties : null,
                 principalProperties != null && principalProperties.Any() ? principalProperties : null,
                 isRequired,
@@ -1138,9 +1466,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 dependentEntityType = dependentEntityTypeBuilder.Metadata;
                 principalEntityType = principalEntityTypeBuilder.Metadata;
 
-                var navigationName = navigationToPrincipalName;
-                navigationToPrincipalName = navigationToDependentName;
-                navigationToDependentName = navigationName;
+                var navigation = navigationToPrincipal;
+                navigationToPrincipal = navigationToDependent;
+                navigationToDependent = navigation;
+
+                dependentProperties = null;
+                principalProperties = null;
             }
 
             newRelationshipBuilder.Metadata.UpdateConfigurationSource(newRelationshipConfigurationSource);
@@ -1148,78 +1479,72 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             newRelationshipBuilder = newRelationshipBuilder.RelatedEntityTypes(
                 principalEntityTypeBuilder,
                 dependentEntityTypeBuilder,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties,
                 principalEndConfigurationSource,
                 configurationSource,
                 existingRelationshipInverted);
 
             if (dependentProperties != null
-                && dependentProperties.Any())
+                && dependentProperties.Any()
+                && configurationSource.HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.HasForeignKey(
                     dependentProperties,
-                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetForeignKeyPropertiesConfigurationSource()).Value,
+                    configurationSource.Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
             if (principalProperties != null
-                && principalProperties.Any())
+                && principalProperties.Any()
+                && configurationSource.HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.HasPrincipalKey(
                     principalProperties,
-                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetPrincipalKeyConfigurationSource()).Value,
+                    configurationSource.Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (isUnique.HasValue)
+            if (isUnique.HasValue
+                && configurationSource.HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsUnique(
                     isUnique.Value,
-                    configurationSource.Max(Metadata.GetIsUniqueConfigurationSource()).Value,
+                    configurationSource.Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (isRequired.HasValue)
+            if (isRequired.HasValue
+                && configurationSource.HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsRequired(
                     isRequired.Value,
-                    configurationSource.Max(Metadata.GetIsRequiredConfigurationSource()).Value,
+                    configurationSource.Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (deleteBehavior.HasValue)
+            if (deleteBehavior.HasValue
+                && configurationSource.HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.DeleteBehavior(
                     deleteBehavior.Value,
-                    configurationSource.Max(Metadata.GetDeleteBehaviorConfigurationSource()).Value)
+                    configurationSource.Value)
                                          ?? newRelationshipBuilder;
             }
-            if (navigationToPrincipalName != null)
+            if ((navigationToPrincipal != null
+                 || navigationToDependent != null)
+                && configurationSource.HasValue)
             {
-                newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                    navigationToPrincipalName == "" ? null : navigationToPrincipalName,
-                    pointsToPrincipal: true,
-                    configurationSource: configurationSource.Max(oldRelationshipInverted
-                        ? Metadata.GetPrincipalToDependentConfigurationSource()
-                        : Metadata.GetDependentToPrincipalConfigurationSource()).Value,
-                    runConventions: false)
-                                         ?? newRelationshipBuilder;
-            }
-            if (navigationToDependentName != null)
-            {
-                newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                    navigationToDependentName == "" ? null : navigationToDependentName,
-                    pointsToPrincipal: false,
-                    configurationSource: configurationSource.Max(oldRelationshipInverted
-                        ? Metadata.GetDependentToPrincipalConfigurationSource()
-                        : Metadata.GetPrincipalToDependentConfigurationSource()).Value,
+                newRelationshipBuilder = newRelationshipBuilder.Navigations(
+                    navigationToPrincipal,
+                    navigationToDependent,
+                    configurationSource: configurationSource.Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
 
-            if ((dependentProperties == null)
+            if ((dependentProperties == null || Metadata.Properties.SequenceEqual(dependentProperties))
                 && !oldRelationshipInverted
                 && Metadata.GetForeignKeyPropertiesConfigurationSource().HasValue)
             {
@@ -1244,7 +1569,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                              ?? newRelationshipBuilder;
                 }
             }
-            if ((principalProperties == null)
+            if ((principalProperties == null || Metadata.PrincipalKey.Properties.SequenceEqual(principalProperties))
                 && !oldRelationshipInverted
                 && Metadata.GetPrincipalKeyConfigurationSource().HasValue)
             {
@@ -1262,14 +1587,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                              ?? newRelationshipBuilder;
                 }
             }
-            if (!isUnique.HasValue
+            if ((!isUnique.HasValue || isUnique.Value == Metadata.IsUnique)
                 && Metadata.GetIsUniqueConfigurationSource().HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsUnique(
                     Metadata.IsUnique, Metadata.GetIsUniqueConfigurationSource().Value, runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (!isRequired.HasValue
+            if ((!isRequired.HasValue || isRequired.Value == Metadata.IsRequired)
                 && Metadata.GetIsRequiredConfigurationSource().HasValue
                 && CanSetRequiredOnProperties(
                     newRelationshipBuilder.Metadata.Properties,
@@ -1282,88 +1607,83 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Metadata.IsRequired, Metadata.GetIsRequiredConfigurationSource().Value, runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (!deleteBehavior.HasValue
+            if ((!deleteBehavior.HasValue || deleteBehavior.Value == Metadata.DeleteBehavior)
                 && Metadata.GetDeleteBehaviorConfigurationSource().HasValue)
             {
                 newRelationshipBuilder = newRelationshipBuilder.DeleteBehavior(Metadata.DeleteBehavior, Metadata.GetDeleteBehaviorConfigurationSource().Value)
                                          ?? newRelationshipBuilder;
             }
 
-            if (Metadata.DependentToPrincipal != null)
+            var preservedNavigationToPrincipal = oldRelationshipInverted
+                ? PropertyIdentity.Create(Metadata.PrincipalToDependent)
+                : PropertyIdentity.Create(Metadata.DependentToPrincipal);
+            var preservedToPrincipalConfigurationSource = oldRelationshipInverted
+                ? Metadata.GetPrincipalToDependentConfigurationSource()
+                : Metadata.GetDependentToPrincipalConfigurationSource();
+            if ((!navigationToPrincipal.HasValue || navigationToPrincipal.Value.Name == preservedNavigationToPrincipal.Name)
+                && preservedToPrincipalConfigurationSource.HasValue)
             {
-                if (oldRelationshipInverted)
-                {
-                    if (navigationToDependentName == null)
-                    {
-                        newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                            Metadata.DependentToPrincipal.Name,
-                            pointsToPrincipal: false,
-                            configurationSource: Metadata.GetDependentToPrincipalConfigurationSource().Value,
-                            runConventions: false)
-                                                 ?? newRelationshipBuilder;
-                    }
-                }
-                else
-                {
-                    if (navigationToPrincipalName == null)
-                    {
-                        newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                            Metadata.DependentToPrincipal.Name,
-                            pointsToPrincipal: true,
-                            configurationSource: Metadata.GetDependentToPrincipalConfigurationSource().Value,
-                            runConventions: false)
-                                                 ?? newRelationshipBuilder;
-                    }
-                }
+                newRelationshipBuilder = newRelationshipBuilder.Navigations(
+                    preservedNavigationToPrincipal,
+                    null,
+                    preservedToPrincipalConfigurationSource.Value,
+                    runConventions: false)
+                                         ?? newRelationshipBuilder;
             }
 
-            if (Metadata.PrincipalToDependent != null)
+            var preservedNavigationToDependent = oldRelationshipInverted
+                ? PropertyIdentity.Create(Metadata.DependentToPrincipal)
+                : PropertyIdentity.Create(Metadata.PrincipalToDependent);
+            var preservedToDependentConfigurationSource = oldRelationshipInverted
+                ? Metadata.GetDependentToPrincipalConfigurationSource()
+                : Metadata.GetPrincipalToDependentConfigurationSource();
+            if ((!navigationToDependent.HasValue || navigationToDependent.Value.Name == preservedNavigationToDependent.Name)
+                && preservedToDependentConfigurationSource.HasValue)
             {
-                if (oldRelationshipInverted)
-                {
-                    if (navigationToPrincipalName == null)
-                    {
-                        newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                            Metadata.PrincipalToDependent.Name,
-                            pointsToPrincipal: true,
-                            configurationSource: Metadata.GetPrincipalToDependentConfigurationSource().Value,
-                            runConventions: false)
-                                                 ?? newRelationshipBuilder;
-                    }
-                }
-                else
-                {
-                    if (navigationToDependentName == null)
-                    {
-                        newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                            Metadata.PrincipalToDependent.Name,
-                            pointsToPrincipal: false,
-                            configurationSource: Metadata.GetPrincipalToDependentConfigurationSource().Value,
-                            runConventions: false)
-                                                 ?? newRelationshipBuilder;
-                    }
-                }
+                newRelationshipBuilder = newRelationshipBuilder.Navigations(
+                    null,
+                    preservedNavigationToDependent,
+                    preservedToDependentConfigurationSource.Value,
+                    runConventions: false)
+                                         ?? newRelationshipBuilder;
             }
 
             if (runConventions)
             {
-                var dependentToPrincipalIsNew = false;
-                if (newRelationshipBuilder.Metadata.DependentToPrincipal != null)
+                var dependentToPrincipalIsNew = newRelationshipBuilder.Metadata.DependentToPrincipal != null;
+                var principalToDependentIsNew = newRelationshipBuilder.Metadata.PrincipalToDependent != null;
+                for (var i = 0; i < removedNavigations.Count; i++)
                 {
-                    dependentToPrincipalIsNew = !removedNavigations.Remove(
-                        newRelationshipBuilder.Metadata.DeclaringEntityType.Name + "." +
-                        newRelationshipBuilder.Metadata.DependentToPrincipal.Name);
+                    var removedNavigation = removedNavigations[i];
+                    if (newRelationshipBuilder.Metadata.DependentToPrincipal != null
+                        && removedNavigation.Item3 == newRelationshipBuilder.Metadata.DependentToPrincipal.Name
+                        && newRelationshipBuilder.Metadata.DeclaringEntityType.IsAssignableFrom(removedNavigation.Item1.Metadata))
+                    {
+                        if (newRelationshipBuilder.Metadata.DeclaringEntityType == removedNavigation.Item1.Metadata)
+                        {
+                            dependentToPrincipalIsNew = false;
+                        }
+
+                        removedNavigations.RemoveAt(i);
+                        i--;
+                        continue;
+                    }
+
+                    if (newRelationshipBuilder.Metadata.PrincipalToDependent != null
+                        && removedNavigation.Item3 == newRelationshipBuilder.Metadata.PrincipalToDependent.Name
+                        && newRelationshipBuilder.Metadata.PrincipalEntityType.IsAssignableFrom(removedNavigation.Item1.Metadata))
+                    {
+                        if (newRelationshipBuilder.Metadata.PrincipalEntityType == removedNavigation.Item1.Metadata)
+                        {
+                            principalToDependentIsNew = false;
+                        }
+
+                        removedNavigations.RemoveAt(i);
+                        i--;
+                    }
                 }
 
-                var principalToDependentIsNew = false;
-                if (newRelationshipBuilder.Metadata.PrincipalToDependent != null)
-                {
-                    principalToDependentIsNew = !removedNavigations.Remove(
-                        newRelationshipBuilder.Metadata.PrincipalEntityType.Name + "." +
-                        newRelationshipBuilder.Metadata.PrincipalToDependent.Name);
-                }
-
-                foreach (var removedNavigation in removedNavigations.Values)
+                foreach (var removedNavigation in removedNavigations)
                 {
                     ModelBuilder.Metadata.ConventionDispatcher.OnNavigationRemoved(
                         removedNavigation.Item1, removedNavigation.Item2, removedNavigation.Item3);
@@ -1374,28 +1694,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyRemoved(removedForeignKey.Item1, removedForeignKey.Item2);
                 }
 
-                if (newRelationshipBuilder == null)
-                {
-                    return null;
-                }
-
                 if (newRelationshipBuilder.Metadata.Builder == null)
                 {
                     newRelationshipBuilder = FindCurrentRelationshipBuilder(
                         principalEntityType,
                         dependentEntityType,
-                        navigationToPrincipalName,
-                        navigationToDependentName,
+                        navigationToPrincipal,
+                        navigationToDependent,
                         dependentProperties,
                         principalProperties);
                 }
 
-                if (newRelationshipBuilder == null)
+                if (newRelationshipBuilder != null)
                 {
-                    return null;
+                    newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAdded(newRelationshipBuilder);
                 }
-
-                newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAdded(newRelationshipBuilder);
 
                 foreach (var addedForeignKey in addedForeignKeys)
                 {
@@ -1412,32 +1725,39 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     newRelationshipBuilder = FindCurrentRelationshipBuilder(
                         principalEntityType,
                         dependentEntityType,
-                        navigationToPrincipalName,
-                        navigationToDependentName,
+                        navigationToPrincipal,
+                        navigationToDependent,
                         dependentProperties,
                         principalProperties);
+                    if (newRelationshipBuilder == null)
+                    {
+                        return null;
+                    }
                 }
 
                 if (strictPrincipal
                     && existingPrincipalEndConfigurationSource != principalEndConfigurationSource)
                 {
                     newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(newRelationshipBuilder);
-                }
+                    if (newRelationshipBuilder == null)
+                    {
+                        return null;
+                    }
 
-                if (newRelationshipBuilder == null)
-                {
-                    return null;
-                }
-
-                if (newRelationshipBuilder.Metadata.Builder == null)
-                {
-                    newRelationshipBuilder = FindCurrentRelationshipBuilder(
-                        principalEntityType,
-                        dependentEntityType,
-                        navigationToPrincipalName,
-                        navigationToDependentName,
-                        dependentProperties,
-                        principalProperties);
+                    if (newRelationshipBuilder.Metadata.Builder == null)
+                    {
+                        newRelationshipBuilder = FindCurrentRelationshipBuilder(
+                            principalEntityType,
+                            dependentEntityType,
+                            navigationToPrincipal,
+                            navigationToDependent,
+                            dependentProperties,
+                            principalProperties);
+                        if (newRelationshipBuilder == null)
+                        {
+                            return null;
+                        }
+                    }
                 }
 
                 var inverted = newRelationshipBuilder.Metadata.DeclaringEntityType != dependentEntityType;
@@ -1446,22 +1766,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnNavigationAdded(
                         newRelationshipBuilder, newRelationshipBuilder.Metadata.DependentToPrincipal);
-                }
+                    if (newRelationshipBuilder == null)
+                    {
+                        return null;
+                    }
 
-                if (newRelationshipBuilder == null)
-                {
-                    return null;
-                }
-
-                if (newRelationshipBuilder.Metadata.Builder == null)
-                {
-                    newRelationshipBuilder = FindCurrentRelationshipBuilder(
-                        principalEntityType,
-                        dependentEntityType,
-                        navigationToPrincipalName,
-                        navigationToDependentName,
-                        dependentProperties,
-                        principalProperties);
+                    if (newRelationshipBuilder.Metadata.Builder == null)
+                    {
+                        newRelationshipBuilder = FindCurrentRelationshipBuilder(
+                            principalEntityType,
+                            dependentEntityType,
+                            navigationToPrincipal,
+                            navigationToDependent,
+                            dependentProperties,
+                            principalProperties);
+                        if (newRelationshipBuilder == null)
+                        {
+                            return null;
+                        }
+                    }
                 }
 
                 if ((principalToDependentIsNew && !inverted)
@@ -1469,22 +1792,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnNavigationAdded(
                         newRelationshipBuilder, newRelationshipBuilder.Metadata.PrincipalToDependent);
-                }
+                    if (newRelationshipBuilder == null)
+                    {
+                        return null;
+                    }
 
-                if (newRelationshipBuilder == null)
-                {
-                    return null;
-                }
-
-                if (newRelationshipBuilder.Metadata.Builder == null)
-                {
-                    newRelationshipBuilder = FindCurrentRelationshipBuilder(
-                        principalEntityType,
-                        dependentEntityType,
-                        navigationToPrincipalName,
-                        navigationToDependentName,
-                        dependentProperties,
-                        principalProperties);
+                    if (newRelationshipBuilder.Metadata.Builder == null)
+                    {
+                        newRelationshipBuilder = FindCurrentRelationshipBuilder(
+                            principalEntityType,
+                            dependentEntityType,
+                            navigationToPrincipal,
+                            navigationToDependent,
+                            dependentProperties,
+                            principalProperties);
+                        if (newRelationshipBuilder == null)
+                        {
+                            return null;
+                        }
+                    }
                 }
             }
 
@@ -1494,41 +1820,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private InternalRelationshipBuilder RelatedEntityTypes(
             InternalEntityTypeBuilder principalEntityTypeBuilder,
             InternalEntityTypeBuilder dependentEntityTypeBuilder,
-            string navigationToPrincipalName,
-            string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             IReadOnlyList<Property> dependentProperties,
             ConfigurationSource? principalEndConfigurationSource,
             ConfigurationSource? configurationSource,
             bool existingRelationshipInverted)
         {
             var newRelationshipBuilder = this;
-            if (newRelationshipBuilder.Metadata.DependentToPrincipal != null
-                && ((!existingRelationshipInverted
-                     && navigationToPrincipalName != null
-                     && navigationToPrincipalName != newRelationshipBuilder.Metadata.DependentToPrincipal.Name)
-                    || (existingRelationshipInverted
-                        && navigationToDependentName != null
-                        && navigationToDependentName != newRelationshipBuilder.Metadata.DependentToPrincipal.Name)))
+            var resetToPrincipal = newRelationshipBuilder.Metadata.DependentToPrincipal != null
+                                   && ((!existingRelationshipInverted
+                                        && navigationToPrincipal != null
+                                        && navigationToPrincipal.Value.Name != newRelationshipBuilder.Metadata.DependentToPrincipal.Name)
+                                       || (existingRelationshipInverted
+                                           && navigationToDependent != null
+                                           && navigationToDependent.Value.Name != newRelationshipBuilder.Metadata.DependentToPrincipal.Name));
+
+            var resetToDependent = newRelationshipBuilder.Metadata.PrincipalToDependent != null
+                                   && ((!existingRelationshipInverted
+                                        && navigationToDependent != null
+                                        && navigationToDependent.Value.Name != newRelationshipBuilder.Metadata.PrincipalToDependent.Name)
+                                       || (existingRelationshipInverted
+                                           && navigationToPrincipal != null
+                                           && navigationToPrincipal.Value.Name != newRelationshipBuilder.Metadata.PrincipalToDependent.Name));
+
+            if (resetToPrincipal
+                || resetToDependent)
             {
-                newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                    null,
-                    pointsToPrincipal: true,
-                    configurationSource: configurationSource,
-                    runConventions: false)
-                                         ?? newRelationshipBuilder;
-            }
-            if (newRelationshipBuilder.Metadata.PrincipalToDependent != null
-                && ((!existingRelationshipInverted
-                     && navigationToDependentName != null
-                     && navigationToDependentName != newRelationshipBuilder.Metadata.PrincipalToDependent.Name)
-                    || (existingRelationshipInverted
-                        && navigationToPrincipalName != null
-                        && navigationToPrincipalName != newRelationshipBuilder.Metadata.PrincipalToDependent.Name)))
-            {
-                newRelationshipBuilder = newRelationshipBuilder.Navigation(
-                    null,
-                    pointsToPrincipal: false,
-                    configurationSource: configurationSource,
+                newRelationshipBuilder = newRelationshipBuilder.Navigations(
+                    resetToPrincipal ? PropertyIdentity.None : (PropertyIdentity?)null,
+                    resetToDependent ? PropertyIdentity.None : (PropertyIdentity?)null,
+                    configurationSource,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1544,20 +1866,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 principalEntityTypeBuilder.Metadata,
                 dependentEntityTypeBuilder.Metadata,
                 principalEndConfigurationSource,
+                configurationSource,
                 runConventions: false);
         }
 
         private InternalRelationshipBuilder GetOrCreateRelationshipBuilder(
             EntityType principalEntityType,
             EntityType dependentEntityType,
-            string navigationToPrincipalName,
-            string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             IReadOnlyList<Property> dependentProperties,
             IReadOnlyList<Property> principalProperties,
             bool? isRequired,
             ConfigurationSource? principalEndConfigurationSource,
             ConfigurationSource? configurationSource,
-            Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>> removedNavigations,
+            List<Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string, PropertyInfo>> removedNavigations,
             List<Tuple<InternalEntityTypeBuilder, ForeignKey>> removedForeignKeys,
             List<InternalRelationshipBuilder> addedForeignKeys,
             out bool existingRelationshipInverted)
@@ -1566,8 +1889,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var matchingRelationships = FindRelationships(
                 principalEntityType,
                 dependentEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties,
                 principalProperties);
             matchingRelationships = matchingRelationships.Distinct().Where(r => r.Metadata != Metadata).ToList();
@@ -1579,17 +1902,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var resolvable = true;
                 var goodMatch = true;
                 var resolution = Resolution.None;
-                if (!string.IsNullOrEmpty(navigationToPrincipalName))
+                var navigationToPrincipalName = navigationToPrincipal?.Name;
+                if (navigationToPrincipalName != null)
                 {
                     if ((navigationToPrincipalName == matchingRelationship.Metadata.DependentToPrincipal?.Name)
                         && dependentEntityType.IsSameHierarchy(matchingRelationship.Metadata.DependentToPrincipal.DeclaringEntityType))
                     {
-                        if (matchingRelationship.CanSetNavigation(null, true, configurationSource, overrideSameSource: false))
+                        if (matchingRelationship.CanSetNavigation((string)null, true, configurationSource, overrideSameSource: false))
                         {
                             resolution |= Resolution.ResetToPrincipal;
                             goodMatch = false;
                         }
-                        else if (matchingRelationship.CanSetNavigation(null, true, configurationSource))
+                        else if (matchingRelationship.CanSetNavigation((string)null, true, configurationSource))
                         {
                             resolution |= Resolution.ResetToPrincipal;
                         }
@@ -1601,12 +1925,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     else if ((navigationToPrincipalName == matchingRelationship.Metadata.PrincipalToDependent?.Name)
                              && dependentEntityType.IsSameHierarchy(matchingRelationship.Metadata.PrincipalToDependent.DeclaringEntityType))
                     {
-                        if (matchingRelationship.CanSetNavigation(null, false, configurationSource, overrideSameSource: false))
+                        if (matchingRelationship.CanSetNavigation((string)null, false, configurationSource, overrideSameSource: false))
                         {
                             resolution |= Resolution.ResetToDependent;
                             goodMatch = false;
                         }
-                        else if (matchingRelationship.CanSetNavigation(null, false, configurationSource))
+                        else if (matchingRelationship.CanSetNavigation((string)null, false, configurationSource))
                         {
                             resolution |= Resolution.ResetToDependent;
                         }
@@ -1617,17 +1941,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                if (!string.IsNullOrEmpty(navigationToDependentName))
+                var navigationToDependentName = navigationToDependent?.Name;
+                if (navigationToDependentName != null)
                 {
                     if ((navigationToDependentName == matchingRelationship.Metadata.PrincipalToDependent?.Name)
                         && principalEntityType.IsSameHierarchy(matchingRelationship.Metadata.PrincipalToDependent.DeclaringEntityType))
                     {
-                        if (matchingRelationship.CanSetNavigation(null, false, configurationSource, overrideSameSource: false))
+                        if (matchingRelationship.CanSetNavigation((string)null, false, configurationSource, overrideSameSource: false))
                         {
                             resolution |= Resolution.ResetToDependent;
                             goodMatch = false;
                         }
-                        else if (matchingRelationship.CanSetNavigation(null, false, configurationSource))
+                        else if (matchingRelationship.CanSetNavigation((string)null, false, configurationSource))
                         {
                             resolution |= Resolution.ResetToDependent;
                         }
@@ -1639,12 +1964,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     else if ((navigationToDependentName == matchingRelationship.Metadata.DependentToPrincipal?.Name)
                              && principalEntityType.IsSameHierarchy(matchingRelationship.Metadata.DependentToPrincipal.DeclaringEntityType))
                     {
-                        if (matchingRelationship.CanSetNavigation(null, true, configurationSource, overrideSameSource: false))
+                        if (matchingRelationship.CanSetNavigation((string)null, true, configurationSource, overrideSameSource: false))
                         {
                             resolution |= Resolution.ResetToPrincipal;
                             goodMatch = false;
                         }
-                        else if (matchingRelationship.CanSetNavigation(null, true, configurationSource))
+                        else if (matchingRelationship.CanSetNavigation((string)null, true, configurationSource))
                         {
                             resolution |= Resolution.ResetToPrincipal;
                         }
@@ -1721,19 +2046,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var candidateRelationship in candidates)
             {
                 bool _;
+                bool? __;
                 if (candidateRelationship.CanSetRelatedTypes(
                     principalEntityType,
                     dependentEntityType,
                     principalEndConfigurationSource,
-                    navigationToPrincipalName,
-                    navigationToDependentName,
+                    navigationToPrincipal,
+                    navigationToDependent,
                     configurationSource,
                     false,
                     out existingRelationshipInverted,
                     out _,
                     out _,
                     out _,
-                    out _))
+                    out _,
+                    out __))
                 {
                     newRelationshipBuilder = candidateRelationship;
                     break;
@@ -1779,23 +2106,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (resolution.HasFlag(Resolution.ResetToPrincipal))
                 {
                     var foreignKey = resolvableRelationship.Metadata;
-                    removedNavigations[foreignKey.DeclaringEntityType.Name + "." + foreignKey.DependentToPrincipal.Name] =
-                        Tuple.Create(
-                            foreignKey.DeclaringEntityType.Builder,
-                            foreignKey.PrincipalEntityType.Builder,
-                            foreignKey.DependentToPrincipal.Name);
-                    resolvableRelationship = resolvableRelationship.Navigation(null, true, foreignKey.GetConfigurationSource(), runConventions: false);
+                    removedNavigations.Add(Tuple.Create(
+                        foreignKey.DeclaringEntityType.Builder,
+                        foreignKey.PrincipalEntityType.Builder,
+                        foreignKey.DependentToPrincipal.Name,
+                        foreignKey.DependentToPrincipal.PropertyInfo));
+                    resolvableRelationship = resolvableRelationship.Navigations(
+                        PropertyIdentity.None, null, foreignKey.GetConfigurationSource(), runConventions: false);
                 }
 
                 if (resolution.HasFlag(Resolution.ResetToDependent))
                 {
                     var foreignKey = resolvableRelationship.Metadata;
-                    removedNavigations[foreignKey.PrincipalEntityType.Name + "." + foreignKey.PrincipalToDependent.Name] =
-                        Tuple.Create(
-                            foreignKey.PrincipalEntityType.Builder,
-                            foreignKey.DeclaringEntityType.Builder,
-                            foreignKey.PrincipalToDependent.Name);
-                    resolvableRelationship = resolvableRelationship.Navigation(null, false, foreignKey.GetConfigurationSource(), runConventions: false);
+                    removedNavigations.Add(Tuple.Create(
+                        foreignKey.PrincipalEntityType.Builder,
+                        foreignKey.DeclaringEntityType.Builder,
+                        foreignKey.PrincipalToDependent.Name,
+                        foreignKey.PrincipalToDependent.PropertyInfo));
+                    resolvableRelationship = resolvableRelationship.Navigations(
+                        null, PropertyIdentity.None, foreignKey.GetConfigurationSource(), runConventions: false);
                 }
 
                 if (resolvableRelationship.Metadata.Builder == null)
@@ -1841,7 +2170,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     principalEntityType.Builder,
                     dependentProperties,
                     principalKey,
-                    navigationToPrincipalName,
+                    navigationToPrincipal?.Name,
                     isRequired,
                     ConfigurationSource.Convention,
                     runConventions: false);
@@ -1852,36 +2181,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (newRelationshipBuilder.Metadata.DependentToPrincipal != null)
                 {
                     var newForeignKey = newRelationshipBuilder.Metadata;
-                    removedNavigations[newForeignKey.DeclaringEntityType.Name + "." + newForeignKey.DependentToPrincipal.Name] =
-                        Tuple.Create(
-                            newForeignKey.DeclaringEntityType.Builder,
-                            newForeignKey.PrincipalEntityType.Builder,
-                            newForeignKey.DependentToPrincipal.Name);
+                    removedNavigations.Add(Tuple.Create(
+                        newForeignKey.DeclaringEntityType.Builder,
+                        newForeignKey.PrincipalEntityType.Builder,
+                        newForeignKey.DependentToPrincipal.Name,
+                        newForeignKey.DependentToPrincipal.PropertyInfo));
                 }
                 if (newRelationshipBuilder.Metadata.PrincipalToDependent != null)
                 {
                     var newForeignKey = newRelationshipBuilder.Metadata;
-                    removedNavigations[newForeignKey.PrincipalEntityType.Name + "." + newForeignKey.PrincipalToDependent.Name] =
-                        Tuple.Create(
-                            newForeignKey.PrincipalEntityType.Builder,
-                            newForeignKey.DeclaringEntityType.Builder,
-                            newForeignKey.PrincipalToDependent.Name);
+                    removedNavigations.Add(Tuple.Create(
+                        newForeignKey.PrincipalEntityType.Builder,
+                        newForeignKey.DeclaringEntityType.Builder,
+                        newForeignKey.PrincipalToDependent.Name,
+                        newForeignKey.PrincipalToDependent.PropertyInfo));
                 }
 
-                if (navigationToPrincipalName != null
-                    && (navigationToPrincipalName == "" ? null : navigationToPrincipalName) != newRelationshipBuilder.Metadata.DependentToPrincipal?.Name
+                if (navigationToPrincipal != null
+                    && navigationToPrincipal?.Name != newRelationshipBuilder.Metadata.DependentToPrincipal?.Name
                     && dependentProperties == null
                     && newRelationshipBuilder.Metadata.GetForeignKeyPropertiesConfigurationSource() == null
                     && (!existingRelationshipInverted
                         || (existingRelationshipInverted
-                            && newRelationshipBuilder.Metadata.IsSelfReferencing())))
+                            && newRelationshipBuilder.Metadata.IsSelfReferencing()
+                            && CanInvert(configurationSource))))
                 {
                     // TODO: Also handle the case where existing relationship cannot be inverted,
-                    // so the new nav to principal will be specified nav to dependent
+                    // so the new nav to principal will be the specified nav to dependent
                     newRelationshipBuilder = newRelationshipBuilder.ReplaceForeignKey(
                         principalEntityType.Builder,
                         dependentEntityType.Builder,
-                        navigationToPrincipalName,
+                        navigationToPrincipal,
                         null,
                         dependentProperties,
                         principalProperties,
@@ -1892,6 +2222,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         null,
                         configurationSource,
                         runConventions: false);
+
+                    existingRelationshipInverted = false;
                 }
             }
 
@@ -1900,23 +2232,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private void RemoveForeignKey(
             ForeignKey foreignKey,
-            Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>> removedNavigations,
+            List<Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string, PropertyInfo>> removedNavigations,
             List<Tuple<InternalEntityTypeBuilder, ForeignKey>> removedForeignKeys)
         {
             var dependentEntityTypeBuilder = foreignKey.DeclaringEntityType.Builder;
             var principalEntityTypeBuilder = foreignKey.PrincipalEntityType.Builder;
-            var navigationToPrincipalName = foreignKey.DependentToPrincipal?.Name;
-            if (navigationToPrincipalName != null)
+            var navigationToPrincipal = foreignKey.DependentToPrincipal;
+            if (navigationToPrincipal != null)
             {
-                removedNavigations[foreignKey.DeclaringEntityType.Name + "." + navigationToPrincipalName] =
-                    Tuple.Create(dependentEntityTypeBuilder, principalEntityTypeBuilder, navigationToPrincipalName);
+                removedNavigations.Add(Tuple.Create(
+                    dependentEntityTypeBuilder, principalEntityTypeBuilder, navigationToPrincipal.Name, navigationToPrincipal.PropertyInfo));
             }
 
-            var navigationToDependentName = foreignKey.PrincipalToDependent?.Name;
-            if (navigationToDependentName != null)
+            var navigationToDependent = foreignKey.PrincipalToDependent;
+            if (navigationToDependent != null)
             {
-                removedNavigations[foreignKey.PrincipalEntityType.Name + "." + navigationToDependentName] =
-                    Tuple.Create(principalEntityTypeBuilder, dependentEntityTypeBuilder, navigationToDependentName);
+                removedNavigations.Add(Tuple.Create(
+                    principalEntityTypeBuilder, dependentEntityTypeBuilder, navigationToDependent.Name, navigationToDependent.PropertyInfo));
             }
 
             var foreignKeyOwner = foreignKey.DeclaringEntityType.Builder;
@@ -1929,23 +2261,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private static IReadOnlyList<InternalRelationshipBuilder> FindRelationships(
             [NotNull] EntityType principalEntityType,
             [NotNull] EntityType dependentEntityType,
-            string navigationToPrincipalName,
-            string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             IReadOnlyList<Property> dependentProperties,
             IReadOnlyList<Property> principalProperties)
         {
             var existingRelationships = new List<InternalRelationshipBuilder>();
-            if (!string.IsNullOrEmpty(navigationToPrincipalName))
+            if (navigationToPrincipal?.Name != null)
             {
                 existingRelationships.AddRange(dependentEntityType
-                    .FindNavigationsInHierarchy(navigationToPrincipalName)
+                    .FindNavigationsInHierarchy(navigationToPrincipal.Value.Name)
                     .Select(n => n.ForeignKey.Builder));
             }
 
-            if (!string.IsNullOrEmpty(navigationToDependentName))
+            if (navigationToDependent?.Name != null)
             {
                 existingRelationships.AddRange(principalEntityType
-                    .FindNavigationsInHierarchy(navigationToDependentName)
+                    .FindNavigationsInHierarchy(navigationToDependent.Value.Name)
                     .Select(n => n.ForeignKey.Builder));
             }
 
@@ -1975,8 +2307,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private InternalRelationshipBuilder FindCurrentRelationshipBuilder(
             EntityType principalEntityType,
             EntityType dependentEntityType,
-            string navigationToPrincipalName = null,
-            string navigationToDependentName = null,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             IReadOnlyList<Property> dependentProperties = null,
             IReadOnlyList<Property> principalProperties = null)
         {
@@ -1984,22 +2316,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var matchingRelationships = FindRelationships(
                 principalEntityType,
                 dependentEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties,
                 principalProperties).Distinct();
 
             foreach (var matchingRelationship in matchingRelationships)
             {
                 var matchingForeignKey = matchingRelationship.Metadata;
-                if (navigationToPrincipalName != null
-                    && (matchingForeignKey.DependentToPrincipal?.Name ?? "") != navigationToPrincipalName)
+                if (navigationToPrincipal != null
+                    && matchingForeignKey.DependentToPrincipal?.Name != navigationToPrincipal.Value.Name)
                 {
                     continue;
                 }
 
-                if (navigationToDependentName != null
-                    && (matchingForeignKey.PrincipalToDependent?.Name ?? "") != navigationToDependentName)
+                if (navigationToDependent != null
+                    && matchingForeignKey.PrincipalToDependent?.Name != navigationToDependent.Value.Name)
                 {
                     continue;
                 }
@@ -2081,8 +2413,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static bool AreCompatible(
             [NotNull] EntityType principalEntityType,
             [NotNull] EntityType dependentEntityType,
-            [CanBeNull] string navigationToPrincipalName,
-            [CanBeNull] string navigationToDependentName,
+            [CanBeNull] PropertyInfo navigationToPrincipal,
+            [CanBeNull] PropertyInfo navigationToDependent,
             [CanBeNull] IReadOnlyList<Property> dependentProperties,
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             bool? isUnique,
@@ -2104,8 +2436,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return ForeignKey.AreCompatible(
                 principalEntityType,
                 dependentEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipal,
+                navigationToDependent,
                 dependentProperties,
                 principalProperties,
                 isUnique,
@@ -2117,48 +2449,53 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             EntityType principalEntityType,
             EntityType dependentEntityType,
             ConfigurationSource? principalEndConfigurationSource,
-            string navigationToPrincipalName,
-            string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             ConfigurationSource? configurationSource,
             bool shouldThrow,
             out bool shouldInvert,
             out bool shouldResetToPrincipal,
             out bool shouldResetToDependent,
             out bool shouldResetPrincipalProperties,
-            out bool shouldResetDependentProperties)
+            out bool shouldResetDependentProperties,
+            out bool? shouldBeUnique)
         {
             shouldInvert = false;
             shouldResetToPrincipal = false;
             shouldResetToDependent = false;
             shouldResetPrincipalProperties = false;
             shouldResetDependentProperties = false;
-            var someAspectsFitNonInverted = false;
+            shouldBeUnique = null;
+
             var sameHierarchyInvertedNavigations =
                 principalEntityType.IsSameHierarchy(dependentEntityType)
-                && (((navigationToPrincipalName != null)
-                     && (navigationToPrincipalName == Metadata.PrincipalToDependent?.Name))
-                    || ((navigationToDependentName != null)
-                        && (navigationToDependentName == Metadata.DependentToPrincipal?.Name)));
+                && (((navigationToPrincipal != null)
+                     && (navigationToPrincipal.Value.Name == Metadata.PrincipalToDependent?.Name))
+                    || ((navigationToDependent != null)
+                        && (navigationToDependent.Value.Name == Metadata.DependentToPrincipal?.Name)));
 
+            var someAspectsFitNonInverted = false;
             if (!sameHierarchyInvertedNavigations
                 && CanSetRelatedTypes(
                     principalEntityType,
                     dependentEntityType,
-                    navigationToPrincipalName,
-                    navigationToDependentName,
+                    navigationToPrincipal,
+                    navigationToDependent,
                     configurationSource,
                     false,
                     false,
                     out shouldResetToPrincipal,
                     out shouldResetToDependent,
                     out shouldResetPrincipalProperties,
-                    out shouldResetDependentProperties))
+                    out shouldResetDependentProperties,
+                    out shouldBeUnique))
             {
                 if (!shouldResetToPrincipal
                     && !shouldResetToDependent)
                 {
                     return true;
                 }
+
                 someAspectsFitNonInverted = true;
             }
 
@@ -2167,21 +2504,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var canInvert = CanInvert(configurationSource);
             bool invertedShouldResetToPrincipal;
             bool invertedShouldResetToDependent;
+            bool? invertedShouldBeUnique;
             bool _;
             if ((!strictPrincipal
                  || canInvert)
                 && CanSetRelatedTypes(
                     dependentEntityType,
                     principalEntityType,
-                    navigationToDependentName,
-                    navigationToPrincipalName,
+                    navigationToDependent,
+                    navigationToPrincipal,
                     configurationSource,
                     strictPrincipal,
                     false,
                     out invertedShouldResetToPrincipal,
                     out invertedShouldResetToDependent,
                     out _,
-                    out _)
+                    out _,
+                    out invertedShouldBeUnique)
                 && (!someAspectsFitNonInverted
                     || (!invertedShouldResetToPrincipal
                         && !invertedShouldResetToDependent)))
@@ -2189,6 +2528,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 shouldInvert = true;
                 shouldResetToPrincipal = invertedShouldResetToDependent;
                 shouldResetToDependent = invertedShouldResetToPrincipal;
+                shouldBeUnique = invertedShouldBeUnique;
                 return true;
             }
 
@@ -2208,20 +2548,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private bool CanSetRelatedTypes(
             EntityType principalEntityType,
             EntityType dependentEntityType,
-            string navigationToPrincipalName,
-            string navigationToDependentName,
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
             ConfigurationSource? configurationSource,
             bool inverted,
             bool shouldThrow,
             out bool shouldResetToPrincipal,
             out bool shouldResetToDependent,
             out bool shouldResetPrincipalProperties,
-            out bool shouldResetDependentProperties)
+            out bool shouldResetDependentProperties,
+            out bool? shouldBeUnique)
         {
             shouldResetToPrincipal = false;
             shouldResetToDependent = false;
             shouldResetPrincipalProperties = false;
             shouldResetDependentProperties = false;
+            shouldBeUnique = null;
 
             if (!Metadata.DeclaringEntityType.IsSameHierarchy(dependentEntityType))
             {
@@ -2235,80 +2577,114 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             bool? _;
             bool __;
-            if (navigationToPrincipalName != null)
+            if (navigationToPrincipal != null)
             {
                 if (!configurationSource.HasValue
                     || !CanSetNavigation(
-                        navigationToPrincipalName == "" ? null : navigationToPrincipalName,
+                        navigationToPrincipal.Value,
                         true,
                         configurationSource.Value,
                         shouldThrow,
-                        true,
-                        out _,
-                        out __))
+                        overrideSameSource: true,
+                        shouldBeUnique: out _,
+                        removeOppositeNavigation: out __))
                 {
                     return false;
                 }
 
-                shouldResetToPrincipal = true;
+                if (Metadata.DependentToPrincipal != null
+                    && navigationToPrincipal.Value.Name != Metadata.DependentToPrincipal.Name)
+                {
+                    shouldResetToPrincipal = true;
+                }
             }
             else
             {
-                navigationToPrincipalName = Metadata.DependentToPrincipal?.Name;
-                if ((navigationToPrincipalName != null)
-                    && !Internal.Navigation.IsCompatible(
-                        navigationToPrincipalName,
+                bool? invertedShouldBeUnique = null;
+                var navigationToPrincipalProperty = Metadata.DependentToPrincipal?.PropertyInfo;
+                if (navigationToPrincipalProperty != null
+                    && !IsCompatible(
+                        navigationToPrincipalProperty,
                         !inverted,
-                        inverted ? principalEntityType : dependentEntityType,
-                        inverted ? dependentEntityType : principalEntityType,
+                        inverted ? principalEntityType.ClrType : dependentEntityType.ClrType,
+                        inverted ? dependentEntityType.ClrType : principalEntityType.ClrType,
                         shouldThrow,
-                        out _))
+                        out invertedShouldBeUnique))
                 {
                     if (!configurationSource.HasValue
-                        || !CanSetNavigation(null, true, configurationSource.Value))
+                        || !CanSetNavigation((string)null, true, configurationSource.Value))
                     {
                         return false;
                     }
 
                     shouldResetToPrincipal = true;
                 }
+                if (inverted)
+                {
+                    shouldBeUnique = invertedShouldBeUnique;
+                }
             }
 
-            if (navigationToDependentName != null)
+            if (navigationToDependent != null)
             {
+                bool? toDependentShouldBeUnique = null;
                 if (!configurationSource.HasValue
                     || !CanSetNavigation(
-                        navigationToDependentName == "" ? null : navigationToDependentName,
+                        navigationToDependent.Value,
                         false,
                         configurationSource.Value,
                         shouldThrow,
-                        true,
-                        out _,
-                        out __))
+                        overrideSameSource: true,
+                        shouldBeUnique: out toDependentShouldBeUnique,
+                        removeOppositeNavigation: out __))
                 {
                     return false;
+                }
+
+                if (Metadata.PrincipalToDependent != null
+                    && navigationToDependent.Value.Name != Metadata.PrincipalToDependent.Name)
+                {
+                    shouldResetToDependent = true;
+                }
+
+                if (toDependentShouldBeUnique != null)
+                {
+                    shouldBeUnique = toDependentShouldBeUnique;
                 }
             }
             else
             {
-                navigationToDependentName = Metadata.PrincipalToDependent?.Name;
-                if ((navigationToDependentName != null)
-                    && !Internal.Navigation.IsCompatible(
-                        navigationToDependentName,
+                bool? toDependentShouldBeUnique = null;
+                var navigationToDependentProperty = Metadata.PrincipalToDependent?.PropertyInfo;
+                if (navigationToDependentProperty != null
+                    && !IsCompatible(
+                        navigationToDependentProperty,
                         inverted,
-                        inverted ? principalEntityType : dependentEntityType,
-                        inverted ? dependentEntityType : principalEntityType,
+                        inverted ? principalEntityType.ClrType : dependentEntityType.ClrType,
+                        inverted ? dependentEntityType.ClrType : principalEntityType.ClrType,
                         shouldThrow,
-                        out _))
+                        out toDependentShouldBeUnique))
                 {
                     if (!configurationSource.HasValue
-                        || !CanSetNavigation(null, false, configurationSource.Value))
+                        || !CanSetNavigation((string)null, false, configurationSource.Value))
                     {
                         return false;
                     }
 
                     shouldResetToDependent = true;
                 }
+
+                if (!inverted
+                    && toDependentShouldBeUnique != null)
+                {
+                    shouldBeUnique = toDependentShouldBeUnique;
+                }
+            }
+
+            if (shouldBeUnique.HasValue
+                && !CanSetUnique(shouldBeUnique.Value, configurationSource, out __))
+            {
+                return false;
             }
 
             if (!Property.AreCompatible(Metadata.PrincipalKey.Properties, principalEntityType))

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyIdentity.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyIdentity.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
+    public struct PropertyIdentity
+    {
+        private readonly object _nameOrProperty;
+
+        public PropertyIdentity([NotNull] string name)
+            : this((object)name)
+        {
+        }
+
+        public PropertyIdentity([NotNull] PropertyInfo property)
+            : this((object)property)
+        {
+        }
+
+        private PropertyIdentity([CanBeNull] object nameOrProperty)
+        {
+            _nameOrProperty = nameOrProperty;
+        }
+
+        public bool IsNone() => _nameOrProperty == null;
+
+        public static readonly PropertyIdentity None = new PropertyIdentity((object)null);
+
+        public static PropertyIdentity Create([CanBeNull] string name)
+            => name == null ? None : new PropertyIdentity(name);
+
+        public static PropertyIdentity Create([CanBeNull] PropertyInfo property)
+            => property == null ? None : new PropertyIdentity(property);
+
+        public static PropertyIdentity Create([CanBeNull] Navigation navigation)
+            => navigation?.PropertyInfo == null ? Create(navigation?.Name) : Create(navigation.PropertyInfo);
+
+        public string Name => Property?.Name ?? (string)_nameOrProperty;
+
+        public PropertyInfo Property => _nameOrProperty as PropertyInfo;
+
+        private string DebuggerDisplay()
+            => Name ?? "NONE";
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -349,6 +349,7 @@
     <Compile Include="Metadata\Internal\PropertyBaseExtensions.cs" />
     <Compile Include="Metadata\Internal\PropertyCounts.cs" />
     <Compile Include="Metadata\Internal\PropertyExtensions.cs" />
+    <Compile Include="Metadata\Internal\PropertyIdentity.cs" />
     <Compile Include="Metadata\Internal\PropertyIndexes.cs" />
     <Compile Include="Metadata\Internal\PropertyListComparer.cs" />
     <Compile Include="Metadata\IProperty.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -537,14 +537,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             if (useBuilder)
             {
-                Assert.Null(dependentEntityBuilder.Relationship(principalEntityBuilder, nameof(OrderDetails.Order), nameof(Order.OrderDetails), ConfigurationSource.Convention));
+                Assert.Null(dependentEntityBuilder.Relationship(principalEntityBuilder, OrderDetails.OrderProperty, Order.OrderDetailsProperty, ConfigurationSource.Convention));
             }
             else
             {
                 var fk = dependentEntityBuilder.Relationship(principalEntityBuilder, ConfigurationSource.Convention)
                     .IsUnique(true, ConfigurationSource.Convention)
                     .Metadata;
-                Assert.Null(fk.HasDependentToPrincipal(nameof(OrderDetails.Order)));
+                Assert.Null(fk.HasDependentToPrincipal(OrderDetails.OrderProperty));
             }
 
             Assert.True(orderIgnored);
@@ -588,11 +588,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             if (useBuilder)
             {
-                Assert.NotNull(relationshipBuilder.DependentToPrincipal(null, ConfigurationSource.Convention));
+                Assert.NotNull(relationshipBuilder.DependentToPrincipal((string)null, ConfigurationSource.Convention));
             }
             else
             {
-                Assert.NotNull(relationshipBuilder.Metadata.HasDependentToPrincipal(null, ConfigurationSource.Convention));
+                Assert.NotNull(relationshipBuilder.Metadata.HasDependentToPrincipal((string)null, ConfigurationSource.Convention));
             }
 
             Assert.Same(dependentEntityTypeBuilderFromConvention, dependentEntityBuilder);
@@ -842,7 +842,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
         private class Order
         {
-            public static readonly PropertyInfo OrderIdProperty = typeof(Order).GetProperty("OrderId");
+            public static readonly PropertyInfo OrderIdProperty = typeof(Order).GetProperty(nameof(OrderId));
+            public static readonly PropertyInfo OrderDetailsProperty = typeof(Order).GetProperty(nameof(OrderDetails));
 
             public int OrderId { get; set; }
 
@@ -857,6 +858,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
         private class OrderDetails
         {
+            public static readonly PropertyInfo OrderProperty = typeof(OrderDetails).GetProperty(nameof(Order));
+
             public int Id { get; set; }
             public virtual Order Order { get; set; }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
             var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
 
-            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Convention)
+            principalEntityBuilder.Relationship(dependentEntityBuilder, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
@@ -76,10 +76,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
             var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
 
-            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Convention)
+            principalEntityBuilder.Relationship(dependentEntityBuilder,  OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention);
 
-            principalEntityBuilder.Relationship(dependentEntityBuilder, null, OneToOneDependent.NavigationProperty, ConfigurationSource.Convention)
+            dependentEntityBuilder.Relationship(principalEntityBuilder, OneToOneDependent.NavigationProperty, null, ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
             var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
 
-            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Explicit)
+            principalEntityBuilder.Relationship(dependentEntityBuilder, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
@@ -584,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
             derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
-            entityBuilder.Relationship(baseBuilder, null, nameof(Base.BaseNavigation), ConfigurationSource.Convention);
+            baseBuilder.Relationship(entityBuilder, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/EntityTypeExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/EntityTypeExtensionsTest.cs
@@ -14,9 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
         [Fact]
         public void Can_get_all_properties_and_navigations()
         {
-            var entityType = new Model().AddEntityType(typeof(SelfRef));
-            var pk = entityType.GetOrSetPrimaryKey(entityType.AddProperty(SelfRef.IdProperty));
-            var fkProp = entityType.AddProperty(SelfRef.SelfRefIdProperty);
+            var entityType = new Model().AddEntityType(nameof(SelfRef));
+            var pk = entityType.GetOrSetPrimaryKey(entityType.AddProperty(nameof(SelfRef.Id), typeof(int), shadow: true));
+            var fkProp = entityType.AddProperty(nameof(SelfRef.SelfRefId), typeof(int?), shadow: true);
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, pk, entityType);
             fk.IsUnique = true;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -208,7 +209,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
                 entityType.GetOrSetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
                 entityType);
 
-            return foreignKey.HasPrincipalToDependent(navigationName);
+            return foreignKey.HasPrincipalToDependent(
+                typeof(MyEntity).GetProperty(navigationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
         }
 
         private class MyEntity

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var b = model.AddEntityType(typeof(B).Name);
 
             Assert.Equal(
-                CoreStrings.NonShadowBaseType(b, a),
+                CoreStrings.NonShadowBaseType(typeof(B).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var b = model.AddEntityType(typeof(B));
 
             Assert.Equal(
-                CoreStrings.NonClrBaseType(b, a),
+                CoreStrings.NonClrBaseType(typeof(B).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var b = model.AddEntityType(typeof(B));
 
             Assert.Equal(
-                CoreStrings.NotAssignableClrBaseType(a, b, typeof(A).Name, typeof(B).Name),
+                CoreStrings.NotAssignableClrBaseType(typeof(A).Name, typeof(B).Name, typeof(A).Name, typeof(B).Name),
                 Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
         }
 
@@ -323,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             b.AddProperty(A.GProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(B).FullName, typeof(A).FullName, "G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(B).Name, typeof(A).Name, "G"),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
         }
 
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             d.AddProperty(A.GProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(D).FullName, typeof(C).FullName, "E, G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(D).Name, typeof(C).Name, "E, G"),
                 Assert.Throws<InvalidOperationException>(() => { d.HasBaseType(c); }).Message);
         }
 
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             d.HasBaseType(c);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(C).FullName, typeof(A).FullName, "E, G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(C).Name, typeof(A).Name, "E, G"),
                 Assert.Throws<InvalidOperationException>(() => { c.HasBaseType(a); }).Message);
         }
 
@@ -486,7 +486,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var key = b.AddKey(h);
 
             Assert.Equal(
-                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).FullName),
+                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
 
             b.RemoveKey(key.Properties);
@@ -495,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             b.SetPrimaryKey(f);
 
             Assert.Equal(
-                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).FullName),
+                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
         }
 
@@ -511,7 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            customerForeignKey.HasPrincipalToDependent("Orders");
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
 
@@ -525,7 +525,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent("DerivedOrders");
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
             Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "Orders", "DerivedOrders" }, ((IEntityType)specialCustomerType).GetNavigations().Select(p => p.Name).ToArray());
@@ -547,14 +547,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
             specialCustomerType.HasBaseType(customerType);
 
-            customerForeignKey.HasPrincipalToDependent("Orders");
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "Orders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
 
             var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent("DerivedOrders");
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
 
             Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
@@ -572,19 +572,19 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            customerForeignKey.HasPrincipalToDependent("Orders");
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
             specialCustomerType.HasBaseType(customerType);
 
             var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent("DerivedOrders");
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
 
             specialCustomerType.HasBaseType(null);
 
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { nameof(Customer.Orders) }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { nameof(SpecialCustomer.DerivedOrders) }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
         }
 
         [Fact]
@@ -598,7 +598,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(SpecialOrder));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasPrincipalToDependent("Orders");
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
             specialCustomerType.HasBaseType(customerType);
@@ -607,9 +607,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
 
             Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
+                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
                 Assert.Throws<InvalidOperationException>(() =>
-                    specialCustomerForeignKey.HasPrincipalToDependent("Orders")).Message);
+                    specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
         }
 
         [Fact]
@@ -623,7 +623,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(SpecialOrder));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasPrincipalToDependent("Orders");
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
             specialCustomerType.HasBaseType(customerType);
@@ -659,7 +659,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent("Orders");
+            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             Assert.Equal(
                 CoreStrings.NavigationForWrongForeignKey("Orders", typeof(SpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
@@ -687,14 +687,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent("Orders");
+            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
             Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(VerySpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
+                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(VerySpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
                 Assert.Throws<InvalidOperationException>(() =>
-                    customerForeignKey.HasPrincipalToDependent("Orders")).Message);
+                    customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
 
-            Assert.Equal("Orders", ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
+            Assert.Equal(nameof(Customer.Orders), ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
         }
 
         [Fact]
@@ -708,7 +708,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(Order));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal("Customer");
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
 
@@ -718,10 +718,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = specialCustomerType.AddProperty("AltId", typeof(int));
             var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal("Customer");
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).FullName, typeof(Order).FullName, "Customer"),
+                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, "Customer"),
                 Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
         }
 
@@ -736,7 +736,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(Order));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal("Customer");
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
 
@@ -747,11 +747,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = specialCustomerType.AddProperty("AltId", typeof(int));
             var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal("Customer");
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
             verySpecialOrderType.HasBaseType(specialOrderType);
 
             Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).FullName, typeof(Order).FullName, "Customer"),
+                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, nameof(Order.Customer)),
                 Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
         }
 
@@ -766,7 +766,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(Order));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal("Customer");
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
             specialOrderType.HasBaseType(orderType);
@@ -778,10 +778,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = specialCustomerType.AddProperty("AltId", typeof(int));
             var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal("Customer");
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(VerySpecialOrder).FullName, typeof(SpecialOrder).FullName, "Customer"),
+                CoreStrings.DuplicateNavigationsOnBase(typeof(VerySpecialOrder).Name, typeof(SpecialOrder).Name, "Customer"),
                 Assert.Throws<InvalidOperationException>(() => { verySpecialOrderType.HasBaseType(specialOrderType); }).Message);
         }
 
@@ -1842,8 +1842,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var fk = orderType.GetOrAddForeignKey(customerFk, customerKey, customerType);
 
-            fk.HasDependentToPrincipal("Customer");
-            fk.HasPrincipalToDependent("Orders");
+            fk.HasDependentToPrincipal(Order.CustomerProperty);
+            fk.HasPrincipalToDependent(Customer.OrdersProperty);
 
             Assert.NotNull(orderType.RemoveForeignKey(fk.Properties, fk.PrincipalKey, fk.PrincipalEntityType));
             Assert.Empty(orderType.GetNavigations());
@@ -1887,10 +1887,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            var customerNavigation = customerForeignKey.HasDependentToPrincipal("Customer");
-            var ordersNavigation = customerForeignKey.HasPrincipalToDependent("Orders");
+            var customerNavigation = customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+            var ordersNavigation = customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
-            Assert.Equal("Customer", customerNavigation.Name);
+            Assert.Equal(nameof(Order.Customer), customerNavigation.Name);
             Assert.Same(orderType, customerNavigation.DeclaringEntityType);
             Assert.Same(customerForeignKey, customerNavigation.ForeignKey);
             Assert.True(customerNavigation.IsDependentToPrincipal());
@@ -1898,7 +1898,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Same(customerType, customerNavigation.GetTargetType());
             Assert.Same(customerNavigation, customerForeignKey.DependentToPrincipal);
 
-            Assert.Equal("Orders", ordersNavigation.Name);
+            Assert.Equal(nameof(Customer.Orders), ordersNavigation.Name);
             Assert.Same(customerType, ordersNavigation.DeclaringEntityType);
             Assert.Same(customerForeignKey, ordersNavigation.ForeignKey);
             Assert.False(ordersNavigation.IsDependentToPrincipal());
@@ -1909,13 +1909,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Same(customerNavigation, orderType.GetNavigations().Single());
             Assert.Same(ordersNavigation, customerType.GetNavigations().Single());
 
-            Assert.Same(customerNavigation, customerForeignKey.HasDependentToPrincipal(null));
-            Assert.Null(customerForeignKey.HasDependentToPrincipal(null));
+            Assert.Same(customerNavigation, customerForeignKey.HasDependentToPrincipal((string)null));
+            Assert.Null(customerForeignKey.HasDependentToPrincipal((string)null));
             Assert.Empty(orderType.GetNavigations());
             Assert.Empty(((IEntityType)orderType).GetNavigations());
 
-            Assert.Same(ordersNavigation, customerForeignKey.HasPrincipalToDependent(null));
-            Assert.Null(customerForeignKey.HasPrincipalToDependent(null));
+            Assert.Same(ordersNavigation, customerForeignKey.HasPrincipalToDependent((string)null));
+            Assert.Null(customerForeignKey.HasPrincipalToDependent((string)null));
             Assert.Empty(customerType.GetNavigations());
             Assert.Empty(((IEntityType)customerType).GetNavigations());
         }
@@ -1930,16 +1930,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(Order));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            var customerNavigation = customerForeignKey.HasDependentToPrincipal("Customer");
+            var customerNavigation = customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
-            Assert.Equal("Customer", customerNavigation.Name);
+            Assert.Equal(nameof(Order.Customer), customerNavigation.Name);
             Assert.Same(orderType, customerNavigation.DeclaringEntityType);
             Assert.Same(customerForeignKey, customerNavigation.ForeignKey);
             Assert.True(customerNavigation.IsDependentToPrincipal());
             Assert.False(customerNavigation.IsCollection());
             Assert.Same(customerType, customerNavigation.GetTargetType());
 
-            Assert.Same(customerNavigation, orderType.FindNavigation("Customer"));
+            Assert.Same(customerNavigation, orderType.FindNavigation(nameof(Order.Customer)));
             Assert.True(customerNavigation.IsDependentToPrincipal());
         }
 
@@ -1953,10 +1953,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var orderType = model.AddEntityType(typeof(Order));
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            var customerNavigation = customerForeignKey.HasDependentToPrincipal("Customer");
+            var customerNavigation = customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
-            Assert.Same(customerNavigation, orderType.FindNavigation("Customer"));
-            Assert.Same(customerNavigation, orderType.FindNavigation("Customer"));
+            Assert.Same(customerNavigation, orderType.FindNavigation(nameof(Order.Customer)));
+            Assert.Same(customerNavigation, orderType.FindNavigation(nameof(Order.Customer)));
 
             Assert.Null(orderType.FindNavigation("Nose"));
         }
@@ -2006,9 +2006,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(
-                CoreStrings.NavigationToShadowEntity("Customer", typeof(Order).Name, "Customer"),
+                CoreStrings.NavigationToShadowEntity(nameof(Order.Customer), typeof(Order).Name, "Customer"),
                 Assert.Throws<InvalidOperationException>(
-                    () => customerForeignKey.HasDependentToPrincipal("Customer")).Message);
+                    () => customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty)).Message);
         }
 
         [Fact]
@@ -2058,9 +2058,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.NavigationCollectionWrongClrType(
-                    "NotCollectionOrders", typeof(Customer).Name, typeof(Order).FullName, typeof(Order).FullName),
+                    nameof(Customer.NotCollectionOrders), typeof(Customer).Name, typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
-                    () => customerForeignKey.HasPrincipalToDependent("NotCollectionOrders")).Message);
+                    () => customerForeignKey.HasPrincipalToDependent(Customer.NotCollectionOrdersProperty)).Message);
         }
 
         [Fact]
@@ -2076,9 +2076,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.NavigationCollectionWrongClrType(
-                    "DerivedOrders", typeof(SpecialCustomer).Name, typeof(IEnumerable<SpecialOrder>).FullName, typeof(Order).FullName),
+                    nameof(SpecialCustomer.DerivedOrders),
+                    typeof(SpecialCustomer).Name,
+                    typeof(IEnumerable<SpecialOrder>).DisplayName(fullName: false),
+                    typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
-                    () => customerForeignKey.HasPrincipalToDependent("DerivedOrders")).Message);
+                    () => customerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty)).Message);
         }
 
         [Fact]
@@ -2092,9 +2095,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            var ordersNavigation = customerForeignKey.HasPrincipalToDependent("Orders");
+            var ordersNavigation = customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
 
-            Assert.Equal("Orders", ordersNavigation.Name);
+            Assert.Equal(nameof(Customer.Orders), ordersNavigation.Name);
             Assert.Same(customerType, ordersNavigation.DeclaringEntityType);
             Assert.Same(customerForeignKey, ordersNavigation.ForeignKey);
             Assert.False(ordersNavigation.IsDependentToPrincipal());
@@ -2115,9 +2118,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(
-                CoreStrings.NavigationSingleWrongClrType("OrderCustomer", typeof(Order).Name, typeof(Order).FullName, typeof(Customer).FullName),
+                CoreStrings.NavigationSingleWrongClrType("OrderCustomer", typeof(Order).Name, typeof(Order).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(
-                    () => customerForeignKey.HasDependentToPrincipal("OrderCustomer")).Message);
+                    () => customerForeignKey.HasDependentToPrincipal(Order.OrderCustomerProperty)).Message);
         }
 
         [Fact]
@@ -2133,9 +2136,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.NavigationSingleWrongClrType(
-                    "DerivedCustomer", typeof(SpecialOrder).Name, typeof(SpecialCustomer).FullName, typeof(Customer).FullName),
+                    nameof(SpecialOrder.DerivedCustomer), typeof(SpecialOrder).Name, typeof(SpecialCustomer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(
-                    () => customerForeignKey.HasDependentToPrincipal("DerivedCustomer")).Message);
+                    () => customerForeignKey.HasDependentToPrincipal(SpecialOrder.DerivedCustomerProperty)).Message);
         }
 
         [Fact]
@@ -2149,7 +2152,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            var customerNavigation = customerForeignKey.HasDependentToPrincipal("Customer");
+            var customerNavigation = customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal("Customer", customerNavigation.Name);
             Assert.Same(orderType, customerNavigation.DeclaringEntityType);
@@ -2170,8 +2173,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
             fk.IsUnique = true;
 
-            var navigationToDependent = fk.HasPrincipalToDependent("SelfRef1");
-            var navigationToPrincipal = fk.HasDependentToPrincipal("SelfRef2");
+            var navigationToDependent = fk.HasPrincipalToDependent(SelfRef.SelfRef1Property);
+            var navigationToPrincipal = fk.HasDependentToPrincipal(SelfRef.SelfRef2Property);
 
             Assert.Same(fk.PrincipalToDependent, navigationToDependent);
             Assert.Same(fk.DependentToPrincipal, navigationToPrincipal);
@@ -2188,9 +2191,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
             fk.IsUnique = true;
 
-            fk.HasPrincipalToDependent("SelfRef1");
-            Assert.Equal(CoreStrings.DuplicateNavigation("SelfRef1", typeof(SelfRef).Name, typeof(SelfRef).Name),
-                Assert.Throws<InvalidOperationException>(() => fk.HasDependentToPrincipal("SelfRef1")).Message);
+            fk.HasPrincipalToDependent(SelfRef.SelfRef1Property);
+            Assert.Equal(CoreStrings.DuplicateNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, typeof(SelfRef).Name),
+                Assert.Throws<InvalidOperationException>(() => fk.HasDependentToPrincipal(SelfRef.SelfRef1Property)).Message);
         }
 
         [Fact]
@@ -2208,8 +2211,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var specialCustomerForeignKeyProperty = specialOrderType.AddProperty(Order.CustomerIdProperty);
             var specialCustomerForeignKey = specialOrderType.AddForeignKey(specialCustomerForeignKeyProperty, customerKey, customerType);
 
-            var navigation2 = customerForeignKey.HasPrincipalToDependent("Orders");
-            var navigation1 = specialCustomerForeignKey.HasPrincipalToDependent("DerivedOrders");
+            var navigation2 = customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+            var navigation1 = specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
 
             Assert.True(new[] { navigation1, navigation2 }.SequenceEqual(customerType.GetNavigations()));
             Assert.True(new[] { navigation1, navigation2 }.SequenceEqual(((IEntityType)customerType).GetNavigations()));
@@ -2399,7 +2402,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrSetPrimaryKey(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).FullName),
+                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 
@@ -2413,7 +2416,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrAddKey(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).FullName),
+                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 
@@ -2429,7 +2432,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             orderType.GetOrAddForeignKey(customerFk, customerPk, customerType);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("CustomerId", typeof(Order).FullName),
+                CoreStrings.PropertyInUse("CustomerId", typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() => orderType.RemoveProperty(customerFk.Name)).Message);
         }
 
@@ -2443,7 +2446,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrAddIndex(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).FullName),
+                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 
@@ -2576,7 +2579,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-            customerForeignKey.HasDependentToPrincipal("Customer");
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
                 CoreStrings.ConflictingNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
@@ -3015,8 +3018,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class Customer : BaseType
         {
-            public static readonly PropertyInfo IdProperty = typeof(BaseType).GetProperty("Id");
-            public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+            public static readonly PropertyInfo IdProperty = typeof(BaseType).GetProperty(nameof(Id));
+            public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty(nameof(Name));
+            public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders));
+            public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders));
 
             public int AlternateId { get; set; }
             public Guid Unique { get; set; }
@@ -3030,6 +3035,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class SpecialCustomer : Customer
         {
+            public static readonly PropertyInfo DerivedOrdersProperty = typeof(SpecialCustomer).GetProperty(nameof(DerivedOrders));
+
             public IEnumerable<SpecialOrder> DerivedOrders { get; set; }
         }
 
@@ -3039,9 +3046,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class Order : BaseType
         {
-            public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
-            public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId");
-            public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty("CustomerUnique");
+            public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
+            public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer));
+            public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId));
+            public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique));
+            public static readonly PropertyInfo OrderCustomerProperty = typeof(Order).GetProperty(nameof(OrderCustomer));
 
             public int CustomerId { get; set; }
             public Guid CustomerUnique { get; set; }
@@ -3052,6 +3061,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class SpecialOrder : Order
         {
+            public static readonly PropertyInfo DerivedCustomerProperty = typeof(SpecialOrder).GetProperty(nameof(DerivedCustomer));
+
             public SpecialCustomer DerivedCustomer { get; set; }
         }
 
@@ -3117,6 +3128,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id");
             public static readonly PropertyInfo ForeignKeyProperty = typeof(SelfRef).GetProperty("ForeignKey");
+            public static readonly PropertyInfo SelfRef1Property = typeof(SelfRef).GetProperty(nameof(SelfRef1));
+            public static readonly PropertyInfo SelfRef2Property = typeof(SelfRef).GetProperty(nameof(SelfRef2));
 
             public int Id { get; set; }
             public SelfRef SelfRef1 { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -58,8 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Null(relationshipBuilder.DeleteBehavior(DeleteBehavior.Restrict, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.DependentEntityType(
                 relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation));
-            Assert.Null(relationshipBuilder.DependentToPrincipal(null, ConfigurationSource.DataAnnotation));
-            Assert.Null(relationshipBuilder.PrincipalToDependent(null, ConfigurationSource.DataAnnotation));
+            Assert.Null(relationshipBuilder.DependentToPrincipal((string)null, ConfigurationSource.DataAnnotation));
+            Assert.Null(relationshipBuilder.PrincipalToDependent((string)null, ConfigurationSource.DataAnnotation));
         }
 
         [Fact]
@@ -77,8 +77,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             foreignKey.UpdatePrincipalKeyConfigurationSource(ConfigurationSource.Explicit);
             foreignKey.UpdatePrincipalEndConfigurationSource(ConfigurationSource.Explicit);
 
-            foreignKey.HasDependentToPrincipal(Order.CustomerProperty.Name);
-            foreignKey.HasPrincipalToDependent(Customer.OrdersProperty.Name);
+            foreignKey.HasDependentToPrincipal(Order.CustomerProperty);
+            foreignKey.HasPrincipalToDependent(Customer.OrdersProperty);
             foreignKey.IsRequired = false;
             foreignKey.IsUnique = false;
             foreignKey.DeleteBehavior = DeleteBehavior.Cascade;
@@ -628,8 +628,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
                 },
                 principalEntityBuilder.Metadata.FindPrimaryKey(),
                 principalEntityBuilder.Metadata);
-            existingForeignKey.HasPrincipalToDependent(Customer.OrdersProperty.Name);
-            existingForeignKey.HasDependentToPrincipal(Order.CustomerProperty.Name);
+            existingForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+            existingForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
             Assert.Equal(ConfigurationSource.Explicit, existingForeignKey.GetDependentToPrincipalConfigurationSource());
             Assert.Equal(ConfigurationSource.Explicit, existingForeignKey.GetPrincipalToDependentConfigurationSource());
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/NavigationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/NavigationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -25,10 +26,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         {
             var foreignKey = CreateForeignKey();
 
-            var navigation = foreignKey.HasDependentToPrincipal("Deception");
+            var navigation = foreignKey.HasDependentToPrincipal(E.DeceptionProperty);
 
             Assert.Same(foreignKey, navigation.ForeignKey);
-            Assert.Equal("Deception", navigation.Name);
+            Assert.Equal(nameof(E.Deception), navigation.Name);
             Assert.Same(foreignKey.DeclaringEntityType, navigation.DeclaringEntityType);
         }
 
@@ -44,6 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class E
         {
+            public static readonly PropertyInfo DeceptionProperty = typeof(E).GetProperty(nameof(Deception));
+
             public E Deception { get; set; }
         }
     }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
@@ -72,6 +73,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
 
         private class Category
         {
+            public static readonly PropertyInfo ProductsProperty = typeof(Category).GetProperty(nameof(Products));
+            public static readonly PropertyInfo FeaturedProductProperty = typeof(Category).GetProperty(nameof(FeaturedProduct));
+
             public int Id { get; set; }
 
             public int FeaturedProductId { get; set; }
@@ -82,6 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
 
         private class Product
         {
+            public static readonly PropertyInfo CategoryProperty = typeof(Product).GetProperty(nameof(Category));
+            public static readonly PropertyInfo FeaturedProductCategoryProperty = typeof(Product).GetProperty(nameof(FeaturedProductCategory));
+
             public int Id { get; set; }
 
             public Category FeaturedProductCategory { get; set; }
@@ -117,20 +124,20 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
 
             if (createProducts)
             {
-                categoryFk.HasPrincipalToDependent(nameof(Category.Products));
+                categoryFk.HasPrincipalToDependent(Category.ProductsProperty);
             }
             if (createCategory)
             {
-                categoryFk.HasDependentToPrincipal(nameof(Product.Category));
+                categoryFk.HasDependentToPrincipal(Product.CategoryProperty);
             }
 
             if (createFeaturedProductCategory)
             {
-                featuredProductFk.HasPrincipalToDependent(nameof(Product.FeaturedProductCategory));
+                featuredProductFk.HasPrincipalToDependent(Product.FeaturedProductCategoryProperty);
             }
             if (createFeaturedProduct)
             {
-                featuredProductFk.HasDependentToPrincipal(nameof(Category.FeaturedProduct));
+                featuredProductFk.HasDependentToPrincipal(Category.FeaturedProductProperty);
             }
 
             return model;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
-            public virtual void Do_not_run_relationship_discovery_on_entity_type_while_removing_it()
+            public virtual void Can_ignore_base_entity_type()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<SpecialBookLabel>();
@@ -201,6 +201,22 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Ignore<BookLabel>();
 
                 Assert.Null(modelBuilder.Model.FindEntityType(typeof(BookLabel).FullName));
+            }
+
+            [Fact]
+            public virtual void Relationships_are_discovered_on_the_base_entity_type()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<SpecialBookLabel>();
+                modelBuilder.Entity<AnotherBookLabel>();
+
+                var bookLabel = modelBuilder.Model.FindEntityType(typeof(BookLabel));
+                var specialNavigation = bookLabel.GetDeclaredNavigations().Single(n => n.Name == nameof(BookLabel.SpecialBookLabel));
+                Assert.Equal(typeof(SpecialBookLabel), specialNavigation.GetTargetType().ClrType);
+                Assert.Equal(nameof(SpecialBookLabel.BookLabel), specialNavigation.FindInverse().Name);
+                var anotherNavigation = bookLabel.GetDeclaredNavigations().Single(n => n.Name == nameof(BookLabel.AnotherBookLabel));
+                Assert.Equal(typeof(AnotherBookLabel), anotherNavigation.GetTargetType().ClrType);
+                Assert.Null(anotherNavigation.FindInverse());
             }
 
             [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -1072,7 +1072,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var dependentType = model.FindEntityType(typeof(Tomato));
                 var principalType = model.FindEntityType(typeof(Whoopper));
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.First().Name == "BurgerId1");
-                fk.HasDependentToPrincipal(null);
+                fk.HasDependentToPrincipal((string)null);
 
                 var principalKey = principalType.FindPrimaryKey();
                 var dependentKey = dependentType.GetKeys().Single();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
-
 namespace Microsoft.EntityFrameworkCore.Tests
 {
     public class ModelBuilderNonGenericStringTest : ModelBuilderNonGenericTest
@@ -136,8 +135,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var orderEntityType = modelBuilder.Entity(typeof(Order));
 
                 Assert.Equal(
-                    CoreStrings.NavigationToShadowEntity("OrderDetails", typeof(Order).DisplayName(fullName: false), "OrderDetails"),
-                    Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne("OrderDetails", "OrderDetails")).Message);
+                    CoreStrings.NavigationToShadowEntity(nameof(Order.Details), typeof(Order).DisplayName(fullName: false), nameof(OrderDetails)),
+                    Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(nameof(OrderDetails), nameof(Order.Details))).Message);
             }
 
             [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -340,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var dependentType = model.FindEntityType(typeof(Pickle));
                 var principalType = model.FindEntityType(typeof(BigMak));
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
-                fk.HasDependentToPrincipal(null);
+                fk.HasDependentToPrincipal((string)null);
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2543,14 +2543,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(fk, principalType.GetNavigations().Single(n => n.Name == nameof(Hob.Nob)).ForeignKey);
                 Assert.True(fk.IsUnique);
 
-                var otherFk1 = dependentType.GetNavigations().Single(n => n.Name == nameof(Nob.Hobs)).ForeignKey;
-                Assert.False(otherFk1.IsUnique);
-                var otherFk2 = principalType.GetNavigations().Single(n => n.Name == nameof(Hob.Nobs)).ForeignKey;
-                Assert.False(otherFk2.IsUnique);
-                Assert.NotSame(otherFk1, otherFk2);
+                // TODO: verify Hobs <-> Nobs
 
-                Assert.Equal(1, dependentType.GetForeignKeys().Count(foreignKey => foreignKey != fk));
-                Assert.Equal(1, principalType.GetForeignKeys().Count(foreignKey => foreignKey != fk));
+                Assert.Equal(0, dependentType.GetForeignKeys().Count(foreignKey => foreignKey != fk));
+                Assert.Equal(0, principalType.GetForeignKeys().Count(foreignKey => foreignKey != fk));
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
                 Assert.Same(principalKey, principalType.FindPrimaryKey());

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -110,6 +110,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         protected class Order
         {
+            public static readonly PropertyInfo DetailsProperty = typeof(Order).GetProperty(nameof(Details));
+
             public int OrderId { get; set; }
 
             public int? CustomerId { get; set; }


### PR DESCRIPTION
Refactor the internal model builders to avoid looking up the PropertyInfo for navigation properties more than once.

Add PropertyIdentity to unify the implementations of methods accepting either string or PropertyInfo, reduce code duplication and get rid of sentry values