### PR TITLE
Add more contextual error messages to EF commands

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/DispatchCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools/DispatchCommand.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
@@ -97,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
                 }
 
                 // TODO remove when https://github.com/dotnet/cli/issues/2645 is resolved
-                Func<bool> isClassLibrary = () => 
+                Func<bool> isClassLibrary = () =>
                 {
                     var projectContext = ProjectContext.Create(
                         projectFile.ProjectFilePath,
@@ -148,6 +149,10 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     if (isClassLibrary())
                     {
                         Reporter.Error.WriteLine(ToolsStrings.ClassLibrariesNotSupportedInCli(fwlink));
+                    }
+                    else if (framework.IsDesktop() && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        Reporter.Error.WriteLine(ToolsStrings.DesktopCommandsRequiresWindows(framework.GetShortFolderName());
                     }
                     else
                     {

--- a/src/Microsoft.EntityFrameworkCore.Tools/Properties/ToolsStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools/Properties/ToolsStrings.Designer.cs
@@ -29,6 +29,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// Could not invoke this command on this project. Commands for framework '{framework}' are only supported on Windows.
+        /// </summary>
+        public static string DesktopCommandsRequiresWindows([CanBeNull] object framework)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DesktopCommandsRequiresWindows", "framework"), framework);
+        }
+
+        /// <summary>
         /// Invoking dependency command '{projectCommand}' in project '{projectName}'
         /// </summary>
         public static string LogBeginDispatch([CanBeNull] object projectCommand, [CanBeNull] object projectName)

--- a/src/Microsoft.EntityFrameworkCore.Tools/Properties/ToolsStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Tools/Properties/ToolsStrings.resx
@@ -123,6 +123,9 @@
   <data name="ClassLibrariesNotSupportedInCli" xml:space="preserve">
     <value>This preview of Entity Framework tools does not support targeting class library projects in ASP.NET Core and .NET Core applications. See {fwlink} for details and workarounds.</value>
   </data>
+  <data name="DesktopCommandsRequiresWindows" xml:space="preserve">
+    <value>Could not invoke this command on this project. Commands for framework '{framework}' are only supported on Windows.</value>
+  </data>
   <data name="LogBeginDispatch" xml:space="preserve">
     <value>Invoking dependency command '{projectCommand}' in project '{projectName}'</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore.Tools/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools/project.json
@@ -33,7 +33,8 @@
         "Microsoft.NETCore.App": {
           "version": "1.0.0-*",
           "type": "platform"
-        }
+        },
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*"
       }
     },
     "net451": {

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psd1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psd1
@@ -1,0 +1,87 @@
+@{
+    # Script module or binary module file associated with this manifest
+    ModuleToProcess = 'EntityFrameworkCore.PowerShell2.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0.0'
+
+    # ID used to uniquely identify this module
+    GUID = '2de7c7fd-c848-41d7-8634-37fed4d3bb36'
+
+    # Author of this module
+    Author = 'Entity Framework Team'
+
+    # Company or vendor of this module
+    CompanyName = 'Microsoft Corporation'
+
+    # Copyright statement for this module
+    Copyright = '(c) .NET Foundation. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    Description = 'Entity Framework PowerShell module used for the Package Manager Console'
+
+    # Minimum version of the Windows PowerShell engine required by this module
+    PowerShellVersion = '1.0'
+
+    # Name of the Windows PowerShell host required by this module
+    PowerShellHostName = 'Package Manager Host'
+
+    # Minimum version of the Windows PowerShell host required by this module
+    PowerShellHostVersion = '1.2'
+
+    # Minimum version of the .NET Framework required by this module
+    DotNetFrameworkVersion = '4.0'
+
+    # Minimum version of the common language runtime (CLR) required by this module
+    CLRVersion = ''
+
+    # Processor architecture (None, X86, Amd64, IA64) required by this module
+    ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules = 'NuGet'
+
+    # Assemblies that must be loaded prior to importing this module
+    RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module
+    ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in ModuleToProcess
+    NestedModules = @()
+
+    # Functions to export from this module
+    FunctionsToExport = (
+        'Add-Migration',
+        'Enable-Migrations',
+        'Remove-Migration',
+        'Scaffold-DbContext',
+        'Script-Migration',
+        'Update-Database',
+        'Use-DbContext'
+    )
+
+    # Cmdlets to export from this module
+    CmdletsToExport = @()
+
+    # Variables to export from this module
+    VariablesToExport = @()
+
+    # Aliases to export from this module
+    AliasesToExport = @()
+
+    # List of all modules packaged with this module
+    ModuleList = @()
+
+    # List of all files packaged with this module
+    FileList = @()
+
+    # Private data to pass to the module specified in ModuleToProcess
+    PrivateData = ''
+}

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+
+$versionErrorMessage = "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+
+function Add-Migration {
+    throw $versionErrorMessage 
+}
+
+function Enable-Migrations {
+    throw $versionErrorMessage 
+}
+
+function Remove-Migration {
+    throw $versionErrorMessage 
+}
+
+function Scaffold-DbContext {
+    throw $versionErrorMessage 
+}
+
+function Script-Migration {
+    throw $versionErrorMessage 
+}
+
+function Update-Database {
+    throw $versionErrorMessage 
+}
+
+function Use-DbContext {
+    throw $versionErrorMessage
+}

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -651,7 +651,7 @@ function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
     }
     if (!$t) {
         $projectName = $project.ProjectName
-        throw "Cannot execute this command because 'Microsoft.EntityFrameworkCore.Tools' is not installed in project '$projectName'. Add 'Microsoft.EntityFrameworkCore.Tools' to the 'tools' section in project.json."
+        throw "Cannot execute this command because 'Microsoft.EntityFrameworkCore.Tools' is not installed in project '$projectName'. Add 'Microsoft.EntityFrameworkCore.Tools' to the 'tools' section in project.json. See http://go.microsoft.com/fwlink/?LinkId=798221 for more details."
     }
 
     $output = $null

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/about_EntityFrameworkCore.help.txt
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/about_EntityFrameworkCore.help.txt
@@ -13,8 +13,7 @@ SHORT DESCRIPTION
     Provides information about Entity Framework Core commands.
 
 LONG DESCRIPTION
-    This topic describes the Entity Framework Core commands. Entity Framework is Microsoft's recommended data access technology
-    for new applications.
+    This topic describes the Entity Framework Core commands. See https://docs.efproject.net for information on Entity Framework Core.
 
     The following Entity Framework cmdlets are included.
 

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
@@ -1,11 +1,20 @@
 param ($installPath, $toolsPath, $package, $project)
 
 if ($PSVersionTable.PSVersion.Major -lt 3) {
+    # This section needs to support PS 2.0 syntax
+    # Use $toolsPath because PS 2 does not support $PSScriptRoot
+    $env:PSModulePath= $env:PSModulePath + ";$toolsPath"
+    
+    # import a "dummy" module that contains matching functions that throw on PS2
+    Import-Module ([System.IO.Path]::Combine($toolsPath, "EntityFrameworkCore.PowerShell2.psd1")) -DisableNameChecking
+    
     throw "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+} else {
+    
+    if (Get-Module | ? Name -eq EntityFrameworkCore) {
+        Remove-Module EntityFrameworkCore
+    }
+
+    Import-Module (Join-Path $PSScriptRoot EntityFrameworkCore.psd1) -DisableNameChecking
 }
 
-if (Get-Module | ? Name -eq EntityFrameworkCore) {
-    Remove-Module EntityFrameworkCore
-}
-
-Import-Module (Join-Path $PSScriptRoot EntityFrameworkCore.psd1) -DisableNameChecking

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
@@ -1,5 +1,9 @@
 param ($installPath, $toolsPath, $package, $project)
 
+if ($PSVersionTable.PSVersion.Major -lt 3) {
+    throw "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+}
+
 if (Get-Module | ? Name -eq EntityFrameworkCore) {
     Remove-Module EntityFrameworkCore
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
@@ -1,5 +1,9 @@
 ﻿param ($installPath, $toolsPath, $package, $project)
 
+if ($PSVersionTable.PSVersion.Major -lt 3) {
+    throw "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+}
+
 Write-Host
 Write-Host 'Type ''get-help EntityFrameworkCore'' to see all available Entity Framework Core commands.'
 Write-Host

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
@@ -1,9 +1,5 @@
 ﻿param ($installPath, $toolsPath, $package, $project)
 
-if ($PSVersionTable.PSVersion.Major -lt 3) {
-    throw "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
-}
-
 Write-Host
 Write-Host 'Type ''get-help EntityFrameworkCore'' to see all available Entity Framework Core commands.'
 Write-Host


### PR DESCRIPTION
Fix #5418 - net451 commands on Linux are not supported
Fix #5272 - add fwlink when PMC command fails on .NET Core projects
Fix #5292 - write error when installing tools on PowerShell 2.0

cc @bricelam @rowanmiller 