### PR TITLE
Use WHERE EXISTS instead of INNER JOIN for collection navigation Include

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -274,6 +274,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             ? selectExpression.Tables[0]
                             : selectExpression.Tables.Last(t => t.QuerySource == querySource);
 
+                    var canGenerateExists = !IsOrderingOnNonPrincipalKeyProperties(selectExpression.OrderBy, navigation.ForeignKey.PrincipalKey.Properties);
+
                     foreach (var property in navigation.ForeignKey.PrincipalKey.Properties)
                     {
                         selectExpression
@@ -306,27 +308,73 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     querySource),
                                 querySource: null);
 
-                    var innerJoinSelectExpression
-                        = selectExpression.Clone(
-                            selectExpression.OrderBy
-                                .Select(o => o.Expression)
-                                .Last(o => o.IsAliasWithColumnExpression())
-                                .TryGetColumnExpression().TableAlias);
+                    if (canGenerateExists)
+                    {
+                        var subqueryExpression = selectExpression.Clone();
+                        subqueryExpression.ClearProjection();
+                        subqueryExpression.ClearOrderBy();
+                        subqueryExpression.IsProjectStar = false;
 
-                    innerJoinSelectExpression.ClearProjection();
+                        var subqueryTable
+                            = subqueryExpression.Tables.Count == 1
+                              && subqueryExpression.Tables
+                                  .OfType<SelectExpression>()
+                                  .Any(s => s.Tables.Any(t => t.QuerySource == querySource))
+                                // true when select is wrapped e.g. when RowNumber paging is enabled
+                                ? subqueryExpression.Tables[0]
+                                : subqueryExpression.Tables.Last(t => t.QuerySource == querySource);
 
-                    var innerJoinExpression = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);
+                        var existsPredicateExpression = new ExistsExpression(subqueryExpression);
 
-                    LiftOrderBy(innerJoinSelectExpression, targetSelectExpression, innerJoinExpression);
+                        AddToPredicate(targetSelectExpression, existsPredicateExpression);
 
-                    innerJoinSelectExpression.IsDistinct = true;
+                        AddToPredicate(subqueryExpression, BuildJoinEqualityExpression(navigation, targetTableExpression, subqueryTable, querySource));
 
-                    innerJoinExpression.Predicate
-                        = BuildJoinEqualityExpression(
-                            navigation,
-                            targetTableExpression,
-                            innerJoinExpression,
-                            querySource);
+                        subqueryExpression.Predicate
+                            = compositePredicateExpressionVisitor
+                                .Visit(subqueryExpression.Predicate);
+
+                        var pkPropertiesToFkPropertiesMap = navigation.ForeignKey.PrincipalKey.Properties
+                            .Zip(navigation.ForeignKey.Properties, (k, v) => new { PkProperty = k, FkProperty = v })
+                            .ToDictionary(x => x.PkProperty, x => x.FkProperty);
+
+                        foreach (var ordering in selectExpression.OrderBy)
+                        {
+                            // ReSharper disable once PossibleNullReferenceException
+                            var principalKeyProperty = ((ordering.Expression as AliasExpression)?.Expression as ColumnExpression).Property;
+                            var referencedForeignKeyProperty = pkPropertiesToFkPropertiesMap[principalKeyProperty];
+                            targetSelectExpression
+                               .AddToOrderBy(
+                                   _relationalAnnotationProvider.For(referencedForeignKeyProperty).ColumnName,
+                                   referencedForeignKeyProperty,
+                                   targetTableExpression,
+                                   ordering.OrderingDirection);
+                        }
+                    }
+                    else
+                    {
+                        var innerJoinSelectExpression
+                           = selectExpression.Clone(
+                               selectExpression.OrderBy
+                                   .Select(o => o.Expression)
+                                   .Last(o => o.IsAliasWithColumnExpression())
+                                   .TryGetColumnExpression().TableAlias);
+
+                        innerJoinSelectExpression.ClearProjection();
+
+                        var innerJoinExpression = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);
+
+                        LiftOrderBy(innerJoinSelectExpression, targetSelectExpression, innerJoinExpression);
+
+                        innerJoinSelectExpression.IsDistinct = true;
+
+                        innerJoinExpression.Predicate
+                            = BuildJoinEqualityExpression(
+                                navigation,
+                                targetTableExpression,
+                                innerJoinExpression,
+                                querySource);
+                    }
 
                     targetSelectExpression.Predicate
                         = compositePredicateExpressionVisitor
@@ -516,6 +564,26 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return joinExpression != null
                 ? ExtractProjections(joinExpression.TableExpression)
                 : Enumerable.Empty<Expression>();
+        }
+
+        private void AddToPredicate(SelectExpression selectExpression, Expression predicateToAdd)
+            => selectExpression.Predicate
+                = selectExpression.Predicate == null
+                    ? predicateToAdd
+                    : Expression.AndAlso(selectExpression.Predicate, predicateToAdd);
+
+        private bool IsOrderingOnNonPrincipalKeyProperties(IReadOnlyList<Ordering> orderings, IReadOnlyList<IProperty> properties)
+        {
+            foreach (var ordering in orderings)
+            {
+                var property = ((ordering.Expression as AliasExpression)?.Expression as ColumnExpression)?.Property;
+                if (!properties.Contains(property))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -63,12 +63,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             ? _projection[0].Type
             : base.Type;
 
-        public virtual SelectExpression Clone([NotNull] string alias)
+        public virtual SelectExpression Clone([CanBeNull] string alias = null)
         {
-            Check.NotNull(alias, nameof(alias));
-
             var selectExpression
-                = new SelectExpression(_querySqlGeneratorFactory, _queryCompilationContext, alias)
+                = new SelectExpression(_querySqlGeneratorFactory, _queryCompilationContext)
                 {
                     _limit = _limit,
                     _offset = _offset,
@@ -77,6 +75,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                     IsProjectStar = IsProjectStar,
                     Predicate = Predicate
                 };
+
+            if (alias != null)
+            {
+                selectExpression.Alias = _queryCompilationContext.CreateUniqueTableAlias(alias);
+            }
 
             selectExpression._projection.AddRange(_projection);
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -128,23 +128,23 @@ ORDER BY [e].[Id]
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE EXISTS (
+    SELECT 1
     FROM [Level1] AS [e]
-) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
-ORDER BY [e0].[Id], [l].[Id]
+    WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+ORDER BY [l].[OneToMany_Optional_InverseId], [l].[Id]
 
 SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l0]
 INNER JOIN (
-    SELECT DISTINCT [e0].[Id], [l].[Id] AS [Id0]
+    SELECT DISTINCT [l].[OneToMany_Optional_InverseId], [l].[Id]
     FROM [Level2] AS [l]
-    INNER JOIN (
-        SELECT DISTINCT [e].[Id]
+    WHERE EXISTS (
+        SELECT 1
         FROM [Level1] AS [e]
-    ) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
-) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id0]
-ORDER BY [l1].[Id], [l1].[Id0]",
+        WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id]
+ORDER BY [l1].[OneToMany_Optional_InverseId], [l1].[Id]",
                 Sql);
         }
 
@@ -159,41 +159,41 @@ ORDER BY [e].[Id]
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE EXISTS (
+    SELECT 1
     FROM [Level1] AS [e]
-) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
-ORDER BY [e0].[Id], [l].[Id]
+    WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+ORDER BY [l].[OneToMany_Optional_InverseId], [l].[Id]
 
 SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l0]
 INNER JOIN (
-    SELECT DISTINCT [e0].[Id], [l].[Id] AS [Id0]
+    SELECT DISTINCT [l].[OneToMany_Optional_InverseId], [l].[Id]
     FROM [Level2] AS [l]
-    INNER JOIN (
-        SELECT DISTINCT [e].[Id]
+    WHERE EXISTS (
+        SELECT 1
         FROM [Level1] AS [e]
-    ) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
-) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id0]
+        WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id]
 INNER JOIN [Level2] AS [l2] ON [l0].[OneToMany_Required_InverseId] = [l2].[Id]
-ORDER BY [l1].[Id], [l1].[Id0], [l2].[Id]
+ORDER BY [l1].[OneToMany_Optional_InverseId], [l1].[Id], [l2].[Id]
 
 SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_InverseId], [l3].[OneToMany_Optional_Self_InverseId], [l3].[OneToMany_Required_InverseId], [l3].[OneToMany_Required_Self_InverseId], [l3].[OneToOne_Optional_PK_InverseId], [l3].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l3]
 INNER JOIN (
-    SELECT DISTINCT [l1].[Id], [l1].[Id0], [l2].[Id] AS [Id1]
+    SELECT DISTINCT [l1].[OneToMany_Optional_InverseId], [l1].[Id], [l2].[Id] AS [Id0]
     FROM [Level3] AS [l0]
     INNER JOIN (
-        SELECT DISTINCT [e0].[Id], [l].[Id] AS [Id0]
+        SELECT DISTINCT [l].[OneToMany_Optional_InverseId], [l].[Id]
         FROM [Level2] AS [l]
-        INNER JOIN (
-            SELECT DISTINCT [e].[Id]
+        WHERE EXISTS (
+            SELECT 1
             FROM [Level1] AS [e]
-        ) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
-    ) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id0]
+            WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+    ) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id]
     INNER JOIN [Level2] AS [l2] ON [l0].[OneToMany_Required_InverseId] = [l2].[Id]
-) AS [l20] ON [l3].[OneToMany_Optional_InverseId] = [l20].[Id1]
-ORDER BY [l20].[Id], [l20].[Id0], [l20].[Id1]",
+) AS [l20] ON [l3].[OneToMany_Optional_InverseId] = [l20].[Id0]
+ORDER BY [l20].[OneToMany_Optional_InverseId], [l20].[Id], [l20].[Id0]",
                 Sql);
         }
 
@@ -202,32 +202,32 @@ ORDER BY [l20].[Id], [l20].[Id0], [l20].[Id1]",
             base.Multi_level_include_with_short_circuiting();
 
             Assert.Equal(
-                @"SELECT [x].[Name], [x].[LabelDefaultText], [x].[PlaceholderDefaultText], [c].[DefaultText], [c3].[DefaultText]
+                @"SELECT [x].[Name], [x].[LabelDefaultText], [x].[PlaceholderDefaultText], [c].[DefaultText], [c2].[DefaultText]
 FROM [ComplexNavigationField] AS [x]
 LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
-LEFT JOIN [ComplexNavigationString] AS [c3] ON [x].[PlaceholderDefaultText] = [c3].[DefaultText]
-ORDER BY [c].[DefaultText], [c3].[DefaultText]
+LEFT JOIN [ComplexNavigationString] AS [c2] ON [x].[PlaceholderDefaultText] = [c2].[DefaultText]
+ORDER BY [c].[DefaultText], [c2].[DefaultText]
 
-SELECT [c0].[Text], [c0].[ComplexNavigationStringDefaultText], [c0].[LanguageName], [c2].[Name], [c2].[CultureString]
+SELECT [c0].[Text], [c0].[ComplexNavigationStringDefaultText], [c0].[LanguageName], [c1].[Name], [c1].[CultureString]
 FROM [ComplexNavigationGlobalization] AS [c0]
-INNER JOIN (
-    SELECT DISTINCT [c].[DefaultText]
+LEFT JOIN [ComplexNavigationLanguage] AS [c1] ON [c0].[LanguageName] = [c1].[Name]
+WHERE EXISTS (
+    SELECT 1
     FROM [ComplexNavigationField] AS [x]
     LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
-) AS [c1] ON [c0].[ComplexNavigationStringDefaultText] = [c1].[DefaultText]
-LEFT JOIN [ComplexNavigationLanguage] AS [c2] ON [c0].[LanguageName] = [c2].[Name]
-ORDER BY [c1].[DefaultText]
+    WHERE [c0].[ComplexNavigationStringDefaultText] = [c].[DefaultText])
+ORDER BY [c0].[ComplexNavigationStringDefaultText]
 
-SELECT [c4].[Text], [c4].[ComplexNavigationStringDefaultText], [c4].[LanguageName], [c5].[Name], [c5].[CultureString]
-FROM [ComplexNavigationGlobalization] AS [c4]
-INNER JOIN (
-    SELECT DISTINCT [c].[DefaultText], [c3].[DefaultText] AS [DefaultText0]
+SELECT [c3].[Text], [c3].[ComplexNavigationStringDefaultText], [c3].[LanguageName], [c4].[Name], [c4].[CultureString]
+FROM [ComplexNavigationGlobalization] AS [c3]
+LEFT JOIN [ComplexNavigationLanguage] AS [c4] ON [c3].[LanguageName] = [c4].[Name]
+WHERE EXISTS (
+    SELECT 1
     FROM [ComplexNavigationField] AS [x]
     LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
-    LEFT JOIN [ComplexNavigationString] AS [c3] ON [x].[PlaceholderDefaultText] = [c3].[DefaultText]
-) AS [c30] ON [c4].[ComplexNavigationStringDefaultText] = [c30].[DefaultText0]
-LEFT JOIN [ComplexNavigationLanguage] AS [c5] ON [c4].[LanguageName] = [c5].[Name]
-ORDER BY [c30].[DefaultText], [c30].[DefaultText0]",
+    LEFT JOIN [ComplexNavigationString] AS [c2] ON [x].[PlaceholderDefaultText] = [c2].[DefaultText]
+    WHERE [c3].[ComplexNavigationStringDefaultText] = [c2].[DefaultText])
+ORDER BY [c3].[ComplexNavigationStringDefaultText]",
                 Sql);
         }
 
@@ -443,12 +443,12 @@ ORDER BY [e].[Id], [l1].[Id]
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
-    FROM [Level1] AS [e]
-) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
 LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
-ORDER BY [e0].[Id]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level1] AS [e]
+    WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+ORDER BY [l].[OneToMany_Optional_InverseId]
 
 SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l2]
@@ -473,21 +473,21 @@ ORDER BY [e].[Id], [l1].[Id]
 
 SELECT [l2].[Id], [l2].[Name], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l2]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id], [l1].[Id] AS [Id0]
+WHERE EXISTS (
+    SELECT 1
     FROM [Level1] AS [e]
     LEFT JOIN [Level1] AS [l1] ON [e].[OneToOne_Optional_SelfId] = [l1].[Id]
-) AS [l10] ON [l2].[OneToMany_Optional_Self_InverseId] = [l10].[Id0]
-ORDER BY [l10].[Id], [l10].[Id0]
+    WHERE [l2].[OneToMany_Optional_Self_InverseId] = [l1].[Id])
+ORDER BY [l2].[OneToMany_Optional_Self_InverseId]
 
 SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Name], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
-    FROM [Level1] AS [e]
-) AS [e0] ON [l].[OneToMany_Optional_Self_InverseId] = [e0].[Id]
 LEFT JOIN [Level1] AS [l0] ON [l].[OneToOne_Optional_SelfId] = [l0].[Id]
-ORDER BY [e0].[Id]",
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level1] AS [e]
+    WHERE [l].[OneToMany_Optional_Self_InverseId] = [e].[Id])
+ORDER BY [l].[OneToMany_Optional_Self_InverseId]",
                 Sql);
         }
 
@@ -503,12 +503,12 @@ ORDER BY [e].[Id], [l1].[Id]
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
-    FROM [Level1] AS [e]
-) AS [e0] ON [l].[OneToMany_Optional_InverseId] = [e0].[Id]
 LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
-ORDER BY [e0].[Id]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level1] AS [e]
+    WHERE [l].[OneToMany_Optional_InverseId] = [e].[Id])
+ORDER BY [l].[OneToMany_Optional_InverseId]
 
 SELECT [l2].[Id], [l2].[Level2_Optional_Id], [l2].[Level2_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l2]
@@ -1027,22 +1027,18 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
-INNER JOIN (
-    SELECT DISTINCT [t0].*
-    FROM (
-        SELECT [e].[Id]
-        FROM [Level1] AS [e]
-        LEFT JOIN (
-            SELECT [e1].[Id], [e1].[Level1_Optional_Id], [e1].[Level1_Required_Id], [e1].[Name], [e1].[OneToMany_Optional_InverseId], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_PK_InverseId], [e1].[OneToOne_Optional_SelfId]
-            FROM [Level2] AS [e1]
-        ) AS [t] ON [e].[Id] = [t].[Level1_Optional_Id]
-        WHERE ([e].[Name] <> N'L1 03') OR [e].[Name] IS NULL
-        ORDER BY [e].[Id]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-    ) AS [t0]
-) AS [e2] ON [l].[OneToMany_Optional_InverseId] = [e2].[Id]
 LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
-ORDER BY [e2].[Id]",
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level1] AS [e]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[Level1_Optional_Id], [e1].[Level1_Required_Id], [e1].[Name], [e1].[OneToMany_Optional_InverseId], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_PK_InverseId], [e1].[OneToOne_Optional_SelfId]
+        FROM [Level2] AS [e1]
+    ) AS [t] ON [e].[Id] = [t].[Level1_Optional_Id]
+    WHERE (([e].[Name] <> N'L1 03') OR [e].[Name] IS NULL) AND (([l].[OneToMany_Optional_InverseId] = [e].[Id]) AND [l].[OneToMany_Optional_InverseId] IS NOT NULL)
+    ORDER BY @@ROWCOUNT
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY)
+ORDER BY [l].[OneToMany_Optional_InverseId]",
                     Sql);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -246,13 +246,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT * FROM ""Customers""
     ) AS [c]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -270,14 +270,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT * FROM ""Customers""
     ) AS [c]
-    WHERE [c].[City] = N'London'
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[City] = N'London') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -39,16 +39,16 @@ ORDER BY [g].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [g].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM [CogTag] AS [t]
     LEFT JOIN (
         SELECT [g].*
         FROM [Gear] AS [g]
         WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
     ) AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
-ORDER BY [g0].[FullName]",
+    WHERE [w].[OwnerFullName] = [g].[FullName])
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -68,16 +68,16 @@ ORDER BY [g].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [g].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM [CogTag] AS [t]
     LEFT JOIN (
         SELECT [g].*
         FROM [Gear] AS [g]
         WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
     ) AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
-ORDER BY [g0].[FullName]",
+    WHERE [w].[OwnerFullName] = [g].[FullName])
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -98,8 +98,8 @@ ORDER BY [s].[Id]
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
-INNER JOIN (
-    SELECT DISTINCT [s].[Id]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [CogTag] AS [t]
     LEFT JOIN (
         SELECT [g].*
@@ -107,9 +107,8 @@ INNER JOIN (
         WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
     ) AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
     LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]
-) AS [s0] ON [g0].[SquadId] = [s0].[Id]
-WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [s0].[Id]", Sql);
+    WHERE [g0].[SquadId] = [s].[Id])
+ORDER BY [g0].[SquadId]", Sql);
         }
 
         public override void Include_multiple_one_to_one_optional_and_one_to_one_required()
@@ -141,14 +140,12 @@ ORDER BY [c].[Name]
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
-INNER JOIN (
-    SELECT DISTINCT [c].[Name]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
     INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [c0] ON [g0].[AssignedCityName] = [c0].[Name]
-WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [c0].[Name]",
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g0].[AssignedCityName] = [c].[Name]))
+ORDER BY [g0].[AssignedCityName]",
                 Sql);
         }
 
@@ -165,14 +162,12 @@ ORDER BY [c].[Name]
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
-INNER JOIN (
-    SELECT DISTINCT [c].[Name]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
     INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = N'Marcus')
-) AS [c0] ON [g0].[AssignedCityName] = [c0].[Name]
-WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [c0].[Name]",
+    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = N'Marcus')) AND ([g0].[AssignedCityName] = [c].[Name]))
+ORDER BY [g0].[AssignedCityName]",
                 Sql);
         }
 
@@ -188,12 +183,11 @@ ORDER BY [g].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [g].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = N'Marcus')
-) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
-ORDER BY [g0].[FullName]",
+    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = N'Marcus')) AND ([w].[OwnerFullName] = [g].[FullName]))
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -279,13 +273,11 @@ ORDER BY [g].[Nickname], [g].[SquadId]
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
-INNER JOIN (
-    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
-    WHERE [g].[Discriminator] = N'Officer'
-) AS [g1] ON ([g0].[LeaderNickname] = [g1].[Nickname]) AND ([g0].[LeaderSquadId] = [g1].[SquadId])
-WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g1].[Nickname], [g1].[SquadId]",
+    WHERE ([g].[Discriminator] = N'Officer') AND (([g0].[LeaderNickname] = [g].[Nickname]) AND ([g0].[LeaderSquadId] = [g].[SquadId])))
+ORDER BY [g0].[LeaderNickname], [g0].[LeaderSquadId]",
                 Sql);
         }
 
@@ -344,13 +336,12 @@ ORDER BY [g].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [g].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
     INNER JOIN [CogTag] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
-ORDER BY [g0].[FullName]",
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([w].[OwnerFullName] = [g].[FullName]))
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -366,12 +357,12 @@ ORDER BY [g].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [g].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM [CogTag] AS [t]
     INNER JOIN [Gear] AS [g] ON ([t].[GearSquadId] = [g].[SquadId]) AND ([t].[GearNickName] = [g].[Nickname])
-) AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
-ORDER BY [g0].[FullName]",
+    WHERE [w].[OwnerFullName] = [g].[FullName])
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -412,15 +403,13 @@ ORDER BY [c].[Name]
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
-INNER JOIN (
-    SELECT DISTINCT [c].[Name]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [Gear] AS [g]
     INNER JOIN [CogTag] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
     INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [c0] ON [g0].[AssignedCityName] = [c0].[Name]
-WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [c0].[Name]",
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g0].[AssignedCityName] = [c].[Name]))
+ORDER BY [g0].[AssignedCityName]",
                 Sql);
         }
 
@@ -456,16 +445,16 @@ ORDER BY [t].[FullName]
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
-INNER JOIN (
-    SELECT DISTINCT [t].[FullName]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
         FROM [Gear] AS [g0]
         WHERE [g0].[Discriminator] = N'Officer'
     ) AS [t]
     INNER JOIN [CogTag] AS [t0] ON ([t].[SquadId] = [t0].[GearSquadId]) AND ([t].[Nickname] = [t0].[GearNickName])
-) AS [t1] ON [w].[OwnerFullName] = [t1].[FullName]
-ORDER BY [t1].[FullName]",
+    WHERE [w].[OwnerFullName] = [t].[FullName])
+ORDER BY [w].[OwnerFullName]",
                 Sql);
         }
 
@@ -485,17 +474,16 @@ ORDER BY [t0].[Nickname], [t0].[SquadId]
 
 SELECT [g1].[Nickname], [g1].[SquadId], [g1].[AssignedCityName], [g1].[CityOrBirthName], [g1].[Discriminator], [g1].[FullName], [g1].[LeaderNickname], [g1].[LeaderSquadId], [g1].[Rank]
 FROM [Gear] AS [g1]
-INNER JOIN (
-    SELECT DISTINCT [t0].[Nickname], [t0].[SquadId]
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
+    SELECT 1
     FROM [CogTag] AS [t]
     INNER JOIN (
         SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
         FROM [Gear] AS [g0]
         WHERE [g0].[Discriminator] = N'Officer'
     ) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
-) AS [t00] ON ([g1].[LeaderNickname] = [t00].[Nickname]) AND ([g1].[LeaderSquadId] = [t00].[SquadId])
-WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [t00].[Nickname], [t00].[SquadId]",
+    WHERE ([g1].[LeaderNickname] = [t0].[Nickname]) AND ([g1].[LeaderSquadId] = [t0].[SquadId]))
+ORDER BY [g1].[LeaderNickname], [g1].[LeaderSquadId]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -29,12 +29,12 @@ ORDER BY [c].[ProductID]
 
 SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Order Details] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[ProductID]
-    FROM [Products] AS [c]
-) AS [c0] ON [o].[ProductID] = [c0].[ProductID]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-ORDER BY [c0].[ProductID]",
+WHERE EXISTS (
+    SELECT 1
+    FROM [Products] AS [c]
+    WHERE [o].[ProductID] = [c].[ProductID])
+ORDER BY [o].[ProductID]",
                 Sql);
         }
 
@@ -49,11 +49,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -69,11 +69,11 @@ ORDER BY [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Order Details] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT [o].[OrderID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Orders] AS [o]
-) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
-ORDER BY [o1].[OrderID]",
+    WHERE [o0].[OrderID] = [o].[OrderID])
+ORDER BY [o0].[OrderID]",
                 Sql);
         }
 
@@ -128,13 +128,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Order Details] AS [od]
     INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o0].[CustomerID] = [c].[CustomerID])
+ORDER BY [o0].[CustomerID]",
                 Sql);
         }
 
@@ -151,14 +151,12 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(2) 1
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-    WHERE [o].[OrderID] = 10248
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([o].[OrderID] = 10248) AND ([o0].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o0].[CustomerID]",
                 Sql);
         }
 
@@ -174,14 +172,12 @@ ORDER BY [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Order Details] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [o].[OrderID]
-    FROM [Orders] AS [o]
-    WHERE [o].[OrderID] = 10248
-    ORDER BY [o].[OrderID]
-) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
 INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
-ORDER BY [o1].[OrderID]",
+WHERE EXISTS (
+    SELECT TOP(2) 1
+    FROM [Orders] AS [o]
+    WHERE ([o].[OrderID] = 10248) AND ([o0].[OrderID] = [o].[OrderID]))
+ORDER BY [o0].[OrderID]",
                 Sql);
         }
 
@@ -196,11 +192,11 @@ ORDER BY [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Order Details] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT [o].[OrderID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Orders] AS [o]
-) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
-ORDER BY [o1].[OrderID]",
+    WHERE [o0].[OrderID] = [o].[OrderID])
+ORDER BY [o0].[OrderID]",
                 Sql);
         }
 
@@ -215,11 +211,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -330,11 +326,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -354,13 +350,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(2) 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -380,13 +374,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(2) 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -402,12 +394,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -423,12 +414,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -443,21 +433,21 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID], [o].[OrderID]
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID], [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Order Details] AS [o0]
 INNER JOIN (
-    SELECT DISTINCT [c0].[CustomerID], [o].[OrderID]
+    SELECT DISTINCT [o].[CustomerID], [o].[OrderID]
     FROM [Orders] AS [o]
-    INNER JOIN (
-        SELECT DISTINCT [c].[CustomerID]
+    WHERE EXISTS (
+        SELECT 1
         FROM [Customers] AS [c]
-    ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+        WHERE [o].[CustomerID] = [c].[CustomerID])
 ) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
 ORDER BY [o1].[CustomerID], [o1].[OrderID]",
                 Sql);
@@ -486,13 +476,12 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-    WHERE [c].[CustomerID] = N'ALFKI'
-) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o0].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o0].[CustomerID]",
                 Sql);
         }
 
@@ -509,13 +498,12 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customers] AS [c1]
     CROSS JOIN [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -539,16 +527,16 @@ ORDER BY [c1].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c1].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT TOP(@__p_0) [c0].*
         FROM [Customers] AS [c0]
         ORDER BY [c0].[CustomerID]
     ) AS [t]
     CROSS JOIN [Customers] AS [c1]
-) AS [c10] ON [o].[CustomerID] = [c10].[CustomerID]
-ORDER BY [c10].[CustomerID]",
+    WHERE [o].[CustomerID] = [c1].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -579,8 +567,8 @@ ORDER BY [t].[CustomerID], [t0].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -592,15 +580,15 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-) AS [t00] ON [o0].[CustomerID] = [t00].[CustomerID0]
-ORDER BY [t00].[CustomerID], [t00].[CustomerID0]
+    WHERE [o0].[CustomerID] = [t0].[CustomerID])
+ORDER BY [o0].[CustomerID]
 
 @__p_0: 2
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [t].[CustomerID]
+WHERE EXISTS (
+    SELECT 1
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -612,8 +600,8 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID]
-ORDER BY [t1].[CustomerID]",
+    WHERE [o].[CustomerID] = [t].[CustomerID])
+ORDER BY [o].[CustomerID]",
                     Sql);
             }
         }
@@ -647,8 +635,8 @@ ORDER BY [t].[CustomerID], [t0].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
+WHERE EXISTS (
+    SELECT TOP(@__p_1) 1
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -660,17 +648,16 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    ORDER BY [t].[CustomerID], [t0].[CustomerID]
-) AS [t00] ON [o0].[CustomerID] = [t00].[CustomerID0]
-ORDER BY [t00].[CustomerID], [t00].[CustomerID0]
+    WHERE [o0].[CustomerID] = [t0].[CustomerID])
+ORDER BY [o0].[CustomerID]
 
 @__p_1: 1
 @__p_0: 2
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(@__p_1) 1
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -682,9 +669,8 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    ORDER BY [t].[CustomerID]
-) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID]
-ORDER BY [t1].[CustomerID]",
+    WHERE [o].[CustomerID] = [t].[CustomerID])
+ORDER BY [o].[CustomerID]",
                     Sql);
             }
         }
@@ -801,8 +787,8 @@ ORDER BY [t].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(@__p_1) 1
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -814,9 +800,8 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    ORDER BY [t].[CustomerID]
-) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID]
-ORDER BY [t1].[CustomerID]",
+    WHERE [o].[CustomerID] = [t].[CustomerID])
+ORDER BY [o].[CustomerID]",
                     Sql);
             }
         }
@@ -984,13 +969,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(2) 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -1010,13 +993,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(2) 1
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] = N'ALFKI'
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -1061,12 +1042,11 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN (
-    SELECT DISTINCT TOP(@__p_0) [c].[CustomerID]
+WHERE EXISTS (
+    SELECT TOP(@__p_0) 1
     FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[CustomerID]",
+    WHERE [o].[CustomerID] = [c].[CustomerID])
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -195,13 +195,11 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [e0].[Id]",
+    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([b].[BaseParentId] = [e].[Id]))
+ORDER BY [b].[BaseParentId]",
                 Sql);
         }
 
@@ -242,13 +240,11 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)
-) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [e0].[Id]",
+    WHERE ([e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)) AND (([b].[BaseParentId] = [e].[Id]) AND [b].[BaseParentId] IS NOT NULL))
+ORDER BY [b].[BaseParentId]",
                 Sql);
         }
 
@@ -289,12 +285,11 @@ ORDER BY [e].[Id]
 
 SELECT [c].[Id], [c].[Name], [c].[ParentId]
 FROM [CollectionOnBase] AS [c]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [e0] ON [c].[ParentId] = [e0].[Id]
-ORDER BY [e0].[Id]",
+    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([c].[ParentId] = [e].[Id]))
+ORDER BY [c].[ParentId]",
                 Sql);
         }
 
@@ -325,12 +320,11 @@ ORDER BY [e].[Id]
 
 SELECT [c].[Id], [c].[Name], [c].[ParentId]
 FROM [CollectionOnBase] AS [c]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)
-) AS [e0] ON [c].[ParentId] = [e0].[Id]
-ORDER BY [e0].[Id]",
+    WHERE ([e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)) AND (([c].[ParentId] = [e].[Id]) AND [c].[ParentId] IS NOT NULL))
+ORDER BY [c].[ParentId]",
                 Sql);
         }
 
@@ -547,13 +541,11 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [e0].[Id]",
+    WHERE ([e].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND ([b].[BaseParentId] = [e].[Id]))
+ORDER BY [b].[BaseParentId]",
                 Sql);
         }
 
@@ -569,13 +561,11 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[ParentId], [b].[DerivedInheritanceRelationshipEntityId]
 FROM [BaseCollectionOnDerived] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnDerived', N'BaseCollectionOnDerived') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [e0] ON [b].[ParentId] = [e0].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnDerived', N'BaseCollectionOnDerived')
-ORDER BY [e0].[Id]",
+    WHERE ([e].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND ([b].[ParentId] = [e].[Id]))
+ORDER BY [b].[ParentId]",
                 Sql);
         }
 
@@ -711,18 +701,16 @@ ORDER BY [b].[Id]
 
 SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
 FROM [NestedCollectionBase] AS [n]
-INNER JOIN (
-    SELECT DISTINCT [b].[Id]
+WHERE [n].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
     LEFT JOIN (
         SELECT [b].*
         FROM [BaseReferenceOnBase] AS [b]
         WHERE [b].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
     ) AS [b] ON [b].[BaseParentId] = [e].[Id]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [b0] ON [n].[ParentReferenceId] = [b0].[Id]
-WHERE [n].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [b0].[Id]",
+    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([n].[ParentReferenceId] = [b].[Id]))
+ORDER BY [n].[ParentReferenceId]",
                 Sql);
         }
 
@@ -752,18 +740,16 @@ ORDER BY [b].[Id]
 
 SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
 FROM [NestedCollectionBase] AS [n]
-INNER JOIN (
-    SELECT DISTINCT [b].[Id]
+WHERE [n].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
     LEFT JOIN (
         SELECT [b].*
         FROM [BaseReferenceOnBase] AS [b]
         WHERE [b].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
     ) AS [b] ON [b].[BaseParentId] = [e].[Id]
-    WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-) AS [b0] ON [n].[ParentReferenceId] = [b0].[Id]
-WHERE [n].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [b0].[Id]",
+    WHERE ([e].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND ([n].[ParentReferenceId] = [b].[Id]))
+ORDER BY [n].[ParentReferenceId]",
                 Sql);
         }
 
@@ -809,18 +795,16 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty], [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
 FROM [BaseCollectionOnBase] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
-    FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
 LEFT JOIN (
     SELECT [n].*
     FROM [NestedReferenceBase] AS [n]
     WHERE [n].[Discriminator] IN (N'NestedReferenceDerived', N'NestedReferenceBase')
 ) AS [n] ON [n].[ParentCollectionId] = [b].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [e0].[Id]",
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+    SELECT 1
+    FROM [BaseInheritanceRelationshipEntity] AS [e]
+    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([b].[BaseParentId] = [e].[Id]))
+ORDER BY [b].[BaseParentId]",
                 Sql);
         }
 
@@ -884,28 +868,24 @@ ORDER BY [e].[Id]
 
 SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
+WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+    SELECT 1
     FROM [BaseInheritanceRelationshipEntity] AS [e]
-    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
-WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-ORDER BY [e0].[Id], [b].[Id]
+    WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([b].[BaseParentId] = [e].[Id]))
+ORDER BY [b].[BaseParentId], [b].[Id]
 
 SELECT [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
 FROM [NestedCollectionBase] AS [n]
 INNER JOIN (
-    SELECT DISTINCT [e0].[Id], [b].[Id] AS [Id0]
+    SELECT DISTINCT [b].[BaseParentId], [b].[Id]
     FROM [BaseCollectionOnBase] AS [b]
-    INNER JOIN (
-        SELECT DISTINCT [e].[Id]
+    WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase') AND EXISTS (
+        SELECT 1
         FROM [BaseInheritanceRelationshipEntity] AS [e]
-        WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
-    ) AS [e0] ON [b].[BaseParentId] = [e0].[Id]
-    WHERE [b].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
-) AS [b0] ON [n].[ParentCollectionId] = [b0].[Id0]
+        WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND ([b].[BaseParentId] = [e].[Id]))
+) AS [b0] ON [n].[ParentCollectionId] = [b0].[Id]
 WHERE [n].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [b0].[Id], [b0].[Id0]",
+ORDER BY [b0].[BaseParentId], [b0].[Id]",
                 Sql);
         }
 
@@ -968,12 +948,12 @@ ORDER BY [e].[Id]
 
 SELECT [p].[Id], [p].[Name], [p].[ReferenceId], [p].[ReferencedEntityId], [r].[Id], [r].[Name]
 FROM [PrincipalEntity] AS [p]
-INNER JOIN (
-    SELECT DISTINCT [e].[Id]
-    FROM [ReferencedEntity] AS [e]
-) AS [e0] ON [p].[ReferencedEntityId] = [e0].[Id]
 LEFT JOIN [ReferencedEntity] AS [r] ON [p].[ReferenceId] = [r].[Id]
-ORDER BY [e0].[Id]",
+WHERE EXISTS (
+    SELECT 1
+    FROM [ReferencedEntity] AS [e]
+    WHERE [p].[ReferencedEntityId] = [e].[Id])
+ORDER BY [p].[ReferencedEntityId]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -223,14 +223,11 @@ ORDER BY [e].[Species]
 
 SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-INNER JOIN (
-    SELECT DISTINCT TOP(2) [e].[Species]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND EXISTS (
+    SELECT TOP(2) 1
     FROM [Animal] AS [e]
-    WHERE [e].[Discriminator] = N'Eagle'
-    ORDER BY [e].[Species]
-) AS [e0] ON [a].[EagleId] = [e0].[Species]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')
-ORDER BY [e0].[Species]",
+    WHERE ([e].[Discriminator] = N'Eagle') AND ([a].[EagleId] = [e].[Species]))
+ORDER BY [a].[EagleId]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -158,11 +158,11 @@ ORDER BY [c].[FirstName], [c].[LastName]
 
 SELECT [o].[Id], [o].[CustomerFirstName], [o].[CustomerLastName], [o].[Name]
 FROM [Order] AS [o]
-INNER JOIN (
-    SELECT DISTINCT [c].[FirstName], [c].[LastName]
+WHERE EXISTS (
+    SELECT 1
     FROM [Customer] AS [c]
-) AS [c0] ON ([o].[CustomerFirstName] = [c0].[FirstName]) AND ([o].[CustomerLastName] = [c0].[LastName])
-ORDER BY [c0].[FirstName], [c0].[LastName]";
+    WHERE ([o].[CustomerFirstName] = [c].[FirstName]) AND ([o].[CustomerLastName] = [c].[LastName]))
+ORDER BY [o].[CustomerFirstName], [o].[CustomerLastName]";
 
                 Assert.Equal(expectedSql, TestSqlLoggerFactory.Sql);
             }


### PR DESCRIPTION
when there is no ORDER BY Clause or ORDER BY is on principal key properties
resolves #4903 