### PR TITLE
Rename PowerShell cmdlets module to EntityFrameworkCore

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psd1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psd1
@@ -1,12 +1,12 @@
 @{
     # Script module or binary module file associated with this manifest
-    ModuleToProcess = 'EntityFramework.psm1'
+    ModuleToProcess = 'EntityFrameworkCore.psm1'
 
     # Version number of this module.
-    ModuleVersion = '7.0'
+    ModuleVersion = '1.0.0'
 
     # ID used to uniquely identify this module
-    GUID = '06e6973e-66a3-4cfc-9a42-3f7d159e945a'
+    GUID = 'c126fb40-c0f1-43ae-8dd0-06bb50512eb2'
 
     # Author of this module
     Author = 'Entity Framework Team'
@@ -58,14 +58,15 @@
 
     # Functions to export from this module
     FunctionsToExport = (
-        'Use-DbContext',
-        'Add-Migration',
-        'Apply-Migration',
-        'Update-Database',
-        'Script-Migration',
-        'Remove-Migration',
         'Enable-Migrations',
-        'Scaffold-DbContext'
+        'Apply-Migration',
+        
+        'Add-Migration',
+        'Remove-Migration',
+        'Scaffold-DbContext',
+        'Script-Migration',
+        'Update-Database',
+        'Use-DbContext'
     )
 
     # Cmdlets to export from this module

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -35,7 +35,7 @@ Register-TabExpansion Use-DbContext @{
     Specifies the environment to use. If omitted, "Development" is used.
 
 .LINK
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Use-DbContext {
     [CmdletBinding(PositionalBinding = $false)]
@@ -106,7 +106,7 @@ Register-TabExpansion Add-Migration @{
 .LINK
     Remove-Migration
     Update-Database
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Add-Migration {
     [CmdletBinding(PositionalBinding = $false)]
@@ -191,7 +191,7 @@ Register-TabExpansion Update-Database @{
 
 .LINK
     Script-Migration
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Update-Database {
     [CmdletBinding(PositionalBinding = $false)]
@@ -275,7 +275,7 @@ Register-TabExpansion Script-Migration @{
 
 .LINK
     Update-Database
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Script-Migration {
     [CmdletBinding(PositionalBinding = $false)]
@@ -373,7 +373,7 @@ Register-TabExpansion Remove-Migration @{
 
 .LINK
     Add-Migration
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Remove-Migration {
     [CmdletBinding(PositionalBinding = $false)]
@@ -458,7 +458,7 @@ Register-TabExpansion Scaffold-DbContext @{
     Specifies the environment to use. If omitted, "Development" is used.
 
 .LINK
-    about_EntityFramework
+    about_EntityFrameworkCore
 #>
 function Scaffold-DbContext {
     [CmdletBinding(PositionalBinding = $false)]
@@ -814,7 +814,7 @@ function InvokeOperation($startupProject, $environment, $project, $operation, $a
         Write-Verbose 'No configuration file found.'
     }
 
-    $domain = [AppDomain]::CreateDomain('EntityFrameworkDesignDomain', $null, $info)
+    $domain = [AppDomain]::CreateDomain('EntityFrameworkCoreDesignDomain', $null, $info)
     if ($dataDirectory) {
         Write-Verbose "Using data directory '$dataDirectory'"
         $domain.SetData('DataDirectory', $dataDirectory)

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/about_EntityFramework.help.txt
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/about_EntityFramework.help.txt
@@ -7,14 +7,14 @@
         |___||_|       /   \\\/\\
 
 TOPIC
-    about_EntityFramework
+    about_EntityFrameworkCore
 
 SHORT DESCRIPTION
-    Provides information about Entity Framework commands.
+    Provides information about Entity Framework Core commands.
 
 LONG DESCRIPTION
-    This topic describes the Entity Framework commands. Entity Framework is Microsoft's recommended data access technology for new
-    applications.
+    This topic describes the Entity Framework Core commands. Entity Framework is Microsoft's recommended data access technology
+    for new applications.
 
     The following Entity Framework cmdlets are included.
 

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
@@ -1,7 +1,7 @@
 param ($installPath, $toolsPath, $package, $project)
 
-if (Get-Module | ? Name -eq EntityFramework) {
-    Remove-Module EntityFramework
+if (Get-Module | ? Name -eq EntityFrameworkCore) {
+    Remove-Module EntityFrameworkCore
 }
 
-Import-Module (Join-Path $PSScriptRoot EntityFramework.psd1) -DisableNameChecking
+Import-Module (Join-Path $PSScriptRoot EntityFrameworkCore.psd1) -DisableNameChecking

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/install.ps1
@@ -1,5 +1,5 @@
 ﻿param ($installPath, $toolsPath, $package, $project)
 
 Write-Host
-Write-Host 'Type ''get-help EntityFramework'' to see all available Entity Framework commands.'
+Write-Host 'Type ''get-help EntityFrameworkCore'' to see all available Entity Framework Core commands.'
 Write-Host


### PR DESCRIPTION
Fix #5145

Related: documenation update https://github.com/aspnet/EntityFramework.Docs/pull/170

~~Btw, we still have "Apply-Migrations" and "Enable-Migrations" in this module. Can we remove these now? Or do we still want them there to throw "obsolete" errors?~~ nevermind. Just realized Brice opened an issue a few hours before me to track this exact question.

cc @rowanmiller @bricelam @divega 