### PR TITLE
Unsubscribe from notification events

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntrySubscriber.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntrySubscriber.cs
@@ -7,6 +7,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public interface IInternalEntityEntrySubscriber
     {
-        InternalEntityEntry SnapshotAndSubscribe([NotNull] InternalEntityEntry entry);
+        bool SnapshotAndSubscribe([NotNull] InternalEntityEntry entry);
+        void Unsubscribe([NotNull] InternalEntityEntry entry);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -61,5 +61,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         DbContext Context { get; }
 
         bool? SingleQueryMode { get; set; }
+
+        void Unsubscribe();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -15,14 +13,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class InternalEntityEntrySubscriber : IInternalEntityEntrySubscriber
     {
-        private readonly IInternalEntityEntryNotifier _notifier;
-
-        public InternalEntityEntrySubscriber([NotNull] IInternalEntityEntryNotifier notifier)
-        {
-            _notifier = notifier;
-        }
-
-        public virtual InternalEntityEntry SnapshotAndSubscribe(InternalEntityEntry entry)
+        public virtual bool SnapshotAndSubscribe(InternalEntityEntry entry)
         {
             var entityType = entry.EntityType;
 
@@ -33,123 +24,100 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
+
+            if (changeTrackingStrategy == ChangeTrackingStrategy.Snapshot)
+            {
+                return false;
+            }
+
+            foreach (var navigation in entityType.GetNavigations().Where(n => n.IsCollection()))
+            {
+                AsINotifyCollectionChanged(entry, navigation, entityType, changeTrackingStrategy).CollectionChanged
+                    += entry.HandleINotifyCollectionChanged;
+            }
+
+            if (changeTrackingStrategy != ChangeTrackingStrategy.ChangedNotifications)
+            {
+                AsINotifyPropertyChanging(entry, entityType, changeTrackingStrategy).PropertyChanging
+                    += entry.HandleINotifyPropertyChanging;
+            }
+
+            AsINotifyPropertyChanged(entry, entityType, changeTrackingStrategy).PropertyChanged
+                += entry.HandleINotifyPropertyChanged;
+
+            return true;
+        }
+
+        public virtual void Unsubscribe(InternalEntityEntry entry)
+        {
+            var entityType = entry.EntityType;
+            var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
+
             if (changeTrackingStrategy != ChangeTrackingStrategy.Snapshot)
             {
                 foreach (var navigation in entityType.GetNavigations().Where(n => n.IsCollection()))
                 {
-                    var notifyingCollection = navigation.GetCollectionAccessor().GetOrCreate(entry.Entity) as INotifyCollectionChanged;
-                    if (notifyingCollection == null)
-                    {
-                        throw new InvalidOperationException(
-                            CoreStrings.NonNotifyingCollection(navigation.Name, entityType.DisplayName(), changeTrackingStrategy));
-                    }
-
-                    notifyingCollection.CollectionChanged += (s, e) =>
-                        {
-                            switch (e.Action)
-                            {
-                                case NotifyCollectionChangedAction.Add:
-                                    _notifier.NavigationCollectionChanged(
-                                        entry,
-                                        navigation,
-                                        e.NewItems.OfType<object>(),
-                                        Enumerable.Empty<object>());
-                                    break;
-                                case NotifyCollectionChangedAction.Remove:
-                                    _notifier.NavigationCollectionChanged(
-                                        entry,
-                                        navigation,
-                                        Enumerable.Empty<object>(),
-                                        e.OldItems.OfType<object>());
-                                    break;
-                                case NotifyCollectionChangedAction.Replace:
-                                    _notifier.NavigationCollectionChanged(
-                                        entry,
-                                        navigation,
-                                        e.NewItems.OfType<object>(),
-                                        e.OldItems.OfType<object>());
-                                    break;
-                                case NotifyCollectionChangedAction.Reset:
-                                    if (e.OldItems == null)
-                                    {
-                                        throw new InvalidOperationException(CoreStrings.ResetNotSupported);
-                                    }
-
-                                    _notifier.NavigationCollectionChanged(
-                                        entry,
-                                        navigation,
-                                        Enumerable.Empty<object>(),
-                                        e.OldItems.OfType<object>());
-                                    break;
-                                // Note: ignoring Move since index not important
-                            }
-                        };
+                    AsINotifyCollectionChanged(entry, navigation, entityType, changeTrackingStrategy).CollectionChanged
+                        -= entry.HandleINotifyCollectionChanged;
                 }
 
                 if (changeTrackingStrategy != ChangeTrackingStrategy.ChangedNotifications)
                 {
-                    var changing = entry.Entity as INotifyPropertyChanging;
-                    if (changing == null)
-                    {
-                        throw new InvalidOperationException(
-                            CoreStrings.ChangeTrackingInterfaceMissing(
-                                entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanging).Name));
-                    }
-
-                    changing.PropertyChanging += (s, e) =>
-                        {
-                            foreach (var propertyBase in GetNotificationProperties(entityType, e.PropertyName))
-                            {
-                                _notifier.PropertyChanging(entry, propertyBase);
-                            }
-                        };
+                    AsINotifyPropertyChanging(entry, entityType, changeTrackingStrategy).PropertyChanging
+                        -= entry.HandleINotifyPropertyChanging;
                 }
 
-                var changed = entry.Entity as INotifyPropertyChanged;
-                if (changed == null)
-                {
-                    throw new InvalidOperationException(
-                        CoreStrings.ChangeTrackingInterfaceMissing(
-                            entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanged).Name));
-                }
-
-                changed.PropertyChanged += (s, e) =>
-                    {
-                        foreach (var propertyBase in GetNotificationProperties(entityType, e.PropertyName))
-                        {
-                            _notifier.PropertyChanged(entry, propertyBase, setModified: true);
-                        }
-                    };
+                AsINotifyPropertyChanged(entry, entityType, changeTrackingStrategy).PropertyChanged
+                    -= entry.HandleINotifyPropertyChanged;
             }
-
-            return entry;
         }
 
-        private static IEnumerable<IPropertyBase> GetNotificationProperties(IEntityType entityType, string propertyName)
+        private static INotifyCollectionChanged AsINotifyCollectionChanged(
+            InternalEntityEntry entry,
+            INavigation navigation,
+            IEntityType entityType,
+            ChangeTrackingStrategy changeTrackingStrategy)
         {
-            if (string.IsNullOrEmpty(propertyName))
+            var notifyingCollection = navigation.GetCollectionAccessor().GetOrCreate(entry.Entity) as INotifyCollectionChanged;
+            if (notifyingCollection == null)
             {
-                foreach (var property in entityType.GetProperties().Where(p => !p.IsReadOnlyAfterSave))
-                {
-                    yield return property;
-                }
+                throw new InvalidOperationException(
+                    CoreStrings.NonNotifyingCollection(navigation.Name, entityType.DisplayName(), changeTrackingStrategy));
+            }
 
-                foreach (var navigation in entityType.GetNavigations())
-                {
-                    yield return navigation;
-                }
-            }
-            else
-            {
-                var property = TryGetPropertyBase(entityType, propertyName);
-                if (property != null)
-                {
-                    yield return property;
-                }
-            }
+            return notifyingCollection;
         }
 
-        private static IPropertyBase TryGetPropertyBase(IEntityType entityType, string propertyName)
-            => (IPropertyBase)entityType.FindProperty(propertyName) ?? entityType.FindNavigation(propertyName);
+        private static INotifyPropertyChanged AsINotifyPropertyChanged(
+            InternalEntityEntry entry,
+            IEntityType entityType,
+            ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            var changed = entry.Entity as INotifyPropertyChanged;
+            if (changed == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ChangeTrackingInterfaceMissing(
+                        entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanged).Name));
+            }
+
+            return changed;
+        }
+
+        private static INotifyPropertyChanging AsINotifyPropertyChanging(
+            InternalEntityEntry entry,
+            IEntityType entityType,
+            ChangeTrackingStrategy changeTrackingStrategy)
+        {
+            var changing = entry.Entity as INotifyPropertyChanging;
+            if (changing == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ChangeTrackingInterfaceMissing(
+                        entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanging).Name));
+            }
+
+            return changing;
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -347,14 +347,20 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         public virtual void Dispose()
         {
-            _disposed = true;
-            _serviceScope?.Dispose();
-            _setInitializer = null;
-            _changeTracker = null;
-            _stateManager = null;
-            _changeDetector = null;
-            _graphAttacher = null;
-            _model = null;
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                _stateManager?.Unsubscribe();
+
+                _serviceScope?.Dispose();
+                _setInitializer = null;
+                _changeTracker = null;
+                _stateManager = null;
+                _changeDetector = null;
+                _graphAttacher = null;
+                _model = null;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -204,6 +204,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return null;
         }
 
+        public static IEnumerable<IPropertyBase> GetNotificationProperties(
+            [NotNull] this IEntityType entityType, [CanBeNull] string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                foreach (var property in entityType.GetProperties().Where(p => !p.IsReadOnlyAfterSave))
+                {
+                    yield return property;
+                }
+
+                foreach (var navigation in entityType.GetNavigations())
+                {
+                    yield return navigation;
+                }
+            }
+            else
+            {
+                var property = (IPropertyBase)entityType.FindProperty(propertyName)
+                    ?? entityType.FindNavigation(propertyName);
+                if (property != null)
+                {
+                    yield return property;
+                }
+            }
+        }
+
         public static EntityType AsEntityType([NotNull] this IEntityType entityType, [NotNull] [CallerMemberName] string methodName = "")
             => entityType.AsConcreteMetadataType<IEntityType, EntityType>(methodName);
     }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -1189,14 +1189,22 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
 
         protected virtual InternalEntityEntry CreateInternalEntry(IServiceProvider contextServices, IEntityType entityType, object entity)
-            => contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
-                new InternalEntityEntryFactory()
-                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity));
+        {
+            var entry = new InternalEntityEntryFactory()
+                .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity);
+
+            contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(entry);
+            return entry;
+        }
 
         protected virtual InternalEntityEntry CreateInternalEntry(IServiceProvider contextServices, IEntityType entityType, object entity, ValueBuffer valueBuffer)
-            => contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
-                new InternalEntityEntryFactory()
-                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity, valueBuffer));
+        {
+            var entry = new InternalEntityEntryFactory()
+                .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity, valueBuffer);
+
+            contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(entry);
+            return entry;
+        }
 
         protected virtual Model BuildModel()
         {

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -220,6 +220,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public bool SaveChangesAsyncCalled { get; set; }
             public virtual bool? SingleQueryMode { get; set; }
 
+            public void Unsubscribe()
+            {
+            }
+
             public void UpdateIdentityMap(InternalEntityEntry entry, IKey principalKey)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Issue #1378

This change ensures that entities are unsubscribed from notification events when they stop being tracked or the context is disposed.