### PR TITLE
Fix to #3101 - .Include() with Self-Join / Coalesce

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -65,7 +65,6 @@
       <Link>StringBuilderExtensions.cs</Link>
     </Compile>
     <Compile Include="Extensions\DbCommandLogData.cs" />
-    <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="Extensions\RelationalExpressionExtensions.cs" />
     <Compile Include="Extensions\RelationalLoggerExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -233,21 +233,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected override void IncludeNavigations(
             IncludeSpecification includeSpecification,
             Type resultType,
-            LambdaExpression accessorLambda,
+            Expression accessorExpression,
             bool querySourceRequiresTracking)
         {
             Check.NotNull(includeSpecification, nameof(includeSpecification));
             Check.NotNull(resultType, nameof(resultType));
 
-            Expression
-                = _includeExpressionVisitorFactory
-                    .Create(
-                        includeSpecification.QuerySource,
-                        includeSpecification.NavigationPath,
-                        QueryCompilationContext,
-                        _navigationIndexMap[includeSpecification],
-                        querySourceRequiresTracking)
-                    .Visit(Expression);
+            var includeExpressionVisitor = _includeExpressionVisitorFactory.Create(
+                includeSpecification.QuerySource,
+                includeSpecification.NavigationPath,
+                QueryCompilationContext,
+                _navigationIndexMap[includeSpecification],
+                querySourceRequiresTracking);
+
+            Expression = includeExpressionVisitor.Visit(Expression);
         }
 
         public override void VisitQueryModel(QueryModel queryModel)

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MethodInfoExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MethodInfoExtensions.cs
@@ -1,15 +1,16 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 // ReSharper disable once CheckNamespace
 namespace System.Reflection
 {
     [DebuggerStepThrough]
-    internal static class MethodInfoExtensions
+    public static class MethodInfoExtensions
     {
-        public static bool MethodIsClosedFormOf(this MethodInfo methodInfo, MethodInfo genericMethod)
+        public static bool MethodIsClosedFormOf([NotNull] this MethodInfo methodInfo, [NotNull] MethodInfo genericMethod)
             => methodInfo.IsGenericMethod
                && ReferenceEquals(
                    methodInfo.GetGenericMethodDefinition(),

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Extensions\Internal\ExpressionExtensions.cs" />
     <Compile Include="Extensions\Internal\ListExtensions.cs" />
     <Compile Include="Extensions\KeyExtensions.cs" />
+    <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="Extensions\ModelExtensions.cs" />
     <Compile Include="Extensions\MutableAnnotatableExtensions.cs" />
     <Compile Include="Extensions\MutableEntityTypeExtensions.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -354,12 +354,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 if (resultQuerySourceReferenceExpression != null)
                 {
-                    var accessorLambda
-                        = AccessorFindingExpressionVisitor
-                            .FindAccessorLambda(
-                                resultQuerySourceReferenceExpression,
-                                queryModel.SelectClause.Selector,
-                                Expression.Parameter(queryModel.SelectClause.Selector.Type, "result"));
+                    var accessorExpression = QueryCompilationContext.QuerySourceMapping.GetExpression(
+                        resultQuerySourceReferenceExpression.ReferencedQuerySource);
 
                     var sequenceType = resultQuerySourceReferenceExpression.Type.TryGetSequenceType();
 
@@ -377,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     IncludeNavigations(
                         includeSpecification,
                         _expression.Type.GetSequenceType(),
-                        accessorLambda,
+                        accessorExpression,
                         QueryCompilationContext.IsTrackingQuery);
 
                     QueryCompilationContext
@@ -422,7 +418,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual void IncludeNavigations(
             [NotNull] IncludeSpecification includeSpecification,
             [NotNull] Type resultType,
-            [NotNull] LambdaExpression accessorLambda,
+            [NotNull] Expression accessorExpression,
             bool querySourceRequiresTracking)
         {
             // template method

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -90,13 +90,24 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return expression;
         }
 
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            return node.NodeType == ExpressionType.Coalesce
+                ? base.VisitBinary(node)
+                : node;
+        }
+
+        protected override Expression VisitConditional(ConditionalExpression node)
+        {
+            Visit(node.IfTrue);
+            Visit(node.IfFalse);
+
+            return node;
+        }
+
         // Prune these nodes...
 
         protected override Expression VisitMember(MemberExpression node) => node;
-
-        protected override Expression VisitConditional(ConditionalExpression node) => node;
-
-        protected override Expression VisitBinary(BinaryExpression node) => node;
 
         protected override Expression VisitTypeBinary(TypeBinaryExpression node) => node;
 

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/QueryBugsInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/QueryBugsInMemoryTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -87,6 +89,246 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase();
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce1()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities
+                                join eRoot in ctx.Entities.Include(e => e.Children).AsNoTracking()
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select eRootJoined ?? eVersion;
+
+                    var result = query.ToList();
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce2()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities
+                                join eRoot in ctx.Entities.Include(e => e.Children)
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select eRootJoined ?? eVersion;
+
+                    var result = query.ToList();
+                    Assert.Equal(2, result.Count(e => e.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce3()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                                join eRoot in ctx.Entities.Include(e => e.Children)
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select eRootJoined ?? eVersion;
+
+                    var result = query.ToList();
+                    Assert.True(result.All(e => e.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_complex_coalesce1()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                                join eRoot in ctx.Entities
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select new { One = 1, Coalesce = eRootJoined ?? eVersion };
+
+                    var result = query.ToList();
+                    Assert.True(result.All(e => e.Coalesce.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_complex_coalesce2()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities
+                                join eRoot in ctx.Entities.Include(e => e.Children)
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select new { Root = eRootJoined, Coalesce = eRootJoined ?? eVersion };
+
+                    var result = query.ToList();
+                    Assert.Equal(2, result.Count(e => e.Coalesce.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_nested_coalesce1()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities
+                                join eRoot in ctx.Entities.Include(e => e.Children)
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select new { One = 1, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
+
+                    var result = query.ToList();
+                    Assert.Equal(2, result.Count(e => e.Coalesce.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_nested_coalesce2()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                                join eRoot in ctx.Entities
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select new { One = eRootJoined, Two = 2, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
+
+                    var result = query.ToList();
+                    Assert.True(result.All(e => e.Coalesce.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_conditional()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                                join eRoot in ctx.Entities
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select eRootJoined != null ? eRootJoined : eVersion;
+
+                    var result = query.ToList();
+                    Assert.True(result.All(e => e.Children.Count > 0));
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_coalesce_tracking()
+        {
+            using (CreateScratch<MyContext3101>(Seed3101))
+            {
+                using (var ctx = new MyContext3101())
+                {
+                    var query = from eVersion in ctx.Entities
+                                join eRoot in ctx.Entities
+                                on eVersion.RootEntityId equals (int?)eRoot.Id
+                                into RootEntities
+                                from eRootJoined in RootEntities.DefaultIfEmpty()
+                                select new { eRootJoined, eVersion, foo = eRootJoined ?? eVersion };
+
+                    var result = query.ToList();
+
+                    var foo = ctx.ChangeTracker.Entries().ToList();
+                    Assert.True(ctx.ChangeTracker.Entries().Count() > 0);
+                }
+            }
+        }
+
+        private static void Seed3101(MyContext3101 context)
+        {
+            var c11 = new Child3101 { Name = "c11" };
+            var c12 = new Child3101 { Name = "c12" };
+            var c13 = new Child3101 { Name = "c13" };
+            var c21 = new Child3101 { Name = "c21" };
+            var c22 = new Child3101 { Name = "c22" };
+            var c31 = new Child3101 { Name = "c31" };
+            var c32 = new Child3101 { Name = "c32" };
+
+            context.Children.AddRange(c11, c12, c13, c21, c22, c31, c32);
+
+            var e1 = new Entity3101 { Id = 1, Children = new[] { c11, c12, c13 } };
+            var e2 = new Entity3101 { Id = 2, Children = new[] { c21, c22 } };
+            var e3 = new Entity3101 { Id = 3, Children = new[] { c31, c32 } };
+
+            e2.RootEntity = e1;
+
+            context.Entities.AddRange(e1, e2, e3);
+            context.SaveChanges();
+        }
+
+        public class MyContext3101 : DbContext
+        {
+            public DbSet<Entity3101> Entities { get; set; }
+
+            public DbSet<Child3101> Children { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Entity3101>().Property(e => e.Id).ValueGeneratedNever();
+            }
+        }
+
+        public class Entity3101
+        {
+            public Entity3101()
+            {
+                this.Children = new Collection<Child3101>();
+            }
+
+            public int Id { get; set; }
+
+            public int? RootEntityId { get; set; }
+
+            public Entity3101 RootEntity { get; set; }
+
+            public ICollection<Child3101> Children { get; set; }
+        }
+
+        public class Child3101
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
         }
 
         private static InMemoryTestStore CreateScratch<TContext>(Action<TContext> Seed)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1098,6 +1098,240 @@ WHERE [c].[Location] + 'Added' LIKE ('%' + 'Add') + '%'",
                 Sql);
         }
 
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g2].[Nickname], [g2].[SquadId], [g2].[AssignedCityName], [g2].[CityOrBirthName], [g2].[Discriminator], [g2].[FullName], [g2].[LeaderNickname], [g2].[LeaderSquadId], [g2].[Rank]
+FROM [Gear] AS [g]
+LEFT JOIN [Gear] AS [g2] ON [g].[LeaderNickname] = [g2].[Nickname]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[LeaderNickname], [g].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName]
+    FROM [Gear] AS [g]
+    LEFT JOIN [Gear] AS [g2] ON [g].[LeaderNickname] = [g2].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
+ORDER BY [g0].[LeaderNickname], [g0].[FullName]",
+                Sql);
+        }
+
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2();
+
+            Assert.Equal(
+                @"SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [Gear] AS [g1]
+LEFT JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g1].[LeaderNickname] = [t].[Nickname]
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g1].[LeaderNickname], [t].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g1].[LeaderNickname], [t].[FullName]
+    FROM [Gear] AS [g1]
+    LEFT JOIN (
+        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+        FROM [Gear] AS [g0]
+        WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g1].[LeaderNickname] = [t].[Nickname]
+    WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
+ORDER BY [t0].[LeaderNickname], [t0].[FullName]",
+                Sql);
+        }
+
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [Gear] AS [g]
+LEFT JOIN (
+    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+    FROM [Gear] AS [g1]
+    WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[LeaderNickname], [g].[FullName], [t].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [g2] ON [w].[OwnerFullName] = [g2].[FullName]
+ORDER BY [g2].[LeaderNickname], [g2].[FullName]
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName], [t].[FullName] AS [FullName0]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON [w0].[OwnerFullName] = [t0].[FullName0]
+ORDER BY [t0].[LeaderNickname], [t0].[FullName], [t0].[FullName0]",
+                Sql);
+        }
+
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_inheritance_and_coalesce_result()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_inheritance_and_coalesce_result();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [Gear] AS [g]
+LEFT JOIN (
+    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+    FROM [Gear] AS [g1]
+    WHERE [g1].[Discriminator] = N'Officer'
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[LeaderNickname], [g].[FullName], [t].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] = N'Officer'
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [g2] ON [w].[OwnerFullName] = [g2].[FullName]
+ORDER BY [g2].[LeaderNickname], [g2].[FullName]
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName], [t].[FullName] AS [FullName0]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] = N'Officer'
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON [w0].[OwnerFullName] = [t0].[FullName0]
+ORDER BY [t0].[LeaderNickname], [t0].[FullName], [t0].[FullName0]",
+                Sql);
+        }
+
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [Gear] AS [g]
+LEFT JOIN (
+    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+    FROM [Gear] AS [g1]
+    WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[LeaderNickname], [g].[FullName], [t].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [g2] ON [w].[OwnerFullName] = [g2].[FullName]
+ORDER BY [g2].[LeaderNickname], [g2].[FullName]
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName], [t].[FullName] AS [FullName0]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON [w0].[OwnerFullName] = [t0].[FullName0]
+ORDER BY [t0].[LeaderNickname], [t0].[FullName], [t0].[FullName0]",
+                Sql);
+        }
+
+        public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_complex_projection_result()
+        {
+            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_complex_projection_result();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [Gear] AS [g]
+LEFT JOIN (
+    SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+    FROM [Gear] AS [g1]
+    WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[LeaderNickname], [g].[FullName], [t].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [g2] ON [w].[OwnerFullName] = [g2].[FullName]
+ORDER BY [g2].[LeaderNickname], [g2].[FullName]
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+INNER JOIN (
+    SELECT DISTINCT [g].[LeaderNickname], [g].[FullName], [t].[FullName] AS [FullName0]
+    FROM [Gear] AS [g]
+    LEFT JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON [w0].[OwnerFullName] = [t0].[FullName0]
+ORDER BY [t0].[LeaderNickname], [t0].[FullName], [t0].[FullName0]",
+                Sql);
+        }
+
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
@@ -748,6 +749,309 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
 
                         context.SaveChanges();
                     });
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce1()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                            join eRoot in ctx.Entities
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select eRootJoined ?? eVersion;
+
+                var result = query.ToList();
+                Assert.True(result.All(e => e.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce2()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities
+                            join eRoot in ctx.Entities.Include(e => e.Children)
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select eRootJoined ?? eVersion;
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count(e => e.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_simple_coalesce3()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                            join eRoot in ctx.Entities.Include(e => e.Children)
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select eRootJoined ?? eVersion;
+
+                var result = query.ToList();
+                Assert.True(result.All(e => e.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_complex_coalesce1()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                            join eRoot in ctx.Entities
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select new { One = 1, Coalesce = eRootJoined ?? eVersion };
+
+                var result = query.ToList();
+                Assert.True(result.All(e => e.Coalesce.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_complex_coalesce2()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities
+                            join eRoot in ctx.Entities.Include(e => e.Children)
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select new { Root = eRootJoined, Coalesce = eRootJoined ?? eVersion };
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count(e => e.Coalesce.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_nested_coalesce1()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities
+                            join eRoot in ctx.Entities.Include(e => e.Children)
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select new { One = 1, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count(e => e.Coalesce.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_nested_coalesce2()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                            join eRoot in ctx.Entities
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select new { One = eRootJoined, Two = 2, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
+
+                var result = query.ToList();
+                Assert.True(result.All(e => e.Coalesce.Children.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Repro3101_conditional()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities.Include(e => e.Children)
+                            join eRoot in ctx.Entities
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select eRootJoined != null ? eRootJoined : eVersion;
+
+                var result = query.ToList();
+                Assert.True(result.All(e => e.Children.Count > 0));
+            }
+        }
+
+
+        [Fact]
+        public virtual void Repro3101_coalesce_tracking()
+        {
+            CreateDatabase3101();
+
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext3101(serviceProvider))
+            {
+                var query = from eVersion in ctx.Entities
+                            join eRoot in ctx.Entities
+                            on eVersion.RootEntityId equals (int?)eRoot.Id
+                            into RootEntities
+                            from eRootJoined in RootEntities.DefaultIfEmpty()
+                            select new { eRootJoined, eVersion, foo = eRootJoined ?? eVersion };
+
+                var result = query.ToList();
+
+                var foo = ctx.ChangeTracker.Entries().ToList();
+                Assert.True(ctx.ChangeTracker.Entries().Count() > 0);
+            }
+        }
+
+        private void CreateDatabase3101()
+        {
+            CreateTestStore(
+                "Repro3101",
+                _fixture.ServiceProvider,
+                (sp, co) => new MyContext3101(sp),
+                context =>
+                {
+                    var c11 = new Child3101 { Name = "c11" };
+                    var c12 = new Child3101 { Name = "c12" };
+                    var c13 = new Child3101 { Name = "c13" };
+                    var c21 = new Child3101 { Name = "c21" };
+                    var c22 = new Child3101 { Name = "c22" };
+                    var c31 = new Child3101 { Name = "c31" };
+                    var c32 = new Child3101 { Name = "c32" };
+
+                    context.Children.AddRange(c11, c12, c13, c21, c22, c31, c32);
+
+                    var e1 = new Entity3101 { Id = 1, Children = new[] { c11, c12, c13 } };
+                    var e2 = new Entity3101 { Id = 2, Children = new[] { c21, c22 } };
+                    var e3 = new Entity3101 { Id = 3, Children = new[] { c31, c32 } };
+
+                    e2.RootEntity = e1;
+
+                    context.Entities.AddRange(e1, e2, e3);
+                    context.SaveChanges();
+                });
+        }
+
+        public class MyContext3101 : DbContext
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public MyContext3101(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public DbSet<Entity3101> Entities { get; set; }
+
+            public DbSet<Child3101> Children { get; set; }
+
+
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro3101"));
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Entity3101>().Property(e => e.Id).ValueGeneratedNever();
+            }
+        }
+
+        public class Entity3101
+        {
+            public Entity3101()
+            {
+                this.Children = new Collection<Child3101>();
+            }
+
+            public int Id { get; set; }
+
+            public int? RootEntityId { get; set; }
+
+            public Entity3101 RootEntity { get; set; }
+
+            public ICollection<Child3101> Children { get; set; }
+        }
+
+        public class Child3101
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
         }
 
         private static void CreateTestStore<TContext>(


### PR DESCRIPTION
Problem was that for include we were using relinq's EntityAccessorFindingVisitor, to extract a accessor lambda to a given query source in the selector (for InMemory scenario). Problem was that EntityAccessorFindingVisitor was not meant to work for some cases that we were using it (e.g. Coalesce, Conditional).

Fix is to refactor InMemory include mechanisms so that we no longer need the accessor lambda. Now Include method is applied either around appropriate elements of the outer-most selector, or in case no Select method has been generated - around EntityQuery/OfType directly.