### PR TITLE
CLI commands on desktop: resolve startup assembly from external project

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/DesktopContext.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/DesktopContext.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace DesktopClassLibrary
+{
+    public class DesktopContext : DbContext
+    {
+        public DesktopContext(DbContextOptions<DesktopContext> options) : base (options) { }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/Program.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/Program.cs
@@ -1,0 +1,8 @@
+namespace DesktopClassLibrary
+{
+    // TODO remove this when https://github.com/dotnet/cli/issues/2919 is resolved
+    public class Program
+    {
+        public static void Main() { }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/project.json.ignore
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.EntityFrameworkCore.Tools": {
+      "version": "1.0.0-$toolVersion$",
+      "type": "build",
+      "target": "package"
+    },
+    "Microsoft.EntityFrameworkCore.Sqlite": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net451": { }
+  },
+  "tools": {
+    "Microsoft.EntityFrameworkCore.Tools": {
+      "version": "1.0.0-$toolVersion$",
+      "imports": [
+        "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/Program.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/Program.cs
@@ -1,0 +1,7 @@
+namespace DesktopStartupProject
+{
+    public class Program
+    {
+        public static void Main() { }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/Startup.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/Startup.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using DesktopClassLibrary;
+
+namespace DesktopStartupProject
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<DesktopContext>(o => o.UseSqlite("Filename=./desktop.db"));
+            
+            // Exercises assembly dependency conflict resolution 
+            JsonConvert.SerializeObject(new object());
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopStartupProject/project.json.ignore
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "DesktopClassLibrary": {
+      "target": "project"
+    },
+    "Newtonsoft.Json": "8.0.3"
+  },
+  "frameworks": {
+    "net451": { }
+  }
+}


### PR DESCRIPTION
Partial fix for https://github.com/aspnet/EntityFramework/issues/4577

This is the minimal change we can make that will enable most users to use dotnet-ef for desktop .NET. Although the implementation will other issues for some users, I believe this is a good tradeoff to the high cost of fixing #4577 perfectly.

Why it's not perfect (simplifed): this tries to pull a "child" assembly into a "parent" app domain. The child may have dependencies that conflicts with the "parent" app domain. Should this problem arise (which may not for most users), the solution is to lift dependencies in the project.json for the "child" assembly.

The "proper" way to do this (the way we do it in Powershell) is to only ever load the "child" in an appdomain with its own dependencies, thus avoiding potential for conflict. But implementing this would mean re-working huge parts of CLI commands.