### PR TITLE
[TINY] Correcting bad example provider name.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextScaffoldCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextScaffoldCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                 "The connection string of the database");
             var provider = command.Argument(
                 "[provider]",
-                "The provider to use. For example, EntityFramework.MicrosoftSqlServer");
+                "The provider to use. For example, Microsoft.EntityFrameworkCore.SqlServer");
 
             var dataAnnotations = command.Option(
                 "-a|--data-annotations",


### PR DESCRIPTION
Fix for #5267. Example had the old provider package name. Updated to the new one.