### PR TITLE
Updating ValueGenerator to pass in entry

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/ValueGeneration/Internal/InMemoryIntegerValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/ValueGeneration/Internal/InMemoryIntegerValueGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -10,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private long _current;
 
-        public override TValue Next() => (TValue)Convert.ChangeType(Interlocked.Increment(ref _current), typeof(TValue));
+        public override TValue Next(EntityEntry entry) 
+            => (TValue)Convert.ChangeType(Interlocked.Increment(ref _current), typeof(TValue));
 
         public override bool GeneratesTemporaryValues => false;
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -14,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
             _discriminator = discriminator;
         }
 
-        protected override object NextValue() => _discriminator;
+        protected override object NextValue(EntityEntry entry) => _discriminator;
 
         public override bool GeneratesTemporaryValues => false;
     }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (valueGenerator != null)
                 {
-                    entry[property] = valueGenerator.Next();
+                    entry[property] = valueGenerator.Next(new EntityEntry(entry));
                 }
             }
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -24,6 +24,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         public virtual void Generate(InternalEntityEntry entry)
         {
+            var entityEntry = new EntityEntry(entry);
+
             foreach (var property in entry.EntityType.GetProperties())
             {
                 var isForeignKey = property.IsForeignKey();
@@ -43,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                         Debug.Assert(valueGenerator != null);
 
-                        SetGeneratedValue(entry, property, valueGenerator.Next(), valueGenerator.GeneratesTemporaryValues);
+                        SetGeneratedValue(entry, property, valueGenerator.Next(entityEntry), valueGenerator.GeneratesTemporaryValues);
                     }
                 }
             }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/GuidValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/GuidValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
 {
@@ -14,8 +15,9 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        public override Guid Next() => Guid.NewGuid();
+        public override Guid Next(EntityEntry entry) => Guid.NewGuid();
 
         /// <summary>
         ///     Gets a value indicating whether the values generated are temporary or permanent. This implementation

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/HiLoValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/HiLoValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
@@ -37,8 +38,9 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        public override TValue Next() => _generatorState.Next<TValue>(GetNewLowValue);
+        public override TValue Next(EntityEntry entry) => _generatorState.Next<TValue>(GetNewLowValue);
 
         /// <summary>
         ///     Gets the low value for the next block of values to be used.

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/BinaryValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/BinaryValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -14,6 +15,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 
         public override bool GeneratesTemporaryValues { get; }
 
-        public override byte[] Next() => Guid.NewGuid().ToByteArray();
+        public override byte[] Next(EntityEntry entry) => Guid.NewGuid().ToByteArray();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/StringValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/StringValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -14,6 +15,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 
         public override bool GeneratesTemporaryValues { get; }
 
-        public override string Next() => Guid.NewGuid().ToString();
+        public override string Next(EntityEntry entry) => Guid.NewGuid().ToString();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryByteValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryByteValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current;
 
-        public override byte Next() => (byte)Interlocked.Decrement(ref _current);
+        public override byte Next(EntityEntry entry) => (byte)Interlocked.Decrement(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryCharValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryCharValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = char.MaxValue - 100;
 
-        public override char Next() => (char)Interlocked.Decrement(ref _current);
+        public override char Next(EntityEntry entry) => (char)Interlocked.Decrement(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDateTimeOffsetValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDateTimeOffsetValueGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -10,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private long _current;
 
-        public override DateTimeOffset Next()
+        public override DateTimeOffset Next(EntityEntry entry)
             => new DateTimeOffset(Interlocked.Increment(ref _current), TimeSpan.Zero);
 
         public override bool GeneratesTemporaryValues => true;

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDateTimeValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDateTimeValueGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -10,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private long _current;
 
-        public override DateTime Next() => new DateTime(Interlocked.Increment(ref _current));
+        public override DateTime Next(EntityEntry entry) => new DateTime(Interlocked.Increment(ref _current));
 
         public override bool GeneratesTemporaryValues => true;
     }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDecimalValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDecimalValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = int.MinValue + 1000;
 
-        public override decimal Next() => Interlocked.Increment(ref _current);
+        public override decimal Next(EntityEntry entry) => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDoubleValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDoubleValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = int.MinValue + 1000;
 
-        public override double Next() => Interlocked.Increment(ref _current);
+        public override double Next(EntityEntry entry) => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryFloatValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryFloatValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = int.MinValue + 1000;
 
-        public override float Next() => Interlocked.Increment(ref _current);
+        public override float Next(EntityEntry entry) => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryIntValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryIntValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = int.MinValue + 1000;
 
-        public override int Next() => Interlocked.Increment(ref _current);
+        public override int Next(EntityEntry entry) => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryLongValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryLongValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private long _current = long.MinValue + 1000;
 
-        public override long Next() => Interlocked.Increment(ref _current);
+        public override long Next(EntityEntry entry) => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporarySByteValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporarySByteValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = sbyte.MinValue;
 
-        public override sbyte Next() => (sbyte)Interlocked.Increment(ref _current);
+        public override sbyte Next(EntityEntry entry) => (sbyte)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryShortValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryShortValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = short.MinValue + 100;
 
-        public override short Next() => (short)Interlocked.Increment(ref _current);
+        public override short Next(EntityEntry entry) => (short)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUIntValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUIntValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = int.MinValue + 1000;
 
-        public override uint Next() => (uint)Interlocked.Increment(ref _current);
+        public override uint Next(EntityEntry entry) => (uint)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryULongValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryULongValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private long _current = long.MinValue + 1000;
 
-        public override ulong Next() => (ulong)Interlocked.Increment(ref _current);
+        public override ulong Next(EntityEntry entry) => (ulong)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUShortValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUShortValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
@@ -9,6 +10,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
     {
         private int _current = short.MinValue + 100;
 
-        public override ushort Next() => (ushort)Interlocked.Increment(ref _current);
+        public override ushort Next(EntityEntry entry) => (ushort)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/SequentialGuidValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/SequentialGuidValueGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
 {
@@ -19,8 +20,9 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        public override Guid Next()
+        public override Guid Next(EntityEntry entry)
         {
             var guidBytes = Guid.NewGuid().ToByteArray();
             var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
 {
@@ -13,14 +15,16 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        public virtual object Next() => NextValue();
+        public virtual object Next([NotNull] EntityEntry entry) => NextValue(entry);
 
         /// <summary>
         ///     Template method to be overridden by implementations to perform value generation.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The generated value. </returns>
-        protected abstract object NextValue();
+        protected abstract object NextValue([NotNull] EntityEntry entry);
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator`.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
 {
     /// <summary>
@@ -11,13 +14,15 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <summary>
         ///     Template method to be overridden by implementations to perform value generation.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The generated value. </returns>
-        public new abstract TValue Next();
+        public new abstract TValue Next([NotNull] EntityEntry entry);
 
         /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        protected override object NextValue() => Next();
+        protected override object NextValue(EntityEntry entry) => Next(entry);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/CustomValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/CustomValueGeneratorTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
@@ -24,17 +25,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [Fact]
         public void Can_use_custom_value_generators()
         {
+            var names = new[]
+            {
+                "Jamie Vardy", "Danny Drinkwater", "Andy King", "Riyad Mahrez",
+                "Kasper Schmeichel", "Wes Morgan", "Robert Huth", "Leonardo Ulloa"
+            };
+
             using (var context = new CustomValueGeneratorContext())
             {
                 var entities = new List<SomeEntity>();
                 for (var i = 0; i < CustomGuidValueGenerator.SpecialGuids.Length; i++)
                 {
-                    entities.Add(context.Add(new SomeEntity()).Entity);
+                    entities.Add(context.Add(new SomeEntity { Name = names[i] }).Entity);
                 }
 
                 Assert.Equal(entities.Select(e => e.Id), entities.OrderBy(e => ToCounter(e.Id)).Select(e => e.Id));
 
                 Assert.Equal(CustomGuidValueGenerator.SpecialGuids, entities.Select(e => e.SpecialId));
+
+                Assert.Equal(names.Select((n, i) => n + " - " + (i + 1)), entities.Select(e => e.SpecialString));
             }
         }
 
@@ -68,19 +77,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .UseInMemoryDatabase();
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder
-                    .Entity<SomeEntity>()
-                    .Property(e => e.SpecialId)
-                    .HasAnnotation("SpecialGuid", true)
-                    .Metadata.RequiresValueGenerator = true;
-            }
+                => modelBuilder
+                    .Entity<SomeEntity>(
+                        b =>
+                            {
+                                b.Property(e => e.SpecialId)
+                                    .HasAnnotation("SpecialGuid", true)
+                                    .Metadata.RequiresValueGenerator = true;
+
+                                b.Property(e => e.SpecialString)
+                                    .Metadata.RequiresValueGenerator = true;
+                            });
         }
 
         private class SomeEntity
         {
             public Guid Id { get; set; }
             public Guid SpecialId { get; set; }
+            public string SpecialString { get; set; }
+            public string Name { get; set; }
         }
 
         private class CustomInMemoryValueGeneratorSelector : InMemoryValueGeneratorSelector
@@ -92,14 +107,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             public override ValueGenerator Create(IProperty property, IEntityType entityType)
             {
-                if (property["SpecialGuid"] != null)
-                {
-                    return new CustomGuidValueGenerator();
-                }
-
                 if (property.ClrType == typeof(Guid))
                 {
-                    return new SequentialGuidValueGenerator();
+                    return property["SpecialGuid"] != null ?
+                        (ValueGenerator)new CustomGuidValueGenerator()
+                        : new SequentialGuidValueGenerator();
+                }
+
+                if (property.ClrType == typeof(string)
+                    && entityType.ClrType == typeof(SomeEntity))
+                {
+                    return new SomeEntityStringValueGenerator();
                 }
 
                 return base.Create(property, entityType);
@@ -116,8 +134,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             private int _counter = -1;
 
-            public override Guid Next()
+            public override Guid Next(EntityEntry entry)
                 => SpecialGuids[Interlocked.Increment(ref _counter)];
+
+            public override bool GeneratesTemporaryValues => false;
+        }
+
+        private class SomeEntityStringValueGenerator : ValueGenerator<string>
+        {
+            private int _counter;
+
+            public override string Next(EntityEntry entry) 
+                => ((SomeEntity)entry.Entity).Name + " - " + Interlocked.Increment(ref _counter);
 
             public override bool GeneratesTemporaryValues => false;
         }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryIntegerValueGeneratorFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryIntegerValueGeneratorFactoryTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
         }
 
         private static object CreateAndUseFactory(IProperty property) 
-            => new InMemoryIntegerValueGeneratorFactory().Create(property).Next();
+            => new InMemoryIntegerValueGeneratorFactory().Create(property).Next(null);
 
         [Fact]
         public void Throws_for_non_integer_property()

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryIntegerValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryIntegerValueGeneratorTest.cs
@@ -14,30 +14,30 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
         {
             var generator = new InMemoryIntegerValueGenerator<int>();
 
-            Assert.Equal(1, generator.Next());
-            Assert.Equal(2, generator.Next());
-            Assert.Equal(3, generator.Next());
-            Assert.Equal(4, generator.Next());
-            Assert.Equal(5, generator.Next());
-            Assert.Equal(6, generator.Next());
+            Assert.Equal(1, generator.Next(null));
+            Assert.Equal(2, generator.Next(null));
+            Assert.Equal(3, generator.Next(null));
+            Assert.Equal(4, generator.Next(null));
+            Assert.Equal(5, generator.Next(null));
+            Assert.Equal(6, generator.Next(null));
 
             generator = new InMemoryIntegerValueGenerator<int>();
 
-            Assert.Equal(1, generator.Next());
-            Assert.Equal(2, generator.Next());
+            Assert.Equal(1, generator.Next(null));
+            Assert.Equal(2, generator.Next(null));
         }
 
         [Fact]
         public void Can_create_values_for_all_integer_types()
         {
-            Assert.Equal(1, new InMemoryIntegerValueGenerator<int>().Next());
-            Assert.Equal(1L, new InMemoryIntegerValueGenerator<long>().Next());
-            Assert.Equal((short)1, new InMemoryIntegerValueGenerator<short>().Next());
-            Assert.Equal(unchecked((byte)1), new InMemoryIntegerValueGenerator<byte>().Next());
-            Assert.Equal(unchecked((uint)1), new InMemoryIntegerValueGenerator<uint>().Next());
-            Assert.Equal(unchecked((ulong)1), new InMemoryIntegerValueGenerator<ulong>().Next());
-            Assert.Equal(unchecked((ushort)1), new InMemoryIntegerValueGenerator<ushort>().Next());
-            Assert.Equal((sbyte)1, new InMemoryIntegerValueGenerator<sbyte>().Next());
+            Assert.Equal(1, new InMemoryIntegerValueGenerator<int>().Next(null));
+            Assert.Equal(1L, new InMemoryIntegerValueGenerator<long>().Next(null));
+            Assert.Equal((short)1, new InMemoryIntegerValueGenerator<short>().Next(null));
+            Assert.Equal(unchecked((byte)1), new InMemoryIntegerValueGenerator<byte>().Next(null));
+            Assert.Equal(unchecked((uint)1), new InMemoryIntegerValueGenerator<uint>().Next(null));
+            Assert.Equal(unchecked((ulong)1), new InMemoryIntegerValueGenerator<ulong>().Next(null));
+            Assert.Equal(unchecked((ushort)1), new InMemoryIntegerValueGenerator<ushort>().Next(null));
+            Assert.Equal((sbyte)1, new InMemoryIntegerValueGenerator<sbyte>().Next(null));
         }
 
         [Fact]
@@ -47,10 +47,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
 
             for (var i = 1; i < 256; i++)
             {
-                generator.Next();
+                generator.Next(null);
             }
 
-            Assert.Throws<OverflowException>(() => generator.Next());
+            Assert.Throws<OverflowException>(() => generator.Next(null));
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             for (var i = 1; i <= 27; i++)
             {
-                Assert.Equal(i, (int)Convert.ChangeType(generator.Next(), typeof(int), CultureInfo.InvariantCulture));
+                Assert.Equal(i, (int)Convert.ChangeType(generator.Next(null), typeof(int), CultureInfo.InvariantCulture));
             }
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
                             var connection = CreateConnection(serviceProvider);
                             var generator = new SqlServerSequenceHiLoValueGenerator<long>(executor, sqlGenerator, state, connection);
 
-                            generatedValues[testNumber].Add(generator.Next());
+                            generatedValues[testNumber].Add(generator.Next(null));
                         }
                     };
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/BinaryValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/BinaryValueGeneratorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var generatedValue = generator.Next();
+                var generatedValue = generator.Next(null);
 
                 values.Add(new Guid(generatedValue));
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/GuidValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/GuidValueGeneratorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var generatedValue = sequentialGuidIdentityGenerator.Next();
+                var generatedValue = sequentialGuidIdentityGenerator.Next(null);
 
                 values.Add(generatedValue);
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/SequentialGuidValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/SequentialGuidValueGeneratorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var generatedValue = sequentialGuidIdentityGenerator.Next();
+                var generatedValue = sequentialGuidIdentityGenerator.Next(null);
 
                 values.Add(generatedValue);
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/StringValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/StringValueGeneratorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var generatedValue = generator.Next();
+                var generatedValue = generator.Next(null);
 
                 values.Add(Guid.Parse(generatedValue));
             }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryDateTimeOffsetValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryDateTimeOffsetValueGeneratorTest.cs
@@ -13,8 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         public void Can_create_values_for_DateTime_types()
         {
             var generator = new TemporaryDateTimeOffsetValueGenerator();
-            Assert.Equal(new DateTimeOffset(1, TimeSpan.Zero), generator.Next());
-            Assert.Equal(new DateTimeOffset(2, TimeSpan.Zero), generator.Next());
+            Assert.Equal(new DateTimeOffset(1, TimeSpan.Zero), generator.Next(null));
+            Assert.Equal(new DateTimeOffset(2, TimeSpan.Zero), generator.Next(null));
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryDateTimeValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryDateTimeValueGeneratorTest.cs
@@ -14,8 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryDateTimeValueGenerator();
 
-            Assert.Equal(new DateTime(1), generator.Next());
-            Assert.Equal(new DateTime(2), generator.Next());
+            Assert.Equal(new DateTime(1), generator.Next(null));
+            Assert.Equal(new DateTime(2), generator.Next(null));
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         }
 
         private static object CreateAndUseFactory(IProperty property)
-            => new TemporaryNumberValueGeneratorFactory().Create(property).Next();
+            => new TemporaryNumberValueGeneratorFactory().Create(property).Next(null);
 
         [Fact]
         public void Throws_for_non_integer_property()

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
@@ -13,9 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryIntValueGenerator();
 
-            Assert.Equal(int.MinValue + 1001, generator.Next());
-            Assert.Equal(int.MinValue + 1002, generator.Next());
-            Assert.Equal(int.MinValue + 1003, generator.Next());
+            Assert.Equal(int.MinValue + 1001, generator.Next(null));
+            Assert.Equal(int.MinValue + 1002, generator.Next(null));
+            Assert.Equal(int.MinValue + 1003, generator.Next(null));
         }
 
         [Fact]
@@ -23,9 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryLongValueGenerator();
 
-            Assert.Equal(long.MinValue + 1001, generator.Next());
-            Assert.Equal(long.MinValue + 1002, generator.Next());
-            Assert.Equal(long.MinValue + 1003, generator.Next());
+            Assert.Equal(long.MinValue + 1001, generator.Next(null));
+            Assert.Equal(long.MinValue + 1002, generator.Next(null));
+            Assert.Equal(long.MinValue + 1003, generator.Next(null));
         }
 
         [Fact]
@@ -33,9 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryShortValueGenerator();
 
-            Assert.Equal(short.MinValue + 101, generator.Next());
-            Assert.Equal(short.MinValue + 102, generator.Next());
-            Assert.Equal(short.MinValue + 103, generator.Next());
+            Assert.Equal(short.MinValue + 101, generator.Next(null));
+            Assert.Equal(short.MinValue + 102, generator.Next(null));
+            Assert.Equal(short.MinValue + 103, generator.Next(null));
         }
 
         [Fact]
@@ -43,9 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryByteValueGenerator();
 
-            Assert.Equal(255, generator.Next());
-            Assert.Equal(254, generator.Next());
-            Assert.Equal(253, generator.Next());
+            Assert.Equal(255, generator.Next(null));
+            Assert.Equal(254, generator.Next(null));
+            Assert.Equal(253, generator.Next(null));
         }
 
         [Fact]
@@ -53,9 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryUIntValueGenerator();
 
-            Assert.Equal(unchecked((uint)int.MinValue + 1001), generator.Next());
-            Assert.Equal(unchecked((uint)int.MinValue + 1002), generator.Next());
-            Assert.Equal(unchecked((uint)int.MinValue + 1003), generator.Next());
+            Assert.Equal(unchecked((uint)int.MinValue + 1001), generator.Next(null));
+            Assert.Equal(unchecked((uint)int.MinValue + 1002), generator.Next(null));
+            Assert.Equal(unchecked((uint)int.MinValue + 1003), generator.Next(null));
         }
 
         [Fact]
@@ -63,9 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryULongValueGenerator();
 
-            Assert.Equal(unchecked((ulong)long.MinValue + 1001), generator.Next());
-            Assert.Equal(unchecked((ulong)long.MinValue + 1002), generator.Next());
-            Assert.Equal(unchecked((ulong)long.MinValue + 1003), generator.Next());
+            Assert.Equal(unchecked((ulong)long.MinValue + 1001), generator.Next(null));
+            Assert.Equal(unchecked((ulong)long.MinValue + 1002), generator.Next(null));
+            Assert.Equal(unchecked((ulong)long.MinValue + 1003), generator.Next(null));
         }
 
         [Fact]
@@ -73,9 +73,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryUShortValueGenerator();
 
-            Assert.Equal(unchecked((ushort)short.MinValue + 101), generator.Next());
-            Assert.Equal(unchecked((ushort)short.MinValue + 102), generator.Next());
-            Assert.Equal(unchecked((ushort)short.MinValue + 103), generator.Next());
+            Assert.Equal(unchecked((ushort)short.MinValue + 101), generator.Next(null));
+            Assert.Equal(unchecked((ushort)short.MinValue + 102), generator.Next(null));
+            Assert.Equal(unchecked((ushort)short.MinValue + 103), generator.Next(null));
         }
 
         [Fact]
@@ -83,9 +83,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporarySByteValueGenerator();
 
-            Assert.Equal(-127, generator.Next());
-            Assert.Equal(-126, generator.Next());
-            Assert.Equal(-125, generator.Next());
+            Assert.Equal(-127, generator.Next(null));
+            Assert.Equal(-126, generator.Next(null));
+            Assert.Equal(-125, generator.Next(null));
         }
 
         [Fact]
@@ -93,9 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryCharValueGenerator();
 
-            Assert.Equal(char.MaxValue - 101, generator.Next());
-            Assert.Equal(char.MaxValue - 102, generator.Next());
-            Assert.Equal(char.MaxValue - 103, generator.Next());
+            Assert.Equal(char.MaxValue - 101, generator.Next(null));
+            Assert.Equal(char.MaxValue - 102, generator.Next(null));
+            Assert.Equal(char.MaxValue - 103, generator.Next(null));
         }
 
         [Fact]
@@ -103,8 +103,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryDecimalValueGenerator();
 
-            Assert.Equal(-2147482647m, generator.Next());
-            Assert.Equal(-2147482646m, generator.Next());
+            Assert.Equal(-2147482647m, generator.Next(null));
+            Assert.Equal(-2147482646m, generator.Next(null));
         }
 
         [Fact]
@@ -112,8 +112,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryFloatValueGenerator();
 
-            Assert.Equal(-2147482647.0f, generator.Next());
-            Assert.Equal(-2147482646.0f, generator.Next());
+            Assert.Equal(-2147482647.0f, generator.Next(null));
+            Assert.Equal(-2147482646.0f, generator.Next(null));
         }
 
         [Fact]
@@ -121,8 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var generator = new TemporaryDoubleValueGenerator();
 
-            Assert.Equal(-2147482647.0, generator.Next());
-            Assert.Equal(-2147482646.0, generator.Next());
+            Assert.Equal(-2147482647.0, generator.Next(null));
+            Assert.Equal(-2147482646.0, generator.Next(null));
         }
 
         [Fact]


### PR DESCRIPTION
See #5303. This allows the value generator to use state from the current entity as part of the value generation process. Doing this before RTM to avoid a breaking change doing it later.