### PR TITLE
Fix #5327 - use backward-compatible powershell API in EF commands

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFramework.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFramework.psm1
@@ -640,7 +640,11 @@ function ShowConsole {
 }
 
 function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
-    $dotnet = (Get-Command dotnet).Source
+    try {
+        $dotnet = (Get-Command dotnet).Path
+    } catch {
+        throw "Could not find .NET Core CLI (dotnet.exe). .NET Core CLI is required to execute EF commands on this project type."
+    }
     Write-Debug "Found $dotnet"
     $fullPath = GetProperty $project.Properties FullPath
     $projectJson = Join-Path $fullPath project.json


### PR DESCRIPTION
Also helps DNX project users who upgrade.

cc @rowanmiller @divega @pranavkm 