### PR TITLE
Test: Add SqliteVersionConditionAttribute

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -512,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Include_collection_order_by_non_key_with_take()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/IncludeSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/IncludeSqliteTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.Utilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             : base(fixture)
         {
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        [SqliteVersionCondition(Min = "3.8.8", SkipReason = "Distinct & Order By gives incorrect result in older version of Sqlite.")]
+        public override void Include_collection_order_by_non_key_with_take()
+        {
+            base.Include_collection_order_by_non_key_with_take();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="TransactionSqliteTest.cs" />
     <Compile Include="UpdatesSqliteFixture.cs" />
     <Compile Include="UpdatesSqliteTest.cs" />
+    <Compile Include="Utilities\SqliteVersionConditionAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="northwind.db">

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Utilities/SqliteVersionConditionAttribute.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Utilities/SqliteVersionConditionAttribute.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.Utilities
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class SqliteVersionConditionAttribute : Attribute, ITestCondition
+    {
+        private Version _min;
+        private Version _max;
+        private Version _skip;
+
+        public string Min
+        {
+            get { return _min.ToString(); }
+            set { _min = new Version(value); }
+        }
+
+        public string Max
+        {
+            get { return _max.ToString(); }
+            set { _max = new Version(value); }
+        }
+
+        public string Skip
+        {
+            get { return _skip.ToString(); }
+            set { _skip = new Version(value); }
+        }
+
+        private Version Current
+        {
+            get
+            {
+                var connection = new SqliteConnection("Data Source=:memory:;");
+                if (connection.ServerVersion != null)
+                {
+                    return new Version(connection.ServerVersion);
+                }
+                return null;
+            }
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                if (Current == _skip)
+                {
+                    return false;
+                }
+
+                if (_min == null && _max == null)
+                {
+                    return true;
+                }
+
+                if (_min == null)
+                {
+                    return Current <= _max;
+                }
+
+                if (_max == null)
+                {
+                    return Current >= _min;
+                }
+
+                return Current <= _max && Current >= _min;
+            }
+        }
+
+        private string _skipReason;
+
+        public string SkipReason
+        {
+            set { _skipReason = value; }
+            get
+            {
+                return _skipReason ??
+                    $"Test only runs for SQLite versions >= { Min ?? "Any"} and <= { Max ?? "Any" }"
+                    + (Skip == null ? "" : "and skipping on " + Skip);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Disable IncludeSqliteTest which fails for Sqlite version below 3.8.8
Skips failing test in SQLite on Linux.