### PR TITLE
Generalize type mapping support for Unicode

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalParameterBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalParameterBuilder.cs
@@ -19,8 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         void AddParameter(
             [NotNull] string invariantName,
             [NotNull] string name,
-            [NotNull] Type type,
-            bool unicode);
+            [NotNull] RelationalTypeMapping typeMapping,
+            bool nullable);
 
         void AddParameter(
             [NotNull] string invariantName,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalTypeMapper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public interface IRelationalTypeMapper
     {
         RelationalTypeMapping FindMapping([NotNull] IProperty property);
-        RelationalTypeMapping FindMapping([NotNull] Type clrType, bool unicode = true);
+        RelationalTypeMapping FindMapping([NotNull] Type clrType);
 
         RelationalTypeMapping FindMapping([NotNull] string typeName);
         void ValidateTypeName([NotNull] string typeName);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/ISqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/ISqlGenerationHelper.cs
@@ -16,9 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         void GenerateParameterName([NotNull] StringBuilder builder, [NotNull] string name);
 
-        string GenerateLiteral([CanBeNull] object value, bool unicode = true);
+        string GenerateLiteral([CanBeNull] object value, [CanBeNull] RelationalTypeMapping typeMapping = null);
 
-        void GenerateLiteral([NotNull] StringBuilder builder, [CanBeNull] object value, bool unicode = true);
+        void GenerateLiteral([NotNull] StringBuilder builder, [CanBeNull] object value, [CanBeNull] RelationalTypeMapping typeMapping = null);
 
         string EscapeLiteral([NotNull] string literal);
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalParameterBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalParameterBuilder.cs
@@ -31,18 +31,18 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     Check.NotEmpty(name, nameof(name)),
                     TypeMapper));
 
-        public virtual void AddParameter(string invariantName, string name, Type type, bool unicode)
+        public virtual void AddParameter(string invariantName, string name, RelationalTypeMapping typeMapping, bool nullable)
         {
             Check.NotEmpty(invariantName, nameof(invariantName));
             Check.NotEmpty(name, nameof(name));
-            Check.NotNull(type, nameof(type));
+            Check.NotNull(typeMapping, nameof(typeMapping));
 
             _parameters.Add(
                 new TypeMappedRelationalParameter(
                     invariantName,
                     name,
-                    TypeMapper.GetMapping(type, unicode),
-                    type.IsNullableType()));
+                    typeMapping,
+                    nullable));
         }
 
         public virtual void AddParameter(string invariantName, string name, IProperty property)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
@@ -97,15 +97,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] this IRelationalCommandBuilder commandBuilder,
             [NotNull] string invariantName,
             [NotNull] string name,
-            [NotNull] Type type,
-            bool unicode)
+            [NotNull] RelationalTypeMapping typeMapping,
+            bool nullable)
         {
             Check.NotNull(commandBuilder, nameof(commandBuilder));
             Check.NotEmpty(invariantName, nameof(invariantName));
             Check.NotEmpty(name, nameof(name));
-            Check.NotNull(type, nameof(type));
+            Check.NotNull(typeMapping, nameof(typeMapping));
 
-            commandBuilder.ParameterBuilder.AddParameter(invariantName, name, type, unicode);
+            commandBuilder.ParameterBuilder.AddParameter(invariantName, name, typeMapping, nullable);
 
             return commandBuilder;
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -50,24 +50,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual void GenerateParameterName(StringBuilder builder, string name)
             => builder.Append("@").Append(name);
 
-        public virtual string GenerateLiteral(object value, bool unicode = true)
+        public virtual string GenerateLiteral(object value, RelationalTypeMapping typeMapping = null)
         {
             if (value != null)
             {
                 var s = value as string;
-                return s != null ? GenerateLiteralValue(s, unicode) : GenerateLiteralValue((dynamic)value);
+                return s != null ? GenerateLiteralValue(s, typeMapping) : GenerateLiteralValue((dynamic)value);
             }
             return "NULL";
         }
 
-        public virtual void GenerateLiteral(StringBuilder builder, object value, bool unicode = true)
+        public virtual void GenerateLiteral(StringBuilder builder, object value, RelationalTypeMapping typeMapping = null)
         {
             if (value != null)
             {
                 var s = value as string;
                 if (s != null)
                 {
-                    GenerateLiteralValue(builder, s, unicode);
+                    GenerateLiteralValue(builder, s, typeMapping);
                 }
                 else
                 {
@@ -185,10 +185,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         protected virtual void GenerateLiteralValue([NotNull] StringBuilder builder, char value)
             => builder.Append("'").Append(value).Append("'");
 
-        protected virtual string GenerateLiteralValue([NotNull] string value, bool unicode = true)
+        protected virtual string GenerateLiteralValue([NotNull] string value, [CanBeNull] RelationalTypeMapping typeMapping)
             => $"'{EscapeLiteral(Check.NotNull(value, nameof(value)))}'";
 
-        protected virtual void GenerateLiteralValue([NotNull] StringBuilder builder, [NotNull] string value, bool unicode = true)
+        protected virtual void GenerateLiteralValue([NotNull] StringBuilder builder, [NotNull] string value, [CanBeNull] RelationalTypeMapping typeMapping)
         {
             builder.Append("'");
             EscapeLiteral(builder, value);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                    ?? FindMapping(property.ClrType);
         }
 
-        public virtual RelationalTypeMapping FindMapping(Type clrType, bool unicode = true)
+        public virtual RelationalTypeMapping FindMapping(Type clrType)
         {
             Check.NotNull(clrType, nameof(clrType));
 
@@ -69,11 +69,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 : null;
         }
 
-        protected virtual RelationalTypeMapping GetCustomMapping([NotNull] IProperty property, bool unicode = true)
+        protected virtual RelationalTypeMapping GetCustomMapping([NotNull] IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
-            var mapping = FindCustomMapping(property, unicode);
+            var mapping = FindCustomMapping(property);
 
             if (mapping != null)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             throw new InvalidOperationException(RelationalStrings.UnsupportedType(property.ClrType.Name));
         }
 
-        protected virtual RelationalTypeMapping FindCustomMapping([NotNull] IProperty property, bool unicode = true) => null;
+        protected virtual RelationalTypeMapping FindCustomMapping([NotNull] IProperty property) => null;
 
         protected virtual bool RequiresKeyMapping([NotNull] IProperty property)
             => property.IsKey() || property.IsForeignKey();

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -38,13 +38,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         public static RelationalTypeMapping GetMapping(
             [NotNull] this IRelationalTypeMapper typeMapper,
-            [NotNull] Type clrType,
-            bool unicode = true)
+            [NotNull] Type clrType)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
             Check.NotNull(clrType, nameof(clrType));
 
-            var mapping = typeMapper.FindMapping(clrType, unicode);
+            var mapping = typeMapper.FindMapping(clrType);
             if (mapping != null)
             {
                 return mapping;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -58,14 +58,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
         }
 
-        protected override string GenerateLiteralValue(string value, bool unicode = true)
-            => unicode
+        protected override string GenerateLiteralValue(string value, RelationalTypeMapping typeMapping = null)
+            => typeMapping == null || typeMapping.IsUnicode
                 ? $"N'{EscapeLiteral(Check.NotNull(value, nameof(value)))}'"
                 : $"'{EscapeLiteral(Check.NotNull(value, nameof(value)))}'";
 
-        protected override void GenerateLiteralValue(StringBuilder builder, string value, bool unicode = true)
+        protected override void GenerateLiteralValue(StringBuilder builder, string value, RelationalTypeMapping typeMapping = null)
         {
-            builder.Append(unicode ? "N'" : "'");
+            builder.Append(typeMapping.IsUnicode ? "N'" : "'");
             EscapeLiteral(builder, value);
             builder.Append("'");
         }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -44,15 +44,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
         {
             protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
-            public override RelationalTypeMapping FindMapping(Type clrType, bool unicode = true)
+            public override RelationalTypeMapping FindMapping(Type clrType)
                 => clrType == typeof(string)
                     ? new RelationalTypeMapping("varchar(4000)", typeof(string), unicode: false)
-                    : base.FindMapping(clrType, unicode);
+                    : base.FindMapping(clrType);
 
-            protected override RelationalTypeMapping FindCustomMapping(IProperty property, bool unicode = true)
+            protected override RelationalTypeMapping FindCustomMapping(IProperty property)
                 => property.ClrType == typeof(string) && property.GetMaxLength().HasValue
-                    ? new RelationalTypeMapping((unicode ? "nvarchar(" : "varchar(") + property.GetMaxLength() + ")", typeof(string), unicode: false)
-                    : base.FindCustomMapping(property, unicode);
+                    ? new RelationalTypeMapping("nvarchar(" + property.GetMaxLength() + ")", typeof(string), unicode: false)
+                    : base.FindCustomMapping(property);
 
             private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
                 = new Dictionary<Type, RelationalTypeMapping>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -322,17 +322,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
 
             protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
-            public override RelationalTypeMapping FindMapping(Type clrType, bool unicode = true)
+            public override RelationalTypeMapping FindMapping(Type clrType)
                 => clrType == typeof(string)
-                    ? (unicode
-                        ? new RelationalTypeMapping("nvarchar(max)", typeof(string))
-                        : new RelationalTypeMapping("varchar(max)", typeof(string), unicode: false))
-                    : base.FindMapping(clrType, unicode);
+                    ? new RelationalTypeMapping("nvarchar(max)", typeof(string))
+                    : base.FindMapping(clrType);
 
-            protected override RelationalTypeMapping FindCustomMapping(IProperty property, bool unicode = true)
+            protected override RelationalTypeMapping FindCustomMapping(IProperty property)
                 => property.ClrType == typeof(string) && property.GetMaxLength().HasValue
-                    ? new RelationalTypeMapping((unicode ? "nvarchar(" : "varchar(") + property.GetMaxLength() + ")", typeof(string))
-                    : base.FindCustomMapping(property, unicode);
+                    ? new RelationalTypeMapping("nvarchar(" + property.GetMaxLength() + ")", typeof(string))
+                    : base.FindCustomMapping(property);
         }
 
         private class ConcreteMigrationSqlGenerator : MigrationsSqlGenerator

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -36,8 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             commandBuilder.ParameterBuilder.AddParameter(
                 "InvariantName",
                 "Name",
-                typeof(string),
-                unicode: true);
+                new RelationalTypeMapping("nvarchar(100)", typeof(string)),
+                nullable: true);
 
             var command = commandBuilder.Build();
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
@@ -36,18 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Can_add_type_mapped_parameter_by_type(bool nullable)
         {
             var typeMapper = new FakeRelationalTypeMapper();
-
-            var type = nullable
-                ? typeof(int?)
-                : typeof(int);
-
+            var typeMapping = typeMapper.GetMapping(nullable ? typeof(int?) : typeof(int));
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
             parameterBuilder.AddParameter(
                 "InvariantName",
                 "Name",
-                type,
-                unicode: true);
+                typeMapping,
+                nullable);
 
             Assert.Equal(1, parameterBuilder.Parameters.Count);
 
@@ -56,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.NotNull(parameter);
             Assert.Equal("InvariantName", parameter.InvariantName);
             Assert.Equal("Name", parameter.Name);
-            Assert.Equal(typeMapper.GetMapping(typeof(int)), parameter.RelationalTypeMapping);
+            Assert.Equal(typeMapping, parameter.RelationalTypeMapping);
             Assert.Equal(nullable, parameter.IsNullable);
         }
 
@@ -102,14 +98,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         builder.AddParameter(
                             "FirstInvariant",
                             "FirstName",
-                            typeof(int),
-                            unicode: true);
+                            new RelationalTypeMapping("int", typeof(int)),
+                            nullable: false);
 
                         builder.AddParameter(
                             "SecondInvariant",
                             "SecondName",
-                            typeof(string),
-                            unicode: true);
+                            new RelationalTypeMapping("nvarchae(max)", typeof(string)),
+                            nullable: true);
                     });
 
             Assert.Equal(1, parameterBuilder.Parameters.Count);

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
             => _simpleNameMappings;
 
-        protected override RelationalTypeMapping FindCustomMapping(IProperty property, bool unicode = true)
+        protected override RelationalTypeMapping FindCustomMapping(IProperty property)
         {
             var clrType = property.ClrType.UnwrapNullableType();
 
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                         property, 2000,
                         l => new RelationalSizedTypeMapping("just_binary(" + l + ")", typeof(string), unicode: true, size: l),
                         _unboundedBinary, _binary, _binaryKey, _rowversion)
-                    : base.FindCustomMapping(property, unicode);
+                    : base.FindCustomMapping(property);
         }
     }
 }


### PR DESCRIPTION
In looking at #4425 and #4134 in became quickly apparent that the support for inferring Unicode was too specific to Unicode. What is really needed is that if the type mapping to be used can be inferred in some way, then this type mapping should be used for all relevant facets, not just Unicode. Only in cases where no inference is possible should the default mapping for the CLR type be used.