### PR TITLE
[rc2] Fix minor issues in commands

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/ExecuteCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/ExecuteCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
         {
             var app = new CommandLineApplication()
             {
-                Name = GetToolName(),
+                Name = "dotnet ef",
                 FullName = "Entity Framework .NET Core CLI Commands"
             };
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/MigrationsOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Design/MigrationsOperations.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
                 var scaffolder = services.GetRequiredService<MigrationsScaffolder>();
                 var migration = scaffolder.ScaffoldMigration(name, _rootNamespace, subNamespace);
-                var files = scaffolder.Save(_projectDir, migration);
+                var files = scaffolder.Save(_projectDir, migration, outputDir);
 
                 return files;
             }

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/MigrationsScaffolder.cs
@@ -299,17 +299,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             return files;
         }
 
-        public virtual MigrationFiles Save([NotNull] string projectDir, [NotNull] ScaffoldedMigration migration)
+        public virtual MigrationFiles Save(
+            [NotNull] string projectDir, 
+            [NotNull] ScaffoldedMigration migration, 
+            [CanBeNull] string outputDir)
         {
             Check.NotEmpty(projectDir, nameof(projectDir));
             Check.NotNull(migration, nameof(migration));
 
             var lastMigrationFileName = migration.PreviousMigrationId + migration.FileExtension;
-            var migrationDirectory = GetDirectory(projectDir, lastMigrationFileName, migration.MigrationSubNamespace);
+            var migrationDirectory = outputDir ?? GetDirectory(projectDir, lastMigrationFileName, migration.MigrationSubNamespace);
             var migrationFile = Path.Combine(migrationDirectory, migration.MigrationId + migration.FileExtension);
             var migrationMetadataFile = Path.Combine(migrationDirectory, migration.MigrationId + ".Designer" + migration.FileExtension);
             var modelSnapshotFileName = migration.SnapshotName + migration.FileExtension;
-            var modelSnapshotDirectory = GetDirectory(projectDir, modelSnapshotFileName, migration.SnapshotSubnamespace);
+            var modelSnapshotDirectory = outputDir ?? GetDirectory(projectDir, modelSnapshotFileName, migration.SnapshotSubnamespace);
             var modelSnapshotFile = Path.Combine(modelSnapshotDirectory, modelSnapshotFileName);
 
             _logger.Value.LogDebug(ToolsCoreStrings.WritingMigration(migrationFile));

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/DotNetEfFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/DotNetEfFixture.cs
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests
                 
             AssertCommand.Passes(
                 new RestoreCommand(projectPath, logger)
-                    .Execute(string.Join(" ", fallbacks))
+                    .Execute(" --verbosity error " + string.Join(" ", fallbacks))
                 );
         }
     }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/AspNetHostingPortableApp/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/AspNetHostingPortableApp/project.json.ignore
@@ -1,8 +1,13 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true,
-    "outputName": "AspNetApp"
+    "outputName": "AspNetApp",
+    "copyToOutput": {
+      "includeFiles": [
+        "config.json"
+      ]
+    }
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
@@ -28,22 +33,18 @@
     "Microsoft.AspNetCore.Hosting": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*"
   },
-  
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   },
-  
-  "content": "config.json",
-  
   "tools": {
     "Microsoft.EntityFrameworkCore.Tools": {
       "version": "1.0.0-$toolVersion$",
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopAppWithTools/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopAppWithTools/project.json.ignore
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true
   },
   "dependencies": {
@@ -20,7 +20,7 @@
     "Microsoft.EntityFrameworkCore.Tools": {
       "version": "1.0.0-$toolVersion$",
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/LibraryUsingSqlite/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/LibraryUsingSqlite/project.json.ignore
@@ -9,7 +9,7 @@
   "frameworks": {
     "netstandard1.5": {
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/PortableAppWithTools/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/PortableAppWithTools/project.json.ignore
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true
   },
   "dependencies": {
@@ -26,7 +26,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   },
@@ -34,7 +34,7 @@
     "Microsoft.EntityFrameworkCore.Tools": {
       "version": "1.0.0-$toolVersion$",
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/StandaloneAppWithTools/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/StandaloneAppWithTools/project.json.ignore
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true
   },
   "dependencies": {
@@ -22,7 +22,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   },
@@ -30,7 +30,7 @@
     "Microsoft.EntityFrameworkCore.Tools": {
       "version": "1.0.0-$toolVersion$",
       "imports": [
-        "portable-net452+win81"
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/clean-assets.cmd
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/clean-assets.cmd
@@ -1,10 +1,16 @@
 @ECHO OFF
 :again
 if not "%1" == "" (
+    if not exist %1\TestProjects goto artifactsDir
     echo "Deleting %1\TestProjects"
     rmdir /s /q %1\TestProjects
+
+    :artifactsDir
+    if not exist %1\artifacts goto iterate
     echo "Deleting %1\artifacts"
     rmdir /s /q %1\artifacts
+
+    :iterate
     shift
     goto again
 )


### PR DESCRIPTION
This PR is a collection of 3 minor tweaks for CLI commands and testing.

Fix #5187 - use `--output-dir` when specified for the directory where migrations are written to

Fix #5260 - improve compatibility of PMC cmdlets with dotnet-ef

Fix #5227 - one line change so "dotnet ef" is used in help text, not "Microsoft.EfCore.Tools.Cli"

cc @divega 