### PR TITLE
Add-Migrations: better handling of outputDir

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/ExecuteCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/ExecuteCommand.cs
@@ -37,6 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
         {
             var app = new CommandLineApplication()
             {
+                // Technically, the real "dotnet-ef.dll" is in Microsoft.EntityFrameworkCore.Tools,
+                // but this name is what the help usage displays
                 Name = "dotnet ef",
                 FullName = "Entity Framework .NET Core CLI Commands"
             };

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsAddCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsAddCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
 
             var outputDir = command.Option(
                 "-o|--output-dir <path>",
-                "The directory (and sub-namespace) to use. If omitted, \"Migrations\" is used.");
+                "The directory (and sub-namespace) to use. If omitted, \"Migrations\" is used. Relative paths are relative the directory in which the command is executed.");
             var context = command.Option(
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/OperationExecutor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/OperationExecutor.cs
@@ -152,7 +152,16 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
             [NotNull] string name,
             [CanBeNull] string outputDir,
             [CanBeNull] string contextType)
-           => _migrationsOperations.Value.AddMigration(name, outputDir, contextType);
+        {
+            if(!string.IsNullOrWhiteSpace(outputDir) && !Path.IsPathRooted(outputDir))
+            {
+                // relative paths adjusted to current working directory, not project directory
+                // PowerShell adjusts the cwd when executing dotnet-ef.
+                outputDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), outputDir));
+            }
+
+            return _migrationsOperations.Value.AddMigration(name, outputDir, contextType);
+        }
 
         public virtual void UpdateDatabase([CanBeNull] string targetMigration, [CanBeNull] string contextType)
             => _migrationsOperations.Value.UpdateDatabase(targetMigration, contextType);

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/project.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "description": "Entity Framework Core Commands for .NET Core CLI on .NET 4.5.1",
+  "description": "Components for Entity Framework Commands on .NET Core CLI",
   "buildOptions": {
     "emitEntryPoint": true,
     "warningsAsErrors": true,

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/MigrationsScaffolder.cs
@@ -300,8 +300,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         public virtual MigrationFiles Save(
-            [NotNull] string projectDir, 
-            [NotNull] ScaffoldedMigration migration, 
+            [NotNull] string projectDir,
+            [NotNull] ScaffoldedMigration migration,
             [CanBeNull] string outputDir)
         {
             Check.NotEmpty(projectDir, nameof(projectDir));

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Properties/ToolsCoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Properties/ToolsCoreStrings.Designer.cs
@@ -301,7 +301,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list. Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}"))
+        /// Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Either change your target project or change your migrations assembly.
+        /// Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}")). By default, the migrations assembly is the assembly containing the DbContext.
+        /// Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list, or by executing "dotnet ef" from the directory containing the migrations project.
         /// </summary>
         public static string MigrationsAssemblyMismatch([CanBeNull] object assembly, [CanBeNull] object migrationsAssembly)
         {

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Properties/ToolsCoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Properties/ToolsCoreStrings.resx
@@ -226,7 +226,9 @@
     <value>Root namespace of the project is required to generate code.</value>
   </data>
   <data name="MigrationsAssemblyMismatch" xml:space="preserve">
-    <value>Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list. Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}"))</value>
+    <value>Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Either change your target project or change your migrations assembly.
+Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}")). By default, the migrations assembly is the assembly containing the DbContext.
+Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list, or by executing "dotnet ef" from the directory containing the migrations project.</value>
   </data>
   <data name="SensitiveInformationWarning" xml:space="preserve">
     <value>To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.</value>


### PR DESCRIPTION
Fixup migrations -outputdir to better handle subnamespace computation normalizing path, and error handling. 

Fix #5274
Fix #5277 
Fix https://github.com/aspnet/EntityFramework/issues/5271