### PR TITLE
Query: Include collection and order by subquery throws 'Variable names must be unique within a query batch or stored procedure.'

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -360,9 +360,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                    .Last(o => o.IsAliasWithColumnExpression())
                                    .TryGetColumnExpression().TableAlias);
 
-                        innerJoinSelectExpression.ClearProjection();
-
-                        var innerJoinExpression = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);
+                    innerJoinSelectExpression.ClearProjection();
+                    
+                    var innerJoinExpression = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);
 
                         LiftOrderBy(innerJoinSelectExpression, targetSelectExpression, innerJoinExpression);
 
@@ -426,7 +426,21 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             SelectExpression targetSelectExpression,
             TableExpressionBase innerJoinExpression)
         {
-            foreach (var ordering in innerJoinSelectExpression.OrderBy)
+            var needOrderingChanges = innerJoinSelectExpression.OrderBy
+                .Any(x => x.Expression is SelectExpression || x.Expression.IsAliasWithColumnExpression());
+
+            IEnumerable<Ordering> orderings;
+            if (needOrderingChanges)
+            {
+                orderings = innerJoinSelectExpression.OrderBy.ToList();
+                innerJoinSelectExpression.ClearOrderBy();
+            }
+            else
+            {
+                orderings = innerJoinSelectExpression.OrderBy;
+            }
+
+            foreach (var ordering in orderings)
             {
                 var orderingExpression = ordering.Expression;
 
@@ -446,9 +460,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     }
                 }
 
-                var index = innerJoinSelectExpression.AddToProjection(orderingExpression);
+                var index = orderingExpression is SelectExpression 
+                    ? innerJoinSelectExpression.AddAliasToProjection(innerJoinSelectExpression.Alias + "_" + innerJoinSelectExpression.Projection.Count, orderingExpression)
+                    : innerJoinSelectExpression.AddToProjection(orderingExpression);
 
                 var expression = innerJoinSelectExpression.Projection[index];
+
+                if (needOrderingChanges)
+                {
+                    innerJoinSelectExpression.AddToOrderBy(new Ordering(expression.TryGetColumnExpression() ?? expression, ordering.OrderingDirection));
+                }
 
                 var newExpression
                     = targetSelectExpression.UpdateColumnExpression(expression, innerJoinExpression);

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -477,6 +477,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
+        public virtual void Include_collection_order_by_collection_column()
+        {
+            using (var context = CreateContext())
+            {
+                var customer
+                    = context.Set<Customer>()
+                        .Include(c => c.Orders)
+                        .Where(c => c.CustomerID.StartsWith("W"))
+                        .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault().OrderDate)
+                        .FirstOrDefault();
+
+                Assert.NotNull(customer);
+                Assert.NotNull(customer.Orders);
+                Assert.NotEmpty(customer.Orders);
+            }
+        }
+
+        [Fact]
         public virtual void Include_collection_order_by_key()
         {
             using (var context = CreateContext())
@@ -565,6 +583,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(7, customer?.Orders.Count);
                 Assert.True(customer?.Orders.All(o => o.Customer != null));
                 Assert.Equal(1 + 7, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Include_collection_order_by_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                var customer
+                    = context.Set<Customer>()
+                        .Include(c => c.Orders)
+                        .Where(c => c.CustomerID == "ALFKI")
+                        .OrderBy(c => c.Orders.Select(oo => oo.OrderDate).FirstOrDefault())
+                        .FirstOrDefault();
+
+                Assert.NotNull(customer);
+                Assert.NotNull(customer.Orders);
+                Assert.NotEmpty(customer.Orders);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -200,6 +200,38 @@ ORDER BY [o0].[OrderID]",
                 Sql);
         }
 
+        public override void Include_collection_order_by_collection_column()
+        {
+            base.Include_collection_order_by_collection_column();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'W' + N'%'
+ORDER BY (
+    SELECT TOP(1) [oo].[OrderDate]
+    FROM [Orders] AS [oo]
+    WHERE [c].[CustomerID] = [oo].[CustomerID]
+    ORDER BY [oo].[OrderDate] DESC
+) DESC, [c].[CustomerID]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT TOP(1) (
+        SELECT TOP(1) [oo].[OrderDate]
+        FROM [Orders] AS [oo]
+        WHERE [c].[CustomerID] = [oo].[CustomerID]
+        ORDER BY [oo].[OrderDate] DESC
+    ) AS [c0_0], [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W' + N'%'
+    ORDER BY [c0_0] DESC, [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0_0] DESC, [c0].[CustomerID]",
+                Sql);
+        }
+
         public override void Include_collection_order_by_key()
         {
             base.Include_collection_order_by_key();
@@ -312,6 +344,36 @@ INNER JOIN (
     ORDER BY [c].[CompanyName] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ORDER BY [c0].[CompanyName] DESC, [c0].[CustomerID]",
+                Sql);
+        }
+
+        public override void Include_collection_order_by_subquery()
+        {
+            base.Include_collection_order_by_subquery();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY (
+    SELECT TOP(1) [oo].[OrderDate]
+    FROM [Orders] AS [oo]
+    WHERE [c].[CustomerID] = [oo].[CustomerID]
+), [c].[CustomerID]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT TOP(1) (
+        SELECT TOP(1) [oo].[OrderDate]
+        FROM [Orders] AS [oo]
+        WHERE [c].[CustomerID] = [oo].[CustomerID]
+    ) AS [c0_0], [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY [c0_0], [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0_0], [c0].[CustomerID]", 
                 Sql);
         }
 


### PR DESCRIPTION
Replaces PR #5405 (that I messad up when syncing code with dev)

@anpete @smitpatel 