### PR TITLE
Optimistic concurrency tests

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
@@ -16,26 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             // TODO: Uncomment when complex types are supported
             //builder.ComplexType<Location>();
-            modelBuilder.Entity<Chassis>(b =>
-                {
-                    b.HasKey(c => c.TeamId);
-                    b.Property(e => e.Version)
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-                });
-
-            modelBuilder.Entity<Driver>(b =>
-                {
-                    b.Property(e => e.Version)
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-                });
-
-            modelBuilder.Entity<Engine>(b =>
-                {
-                    b.Property(e => e.EngineSupplierId).IsConcurrencyToken();
-                    b.Property(e => e.Name).IsConcurrencyToken();
-                });
+            modelBuilder.Entity<Chassis>().HasKey(c => c.TeamId);
 
             // TODO: Complex type
             // .Property(c => c.StorageLocation);
@@ -45,40 +26,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             modelBuilder.Entity<Gearbox>();
 
-            // TODO: Complex type
-            //builder
-            //    .ComplexType<Location>()
-            //    .Properties(ps =>
-            //        {
-            //            // TODO: Use lambda expression
-            //            ps.Property<double>("Latitude", concurrencyToken: true);
-            //            // TODO: Use lambda expression
-            //            ps.Property<double>("Longitude", concurrencyToken: true);
-            //        });
-
-            modelBuilder.Entity<Sponsor>(b =>
-                {
-                    b.Property(e => e.Version)
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-                });
-
-            // TODO: Complex type
-            //builder
-            //    .ComplexType<SponsorDetails>()
-            //    .Properties(ps =>
-            //        {
-            //            ps.Property(s => s.Days);
-            //            ps.Property(s => s.Space);
-            //        });
             modelBuilder.Ignore<SponsorDetails>();
 
             modelBuilder.Entity<Team>(b =>
                 {
-                    b.Property(t => t.Version)
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-
                     b.HasOne(e => e.Gearbox).WithOne().HasForeignKey<Team>(e => e.GearboxId);
                     b.HasOne(e => e.Chassis).WithOne(e => e.Team).HasForeignKey<Chassis>(e => e.TeamId);
                 });

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -105,8 +105,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             result.Add(entityType.FindProperty("Poles"), driver.Poles);
             result.Add(entityType.FindProperty("Races"), driver.Races);
             result.Add(entityType.FindProperty("TeamId"), driver.TeamId);
-            result.Add(entityType.FindProperty("Version"), driver.Version);
             result.Add(entityType.FindProperty("Wins"), driver.Wins);
+
+
             return result;
         }
 
@@ -131,9 +132,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateF1Context())
             {
                 var driver = context.Drivers.Single(d => d.CarNumber == 1);
-                Assert.NotEqual(1, driver.Version[0]);
+                Assert.NotEqual(1, context.Entry(driver).Property<byte[]>("Version").CurrentValue[0]);
                 driver.Podiums = StorePodiums;
-                firstVersion = driver.Version;
+                firstVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
                 await context.SaveChangesAsync();
             }
 
@@ -141,18 +142,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateF1Context())
             {
                 var driver = context.Drivers.Single(d => d.CarNumber == 1);
-                Assert.NotEqual(firstVersion, driver.Version);
+                Assert.NotEqual(firstVersion, context.Entry(driver).Property<byte[]>("Version").CurrentValue);
                 Assert.Equal(StorePodiums, driver.Podiums);
 
-                secondVersion = driver.Version;
-                driver.Version = firstVersion;
+                secondVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
+                context.Entry(driver).Property<byte[]>("Version").CurrentValue = firstVersion;
                 await context.SaveChangesAsync();
             }
 
             using (var validationContext = CreateF1Context())
             {
                 var driver = validationContext.Drivers.Single(d => d.CarNumber == 1);
-                Assert.Equal(secondVersion, driver.Version);
+                Assert.Equal(secondVersion, validationContext.Entry(driver).Property<byte[]>("Version").CurrentValue);
                 Assert.Equal(StorePodiums, driver.Podiums);
             }
         }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
@@ -5,8 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
 {
     public class Chassis
     {
-        public byte[] Version { get; set; }
-
         public int TeamId { get; set; }
 
         public string Name { get; set; }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
@@ -5,8 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
 {
     public class Driver
     {
-        public byte[] Version { get; set; }
-
         public int Id { get; set; }
 
         public string Name { get; set; }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
@@ -11,8 +11,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
     {
         private readonly ObservableCollection<Team> _teams = new ObservableCollection<Team>();
 
-        public byte[] Version { get; set; }
-
         public int Id { get; set; }
         public string Name { get; set; }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -12,8 +12,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
         private readonly ObservableCollection<Driver> _drivers = new ObservableCollection<Driver>();
         private readonly ObservableCollection<Sponsor> _sponsors = new ObservableCollection<Sponsor>();
 
-        public byte[] Version { get; set; }
-
         public int Id { get; set; }
 
         public string Name { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -59,5 +59,64 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             context.Database.UseTransaction(testStore.Transaction);
             return context;
         }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Chassis>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            modelBuilder.Entity<Driver>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            modelBuilder.Entity<Engine>(b =>
+            {
+                b.Property(e => e.EngineSupplierId).IsConcurrencyToken();
+                b.Property(e => e.Name).IsConcurrencyToken();
+            });
+
+            // TODO: Complex type
+            //builder
+            //    .ComplexType<Location>()
+            //    .Properties(ps =>
+            //        {
+            //            // TODO: Use lambda expression
+            //            ps.Property<double>("Latitude", concurrencyToken: true);
+            //            // TODO: Use lambda expression
+            //            ps.Property<double>("Longitude", concurrencyToken: true);
+            //        });
+
+            modelBuilder.Entity<Sponsor>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            // TODO: Complex type
+            //builder
+            //    .ComplexType<SponsorDetails>()
+            //    .Properties(ps =>
+            //        {
+            //            ps.Property(s => s.Days);
+            //            ps.Property(s => s.Space);
+            //        });
+
+            modelBuilder.Entity<Team>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
@@ -58,5 +58,64 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             context.Database.UseTransaction(testStore.Transaction);
             return context;
         }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Chassis>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            modelBuilder.Entity<Driver>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            modelBuilder.Entity<Engine>(b =>
+            {
+                b.Property(e => e.EngineSupplierId).IsConcurrencyToken();
+                b.Property(e => e.Name).IsConcurrencyToken();
+            });
+
+            // TODO: Complex type
+            //builder
+            //    .ComplexType<Location>()
+            //    .Properties(ps =>
+            //        {
+            //            // TODO: Use lambda expression
+            //            ps.Property<double>("Latitude", concurrencyToken: true);
+            //            // TODO: Use lambda expression
+            //            ps.Property<double>("Longitude", concurrencyToken: true);
+            //        });
+
+            modelBuilder.Entity<Sponsor>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+
+            // TODO: Complex type
+            //builder
+            //    .ComplexType<SponsorDetails>()
+            //    .Properties(ps =>
+            //        {
+            //            ps.Property(s => s.Days);
+            //            ps.Property(s => s.Space);
+            //        });
+
+            modelBuilder.Entity<Team>(b =>
+            {
+                b.Property<byte[]>("Version")
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+            });
+        }
     }
 }


### PR DESCRIPTION
Some fixes to the optimistic concurrency test suite to make it more usable with non-SqlServer providers. Specifically, move the usage of byte[] Versions to the SqlServer-specific fixture (not supported by PostgreSQL).

The second commit turns Version into a shadow property, which again cleans up the model somewhat for non-SqlServer (where it wouldn't be used), and seems to make sense in general for concurrency tokens.