### PR TITLE
PS commands: add catch around GetProperty for non-existent properties

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFramework.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFramework.psm1
@@ -887,12 +887,11 @@ function InvokeOperation($startupProject, $environment, $project, $operation, $a
 }
 
 function GetProperty($properties, $propertyName) {
-    $property = $properties.Item($propertyName)
-    if (!$property) {
+    try {
+        return $properties.Item($propertyName).Value
+    } catch {
         return $null
     }
-
-    return $property.Value
 }
 
 function GetProjectItem($project, $path) {


### PR DESCRIPTION
Fix #5383.
Possibly also fixes https://github.com/aspnet/EntityFramework/issues/5293

> The Item method throws a ArgumentException exception if the specified value cannot be found in the collection.

https://msdn.microsoft.com/en-us/library/envdte.properties.item(v=vs.120).aspx

e.g. UWP class libraries don't define "ProjectN.UseDotNetNativeToolchain" at all but UWP app projects do.

cc @bricelam 