### PR TITLE
[TINY] Correct references to an Internal namespace

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
-    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDesignTimeServices",
+    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqlServerDesignTimeServices",
     assemblyName: "Microsoft.EntityFrameworkCore.SqlServer.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.SqlServer.Design")]
 [assembly: AssemblyCompany("Microsoft Corporation.")]

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
-    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqliteDesignTimeServices",
+    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqliteDesignTimeServices",
     assemblyName: "Microsoft.EntityFrameworkCore.Sqlite.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.Sqlite.Design")]
 [assembly: AssemblyCompany("Microsoft Corporation.")]


### PR DESCRIPTION
In #5209 I changed the namespaces of a lot of files to add `.Internal`. But I missed the couple of references (by reflection) in the `DesignTimeProviderServices` attributes.