### PR TITLE
SQL Server datepart translation support (fixes #4582)

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -36,7 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             { DbType.Int16, "smallint" },
             { DbType.Int32, "int" },
             { DbType.Int64, "bigint" },
-            { DbType.String, "nvarchar" }
+            { DbType.String, "nvarchar" },
+            { DbType.Date, "date" }
         };
 
         public virtual string StatementTerminator => ";";

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -1099,6 +1099,91 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Where_datetime_date_component()
+        {
+            var myDatetime = new DateTime(1998, 5, 4);
+            AssertQuery<Order>(
+                oc => oc.Where(o =>
+                o.OrderDate.Value.Date == myDatetime),
+                entryCount: 3);
+        }
+
+
+        [ConditionalFact]
+        public virtual void Where_datetime_year_component()
+        {
+            AssertQuery<Order>(
+               oc => oc.Where(o =>
+               o.OrderDate.Value.Year == 1998),
+               entryCount: 270);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_month_component()
+        {
+            AssertQuery<Order>(
+                oc => oc.Where(o =>
+                o.OrderDate.Value.Month == 4),
+                entryCount: 105);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_dayOfYear_component()
+        {
+            AssertQuery<Order>(
+                oc => oc.Where(o =>
+                o.OrderDate.Value.DayOfYear == 68),
+                entryCount: 3);
+        }
+
+
+        [ConditionalFact]
+        public virtual void Where_datetime_day_component()
+        {
+            AssertQuery<Order>(
+              oc => oc.Where(o =>
+              o.OrderDate.Value.Day == 4),
+              entryCount: 27);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_hour_component()
+        {
+            AssertQuery<Order>(
+              oc => oc.Where(o =>
+              o.OrderDate.Value.Hour == 14),
+              entryCount: 0);
+        }
+
+
+        [ConditionalFact]
+        public virtual void Where_datetime_minute_component()
+        {
+            AssertQuery<Order>(
+              oc => oc.Where(o =>
+              o.OrderDate.Value.Minute == 23),
+              entryCount: 0);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_second_component()
+        {
+            AssertQuery<Order>(
+              oc => oc.Where(o =>
+              o.OrderDate.Value.Second == 44),
+              entryCount: 0);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_millisecond_component()
+        {
+            AssertQuery<Order>(
+              oc => oc.Where(o =>
+              o.OrderDate.Value.Millisecond == 88),
+              entryCount: 0);
+        }
+
+        [ConditionalFact]
         public virtual void Where_simple_reversed()
         {
             AssertQuery<Customer>(

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -103,10 +103,12 @@
       <DependentUpon>SqlServerStrings.resx</DependentUpon>
     </Compile>
     <Compile Include="Properties\InternalsVisibleTo.cs" />
+    <Compile Include="Query\Expressions\Internal\DatePartExpression.cs" />
     <Compile Include="Query\Expressions\Internal\RowNumberExpression.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerCompositeMemberTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerCompositeMethodCallTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerConvertTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerDateTimeDateComponentTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerDateTimeNowTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathAbsTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathCeilingTranslator.cs" />
@@ -120,6 +122,7 @@
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringSubstringTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringToLowerTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringToUpperTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerDateTimeDatePartComponentTranslator.cs" />
     <Compile Include="Query\Internal\SqlServerCompiledQueryCacheKeyGenerator.cs" />
     <Compile Include="Query\Internal\SqlServerQueryCompilationContext.cs" />
     <Compile Include="Query\Internal\SqlServerQueryCompilationContextFactory.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMemberTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMemberTranslator.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             var sqlServerTranslators = new List<IMemberTranslator>
             {
                 new SqlServerStringLengthTranslator(),
-                new SqlServerDateTimeNowTranslator()
+                new SqlServerDateTimeNowTranslator(),
+                new SqlServerDateTimeDateComponentTranslator(),
+                new SqlServerDateTimeDatePartComponentTranslator(),
             };
 
             AddTranslators(sqlServerTranslators);

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDateComponentTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDateComponentTranslator.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerDateTimeDateComponentTranslator : IMemberTranslator
+    {
+        public virtual Expression Translate(MemberExpression memberExpression)
+            => (memberExpression.Expression != null)
+            && (memberExpression.Expression.Type == typeof(DateTime))
+            && (memberExpression.Member.Name == nameof(DateTime.Date))
+            ? new SqlFunctionExpression("CONVERT", 
+                memberExpression.Type, 
+                new[]
+                {
+                   Expression.Constant(DbType.Date),
+                   memberExpression.Expression
+                })
+            : null;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDatePartComponentTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDatePartComponentTranslator.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class SqlServerDateTimeDatePartComponentTranslator : IMemberTranslator
+    {
+        public Expression Translate(MemberExpression memberExpression)
+        {
+            string datePart;
+            if (memberExpression.Expression != null
+               && memberExpression.Expression.Type == typeof(DateTime)
+               && (datePart = GetDatePart(memberExpression.Member.Name)) != null)
+            {
+                return new DatePartExpression(datePart,
+                    memberExpression.Type,
+                    memberExpression.Expression);
+            }
+            return null;
+        }
+
+        private static string GetDatePart(string memberName)
+        {
+            switch (memberName)
+            {
+                case nameof(DateTime.Year): return "year";
+                case nameof(DateTime.Month): return "month";
+                case nameof(DateTime.DayOfYear): return "dayofyear";
+                case nameof(DateTime.Day): return "day";
+                case nameof(DateTime.Hour): return "hour";
+                case nameof(DateTime.Minute): return "minute";
+                case nameof(DateTime.Second): return "second";
+                case nameof(DateTime.Millisecond): return "millisecond";
+                default: return null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/DatePartExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/DatePartExpression.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    public class DatePartExpression : Expression
+    {
+        public DatePartExpression(
+            [NotNull] string datePart,
+            [NotNull] Type type,
+            [NotNull] Expression argument)
+        {
+            DatePart = datePart;
+            Type = type;
+            Argument = argument;
+        }
+
+        public override Type Type { get; }
+        public override ExpressionType NodeType => ExpressionType.Extension;
+        
+        public Expression Argument { get; }
+        public string DatePart { get; }
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as ISqlServerExpressionVisitor;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitDatePartExpression(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/ISqlServerExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/ISqlServerExpressionVisitor.cs
@@ -10,5 +10,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
     public interface ISqlServerExpressionVisitor
     {
         Expression VisitRowNumber([NotNull] RowNumberExpression rowNumberExpression);
+        Expression VisitDatePartExpression([NotNull] DatePartExpression datePartExpression);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -92,6 +92,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             return rowNumberExpression;
         }
 
+        public virtual Expression VisitDatePartExpression(DatePartExpression datePartExpression)
+        {
+            Check.NotNull(datePartExpression, nameof(datePartExpression));
+
+            Sql.Append("DATEPART(")
+                .Append(datePartExpression.DatePart)
+                .Append(", ");
+            Visit(datePartExpression.Argument);
+            Sql.Append(")");
+            return datePartExpression;
+        }
+
         public override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
         {
             if (sqlFunctionExpression.FunctionName.StartsWith("@@", StringComparison.Ordinal))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1968,6 +1968,110 @@ FROM [Customers] AS [c]
 WHERE LEN([c].[City]) = 6",
                 Sql);
         }
+        
+        public override void Where_datetime_date_component()
+        {
+            base.Where_datetime_date_component();
+
+            Assert.Equal(
+              @"@__myDatetime_0: 05/04/1998 00:00:00
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE CONVERT(date, [o].[OrderDate]) = @__myDatetime_0",
+              Sql);
+        }
+
+        public override void Where_datetime_day_component()
+        {
+            base.Where_datetime_day_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(day, [o].[OrderDate]) = 4",
+              Sql);
+
+        }
+
+        public override void Where_datetime_year_component()
+        {
+            base.Where_datetime_year_component();
+            
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(year, [o].[OrderDate]) = 1998",
+              Sql);
+
+        }
+
+        public override void Where_datetime_dayOfYear_component()
+        {
+            base.Where_datetime_dayOfYear_component();
+            
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(dayofyear, [o].[OrderDate]) = 68",
+              Sql);
+
+        }
+
+        public override void Where_datetime_month_component()
+        {
+            base.Where_datetime_month_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(month, [o].[OrderDate]) = 4",
+              Sql);
+        }
+
+        public override void Where_datetime_hour_component()
+        {
+            base.Where_datetime_hour_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(hour, [o].[OrderDate]) = 14",
+              Sql);
+        }
+
+        public override void Where_datetime_minute_component()
+        {
+            base.Where_datetime_minute_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(minute, [o].[OrderDate]) = 23",
+              Sql);
+        }
+
+        public override void Where_datetime_second_component()
+        {
+            base.Where_datetime_second_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(second, [o].[OrderDate]) = 44",
+              Sql);
+        }
+
+        public override void Where_datetime_millisecond_component()
+        {
+            base.Where_datetime_millisecond_component();
+
+            Assert.Equal(
+@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE DATEPART(millisecond, [o].[OrderDate]) = 88",
+              Sql);
+        }
 
         public override void Where_datetime_now()
         {


### PR DESCRIPTION
This PR adds sql server translation support for the following DateTime properties in LINQ (See also: https://github.com/aspnet/EntityFramework/issues/4582):
- DateTime.Date
- DateTime.Year
- DateTime.Month
- DateTime.Day
- DateTime.DayOfYear
- DateTime.Day
- DateTime.Hour
- DateTime.Minute
- DateTime.Second
- DateTime.Millisecond

This is SQL server only atm, but I would also be willing to add support for sqlite. 
However, I thought I would gather some feedback on this part first.

Looking forward to your feedback :)

