### PR TITLE
Add some guards to relational property metadata builders

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalModelValidator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalModelValidator.cs
@@ -123,9 +123,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
                                 table));
                         }
 
-                        var currentComputedValueSql = propertyAnnotations.ComputedValueSql ?? "";
-                        var previousComputedValueSql = previousAnnotations.ComputedValueSql ?? "";
-                        if (!currentComputedValueSql.Equals(previousComputedValueSql, StringComparison.OrdinalIgnoreCase))
+                        var currentComputedColumnSql = propertyAnnotations.ComputedColumnSql ?? "";
+                        var previousComputedColumnSql = previousAnnotations.ComputedColumnSql ?? "";
+                        if (!currentComputedColumnSql.Equals(previousComputedColumnSql, StringComparison.OrdinalIgnoreCase))
                         {
                             ShowError(RelationalStrings.DuplicateColumnNameComputedSqlMismatch(
                                 duplicateProperty.DeclaringEntityType.DisplayName(),
@@ -134,8 +134,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
                                 property.Name,
                                 columnName,
                                 table,
-                                previousComputedValueSql,
-                                currentComputedValueSql));
+                                previousComputedColumnSql,
+                                currentComputedColumnSql));
                         }
 
                         var currentDefaultValue = propertyAnnotations.DefaultValue;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/IRelationalPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/IRelationalPropertyAnnotations.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         string ColumnName { get; }
         string ColumnType { get; }
         string DefaultValueSql { get; }
-        string ComputedValueSql { get; }
+        string ComputedColumnSql { get; }
         object DefaultValue { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public const string ColumnName = "ColumnName";
         public const string ColumnType = "ColumnType";
         public const string DefaultValueSql = "DefaultValueSql";
-        public const string ComputedValueSql = "ComputedValueSql";
+        public const string ComputedColumnSql = "ComputedColumnSql";
         public const string DefaultValue = "DefaultValue";
         public const string DatabaseName = "DatabaseName";
         public const string TableName = "TableName";

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationsBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationsBuilder.cs
@@ -28,5 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             string providerAnnotationName,
             object value)
             => MetadataBuilder.HasAnnotation(providerAnnotationName ?? relationalAnnotationName, value, ConfigurationSource);
+
+        public override bool CanSetAnnotation(
+            string relationalAnnotationName,
+            string providerAnnotationName,
+            object value)
+            => MetadataBuilder.CanSetAnnotation(providerAnnotationName ?? relationalAnnotationName, value, ConfigurationSource);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalFullAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalFullAnnotationNames.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ColumnName = prefix + RelationalAnnotationNames.ColumnName;
             ColumnType = prefix + RelationalAnnotationNames.ColumnType;
             DefaultValueSql = prefix + RelationalAnnotationNames.DefaultValueSql;
-            ComputedValueSql = prefix + RelationalAnnotationNames.ComputedValueSql;
+            ComputedColumnSql = prefix + RelationalAnnotationNames.ComputedColumnSql;
             DefaultValue = prefix + RelationalAnnotationNames.DefaultValue;
             DatabaseName = prefix + RelationalAnnotationNames.DatabaseName;
             TableName = prefix + RelationalAnnotationNames.TableName;
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public readonly string ColumnName;
         public readonly string ColumnType;
         public readonly string DefaultValueSql;
-        public readonly string ComputedValueSql;
+        public readonly string ComputedColumnSql;
         public readonly string DefaultValue;
         public readonly string DatabaseName;
         public readonly string TableName;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
@@ -15,14 +15,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
         }
 
+        protected new virtual RelationalAnnotationsBuilder Annotations => (RelationalAnnotationsBuilder)base.Annotations;
+        private InternalPropertyBuilder PropertyBuilder => ((Property)Property).Builder;
+        protected override bool ShouldThrowOnConflict => false;
+
         public virtual bool HasColumnName([CanBeNull] string value) => SetColumnName(value);
 
         public virtual bool HasColumnType([CanBeNull] string value) => SetColumnType(value);
 
-        public virtual bool HasDefaultValueSql([CanBeNull] string value) => SetDefaultValueSql(value);
+        public virtual bool HasDefaultValueSql([CanBeNull] string value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
 
-        public virtual bool HasComputedValueSql([CanBeNull] string value) => SetComputedValueSql(value);
+            return SetDefaultValueSql(value);
+        }
 
-        public virtual bool HasDefaultValue([CanBeNull] object value) => SetDefaultValue(value);
+        public virtual bool HasComputedColumnSql([CanBeNull] string value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
+
+            return SetComputedColumnSql(value);
+        }
+
+        public virtual bool HasDefaultValue([CanBeNull] object value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+
+            return SetDefaultValue(value);
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalAnnotations.cs
@@ -19,14 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         public virtual IAnnotatable Metadata { get; }
 
-        public virtual object GetAnnotation([NotNull] string fallbackAnnotationName, [CanBeNull] string primaryAnnotationName)
-        {
-            // Not using Check for perf
-            Debug.Assert(!string.IsNullOrEmpty(fallbackAnnotationName));
-
-            return (primaryAnnotationName == null ? null : Metadata[primaryAnnotationName])
-                   ?? Metadata[fallbackAnnotationName];
-        }
+        public virtual object GetAnnotation([CanBeNull] string fallbackAnnotationName, [CanBeNull] string primaryAnnotationName)
+            => (primaryAnnotationName == null ? null : Metadata[primaryAnnotationName])
+               ?? (fallbackAnnotationName == null ? null : Metadata[fallbackAnnotationName]);
 
         public virtual bool SetAnnotation(
             [NotNull] string relationalAnnotationName,
@@ -42,5 +37,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             annotatable[providerAnnotationName ?? relationalAnnotationName] = value;
             return true;
         }
+
+        public virtual bool CanSetAnnotation(
+            [NotNull] string relationalAnnotationName,
+            [CanBeNull] string providerAnnotationName,
+            [CanBeNull] object value)
+            => true;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -447,7 +447,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             if (isNullableChanged
                 || columnTypeChanged
                 || sourceAnnotations.DefaultValueSql != targetAnnotations.DefaultValueSql
-                || sourceAnnotations.ComputedValueSql != targetAnnotations.ComputedValueSql
+                || sourceAnnotations.ComputedColumnSql != targetAnnotations.ComputedColumnSql
                 || !Equals(sourceAnnotations.DefaultValue, targetAnnotations.DefaultValue)
                 || HasDifferences(MigrationsAnnotations.For(source), targetMigrationsAnnotations))
             {
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     IsNullable = isTargetColumnNullable,
                     DefaultValue = targetAnnotations.DefaultValue,
                     DefaultValueSql = targetAnnotations.DefaultValueSql,
-                    ComputedColumnSql = targetAnnotations.ComputedValueSql,
+                    ComputedColumnSql = targetAnnotations.ComputedColumnSql,
                     IsDestructiveChange = isDestructiveChange
                 };
                 CopyAnnotations(targetMigrationsAnnotations, alterColumnOperation);
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                                    ? null
                                    : GetDefaultValue(target.ClrType)),
                 DefaultValueSql = targetAnnotations.DefaultValueSql,
-                ComputedColumnSql = targetAnnotations.ComputedValueSql
+                ComputedColumnSql = targetAnnotations.ComputedColumnSql
             };
             CopyAnnotations(MigrationsAnnotations.For(target), operation);
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -436,6 +436,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateColumnNameDefaultSqlMismatch", "entityType1", "property1", "entityType2", "property2", "columnName", "table", "value1", "value2"), entityType1, property1, entityType2, property2, columnName, table, value1, value2);
         }
 
+        /// <summary>
+        /// {conflictingConfiguration} cannot be set for '{property}', because {existingConfiguration} is already set.
+        /// </summary>
+        public static string ConflictingColumnServerGeneration([CanBeNull] object conflictingConfiguration, [CanBeNull] object property, [CanBeNull] object existingConfiguration)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingColumnServerGeneration", "conflictingConfiguration", "property", "existingConfiguration"), conflictingConfiguration, property, existingConfiguration);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
@@ -277,4 +277,7 @@
   <data name="DuplicateColumnNameDefaultSqlMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different default values ('{value1}' and '{value2}').</value>
   </data>
+  <data name="ConflictingColumnServerGeneration" xml:space="preserve">
+    <value>{conflictingConfiguration} cannot be set for '{property}', because {existingConfiguration} is already set.</value>
+  </data>
 </root>

--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalMetadataExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalMetadataExtensions.cs
@@ -11,21 +11,39 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalMetadataExtensions
     {
         public static RelationalPropertyAnnotations Relational([NotNull] this IMutableProperty property)
+            => (RelationalPropertyAnnotations)Relational((IProperty)property);
+
+        public static IRelationalPropertyAnnotations Relational([NotNull] this IProperty property)
             => new RelationalPropertyAnnotations(Check.NotNull(property, nameof(property)), null);
 
         public static RelationalEntityTypeAnnotations Relational([NotNull] this IMutableEntityType entityType)
+            => (RelationalEntityTypeAnnotations)Relational((IEntityType)entityType);
+
+        public static IRelationalEntityTypeAnnotations Relational([NotNull] this IEntityType entityType)
             => new RelationalEntityTypeAnnotations(Check.NotNull(entityType, nameof(entityType)), null);
 
         public static RelationalKeyAnnotations Relational([NotNull] this IMutableKey key)
+            => (RelationalKeyAnnotations)Relational((IKey)key);
+
+        public static IRelationalKeyAnnotations Relational([NotNull] this IKey key)
             => new RelationalKeyAnnotations(Check.NotNull(key, nameof(key)), null);
 
         public static RelationalIndexAnnotations Relational([NotNull] this IMutableIndex index)
+            => (RelationalIndexAnnotations)Relational((IIndex)index);
+
+        public static IRelationalIndexAnnotations Relational([NotNull] this IIndex index)
             => new RelationalIndexAnnotations(Check.NotNull(index, nameof(index)), null);
 
         public static RelationalForeignKeyAnnotations Relational([NotNull] this IMutableForeignKey foreignKey)
+            => (RelationalForeignKeyAnnotations)Relational((IForeignKey)foreignKey);
+
+        public static IRelationalForeignKeyAnnotations Relational([NotNull] this IForeignKey foreignKey)
             => new RelationalForeignKeyAnnotations(Check.NotNull(foreignKey, nameof(foreignKey)), null);
 
         public static RelationalModelAnnotations Relational([NotNull] this IMutableModel model)
+            => (RelationalModelAnnotations)Relational((IModel)model);
+
+        public static IRelationalModelAnnotations Relational([NotNull] this IModel model)
             => new RelationalModelAnnotations(Check.NotNull(model, nameof(model)), null);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -54,13 +53,8 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasDefaultValueSql(sql);
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.Relational(ConfigurationSource.Explicit).HasDefaultValueSql(sql);
 
             return propertyBuilder;
         }
@@ -77,13 +71,8 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasComputedValueSql(sql);
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.Relational(ConfigurationSource.Explicit).HasComputedColumnSql(sql);
 
             return propertyBuilder;
         }
@@ -99,13 +88,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasDefaultValue(value);
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.Relational(ConfigurationSource.Explicit).HasDefaultValue(value);
 
             return propertyBuilder;
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             if (column.ComputedValue != null)
             {
                 ((Property)propertyBuilder.Metadata).SetValueGenerated(null, ConfigurationSource.Explicit);
-                propertyBuilder.Metadata.Relational().ComputedValueSql = null;
+                propertyBuilder.Metadata.Relational().ComputedColumnSql = null;
 
                 var computedExpression = ConvertSqlServerDefaultValue(column.ComputedValue);
                 if (computedExpression != null)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -53,13 +54,8 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.Metadata.SqlServer().DefaultValueSql = sql;
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.SqlServer(ConfigurationSource.Explicit).DefaultValueSql(sql);
 
             return propertyBuilder;
         }
@@ -75,13 +71,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.Metadata.SqlServer().DefaultValue = value;
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.SqlServer(ConfigurationSource.Explicit).DefaultValue(value);
 
             return propertyBuilder;
         }
@@ -98,13 +89,8 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            var property = (Property)propertyBuilder.Metadata;
-            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
-            {
-                property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
-            }
-
-            propertyBuilder.Metadata.SqlServer().ComputedValueSql = sql;
+            var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
+            internalPropertyBuilder.SqlServer(ConfigurationSource.Explicit).ComputedColumnSql(sql);
 
             return propertyBuilder;
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
@@ -14,16 +14,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
         }
 
+        private InternalPropertyBuilder PropertyBuilder => ((Property)Property).Builder;
+        protected override bool ShouldThrowOnConflict => false;
+
 #pragma warning disable 109
         public new virtual bool ColumnName([CanBeNull] string value) => SetColumnName(value);
 
         public new virtual bool ColumnType([CanBeNull] string value) => SetColumnType(value);
 
-        public new virtual bool DefaultValueSql([CanBeNull] string value) => SetDefaultValueSql(value);
+        public new virtual bool DefaultValueSql([CanBeNull] string value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            return SetDefaultValueSql(value);
+        }
 
-        public new virtual bool ComputedValueSql([CanBeNull] string value) => SetComputedValueSql(value);
+        public new virtual bool ComputedColumnSql([CanBeNull] string value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
+            return SetComputedColumnSql(value);
+        }
 
-        public new virtual bool DefaultValue([CanBeNull] object value) => SetDefaultValue(value);
+        public new virtual bool DefaultValue([CanBeNull] object value)
+        {
+            PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            return SetDefaultValue(value);
+        }
 
         public new virtual bool HiLoSequenceName([CanBeNull] string value) => SetHiLoSequenceName(value);
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -249,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ColumnType, nameof(RelationalPropertyBuilderExtensions.HasColumnType), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.DefaultValueSql, nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql), stringBuilder);
-            GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ComputedValueSql, nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), stringBuilder);
+            GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ComputedColumnSql, nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.DefaultValue, nameof(RelationalPropertyBuilderExtensions.HasDefaultValue), stringBuilder);
 
             GenerateAnnotations(annotations, stringBuilder);

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Configuration/Internal/ModelConfiguration.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/Scaffolding/Configuration/Internal/ModelConfiguration.cs
@@ -550,14 +550,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Configuration.Internal
         {
             Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
 
-            if (AnnotationProvider.For(propertyConfiguration.Property).ComputedValueSql != null)
+            if (AnnotationProvider.For(propertyConfiguration.Property).ComputedColumnSql != null)
             {
                 propertyConfiguration.FluentApiConfigurations.Add(
                     _configurationFactory.CreateFluentApiConfiguration(
                         /* hasAttributeEquivalent */ false,
                         nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
                         CSharpUtilities.DelimitString(
-                            AnnotationProvider.For(propertyConfiguration.Property).ComputedValueSql)));
+                            AnnotationProvider.For(propertyConfiguration.Property).ComputedColumnSql)));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalMetadataBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalMetadataBuilder.cs
@@ -32,9 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     return true;
                 }
 
-                var existingConfigurationSource = existingAnnotation.GetConfigurationSource();
-                if (!configurationSource.Overrides(existingConfigurationSource)
-                    || ((configurationSource == existingConfigurationSource) && !canOverrideSameSource))
+                if (!CanSetAnnotationValue(existingAnnotation, value, configurationSource, canOverrideSameSource))
                 {
                     return false;
                 }
@@ -55,6 +53,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (value != null)
             {
                 Metadata.AddAnnotation(name, value, configurationSource);
+            }
+
+            return true;
+        }
+
+        public virtual bool CanSetAnnotation([NotNull] string name, [CanBeNull] object value, ConfigurationSource configurationSource)
+        {
+            var existingAnnotation = Metadata.FindAnnotation(name);
+            if (existingAnnotation != null)
+            {
+                return CanSetAnnotationValue(existingAnnotation, value, configurationSource, canOverrideSameSource: true);
+            }
+
+            return true;
+        }
+
+        private bool CanSetAnnotationValue(
+            ConventionalAnnotation annotation, object value, ConfigurationSource configurationSource, bool canOverrideSameSource)
+        {
+            if (annotation.Value.Equals(value))
+            {
+                return true;
+            }
+
+            var existingConfigurationSource = annotation.GetConfigurationSource();
+            if (!configurationSource.Overrides(existingConfigurationSource)
+                || ((configurationSource == existingConfigurationSource) && !canOverrideSameSource))
+            {
+                return false;
             }
 
             return true;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
                     {
                         Assert.Equal("Current", col2.Name);
                         Assert.Equal(typeof(string), col2.ClrType);
-                        Assert.Equal("compute_this()", col2.Relational().ComputedValueSql);
+                        Assert.Equal("compute_this()", col2.Relational().ComputedColumnSql);
                     },
                 col3 =>
                     {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -87,37 +87,31 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Property("Id", typeof(int), ConfigurationSource.Convention);
 
             Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnName("Splew"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedValueSql("3"));
             Assert.Equal("Splew", propertyBuilder.Metadata.Relational().ColumnName);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
             Assert.Equal("int", propertyBuilder.Metadata.Relational().ColumnType);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
             Assert.Equal(1, propertyBuilder.Metadata.Relational().DefaultValue);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
             Assert.Equal("2", propertyBuilder.Metadata.Relational().DefaultValueSql);
-            Assert.Equal("3", propertyBuilder.Metadata.Relational().ComputedValueSql);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedColumnSql("3"));
+            Assert.Equal("3", propertyBuilder.Metadata.Relational().ComputedColumnSql);
 
             Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasColumnName("Splow"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasColumnType("varchar"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValue(0));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValueSql("NULL"));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasComputedValueSql("runthis()"));
-            Assert.Equal("Splow", propertyBuilder.Metadata.Relational().ColumnName);
-            Assert.Equal("varchar", propertyBuilder.Metadata.Relational().ColumnType);
-            Assert.Equal(0, propertyBuilder.Metadata.Relational().DefaultValue);
-            Assert.Equal("NULL", propertyBuilder.Metadata.Relational().DefaultValueSql);
-            Assert.Equal("runthis()", propertyBuilder.Metadata.Relational().ComputedValueSql);
-
             Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnName("Splod"));
-            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
-            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
-            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
-            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedValueSql("3"));
             Assert.Equal("Splow", propertyBuilder.Metadata.Relational().ColumnName);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasColumnType("varchar"));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
             Assert.Equal("varchar", propertyBuilder.Metadata.Relational().ColumnType);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValue(0));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
             Assert.Equal(0, propertyBuilder.Metadata.Relational().DefaultValue);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValueSql("NULL"));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
             Assert.Equal("NULL", propertyBuilder.Metadata.Relational().DefaultValueSql);
-            Assert.Equal("runthis()", propertyBuilder.Metadata.Relational().ComputedValueSql);
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasComputedColumnSql("runthis()"));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedColumnSql("3"));
+            Assert.Equal("runthis()", propertyBuilder.Metadata.Relational().ComputedColumnSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedColumnSql);
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedColumnSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 
@@ -160,6 +160,63 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
             Assert.Equal(typeof(ulong), property.Relational().DefaultValue.GetType());
             Assert.Equal((ulong)2, property.Relational().DefaultValue);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_value_overrides_default_sql_and_computed_column_sql()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Id)
+                .HasComputedColumnSql("0")
+                .HasDefaultValueSql("1")
+                .HasDefaultValue(2);
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
+
+            Assert.Equal(2, property.Relational().DefaultValue);
+            Assert.Null(property.Relational().DefaultValueSql);
+            Assert.Null(property.Relational().ComputedColumnSql);
+        }
+
+        [Fact]
+        public void Setting_column_default_sql_value_overrides_default_value_and_computed_column_sql()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Id)
+                .HasDefaultValue(2)
+                .HasComputedColumnSql("0")
+                .HasDefaultValueSql("1");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
+
+            Assert.Equal("1", property.Relational().DefaultValueSql);
+            Assert.Null(property.Relational().DefaultValue);
+            Assert.Null(property.Relational().ComputedColumnSql);
+        }
+
+        [Fact]
+        public void Setting_computed_column_sql_overrides_default_sql_and_column_default_value()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Id)
+                .HasDefaultValueSql("1")
+                .HasDefaultValue(2)
+                .HasComputedColumnSql("0");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
+
+            Assert.Equal("0", property.Relational().ComputedColumnSql);
+            Assert.Null(property.Relational().DefaultValue);
+            Assert.Null(property.Relational().DefaultValueSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
-                        Assert.Equal("Draco", operation.DefaultValue);
+                        Assert.Equal("", operation.DefaultValue);
                         Assert.Equal("CreateDragonName()", operation.DefaultValueSql);
                     });
         }
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
-                        Assert.Equal("Draco", operation.DefaultValue);
+                        Assert.Equal("", operation.DefaultValue);
                         Assert.Equal("CreateDragonName()", operation.ComputedColumnSql);
                     });
         }
@@ -523,7 +523,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.True(operation.IsNullable);
-                        Assert.Equal("Buffy", operation.DefaultValue);
+                        Assert.Null(operation.DefaultValue);
                         Assert.Equal("CreateBisonName()", operation.DefaultValueSql);
                     });
         }
@@ -569,7 +569,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("varchar(450)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
-                        Assert.Equal("Puff", operation.DefaultValue);
+                        Assert.Null(operation.DefaultValue);
                         Assert.Equal("CreatePumaName()", operation.DefaultValueSql);
                     });
         }
@@ -618,8 +618,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                             x.Property<string>("Name")
                                 .HasColumnType("nvarchar(30)")
                                 .IsRequired()
-                                .HasDefaultValue("Butch")
-                                .HasDefaultValueSql("CreateCougarName()");
+                                .HasDefaultValueSql("CreateCougarName()")
+                                .HasDefaultValue("Butch");
                         }),
                 target => target.Entity(
                     "Cougar",
@@ -631,8 +631,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                             x.Property<string>("Name")
                                 .HasColumnType("nvarchar(30)")
                                 .IsRequired()
-                                .HasDefaultValue("Cosmo")
-                                .HasDefaultValueSql("CreateCougarName()");
+                                .HasDefaultValueSql("CreateCougarName()")
+                                .HasDefaultValue("Cosmo");
                         }),
                 operations =>
                     {
@@ -646,7 +646,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
                         Assert.Equal("Cosmo", operation.DefaultValue);
-                        Assert.Equal("CreateCougarName()", operation.DefaultValueSql);
+                        Assert.Null(operation.DefaultValueSql);
                     });
         }
 
@@ -691,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
-                        Assert.Equal("Liam", operation.DefaultValue);
+                        Assert.Null(operation.DefaultValue);
                         Assert.Equal("CreateCatamountName()", operation.DefaultValueSql);
                     });
         }
@@ -737,7 +737,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                         Assert.Equal(typeof(string), operation.ClrType);
                         Assert.Equal("nvarchar(30)", operation.ColumnType);
                         Assert.False(operation.IsNullable);
-                        Assert.Equal("Liam", operation.DefaultValue);
+                        Assert.Null(operation.DefaultValue);
                         Assert.Equal("CreateCatamountName()", operation.ComputedColumnSql);
                     });
         }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -985,7 +985,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrat
         b.ToTable(""EntityWithTwoProperties"");
     });
 ",
-                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedValueSql"]); });
+                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]); });
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Detect conflicting DefaultValue, DefaultValueSql, ComputedColumnSql and SqlServerValueGenerationStrategy
Rename ComputedValueSql extension method to ComputedColumnSql to be consistent with fluent API

Fixes #5384