### PR TITLE
[SMALL] Generated DbContext classes need "using System;"

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Internal/DbContextWriter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Internal/DbContextWriter.cs
@@ -38,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _model = modelConfiguration;
             _sb = new IndentedStringBuilder();
 
+            _sb.AppendLine("using System;"); // Guid default values require new Guid() which requires this using
             _sb.AppendLine("using Microsoft.EntityFrameworkCore;");
             _sb.AppendLine("using Microsoft.EntityFrameworkCore.Metadata;");
             _sb.AppendLine();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/SequenceContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/SequenceContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/NoPrincipalPk/NoPrincipalPkFluentApiContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/NoPrincipalPk/NoPrincipalPkFluentApiContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/FkToAltKey/FkToAltKeyContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/ManyToMany/ManyToManyAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/ManyToMany/ManyToManyAttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/NoPrincipalPkAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/NoPrincipalPkAttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyAttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/SelfRef/SelfRefAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/SelfRef/SelfRefAttributesContext.expected
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 


### PR DESCRIPTION
Fix for #5238. One file is the fix - the rest are just updating the expected results.