### PR TITLE
Switches the order of Configure*Services methods.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/Internal/StartupInvoker.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/Internal/StartupInvoker.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             return Invoke(
                 _startupType,
-                new[] { "ConfigureServices", "Configure" + _environment + "Services" },
+                new[] { "Configure" + _environment + "Services", "ConfigureServices" },
                 services) as IServiceProvider
                    ?? services.BuildServiceProvider();
         }


### PR DESCRIPTION
Fixes #5236

This array is used in a loop that stops on the first method it finds.  It should try the more specific methods before the less specific methods.