### PR TITLE
[SMALL] Using Column(TypeName=xyz) annotation instead of fluent API where appropriate

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Internal/Configuration/ModelConfiguration.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Internal/Configuration/ModelConfiguration.cs
@@ -470,38 +470,45 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal.Configuration
                         AnnotationProvider.For(propertyConfiguration.Property).ColumnType)
                     : null;
 
-            if (delimitedColumnName != null)
+            if (delimitedColumnName != null
+                && delimitedColumnTypeName != null)
             {
                 propertyConfiguration.FluentApiConfigurations.Add(
                     _configurationFactory.CreateFluentApiConfiguration(
                         /* hasAttributeEquivalent */ true,
                         nameof(RelationalPropertyBuilderExtensions.HasColumnName),
                         delimitedColumnName));
-
-                if (delimitedColumnTypeName == null)
-                {
-                    propertyConfiguration.AttributeConfigurations.Add(
-                        _configurationFactory.CreateAttributeConfiguration(nameof(ColumnAttribute), delimitedColumnName));
-                }
-                else
-                {
-                    propertyConfiguration.FluentApiConfigurations.Add(
-                        _configurationFactory.CreateFluentApiConfiguration(
-                            /* hasAttributeEquivalent */ true,
-                            nameof(RelationalPropertyBuilderExtensions.HasColumnType),
-                            delimitedColumnTypeName));
-                    propertyConfiguration.AttributeConfigurations.Add(
-                        _configurationFactory.CreateAttributeConfiguration(
-                            nameof(ColumnAttribute), delimitedColumnName, nameof(ColumnAttribute.TypeName) + " = " + delimitedColumnTypeName));
-                }
+                propertyConfiguration.FluentApiConfigurations.Add(
+                    _configurationFactory.CreateFluentApiConfiguration(
+                        /* hasAttributeEquivalent */ true,
+                        nameof(RelationalPropertyBuilderExtensions.HasColumnType),
+                        delimitedColumnTypeName));
+                propertyConfiguration.AttributeConfigurations.Add(
+                    _configurationFactory.CreateAttributeConfiguration(
+                        nameof(ColumnAttribute),
+                        delimitedColumnName,
+                        nameof(ColumnAttribute.TypeName) + " = " + delimitedColumnTypeName));
+            }
+            else if (delimitedColumnName != null)
+            {
+                propertyConfiguration.FluentApiConfigurations.Add(
+                    _configurationFactory.CreateFluentApiConfiguration(
+                        /* hasAttributeEquivalent */ true,
+                        nameof(RelationalPropertyBuilderExtensions.HasColumnName),
+                        delimitedColumnName));
+                propertyConfiguration.AttributeConfigurations.Add(
+                    _configurationFactory.CreateAttributeConfiguration(nameof(ColumnAttribute), delimitedColumnName));
             }
             else if (delimitedColumnTypeName != null)
             {
                 propertyConfiguration.FluentApiConfigurations.Add(
                     _configurationFactory.CreateFluentApiConfiguration(
-                        /* hasAttributeEquivalent */ false,
+                        /* hasAttributeEquivalent */ true,
                         nameof(RelationalPropertyBuilderExtensions.HasColumnType),
                         delimitedColumnTypeName));
+                propertyConfiguration.AttributeConfigurations.Add(
+                    _configurationFactory.CreateAttributeConfiguration(
+                        nameof(ColumnAttribute), nameof(ColumnAttribute.TypeName) + " = " + delimitedColumnTypeName));
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AllDataTypes.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AllDataTypes.expected
@@ -10,64 +10,99 @@ namespace E2ETest.Namespace
         public int AllDataTypesID { get; set; }
         public long bigintColumn { get; set; }
         public bool bitColumn { get; set; }
+        [Column(TypeName = "decimal")]
         public decimal decimalColumn { get; set; }
         public int intColumn { get; set; }
+        [Column(TypeName = "money")]
         public decimal moneyColumn { get; set; }
+        [Column(TypeName = "numeric")]
         public decimal numericColumn { get; set; }
         public short smallintColumn { get; set; }
+        [Column(TypeName = "smallmoney")]
         public decimal smallmoneyColumn { get; set; }
         public byte tinyintColumn { get; set; }
         public double floatColumn { get; set; }
         public float? realColumn { get; set; }
+        [Column(TypeName = "date")]
         public DateTime dateColumn { get; set; }
+        [Column(TypeName = "datetime")]
         public DateTime? datetimeColumn { get; set; }
         public DateTime? datetime2Column { get; set; }
+        [Column(TypeName = "datetime2(4)")]
         public DateTime? datetime24Column { get; set; }
         public DateTimeOffset? datetimeoffsetColumn { get; set; }
+        [Column(TypeName = "datetimeoffset(5)")]
         public DateTimeOffset? datetimeoffset5Column { get; set; }
+        [Column(TypeName = "smalldatetime")]
         public DateTime? smalldatetimeColumn { get; set; }
         public TimeSpan? timeColumn { get; set; }
+        [Column(TypeName = "time(4)")]
         public TimeSpan? time4Column { get; set; }
+        [Column(TypeName = "char(1)")]
         public string charColumn { get; set; }
+        [Column(TypeName = "char(10)")]
         public string char10Column { get; set; }
+        [Column(TypeName = "text")]
         public string textColumn { get; set; }
+        [Column(TypeName = "varchar(1)")]
         public string varcharColumn { get; set; }
+        [Column(TypeName = "varchar(66)")]
         public string varchar66Column { get; set; }
+        [Column(TypeName = "varchar(max)")]
         public string varcharMaxColumn { get; set; }
+        [Column(TypeName = "nchar(1)")]
         public string ncharColumn { get; set; }
+        [Column(TypeName = "nchar(99)")]
         public string nchar99Column { get; set; }
+        [Column(TypeName = "ntext")]
         public string ntextColumn { get; set; }
         [MaxLength(1)]
         public string nvarcharColumn { get; set; }
         [MaxLength(100)]
         public string nvarchar100Column { get; set; }
         public string nvarcharMaxColumn { get; set; }
+        [Column(TypeName = "binary(1)")]
         public byte[] binaryColumn { get; set; }
+        [Column(TypeName = "binary(111)")]
         public byte[] binary111Column { get; set; }
+        [Column(TypeName = "image")]
         public byte[] imageColumn { get; set; }
         [MaxLength(1)]
         public byte[] varbinaryColumn { get; set; }
         [MaxLength(123)]
         public byte[] varbinary123Column { get; set; }
         public byte[] varbinaryMaxColumn { get; set; }
+        [Column(TypeName = "timestamp")]
         public byte[] timestampColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
+        [Column(TypeName = "xml")]
         public string xmlColumn { get; set; }
+        [Column(TypeName = "TestTypeAlias")]
         public string typeAliasColumn { get; set; }
         [MaxLength(1)]
         public byte[] binaryVaryingColumn { get; set; }
         [MaxLength(133)]
         public byte[] binaryVarying133Column { get; set; }
         public byte[] binaryVaryingMaxColumn { get; set; }
+        [Column(TypeName = "varchar(1)")]
         public string charVaryingColumn { get; set; }
+        [Column(TypeName = "varchar(144)")]
         public string charVarying144Column { get; set; }
+        [Column(TypeName = "varchar(max)")]
         public string charVaryingMaxColumn { get; set; }
+        [Column(TypeName = "char(1)")]
         public string characterColumn { get; set; }
+        [Column(TypeName = "char(155)")]
         public string character155Column { get; set; }
+        [Column(TypeName = "varchar(1)")]
         public string characterVaryingColumn { get; set; }
+        [Column(TypeName = "varchar(166)")]
         public string characterVarying166Column { get; set; }
+        [Column(TypeName = "varchar(max)")]
         public string characterVaryingMaxColumn { get; set; }
+        [Column(TypeName = "nchar(1)")]
         public string nationalCharacterColumn { get; set; }
+        [Column(TypeName = "nchar(171)")]
         public string nationalCharacter171Column { get; set; }
         [MaxLength(1)]
         public string nationalCharVaryingColumn { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
@@ -16,77 +16,7 @@ namespace E2ETest.Namespace
         {
             modelBuilder.Entity<AllDataTypes>(entity =>
             {
-                entity.Property(e => e.binary111Column).HasColumnType("binary(111)");
-
-                entity.Property(e => e.binaryColumn).HasColumnType("binary(1)");
-
-                entity.Property(e => e.char10Column).HasColumnType("char(10)");
-
-                entity.Property(e => e.charColumn).HasColumnType("char(1)");
-
-                entity.Property(e => e.charVarying144Column).HasColumnType("varchar(144)");
-
-                entity.Property(e => e.charVaryingColumn).HasColumnType("varchar(1)");
-
-                entity.Property(e => e.charVaryingMaxColumn).HasColumnType("varchar(max)");
-
-                entity.Property(e => e.character155Column).HasColumnType("char(155)");
-
-                entity.Property(e => e.characterColumn).HasColumnType("char(1)");
-
-                entity.Property(e => e.characterVarying166Column).HasColumnType("varchar(166)");
-
-                entity.Property(e => e.characterVaryingColumn).HasColumnType("varchar(1)");
-
-                entity.Property(e => e.characterVaryingMaxColumn).HasColumnType("varchar(max)");
-
-                entity.Property(e => e.dateColumn).HasColumnType("date");
-
-                entity.Property(e => e.datetime24Column).HasColumnType("datetime2(4)");
-
-                entity.Property(e => e.datetimeColumn).HasColumnType("datetime");
-
-                entity.Property(e => e.datetimeoffset5Column).HasColumnType("datetimeoffset(5)");
-
-                entity.Property(e => e.decimalColumn).HasColumnType("decimal");
-
-                entity.Property(e => e.imageColumn).HasColumnType("image");
-
-                entity.Property(e => e.moneyColumn).HasColumnType("money");
-
-                entity.Property(e => e.nationalCharacter171Column).HasColumnType("nchar(171)");
-
-                entity.Property(e => e.nationalCharacterColumn).HasColumnType("nchar(1)");
-
-                entity.Property(e => e.nchar99Column).HasColumnType("nchar(99)");
-
-                entity.Property(e => e.ncharColumn).HasColumnType("nchar(1)");
-
-                entity.Property(e => e.ntextColumn).HasColumnType("ntext");
-
-                entity.Property(e => e.numericColumn).HasColumnType("numeric");
-
-                entity.Property(e => e.smalldatetimeColumn).HasColumnType("smalldatetime");
-
-                entity.Property(e => e.smallmoneyColumn).HasColumnType("smallmoney");
-
-                entity.Property(e => e.textColumn).HasColumnType("text");
-
-                entity.Property(e => e.time4Column).HasColumnType("time(4)");
-
-                entity.Property(e => e.timestampColumn)
-                    .HasColumnType("timestamp")
-                    .ValueGeneratedOnAddOrUpdate();
-
-                entity.Property(e => e.typeAliasColumn).HasColumnType("TestTypeAlias");
-
-                entity.Property(e => e.varchar66Column).HasColumnType("varchar(66)");
-
-                entity.Property(e => e.varcharColumn).HasColumnType("varchar(1)");
-
-                entity.Property(e => e.varcharMaxColumn).HasColumnType("varchar(max)");
-
-                entity.Property(e => e.xmlColumn).HasColumnType("xml");
+                entity.Property(e => e.timestampColumn).ValueGeneratedOnAddOrUpdate();
             });
 
             modelBuilder.Entity<MultipleFKsDependent>(entity =>
@@ -172,13 +102,10 @@ namespace E2ETest.Namespace
                     .HasName("Test_PropertyConfiguration_Index");
 
                 entity.Property(e => e.ComputedDateTimeColumn)
-                    .HasColumnType("datetime")
                     .HasComputedColumnSql("getdate()")
                     .ValueGeneratedOnAddOrUpdate();
 
-                entity.Property(e => e.RowversionColumn)
-                    .HasColumnType("timestamp")
-                    .ValueGeneratedOnAddOrUpdate();
+                entity.Property(e => e.RowversionColumn).ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.SumOfAAndB)
                     .HasComputedColumnSql("[A]+[B]")
@@ -192,11 +119,7 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.WithGuidDefaultExpression).HasDefaultValueSql("newsequentialid()");
 
-                entity.Property(e => e.WithMoneyDefaultValue)
-                    .HasColumnType("money")
-                    .HasDefaultValueSql("0.00");
-
-                entity.Property(e => e.WithVarcharNullDefaultValue).HasColumnType("varchar(1)");
+                entity.Property(e => e.WithMoneyDefaultValue).HasDefaultValueSql("0.00");
             });
 
             modelBuilder.Entity<SelfReferencing>(entity =>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PropertyConfiguration.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PropertyConfiguration.expected
@@ -12,17 +12,21 @@ namespace E2ETest.Namespace
         public DateTime WithDateFixedDefault { get; set; }
         public DateTime? WithDateNullDefault { get; set; }
         public Guid WithGuidDefaultExpression { get; set; }
+        [Column(TypeName = "varchar(1)")]
         public string WithVarcharNullDefaultValue { get; set; }
         public int WithDefaultValue { get; set; }
         public short? WithNullDefaultValue { get; set; }
+        [Column(TypeName = "money")]
         public decimal WithMoneyDefaultValue { get; set; }
         public int A { get; set; }
         public int B { get; set; }
         public int? SumOfAAndB { get; set; }
         [Required]
+        [Column(TypeName = "timestamp")]
         public byte[] RowversionColumn { get; set; }
         [Column("PropertyConfiguration")]
         public int? PropertyConfiguration1 { get; set; }
+        [Column(TypeName = "datetime")]
         public DateTime ComputedDateTimeColumn { get; set; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/Dependent.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/Dependent.expected
@@ -8,6 +8,7 @@ namespace E2E.Sqlite
     public partial class Dependent
     {
         public string Id { get; set; }
+        [Column(TypeName = "INT")]
         public long? PrincipalId { get; set; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/NoPrincipalPkAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/NoPrincipalPk/NoPrincipalPkAttributesContext.expected
@@ -14,10 +14,6 @@ namespace E2E.Sqlite
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Dependent>(entity =>
-            {
-                entity.Property(e => e.PrincipalId).HasColumnType("INT");
-            });
         }
 
         public virtual DbSet<Dependent> Dependent { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyAttributesContext.expected
@@ -18,26 +18,12 @@ namespace E2E.Sqlite
             {
                 entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 })
                     .HasName("sqlite_autoindex_OneToManyDependent_1");
-
-                entity.Property(e => e.OneToManyDependentID1).HasColumnType("INT");
-
-                entity.Property(e => e.OneToManyDependentID2).HasColumnType("INT");
-
-                entity.Property(e => e.OneToManyDependentFK1).HasColumnType("INT");
-
-                entity.Property(e => e.OneToManyDependentFK2).HasColumnType("INT");
-
-                entity.Property(e => e.SomeDependentEndColumn).HasColumnType("VARCHAR");
             });
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
                 entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 })
                     .HasName("sqlite_autoindex_OneToManyPrincipal_1");
-
-                entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
-
-                entity.Property(e => e.OneToManyPrincipalID2).HasColumnType("INT");
             });
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyDependent.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyDependent.expected
@@ -7,11 +7,16 @@ namespace E2E.Sqlite
 {
     public partial class OneToManyDependent
     {
+        [Column(TypeName = "INT")]
         public long OneToManyDependentID1 { get; set; }
+        [Column(TypeName = "INT")]
         public long OneToManyDependentID2 { get; set; }
         [Required]
+        [Column(TypeName = "VARCHAR")]
         public string SomeDependentEndColumn { get; set; }
+        [Column(TypeName = "INT")]
         public long? OneToManyDependentFK1 { get; set; }
+        [Column(TypeName = "INT")]
         public long? OneToManyDependentFK2 { get; set; }
 
         [ForeignKey("OneToManyDependentFK1,OneToManyDependentFK2")]

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyPrincipal.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToMany/OneToManyPrincipal.expected
@@ -12,7 +12,9 @@ namespace E2E.Sqlite
             OneToManyDependent = new HashSet<OneToManyDependent>();
         }
 
+        [Column(TypeName = "INT")]
         public long OneToManyPrincipalID1 { get; set; }
+        [Column(TypeName = "INT")]
         public long OneToManyPrincipalID2 { get; set; }
         [Required]
         public string Other { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/Dependent.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/Dependent.expected
@@ -7,7 +7,9 @@ namespace E2E.Sqlite
 {
     public partial class Dependent
     {
+        [Column(TypeName = "INT")]
         public long Id { get; set; }
+        [Column(TypeName = "INT")]
         public long PrincipalId { get; set; }
 
         [ForeignKey("PrincipalId")]

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.expected
@@ -19,10 +19,6 @@ namespace E2E.Sqlite
                 entity.HasIndex(e => e.PrincipalId)
                     .HasName("sqlite_autoindex_Dependent_1")
                     .IsUnique();
-
-                entity.Property(e => e.Id).HasColumnType("INT");
-
-                entity.Property(e => e.PrincipalId).HasColumnType("INT");
             });
         }
 


### PR DESCRIPTION
Fix for scaffolding issue #5289. Use `[Column(TypeName = "xyz")]` instead of `HasColumnType("xyz")` when the user asks for DataAnnotations.