### PR TITLE
Include parameter facets in command log data

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/DbCommandLogData.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/DbCommandLogData.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string commandText,
             CommandType commandType,
             int commandTimeout,
-            [NotNull] IReadOnlyDictionary<string, object> parameters,
+            [NotNull] IReadOnlyList<DbParameterLogData> parameters,
             long? elapsedMilliseconds)
         {
             CommandText = commandText;
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual string CommandText { get; }
         public virtual CommandType CommandType { get; }
         public virtual int CommandTimeout { get; }
-        public virtual IReadOnlyDictionary<string, object> Parameters { get; }
+        public virtual IReadOnlyList<DbParameterLogData> Parameters { get; }
         public virtual long? ElapsedMilliseconds { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/DbParameterLogData.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/DbParameterLogData.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class DbParameterLogData
+    {
+        public DbParameterLogData(
+            [NotNull] string name,
+            [CanBeNull] object value,
+            bool hasValue,
+            ParameterDirection direction,
+            DbType dbType,
+            bool nullable,
+            int size,
+            byte precision,
+            byte scale)
+        {
+            Name = name;
+            Value = value;
+            HasValue = hasValue;
+            Direction = direction;
+            DbType = dbType;
+            IsNullable = nullable;
+            Size = size;
+            Precision = precision;
+            Scale = scale;
+        }
+
+        public virtual string Name { get; }
+        public virtual object Value { get; }
+        public virtual bool HasValue { get; set; }
+        public virtual ParameterDirection Direction { get; set; }
+        public virtual DbType DbType { get; set; }
+        public virtual bool IsNullable { get; }
+        public virtual int Size { get; }
+        public virtual byte Precision { get; }
+        public virtual byte Scale { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalLoggerExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalLoggerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.Linq;
@@ -38,7 +39,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     command.CommandTimeout,
                     command.Parameters
                         .Cast<DbParameter>()
-                        .ToDictionary(p => p.ParameterName, p => logParameterValues ? p.Value : "?"),
+                        .Select(
+                            p => new DbParameterLogData(
+                                p.ParameterName,
+                                logParameterValues ? p.Value : "?",
+                                logParameterValues,
+                                p.Direction,
+                                p.DbType,
+                                p.IsNullable,
+                                p.Size,
+                                p.Precision,
+                                p.Scale))
+                        .ToList(),
                     DeriveTimespan(startTimestamp, currentTimestamp));
 
                 logger.Log(
@@ -53,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             return RelationalStrings.RelationalLoggerExecutedCommand(
                                 string.Format($"{elapsedMilliseconds:N0}"),
                                 state.Parameters
-                                    .Select(kv => $"{kv.Key}='{FormatParameterValue(kv.Value)}'")
+                                    .Select(p => $"{p.Name}={FormatParameter(p)}")
                                     .Join(),
                                 state.CommandType,
                                 state.CommandTimeout,
@@ -63,27 +75,165 @@ namespace Microsoft.EntityFrameworkCore.Storage
             }
         }
 
-        public static object FormatParameterValue(object parameterValue)
+        public static string FormatParameter(DbParameterLogData parameterData)
         {
-            if (parameterValue.GetType() != typeof(byte[]))
-            {
-                return Convert.ToString(parameterValue, CultureInfo.InvariantCulture);
-            }
-            var stringValueBuilder = new StringBuilder();
-            var buffer = (byte[])parameterValue;
-            stringValueBuilder.Append("0x");
+            var builder = new StringBuilder();
 
-            for (var i = 0; i < buffer.Length; i++)
+            var value = parameterData.Value;
+            var clrType = value?.GetType();
+
+            FormatParameterValue(builder, value);
+
+            if (parameterData.IsNullable
+                && value != null
+                && !clrType.IsNullableType())
             {
-                if (i > 31)
+                builder.Append(" (Nullable = true)");
+            }
+            else
+            {
+                if (!parameterData.IsNullable
+                    && parameterData.HasValue
+                    && (value == null
+                        || clrType.IsNullableType()))
                 {
-                    stringValueBuilder.Append("...");
-                    break;
+                    builder.Append(" (Nullable = false)");
                 }
-                stringValueBuilder.Append(buffer[i].ToString("X2", CultureInfo.InvariantCulture));
             }
 
-            return stringValueBuilder.ToString();
+            if (parameterData.Size != 0)
+            {
+                builder
+                    .Append(" (Size = ")
+                    .Append(parameterData.Size)
+                    .Append(')');
+            }
+
+            if (parameterData.Precision != 0)
+            {
+                builder
+                    .Append(" (Precision = ")
+                    .Append(parameterData.Precision)
+                    .Append(')');
+            }
+
+            if (parameterData.Scale != 0)
+            {
+                builder
+                    .Append(" (Scale = ")
+                    .Append(parameterData.Scale)
+                    .Append(')');
+            }
+
+            if (parameterData.Direction != ParameterDirection.Input)
+            {
+                builder
+                    .Append(" (Direction = ")
+                    .Append(parameterData.Direction)
+                    .Append(')');
+            }
+
+            if (parameterData.HasValue
+                && !IsNormalDbType(parameterData.DbType, clrType))
+            {
+                builder
+                    .Append(" (DbType = ")
+                    .Append(parameterData.DbType)
+                    .Append(')');
+            }
+
+            return builder.ToString();
+
+        }
+
+        public static void FormatParameterValue([NotNull] StringBuilder builder, [CanBeNull] object parameterValue)
+        {
+            builder.Append('\'');
+
+            if (parameterValue?.GetType() != typeof(byte[]))
+            {
+                builder.Append(Convert.ToString(parameterValue, CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                var buffer = (byte[])parameterValue;
+                builder.Append("0x");
+
+                for (var i = 0; i < buffer.Length; i++)
+                {
+                    if (i > 31)
+                    {
+                        builder.Append("...");
+                        break;
+                    }
+                    builder.Append(buffer[i].ToString("X2", CultureInfo.InvariantCulture));
+                }
+            }
+
+            builder.Append('\'');
+        }
+
+        private static bool IsNormalDbType(DbType dbType, Type clrType)
+        {
+            if (clrType == null)
+            {
+                return false;
+            }
+
+            clrType = clrType.UnwrapNullableType().UnwrapEnumType();
+
+            switch (dbType)
+            {
+                case DbType.AnsiString: // Zero
+                    return clrType != typeof(string);
+                case DbType.Binary:
+                    return clrType == typeof(byte[]);
+                case DbType.Byte:
+                    return clrType == typeof(byte);
+                case DbType.Boolean:
+                    return clrType == typeof(bool);
+                case DbType.Decimal:
+                    return clrType == typeof(decimal);
+                case DbType.Double:
+                    return clrType == typeof(double);
+                case DbType.Guid:
+                    return clrType == typeof(Guid);
+                case DbType.Int16:
+                    return clrType == typeof(short);
+                case DbType.Int32:
+                    return clrType == typeof(int);
+                case DbType.Int64:
+                    return clrType == typeof(long);
+                case DbType.Object:
+                    return clrType == typeof(object);
+                case DbType.SByte:
+                    return clrType == typeof(sbyte);
+                case DbType.Single:
+                    return clrType == typeof(float);
+                case DbType.String:
+                    return clrType == typeof(string);
+                case DbType.Time:
+                    return clrType == typeof(TimeSpan);
+                case DbType.UInt16:
+                    return clrType == typeof(ushort);
+                case DbType.UInt32:
+                    return clrType == typeof(uint);
+                case DbType.UInt64:
+                    return clrType == typeof(ulong);
+                case DbType.DateTime2:
+                    return clrType == typeof(DateTime);
+                case DbType.DateTimeOffset:
+                    return clrType == typeof(DateTimeOffset);
+                //case DbType.VarNumeric:
+                //case DbType.AnsiStringFixedLength:
+                //case DbType.StringFixedLength:
+                //case DbType.Xml:
+                //case DbType.Currency:
+                //case DbType.Date:
+                //case DbType.DateTime:
+                default:
+                    return false;
+            }
         }
 
         public static void LogInformation<TState>(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -65,6 +65,7 @@
       <Link>StringBuilderExtensions.cs</Link>
     </Compile>
     <Compile Include="Extensions\DbCommandLogData.cs" />
+    <Compile Include="Extensions\DbParameterLogData.cs" />
     <Compile Include="Extensions\RelationalExpressionExtensions.cs" />
     <Compile Include="Extensions\RelationalLoggerExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerMaxLengthMapping.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerMaxLengthMapping.cs
@@ -38,6 +38,16 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     : 4000;
         }
 
+        public override RelationalTypeMapping CreateCopy(string storeType, int? size)
+            => new SqlServerMaxLengthMapping(
+                storeType,
+                ClrType,
+                DbType,
+                IsUnicode,
+                size,
+                HasNonDefaultUnicode,
+                hasNonDefaultSize: size != Size);
+
         protected override void ConfigureParameter(DbParameter parameter)
         {
             // For strings and byte arrays, set the max length to 8000 bytes if the data will

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameter.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameter.cs
@@ -21,12 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvi
         public static DbType DefaultDbType = DbType.AnsiString;
         public override DbType DbType { get; set; } = DefaultDbType;
 
-        public override int Size
-        {
-            get { throw new NotImplementedException(); }
-
-            set { throw new NotImplementedException(); }
-        }
+        public override int Size { get; set; }
 
         public override string SourceColumn
         {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using System.Linq;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using Xunit;
 
@@ -16,8 +18,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
             var shortArray = new Guid("21EC2020-3AEA-4069-A2DD-08002B30309D").ToByteArray();
             var longerShortArray = shortArray.Concat(shortArray).ToArray();
 
-            Assert.Equal("0x2020EC21EA3A6940A2DD08002B30309D", RelationalLoggerExtensions.FormatParameterValue(shortArray));
-            Assert.Equal("0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D", RelationalLoggerExtensions.FormatParameterValue(longerShortArray));
+            var builder = new StringBuilder();
+            RelationalLoggerExtensions.FormatParameterValue(builder, shortArray);
+
+            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D'", builder.ToString());
+
+            builder.Clear();
+            RelationalLoggerExtensions.FormatParameterValue(builder, longerShortArray);
+
+            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D'", builder.ToString());
         }
 
         [Fact]
@@ -25,7 +34,501 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             var shortArray = new Guid("21EC2020-3AEA-4069-A2DD-08002B30309D").ToByteArray();
             var longArray = shortArray.Concat(shortArray).Concat(shortArray).ToArray();
-            Assert.Equal("0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...", RelationalLoggerExtensions.FormatParameterValue(longArray));
+
+            var builder = new StringBuilder();
+            RelationalLoggerExtensions.FormatParameterValue(builder, longArray);
+
+            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...'", builder.ToString());
+        }
+
+        [Fact]
+        public void Formats_string_parameter()
+        {
+            Assert.Equal(
+                "'Muffin'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Format_parameter_with_direction()
+        {
+            Assert.Equal(
+                "'Muffin' (Direction = Output)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Output, DbType.String, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_non_nullable_string_parameter()
+        {
+            Assert.Equal(
+                "'Muffin' (Nullable = false)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_non_unicode_string_parameter()
+        {
+            Assert.Equal(
+                "'Muffin' (DbType = AnsiString)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_non_unicode_non_nullable_string_parameter()
+        {
+            Assert.Equal(
+                "'Muffin' (Nullable = false) (DbType = AnsiString)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_non_unicode_non_nullable_sized_string_parameter()
+        {
+            Assert.Equal(
+                "'Muffin' (Nullable = false) (Size = 100) (DbType = AnsiString)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 100, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_null_string_parameter()
+        {
+            Assert.Equal(
+                "'' (DbType = String)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_null_non_unicode_string_parameter()
+        {
+            Assert.Equal(
+                "'' (DbType = AnsiString)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sensitive_string_parameter()
+        {
+            Assert.Equal(
+                "'?'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sensitive_non_nullable_string_parameter()
+        {
+            Assert.Equal(
+                "'?'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.String, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_int_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_nullable_int_parameter()
+        {
+            Assert.Equal(
+                "'777' (Nullable = true)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_int_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_int_parameter_with_no_type()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, 0, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_null_nullable_int_parameter()
+        {
+            Assert.Equal(
+                "'' (DbType = Int32)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sensitive_int_parameter()
+        {
+            Assert.Equal(
+                "'?'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sensitive_nullable_int_parameter()
+        {
+            Assert.Equal(
+                "'?'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_short_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (short)777, true, ParameterDirection.Input, DbType.Int16, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_short_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (short)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_long_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (long)777, true, ParameterDirection.Input, DbType.Int64, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_long_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (long)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_byte_parameter()
+        {
+            Assert.Equal(
+                "'77'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (byte)77, true, ParameterDirection.Input, DbType.Byte, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_byte_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'77' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (byte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_uint_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (uint)777, true, ParameterDirection.Input, DbType.UInt32, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_uint_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (uint)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_ushort_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.UInt16, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_ushort_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_ulong_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.UInt64, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_ulong_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sbyte_parameter()
+        {
+            Assert.Equal(
+                "'77'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.SByte, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_sbyte_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'77' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_binary_parameter()
+        {
+            Assert.Equal(
+                "'0x0102'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_binary_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'0x0102' (DbType = Object)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_bool_parameter()
+        {
+            Assert.Equal(
+                "'True'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", true, true, ParameterDirection.Input, DbType.Boolean, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_bool_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'True' (DbType = Int32)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", true, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_decimal_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_decimal_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_decimal_parameter_with_precision()
+        {
+            Assert.Equal(
+                "'77.7' (Precision = 18)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 0)));
+        }
+
+        [Fact]
+        public void Formats_decimal_parameter_with_scale()
+        {
+            Assert.Equal(
+                "'77.7' (Scale = 2)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 2)));
+        }
+
+        [Fact]
+        public void Formats_decimal_parameter_with_precision_and_scale()
+        {
+            Assert.Equal(
+                "'77.7' (Precision = 18) (Scale = 2)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 2)));
+        }
+
+        [Fact]
+        public void Formats_double_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (double)777, true, ParameterDirection.Input, DbType.Double, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_double_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (double)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_float_parameter()
+        {
+            Assert.Equal(
+                "'777'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (float)777, true, ParameterDirection.Input, DbType.Single, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_float_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'777' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", (float)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_Guid_parameter()
+        {
+            Assert.Equal(
+                "'304afb2a-8b8c-49ac-996e-8561f7559a3f'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
+                    true, ParameterDirection.Input, DbType.Guid, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_Guid_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'304afb2a-8b8c-49ac-996e-8561f7559a3f' (DbType = Binary)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
+                    true, ParameterDirection.Input, DbType.Binary, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_object_parameter()
+        {
+            Assert.Equal(
+                "'System.Object'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new object(), true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_object_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'System.Object' (DbType = VarNumeric)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new object(), true, ParameterDirection.Input, DbType.VarNumeric, true, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_DateTime_parameter()
+        {
+            Assert.Equal(
+                "'09/03/1973 00:00:00'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime2, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_DateTime_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'09/03/1973 00:00:00' (DbType = DateTime)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_DateTimeOffset_parameter()
+        {
+            Assert.Equal(
+                "'09/03/1973 00:00:00 -08:00'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
+                    true, ParameterDirection.Input, DbType.DateTimeOffset, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_DateTimeOffset_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'09/03/1973 00:00:00 -08:00' (DbType = Date)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
+                    true, ParameterDirection.Input, DbType.Date, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_TimeSpan_parameter()
+        {
+            Assert.Equal(
+                "'-08:00:00'",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.Time, false, 0, 0, 0)));
+        }
+
+        [Fact]
+        public void Formats_TimeSpan_parameter_with_unusual_type()
+        {
+            Assert.Equal(
+                "'-08:00:00' (DbType = DateTime)",
+                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0)));
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             ComplexNavigationsModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             DataAnnotationModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -27,7 +27,7 @@ FROM [Sample] AS [r]
 WHERE [r].[UniqueNo] = 1
 
 @p2: 1
-@p0: ModifiedData
+@p0: ModifiedData (Nullable = false) (Size = 4000)
 @p1: 00000000-0000-0000-0003-000000000001
 @p3: 00000001-0000-0000-0000-000000000001
 
@@ -37,7 +37,7 @@ WHERE [UniqueNo] = @p2 AND [RowVersion] = @p3;
 SELECT @@ROWCOUNT;
 
 @p2: 1
-@p0: ChangedData
+@p0: ChangedData (Nullable = false) (Size = 4000)
 @p1: 00000000-0000-0000-0002-000000000001
 @p3: 00000001-0000-0000-0000-000000000001
 
@@ -52,8 +52,8 @@ SELECT @@ROWCOUNT;",
         {
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
-            Assert.Equal(@"@p0: 
-@p1: Third
+            Assert.Equal(@"@p0:  (Size = -1) (DbType = String)
+@p1: Third (Nullable = false) (Size = 4000)
 @p2: 00000000-0000-0000-0000-000000000003
 
 SET NOCOUNT ON;
@@ -69,8 +69,8 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.MaxLengthAttribute_throws_while_inserting_value_longer_than_max_length();
 
-            Assert.Equal(@"@p0: Short
-@p1: ValidString
+            Assert.Equal(@"@p0: Short (Size = 4000)
+@p1: ValidString (Nullable = false) (Size = 4000)
 @p2: 00000000-0000-0000-0000-000000000001
 
 SET NOCOUNT ON;
@@ -80,8 +80,8 @@ SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();
 
-@p0: VeryVeryVeryVeryVeryVeryLongString
-@p1: ValidString
+@p0: VeryVeryVeryVeryVeryVeryLongString (Size = 4000)
+@p1: ValidString (Nullable = false) (Size = 4000)
 @p2: 00000000-0000-0000-0000-000000000002
 
 SET NOCOUNT ON;
@@ -97,11 +97,11 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p1: Book1
+            Assert.Contains(@"@p1: Book1 (Nullable = false) (Size = 4000)
 ",
                 Sql);
 
-            Assert.Contains(@"@p1: 
+            Assert.Contains(@"@p1:  (Nullable = false) (Size = -1) (DbType = String)
 ",
                 Sql);
         }
@@ -110,8 +110,8 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
-            Assert.Equal(@"@p0: 
-@p1: ValidString
+            Assert.Equal(@"@p0:  (Size = -1) (DbType = String)
+@p1: ValidString (Nullable = false) (Size = 4000)
 @p2: 00000000-0000-0000-0000-000000000001
 
 SET NOCOUNT ON;
@@ -121,8 +121,8 @@ SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();
 
-@p0: 
-@p1: 
+@p0:  (Size = -1) (DbType = String)
+@p1:  (Nullable = false) (Size = -1) (DbType = String)
 @p2: 00000000-0000-0000-0000-000000000002
 
 SET NOCOUNT ON;
@@ -138,7 +138,7 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.StringLengthAttribute_throws_while_inserting_value_longer_than_max_length();
 
-            Assert.Equal(@"@p0: ValidString
+            Assert.Equal(@"@p0: ValidString (Size = 4000)
 
 SET NOCOUNT ON;
 INSERT INTO [Two] ([Data])
@@ -147,7 +147,7 @@ SELECT [Id], [Timestamp]
 FROM [Two]
 WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
 
-@p0: ValidButLongString
+@p0: ValidButLongString (Size = 4000)
 
 SET NOCOUNT ON;
 INSERT INTO [Two] ([Data])
@@ -171,8 +171,8 @@ FROM [Two] AS [r]
 WHERE [r].[Id] = 1
 
 @p1: 1
-@p0: ModifiedData
-@p2: System.Byte[]
+@p0: ModifiedData (Size = 4000)
+@p2: 0x00000000000007D1 (Size = 8)
 
 SET NOCOUNT ON;
 DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));
@@ -183,8 +183,8 @@ WHERE [Id] = @p1 AND [Timestamp] = @p2;
 SELECT [Timestamp] FROM @inserted0;
 
 @p1: 1
-@p0: ChangedData
-@p2: System.Byte[]
+@p0: ChangedData (Size = 4000)
+@p2: 0x00000000000007D1 (Size = 8)
 
 SET NOCOUNT ON;
 DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             ConcurrencyModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -90,7 +90,7 @@ WHERE [c].[CustomerID] = [o].[CustomerID]",
             base.From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters();
 
             Assert.Equal(
-                @"@p0: London
+                @"@p0: London (Size = 4000)
 @__8__locals1_startDate_1: 01/01/1997 00:00:00
 @__8__locals1_endDate_2: 01/01/1998 00:00:00
 
@@ -135,8 +135,8 @@ WHERE [c].[City] = N'London'",
             base.From_sql_queryable_with_parameters();
 
             Assert.Equal(
-                @"@p0: London
-@p1: Sales Representative
+                @"@p0: London (Size = 4000)
+@p1: Sales Representative (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
                 Sql);
@@ -147,8 +147,8 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
             base.From_sql_queryable_with_parameters_inline();
 
             Assert.Equal(
-                @"@p0: London
-@p1: Sales Representative
+                @"@p0: London (Size = 4000)
+@p1: Sales Representative (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
                 Sql);
@@ -159,7 +159,7 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
             base.From_sql_queryable_with_null_parameter();
 
             Assert.Equal(
-                @"@p0: 
+                @"@p0:  (Nullable = false) (DbType = String)
 
 SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL AND @p0 IS NULL)",
                 Sql);
@@ -170,8 +170,8 @@ SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL 
             base.From_sql_queryable_with_parameters_and_closure();
 
             Assert.Equal(
-                @"@p0: London
-@__contactTitle_1: Sales Representative
+                @"@p0: London (Size = 4000)
+@__contactTitle_1: Sales Representative (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
@@ -197,13 +197,13 @@ SELECT * FROM ""Customers"" WHERE ""City"" = 'Seattle'",
             base.From_sql_queryable_with_parameters_cache_key_includes_parameters();
 
             Assert.Equal(
-                @"@p0: London
-@p1: Sales Representative
+                @"@p0: London (Size = 4000)
+@p1: Sales Representative (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1
 
-@p0: Madrid
-@p1: Accounting Manager
+@p0: Madrid (Size = 4000)
+@p1: Accounting Manager (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
                 Sql);
@@ -311,7 +311,7 @@ WHERE ([c].[ContactName] = [c].[CompanyName]) OR ([c].[ContactName] IS NULL AND 
             base.From_sql_with_dbParameter();
 
             Assert.Equal(
-                @"@city: London
+                @"@city: London (Nullable = false) (Size = 6)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @city",
                 Sql);
@@ -322,13 +322,13 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @city",
             base.From_sql_with_dbParameter_mixed();
 
             Assert.Equal(
-                @"@p0: London
-@title: Sales Representative
+                @"@p0: London (Size = 4000)
+@title: Sales Representative (Nullable = false) (Size = 20)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @title
 
-@city: London
-@p1: Sales Representative
+@city: London (Nullable = false) (Size = 6)
+@p1: Sales Representative (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p1",
                 Sql);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_with_parameter();
 
             Assert.Equal(
-                @"@p0: ALFKI
+                @"@p0: ALFKI (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql);
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_with_parameter_composed();
 
             Assert.Equal(
-                @"@p0: ALFKI
+                @"@p0: ALFKI (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             GearsOfWarModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -572,7 +572,7 @@ WHERE [w].[AmmunitionType] = @__ammunitionType_0",
             base.Where_nullable_enum_with_nullable_parameter();
 
             Assert.Equal(
-                @"@__ammunitionType_0: Cartridge
+                @"@__ammunitionType_0: Cartridge (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -632,8 +632,8 @@ WHERE [w].[IsAutomatic] = 1",
             base.Select_comparison_with_null();
 
             Assert.Equal(
-                @"@__ammunitionType_1: Cartridge
-@__ammunitionType_0: Cartridge
+                @"@__ammunitionType_1: Cartridge (Nullable = true)
+@__ammunitionType_0: Cartridge (Nullable = true)
 
 SELECT [w].[Id], CASE
     WHEN [w].[AmmunitionType] = @__ammunitionType_1
@@ -1031,7 +1031,7 @@ WHERE 'Unknown' = [c].[Location]",
             base.Non_unicode_parameter_is_used_for_non_unicode_column();
 
             Assert.Equal(
-                @"@__value_0: Unknown
+                @"@__value_0: Unknown (Size = 8000) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location]
 FROM [City] AS [c]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             InheritanceRelationshipsModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -299,11 +299,11 @@ FROM (
 FROM [Country] AS [c]
 WHERE [c].[Id] = 1
 
-@p0: Apteryx owenii
+@p0: Apteryx owenii (Nullable = false) (Size = 4000)
 @p1: 1
-@p2: Kiwi
-@p3: Little spotted kiwi
-@p4: 
+@p2: Kiwi (Nullable = false) (Size = 4000)
+@p3: Little spotted kiwi (Size = 4000)
+@p4:  (Size = -1) (DbType = String)
 @p5: True
 @p6: North
 
@@ -315,8 +315,8 @@ SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'
 
-@p1: Apteryx owenii
-@p0: Aquila chrysaetos canadensis
+@p1: Apteryx owenii (Nullable = false) (Size = 4000)
+@p0: Aquila chrysaetos canadensis (Size = 4000)
 
 SET NOCOUNT ON;
 UPDATE [Animal] SET [EagleId] = @p0
@@ -327,7 +327,7 @@ SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'
 
-@p0: Apteryx owenii
+@p0: Apteryx owenii (Nullable = false) (Size = 4000)
 
 SET NOCOUNT ON;
 DELETE FROM [Animal]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                             NullSemanticsModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -666,7 +666,7 @@ WHERE [e].[NullableStringA] IS NULL",
             base.Compare_nullable_with_non_null_parameter_not_equal();
 
             Assert.Equal(
-                @"@__prm_0: Foo
+                @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -756,7 +756,7 @@ WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL",
             base.Where_multiple_ands_with_nullable_parameter_and_constant();
 
             Assert.Equal(
-                @"@__prm3_2: Blah
+                @"@__prm3_2: Blah (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -769,7 +769,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo', @__prm3_2) AND [e].[NullableStringA]
             base.Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized();
 
             Assert.Equal(
-                @"@__prm3_2: Blah
+                @"@__prm3_2: Blah (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -434,8 +434,8 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
                 ctx.Customers.Where(c => c.FirstName == firstName && c.LastName == details.LastName).ToList();
 
                 const string expectedSql
-                    = @"@__firstName_0: Foo
-@__8__locals1_details_LastName_1: Bar
+                    = @"@__firstName_0: Foo (Size = 4000)
+@__8__locals1_details_LastName_1: Bar (Size = 4000)
 
 SELECT [c].[FirstName], [c].[LastName]
 FROM [Customer] AS [c]
@@ -1074,7 +1074,7 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                             contextInitializer(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.Local_array();
 
             Assert.Equal(
-                @"@__get_Item_0: ALFKI
+                @"@__get_Item_0: ALFKI (Size = 4000)
 
 SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -54,7 +54,7 @@ WHERE [c].[CustomerID] = [c].[CustomerID]",
             base.Entity_equality_local();
 
             Assert.Equal(
-                @"@__local_0_CustomerID: ANATR
+                @"@__local_0_CustomerID: ANATR (Nullable = false) (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -463,7 +463,7 @@ ORDER BY [order].[OrderID]",
             base.Where_simple_closure();
 
             Assert.Equal(
-                @"@__city_0: London
+                @"@__city_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -493,13 +493,13 @@ WHERE @__predicate_0 = 1",
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] IS NULL
 
-@__reportsTo_0: 5
+@__reportsTo_0: 5 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__reportsTo_0
 
-@__reportsTo_0: 2
+@__reportsTo_0: 2 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -512,13 +512,13 @@ WHERE [e].[ReportsTo] = @__reportsTo_0",
             base.Where_simple_closure_via_query_cache_nullable_type();
 
             Assert.Equal(
-                @"@__reportsTo_0: 2
+                @"@__reportsTo_0: 2 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__reportsTo_0
 
-@__reportsTo_0: 5
+@__reportsTo_0: 5 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -535,13 +535,13 @@ WHERE [e].[ReportsTo] IS NULL",
             base.Where_new_instance_field_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__InstanceFieldValue_0: London
+                @"@__InstanceFieldValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__InstanceFieldValue_0
 
-@__InstanceFieldValue_0: Seattle
+@__InstanceFieldValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -554,13 +554,13 @@ WHERE [c].[City] = @__InstanceFieldValue_0",
             base.Where_nested_property_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_Nested_InstancePropertyValue_0: London
+                @"@__city_Nested_InstancePropertyValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0
 
-@__city_Nested_InstancePropertyValue_0: Seattle
+@__city_Nested_InstancePropertyValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -573,13 +573,13 @@ WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0",
             base.Where_nested_field_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_Nested_InstanceFieldValue_0: London
+                @"@__city_Nested_InstanceFieldValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0
 
-@__city_Nested_InstanceFieldValue_0: Seattle
+@__city_Nested_InstanceFieldValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -592,13 +592,13 @@ WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0",
             base.Where_static_property_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__StaticPropertyValue_0: London
+                @"@__StaticPropertyValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__StaticPropertyValue_0
 
-@__StaticPropertyValue_0: Seattle
+@__StaticPropertyValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -611,13 +611,13 @@ WHERE [c].[City] = @__StaticPropertyValue_0",
             base.Where_property_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_InstancePropertyValue_0: London
+                @"@__city_InstancePropertyValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_InstancePropertyValue_0
 
-@__city_InstancePropertyValue_0: Seattle
+@__city_InstancePropertyValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -630,13 +630,13 @@ WHERE [c].[City] = @__city_InstancePropertyValue_0",
             base.Where_static_field_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__StaticFieldValue_0: London
+                @"@__StaticFieldValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__StaticFieldValue_0
 
-@__StaticFieldValue_0: Seattle
+@__StaticFieldValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -649,13 +649,13 @@ WHERE [c].[City] = @__StaticFieldValue_0",
             base.Where_field_access_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_InstanceFieldValue_0: London
+                @"@__city_InstanceFieldValue_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_InstanceFieldValue_0
 
-@__city_InstanceFieldValue_0: Seattle
+@__city_InstanceFieldValue_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -668,13 +668,13 @@ WHERE [c].[City] = @__city_InstanceFieldValue_0",
             base.Where_method_call_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__GetCity_0: London
+                @"@__GetCity_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__GetCity_0
 
-@__GetCity_0: Seattle
+@__GetCity_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -687,13 +687,13 @@ WHERE [c].[City] = @__GetCity_0",
             base.Where_method_call_nullable_type_reverse_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_NullableInt_0: 1
+                @"@__city_NullableInt_0: 1 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] > @__city_NullableInt_0
 
-@__city_NullableInt_0: 5
+@__city_NullableInt_0: 5 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -725,13 +725,13 @@ WHERE [e].[ReportsTo] = @__city_Int_0",
             base.Where_simple_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__city_0: London
+                @"@__city_0: London (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_0
 
-@__city_0: Seattle
+@__city_0: Seattle (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -744,7 +744,7 @@ WHERE [c].[City] = @__city_0",
             base.Where_subquery_closure_via_query_cache();
 
             Assert.Equal(
-                @"@__customerID_0: ALFKI
+                @"@__customerID_0: ALFKI (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -753,7 +753,7 @@ WHERE EXISTS (
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] = [c].[CustomerID]))
 
-@__customerID_0: ANATR
+@__customerID_0: ANATR (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1932,7 +1932,7 @@ WHERE 1 = 0",
             base.Where_equals_using_int_overload_on_mismatched_types();
 
             Assert.Equal(
-                @"@__shortPrm_0: 1
+                @"@__shortPrm_0: 1 (DbType = Int32)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -2006,13 +2006,13 @@ WHERE 1 = 0",
             base.Where_equals_on_matched_nullable_int_types();
 
             Assert.Equal(
-                @"@__nullableIntPrm_0: 2
+                @"@__nullableIntPrm_0: 2 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE @__nullableIntPrm_0 = [e].[ReportsTo]
 
-@__nullableIntPrm_0: 2
+@__nullableIntPrm_0: 2 (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -2315,8 +2315,8 @@ WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle', N'Lisboa')",
             base.Where_select_many_or_with_parameter();
 
             Assert.Equal(
-                @"@__london_0: London
-@__lisboa_1: Lisboa
+                @"@__london_0: London (Size = 4000)
+@__lisboa_1: Lisboa (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
@@ -3479,7 +3479,7 @@ WHERE @__flag_0 = 1 AND ([p].[UnitsInStock] >= 20)",
             base.Where_concat_string_int_comparison1();
 
             Assert.Equal(
-                @"@__i_0: 10
+                @"@__i_0: 10 (Size = -1)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -3492,7 +3492,7 @@ WHERE ([c].[CustomerID] + CAST(@__i_0 AS nvarchar(max))) = [c].[CompanyName]",
             base.Where_concat_string_int_comparison2();
 
             Assert.Equal(
-                @"@__i_0: 10
+                @"@__i_0: 10 (Size = -1)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -3505,8 +3505,8 @@ WHERE (CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID]) = [c].[CompanyName]",
             base.Where_concat_string_int_comparison3();
 
             Assert.Equal(
-                @"@__i_0: 10
-@__j_1: 21
+                @"@__i_0: 10 (Size = -1)
+@__j_1: 21 (Size = -1)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -3926,7 +3926,7 @@ WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
             base.String_StartsWith_MethodCall();
 
             Assert.Equal(
-                @"@__LocalMethod1_0: M
+                @"@__LocalMethod1_0: M (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -3972,7 +3972,7 @@ WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
             base.String_EndsWith_MethodCall();
 
             Assert.Equal(
-                @"@__LocalMethod2_0: m
+                @"@__LocalMethod2_0: m (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4024,7 +4024,7 @@ WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
                 entryCount: 34);
 
             Assert.Equal(
-                @"@__LocalMethod1_0: M
+                @"@__LocalMethod1_0: M (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4123,7 +4123,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <> UPPER([c].[CustomerID])
 
-@__ToUpper_0: ALF
+@__ToUpper_0: ALF (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4137,7 +4137,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] > UPPER([c].[CustomerID])
 
-@__ToUpper_0: ALF
+@__ToUpper_0: ALF (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4886,13 +4886,13 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')",
             base.Contains_with_local_list_inline_closure_mix();
 
             Assert.Equal(
-                @"@__id_0: ALFKI
+                @"@__id_0: ALFKI (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ABCDE', @__id_0)
 
-@__id_0: ANATR
+@__id_0: ANATR (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4993,7 +4993,7 @@ WHERE 1 = 1",
             base.Contains_top_level();
 
             Assert.Equal(
-                @"@__p_0: ALFKI
+                @"@__p_0: ALFKI (Size = 4000)
 
 SELECT CASE
     WHEN @__p_0 IN (
@@ -5362,7 +5362,7 @@ FROM [Orders] AS [o]",
 
             Assert.Equal(
                 @"@__NewLine_0: 
-
+ (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -221,7 +221,7 @@ WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
                 entryCount: 34);
 
             Assert.Equal(
-                @"@__LocalMethod1_0: M
+                @"@__LocalMethod1_0: M (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.Executes_stored_procedure_with_parameter();
 
             Assert.Equal(
-                @"@CustomerID: ALFKI
+                @"@CustomerID: ALFKI (Nullable = false) (Size = 5)
 
 [dbo].[CustOrderHist] @CustomerID",
                 Sql);
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.Executes_stored_procedure_with_generated_parameter();
 
             Assert.Equal(
-                @"@p0: ALFKI
+                @"@p0: ALFKI (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql);

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                                 ComplexNavigationsModelInitializer.Seed(context);
                             }
 
-                            TestSqlLoggerFactory.SqlStatements.Clear();
+                            TestSqlLoggerFactory.Reset();
                         }
                     });
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                             DataAnnotationModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -28,19 +28,19 @@ FROM ""Sample"" AS ""r""
 WHERE ""r"".""UniqueNo"" = 1
 LIMIT 1
 
-@p2: 1
-@p0: ModifiedData
-@p1: 00000000-0000-0000-0003-000000000001
-@p3: 00000001-0000-0000-0000-000000000001
+@p2: 1 (DbType = String)
+@p0: ModifiedData (Nullable = false)
+@p1: 00000000-0000-0000-0003-000000000001 (DbType = String)
+@p3: 00000001-0000-0000-0000-000000000001 (DbType = String)
 
 UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
 WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
 SELECT changes();
 
-@p2: 1
-@p0: ChangedData
-@p1: 00000000-0000-0000-0002-000000000001
-@p3: 00000001-0000-0000-0000-000000000001
+@p2: 1 (DbType = String)
+@p0: ChangedData (Nullable = false)
+@p1: 00000000-0000-0000-0002-000000000001 (DbType = String)
+@p3: 00000001-0000-0000-0000-000000000001 (DbType = String)
 
 UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
 WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
@@ -52,9 +52,9 @@ SELECT changes();",
         {
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
-            Assert.Contains(@"@p0: 
-@p1: Third
-@p2: 00000000-0000-0000-0000-000000000003
+            Assert.Contains(@"@p0:  (DbType = String)
+@p1: Third (Nullable = false)
+@p2: 00000000-0000-0000-0000-000000000003 (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);
@@ -77,11 +77,11 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p1: Book1
+            Assert.Contains(@"@p1: Book1 (Nullable = false)
 ",
                 Sql);
 
-            Assert.Contains(@"@p1: 
+            Assert.Contains(@"@p1:  (Nullable = false) (DbType = String)
 ",
                 Sql);
         }
@@ -90,9 +90,9 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p0: 
-@p1: ValidString
-@p2: 00000000-0000-0000-0000-000000000001
+            Assert.Contains(@"@p0:  (DbType = String)
+@p1: ValidString (Nullable = false)
+@p2: 00000000-0000-0000-0000-000000000001 (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);
@@ -101,9 +101,9 @@ FROM ""Sample""
 WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
                 Sql);
 
-            Assert.Contains(@"@p0: 
-@p1: 
-@p2: 00000000-0000-0000-0000-000000000002
+            Assert.Contains(@"@p0:  (DbType = String)
+@p1:  (Nullable = false) (DbType = String)
+@p2: 00000000-0000-0000-0000-000000000002 (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                             ConcurrencyModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GearsOfWarQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GearsOfWarQuerySqliteFixture.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                             GearsOfWarModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceRelationshipsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceRelationshipsQuerySqliteFixture.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                                 InheritanceRelationshipsModelInitializer.Seed(context);
                             }
 
-                            TestSqlLoggerFactory.SqlStatements.Clear();
+                            TestSqlLoggerFactory.Reset();
                         }
                     });
     }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullSemanticsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullSemanticsQuerySqliteFixture.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                             NullSemanticsModelInitializer.Seed(context);
                         }
 
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        TestSqlLoggerFactory.Reset();
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                                 UpdatesModelInitializer.Seed(context);
                             }
 
-                            TestSqlLoggerFactory.SqlStatements.Clear();
+                            TestSqlLoggerFactory.Reset();
                         }
                     });
 


### PR DESCRIPTION
Related to #4952

Also, start logging facets when this is likely to provide value--e.g. log size when not default, nullable when different from nullability of type, etc.