### PR TITLE
Look at all derived types when creating a column during migration.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -783,11 +784,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
         }
 
-        protected virtual IEntityType FindEntityType(
+        protected virtual IEnumerable<IEntityType> FindEntityTypes(
             [CanBeNull] IModel model,
             [CanBeNull] string schema,
             [NotNull] string tableName)
-            => model?.GetEntityTypes().FirstOrDefault(
+            => model?.GetEntityTypes().Where(
                 t => (_annotations.For(t).TableName == tableName) && (_annotations.For(t).Schema == schema));
 
         protected virtual IProperty FindProperty(
@@ -795,8 +796,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] string schema,
             [NotNull] string tableName,
             [NotNull] string columnName)
-            => FindEntityType(model, schema, tableName)
-                ?.GetProperties().FirstOrDefault(p => _annotations.For(p).ColumnName == columnName);
+            => FindEntityTypes(model, schema, tableName)?.SelectMany(e => e.GetDeclaredProperties())
+                .SingleOrDefault(p => _annotations.For(p).ColumnName == columnName);
 
         protected virtual void EndStatement(
             [NotNull] MigrationCommandListBuilder builder,

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -74,6 +73,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
         public override void AddColumnOperation_with_maxLength()
         {
             base.AddColumnOperation_with_maxLength();
+
+            Assert.Equal(
+                "ALTER TABLE \"Person\" ADD \"Name\" nvarchar(30);" + EOL,
+                Sql);
+        }
+
+        public override void AddColumnOperation_with_maxLength_on_derived()
+        {
+            base.AddColumnOperation_with_maxLength_on_derived();
 
             Assert.Equal(
                 "ALTER TABLE \"Person\" ADD \"Name\" nvarchar(30);" + EOL,

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
@@ -72,6 +72,28 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
         public virtual void AddColumnOperation_with_maxLength()
             => Generate(
                 modelBuilder => modelBuilder.Entity("Person").Property<string>("Name").HasMaxLength(30),
+                new AddColumnOperation
+                {
+                    Table = "Person",
+                    Name = "Name",
+                    ClrType = typeof(string),
+                    IsNullable = true
+                });
+
+        [Fact]
+        public virtual void AddColumnOperation_with_maxLength_on_derived()
+            => Generate(
+                modelBuilder =>
+                    {
+                        modelBuilder.Entity("Person");
+                        modelBuilder.Entity("SpecialPerson", b =>
+                            {
+                                b.HasBaseType("Person");
+                                b.Property<string>("Name").HasMaxLength(30);
+                            });
+
+                        modelBuilder.Entity("MoreSpecialPerson").HasBaseType("SpecialPerson");
+                    },
                 new AddColumnOperation
                 {
                     Table = "Person",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -97,6 +97,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Migrations
                 Sql);
         }
 
+        public override void AddColumnOperation_with_maxLength_on_derived()
+        {
+            base.AddColumnOperation_with_maxLength_on_derived();
+
+            Assert.Equal(
+                "ALTER TABLE [Person] ADD [Name] nvarchar(30);" + EOL,
+                Sql);
+        }
+
         [Fact]
         public virtual void AddPrimaryKeyOperation_nonclustered()
         {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -215,6 +215,16 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Migrations
                 Sql);
         }
 
+        public override void AddColumnOperation_with_maxLength_on_derived()
+        {
+            base.AddColumnOperation_with_maxLength_on_derived();
+
+            // See issue #3698
+            Assert.Equal(
+                "ALTER TABLE \"Person\" ADD \"Name\" TEXT;" + EOL,
+                Sql);
+        }
+
         [Fact]
         public override void AddColumnOperation_with_computed_column_SQL()
         {


### PR DESCRIPTION
Fixes #5379