### PR TITLE
RevEng: Do not produce ValueGenerated.Never for PK key columns with default values

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -91,7 +91,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             // TODO use KeyConvention directly to detect when it will be applied
             var pkColumns = table.Columns.Where(c => c.PrimaryKeyOrdinal.HasValue).ToList();
             if (pkColumns.Count != 1
-                || pkColumns[0].SqlServer().IsIdentity)
+                || pkColumns[0].ValueGenerated != null
+                || pkColumns[0].DefaultValue != null)
             {
                 return keyBuilder;
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests.csproj
@@ -77,6 +77,7 @@
     <None Include="ReverseEngineering\Expected\AllFluentApi\OneToOneSeparateFKPrincipal.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="ReverseEngineering\Expected\AllFluentApi\PrimaryKeyWithSequence.expected" />
     <None Include="ReverseEngineering\Expected\AllFluentApi\PropertyConfiguration.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -128,6 +129,7 @@
     <None Include="ReverseEngineering\Expected\Attributes\OneToOneSeparateFKPrincipal.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="ReverseEngineering\Expected\Attributes\PrimaryKeyWithSequence.expected" />
     <None Include="ReverseEngineering\Expected\Attributes\PropertyConfiguration.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -111,7 +111,21 @@ if exists (select * from sysobjects where id = object_id('dbo.FilteredOut') and 
 	drop table "dbo"."FilteredOut"
 GO
 
+if exists (select * from sysobjects where id = object_id('dbo.PrimaryKeyWithSequence') and sysstat & 0xf = 3)
+	drop table "dbo"."PrimaryKeyWithSequence"
+GO
+
+if exists (select * from sysobjects where id = object_id('dbo.PrimaryKeyWithSequenceSequence'))
+	drop sequence "dbo"."PrimaryKeyWithSequenceSequence"
+GO
+
 CREATE TYPE TestTypeAlias FROM nvarchar(max)
+GO
+
+CREATE SEQUENCE PrimaryKeyWithSequenceSequence
+AS int
+START WITH 1
+INCREMENT BY 1
 GO
 
 CREATE TABLE "dbo"."AllDataTypes" (
@@ -452,6 +466,14 @@ CREATE TABLE "FilteredOut" (
 	"FilteredOutID" "int" PRIMARY KEY,
 	"Unused1" nvarchar(20) NOT NULL,
 	"Unused2" "int" NOT NULL,
+)
+
+GO
+
+CREATE TABLE PrimaryKeyWithSequence (
+	PrimaryKeyWithSequenceId int DEFAULT(NEXT VALUE FOR PrimaryKeyWithSequenceSequence),
+	OtherColumn nvarchar (20) NOT NULL,
+	PRIMARY KEY (PrimaryKeyWithSequenceId)
 )
 
 GO

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/PrimaryKeyWithSequence.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/PrimaryKeyWithSequence.expected
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace E2ETest.Namespace
+{
+    public partial class PrimaryKeyWithSequence
+    {
+        public int PrimaryKeyWithSequenceId { get; set; }
+        public string OtherColumn { get; set; }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -388,6 +388,15 @@ namespace E2ETest.Namespace
                     .HasMaxLength(20);
             });
 
+            modelBuilder.Entity<PrimaryKeyWithSequence>(entity =>
+            {
+                entity.Property(e => e.PrimaryKeyWithSequenceId).HasDefaultValueSql("NEXT VALUE FOR [PrimaryKeyWithSequenceSequence]");
+
+                entity.Property(e => e.OtherColumn)
+                    .IsRequired()
+                    .HasMaxLength(20);
+            });
+
             modelBuilder.Entity<PropertyConfiguration>(entity =>
             {
                 entity.HasIndex(e => new { e.A, e.B })
@@ -483,6 +492,8 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.ValueGeneratedOnAddColumn).ValueGeneratedOnAdd();
             });
+
+            modelBuilder.HasSequence<int>("PrimaryKeyWithSequenceSequence");
         }
 
         public virtual DbSet<AllDataTypes> AllDataTypes { get; set; }
@@ -496,6 +507,7 @@ namespace E2ETest.Namespace
         public virtual DbSet<OneToOnePrincipal> OneToOnePrincipal { get; set; }
         public virtual DbSet<OneToOneSeparateFKDependent> OneToOneSeparateFKDependent { get; set; }
         public virtual DbSet<OneToOneSeparateFKPrincipal> OneToOneSeparateFKPrincipal { get; set; }
+        public virtual DbSet<PrimaryKeyWithSequence> PrimaryKeyWithSequence { get; set; }
         public virtual DbSet<PropertyConfiguration> PropertyConfiguration { get; set; }
         public virtual DbSet<SelfReferencing> SelfReferencing { get; set; }
         public virtual DbSet<Test_Spaces_Keywords_Table> Test_Spaces_Keywords_Table { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
@@ -96,6 +96,11 @@ namespace E2ETest.Namespace
                     .HasName("PK_OneToOneSeparateFKPrincipal");
             });
 
+            modelBuilder.Entity<PrimaryKeyWithSequence>(entity =>
+            {
+                entity.Property(e => e.PrimaryKeyWithSequenceId).HasDefaultValueSql("NEXT VALUE FOR [PrimaryKeyWithSequenceSequence]");
+            });
+
             modelBuilder.Entity<PropertyConfiguration>(entity =>
             {
                 entity.HasIndex(e => new { e.A, e.B })
@@ -138,6 +143,8 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.ValueGeneratedOnAddColumn).ValueGeneratedOnAdd();
             });
+
+            modelBuilder.HasSequence<int>("PrimaryKeyWithSequenceSequence");
         }
 
         public virtual DbSet<AllDataTypes> AllDataTypes { get; set; }
@@ -151,6 +158,7 @@ namespace E2ETest.Namespace
         public virtual DbSet<OneToOnePrincipal> OneToOnePrincipal { get; set; }
         public virtual DbSet<OneToOneSeparateFKDependent> OneToOneSeparateFKDependent { get; set; }
         public virtual DbSet<OneToOneSeparateFKPrincipal> OneToOneSeparateFKPrincipal { get; set; }
+        public virtual DbSet<PrimaryKeyWithSequence> PrimaryKeyWithSequence { get; set; }
         public virtual DbSet<PropertyConfiguration> PropertyConfiguration { get; set; }
         public virtual DbSet<SelfReferencing> SelfReferencing { get; set; }
         public virtual DbSet<Test_Spaces_Keywords_Table> Test_Spaces_Keywords_Table { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PrimaryKeyWithSequence.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/PrimaryKeyWithSequence.expected
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace E2ETest.Namespace
+{
+    public partial class PrimaryKeyWithSequence
+    {
+        public int PrimaryKeyWithSequenceId { get; set; }
+        [Required]
+        [MaxLength(20)]
+        public string OtherColumn { get; set; }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests.Reverse
                 "OneToOneSeparateFKPrincipal",
                 "OneToOneFKToUniqueKeyDependent",
                 "OneToOneFKToUniqueKeyPrincipal",
+                "PrimaryKeyWithSequence",
                 "UnmappablePKColumn",
                 "TableWithUnmappablePrimaryKeyColumn",
                 "selfreferencing"
@@ -81,6 +82,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests.Reverse
             "OneToOnePrincipal.expected",
             "OneToOneSeparateFKDependent.expected",
             "OneToOneSeparateFKPrincipal.expected",
+            "PrimaryKeyWithSequence.expected",
             "PropertyConfiguration.expected",
             "SelfReferencing.expected",
             "Test_Spaces_Keywords_Table.expected",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class IdentityColumnWithDefaultValue : TestBase<IdentityColumnWithDefaultValue.BlogContext>
+        public class SequenceKeyColumnWithDefaultValue : TestBase<SequenceKeyColumnWithDefaultValue.BlogContext>
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class ReadOnlyIdentityColumnWithDefaultValue : TestBase<ReadOnlyIdentityColumnWithDefaultValue.BlogContext>
+        public class ReadOnlySequenceKeyColumnWithDefaultValue : TestBase<ReadOnlySequenceKeyColumnWithDefaultValue.BlogContext>
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]
@@ -512,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class ReadOnlyIdentityColumnWithDefaultValueThrows : TestBase<ReadOnlyIdentityColumnWithDefaultValueThrows.BlogContext>
+        public class ReadOnlySequenceKeyColumnWithDefaultValueThrows : TestBase<ReadOnlySequenceKeyColumnWithDefaultValueThrows.BlogContext>
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]


### PR DESCRIPTION
Fix for #5428. For SQL Server We used to generate a `ValueGeneratedNever()` call for single primary key columns which generated their value through a default value which referenced a sequence. Now we no longer do that.

Also renamed some tests which said they were testing identity columns with default values (which is not allowed) - they are actually testing PK columns with a sequence (which is allowed).
