### PR TITLE
Query: Add translators for string functions

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Query\Expressions\SumExpression.cs" />
     <Compile Include="Query\Expressions\TableExpression.cs" />
     <Compile Include="Query\Expressions\TableExpressionBase.cs" />
+    <Compile Include="Query\ExpressionTranslators\IsNullOrEmptyTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\ContainsTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\EndsWithTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\EqualsTranslator.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/IsNullOrEmptyTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/IsNullOrEmptyTranslator.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
+{
+    public class IsNullOrEmptyTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrEmpty), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            return ReferenceEquals(methodCallExpression.Method, _methodInfo)
+                ? Expression.MakeBinary(
+                    ExpressionType.OrElse,
+                    new IsNullExpression(methodCallExpression.Arguments[0]),
+                    Expression.Equal(methodCallExpression.Arguments[0], Expression.Constant("", typeof(string))))
+                : null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
                     new ContainsTranslator(),
                     new EndsWithTranslator(),
                     new EqualsTranslator(logger),
+                    new IsNullOrEmptyTranslator(),
                     new StartsWithTranslator()
                 };
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -511,7 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     = methodCallExpression.Arguments
                         .Where(e => !(e is QuerySourceReferenceExpression)
                                     && !(e is SubQueryExpression))
-                        .Select(Visit)
+                        .Select(e => (e as ConstantExpression)?.Value is Array ? e : Visit(e))
                         .Where(e => e != null)
                         .ToArray();
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4678,6 +4678,83 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void IsNullOrEmpty_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.IsNullOrEmpty(c.Region)),
+                entryCount: 60);
+        }
+
+        [ConditionalFact]
+        public virtual void IsNullOrEmpty_in_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<Customer>()
+                    .Select(c => new { Id = c.CustomerID, Value = string.IsNullOrEmpty(c.Region) })
+                    .ToList();
+
+                Assert.Equal(91, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void IsNullOrWhiteSpace_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.IsNullOrWhiteSpace(c.Region)),
+                entryCount: 60);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimStart_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimStart() == "Owner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimStart_with_arguments_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimStart('O','w') == "ner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimEnd_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimEnd() == "Owner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimEnd_with_arguments_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimEnd('e', 'r') == "Own"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void Trim_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.Trim() == "Owner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void Trim_with_arguments_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.Trim('O', 'r') == "wne"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
         public virtual void Where_chain()
         {
             AssertQuery<Order>(order => order

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -117,6 +117,10 @@
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerNewGuidTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringLengthTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringReplaceTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringTrimEndTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringIsNullOrWhiteSpaceTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringTrimTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringTrimStartTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringSubstringTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringToLowerTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringToUpperTranslator.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
@@ -10,17 +10,21 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     {
         private static readonly IMethodCallTranslator[] _methodCallTranslators =
         {
-            new SqlServerNewGuidTranslator(),
-            new SqlServerStringSubstringTranslator(),
             new SqlServerMathAbsTranslator(),
             new SqlServerMathCeilingTranslator(),
             new SqlServerMathFloorTranslator(),
             new SqlServerMathPowerTranslator(),
             new SqlServerMathRoundTranslator(),
             new SqlServerMathTruncateTranslator(),
+            new SqlServerNewGuidTranslator(),
+            new SqlServerStringIsNullOrWhiteSpaceTranslator(),
             new SqlServerStringReplaceTranslator(),
+            new SqlServerStringSubstringTranslator(),
             new SqlServerStringToLowerTranslator(),
             new SqlServerStringToUpperTranslator(),
+            new SqlServerStringTrimEndTranslator(),
+            new SqlServerStringTrimStartTranslator(),
+            new SqlServerStringTrimTranslator(),
             new SqlServerConvertTranslator()
         };
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerStringIsNullOrWhiteSpaceTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_methodInfo == methodCallExpression.Method)
+            {
+                var argument = methodCallExpression.Arguments[0];
+
+                return Expression.MakeBinary(
+                    ExpressionType.OrElse,
+                    new IsNullExpression(argument),
+                    Expression.Equal(
+                        new SqlFunctionExpression(
+                            "LTRIM",
+                            typeof(string),
+                            new[]
+                            {
+                                new SqlFunctionExpression(
+                                    "RTRIM",
+                                    typeof(string),
+                                    new [] { argument})
+                            }),
+                        Expression.Constant("", typeof(string))));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerStringTrimEndTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _trimEnd = typeof(string).GetTypeInfo()
+            .GetDeclaredMethod(nameof(string.TrimEnd));
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if ((_trimEnd == methodCallExpression.Method)
+                // SqlServer RTRIM does not take arguments
+                && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
+            {
+                var sqlArguments = new[] { methodCallExpression.Object };
+                return new SqlFunctionExpression("RTRIM", methodCallExpression.Type, sqlArguments);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerStringTrimStartTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
+            .GetDeclaredMethod(nameof(string.TrimStart));
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if ((_trimStart == methodCallExpression.Method)
+                // SqlServer LTRIM does not take arguments
+                && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
+            {
+                var sqlArguments = new[] { methodCallExpression.Object };
+                return new SqlFunctionExpression("LTRIM", methodCallExpression.Type, sqlArguments);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerStringTrimTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _trim = typeof(string).GetTypeInfo()
+            .GetDeclaredMethods(nameof(string.Trim))
+            .SingleOrDefault(m => !m.GetParameters().Any());
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_trim == methodCallExpression.Method)
+            {
+                var sqlArguments = new[] { methodCallExpression.Object };
+                return new SqlFunctionExpression(
+                    "LTRIM",
+                    methodCallExpression.Type,
+                    new[]
+                    {
+                        new SqlFunctionExpression(
+                            "RTRIM",
+                            methodCallExpression.Type,
+                            sqlArguments),
+                    });
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
@@ -88,6 +88,10 @@
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringLengthTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringToLowerTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringToUpperTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringIsNullOrWhiteSpaceTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimEndTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimStartTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimTranslator.cs" />
     <Compile Include="Query\Sql\SqliteQuerySqlGenerator.cs" />
     <Compile Include="Query\Sql\SqliteQuerySqlGeneratorFactory.cs" />
     <Compile Include="SqliteDbContextOptionsBuilderExtensions.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
@@ -11,8 +11,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         private static readonly IMethodCallTranslator[] _sqliteTranslators =
         {
             new SqliteMathAbsTranslator(),
+            new SqliteStringIsNullOrWhiteSpaceTranslator(),
             new SqliteStringToLowerTranslator(),
-            new SqliteStringToUpperTranslator()
+            new SqliteStringToUpperTranslator(),
+            new SqliteStringTrimEndTranslator(),
+            new SqliteStringTrimStartTranslator(),
+            new SqliteStringTrimTranslator()
         };
 
         public SqliteCompositeMethodCallTranslator(

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqliteStringIsNullOrWhiteSpaceTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_methodInfo == methodCallExpression.Method)
+            {
+                var argument = methodCallExpression.Arguments[0];
+
+                return Expression.MakeBinary(
+                    ExpressionType.OrElse,
+                    new IsNullExpression(argument),
+                    Expression.Equal(
+                        new SqlFunctionExpression(
+                            "trim",
+                            typeof(string),
+                            new[] { argument }),
+                        Expression.Constant("", typeof(string))));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqliteStringTrimEndTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _trimEnd = typeof(string).GetTypeInfo()
+            .GetDeclaredMethod(nameof(string.TrimEnd));
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_trimEnd == methodCallExpression.Method)
+            {
+                var sqlArguments = new List<Expression> { methodCallExpression.Object };
+                var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];
+                if (charactersToTrim?.Length > 0)
+                {
+                    sqlArguments.Add(Expression.Constant(new string(charactersToTrim), typeof(string)));
+                }
+                return new SqlFunctionExpression("rtrim", methodCallExpression.Type, sqlArguments);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqliteStringTrimStartTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
+            .GetDeclaredMethod(nameof(string.TrimStart));
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_trimStart == methodCallExpression.Method)
+            {
+                var sqlArguments = new List<Expression> { methodCallExpression.Object };
+                var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];
+                if (charactersToTrim?.Length > 0)
+                {
+                    sqlArguments.Add(Expression.Constant(new string(charactersToTrim), typeof(string)));
+                }
+                return new SqlFunctionExpression("ltrim", methodCallExpression.Type, sqlArguments);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqliteStringTrimTranslator : IMethodCallTranslator
+    {
+        private static readonly IEnumerable<MethodInfo> _trims = typeof(string).GetTypeInfo()
+            .GetDeclaredMethods(nameof(string.Trim));
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (_trims.Contains(methodCallExpression.Method))
+            {
+                var sqlArguments = new List<Expression> { methodCallExpression.Object };
+                var charactersToTrim = methodCallExpression.Arguments.Count == 1
+                    ? (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[]
+                    : null;
+                if (charactersToTrim?.Length > 0)
+                {
+                    sqlArguments.Add(Expression.Constant(new string(charactersToTrim), typeof(string)));
+                }
+                return new SqlFunctionExpression("trim", methodCallExpression.Type, sqlArguments);
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4829,6 +4829,104 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
+        public override void IsNullOrEmpty_in_predicate()
+        {
+            base.IsNullOrEmpty_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')",
+                Sql);
+        }
+
+        public override void IsNullOrEmpty_in_projection()
+        {
+            base.IsNullOrEmpty_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], CASE
+    WHEN [c].[Region] IS NULL OR ([c].[Region] = N'')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void IsNullOrWhiteSpace_in_predicate()
+        {
+            base.IsNullOrWhiteSpace_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NULL OR (LTRIM(RTRIM([c].[Region])) = N'')",
+                Sql);
+        }
+
+        public override void TrimStart_in_predicate()
+        {
+            base.TrimStart_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE LTRIM([c].[ContactTitle]) = N'Owner'",
+                Sql);
+        }
+
+        public override void TrimStart_with_arguments_in_predicate()
+        {
+            base.TrimStart_with_arguments_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void TrimEnd_in_predicate()
+        {
+            base.TrimEnd_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE RTRIM([c].[ContactTitle]) = N'Owner'",
+                Sql);
+        }
+
+        public override void TrimEnd_with_arguments_in_predicate()
+        {
+            base.TrimEnd_with_arguments_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Trim_in_predicate()
+        {
+            base.Trim_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE LTRIM(RTRIM([c].[ContactTitle])) = N'Owner'",
+                Sql);
+        }
+
+        public override void Trim_with_arguments_in_predicate()
+        {
+            base.Trim_with_arguments_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void Projection_null_coalesce_operator()
         {
             base.Projection_null_coalesce_operator();

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -17,6 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
     [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
     public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
     {
+        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
         public override void String_Contains_Literal()
         {
             AssertQuery<Customer>(
@@ -50,9 +55,81 @@ LIMIT -1 OFFSET @__p_1",
                 Sql);
         }
 
-        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture)
-            : base(fixture)
+        public override void IsNullOrWhiteSpace_in_predicate()
         {
+            base.IsNullOrWhiteSpace_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')",
+                Sql);
+        }
+
+        public override void TrimStart_in_predicate()
+        {
+            base.TrimStart_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ltrim(""c"".""ContactTitle"") = 'Owner'",
+                Sql);
+        }
+
+        public override void TrimStart_with_arguments_in_predicate()
+        {
+            base.TrimStart_with_arguments_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ltrim(""c"".""ContactTitle"", 'Ow') = 'ner'",
+                Sql);
+        }
+
+        public override void TrimEnd_in_predicate()
+        {
+            base.TrimEnd_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE rtrim(""c"".""ContactTitle"") = 'Owner'",
+                Sql);
+        }
+
+        public override void TrimEnd_with_arguments_in_predicate()
+        {
+            base.TrimEnd_with_arguments_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE rtrim(""c"".""ContactTitle"", 'er') = 'Own'",
+                Sql);
+        }
+
+        public override void Trim_in_predicate()
+        {
+            base.Trim_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE trim(""c"".""ContactTitle"") = 'Owner'",
+                Sql);
+        }
+
+        public override void Trim_with_arguments_in_predicate()
+        {
+            base.Trim_with_arguments_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'",
+                Sql);
         }
 
         private const string FileLineEnding = @"


### PR DESCRIPTION
Resolves #5199 
@anpete @divega - Are there anymore translators which we should have?
Currently we have following translators for string
Contains, EndsWith, Equals, StartsWith, Compare, Concat (in relational)
Length, Replace, Substring, ToLower, ToUpper (in sql server)
Adding IsNullOrEmpty in this PR.