### PR TITLE
Fix to 4355 - Contains on Sub query with entity type generates invalid SQL

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -220,7 +220,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 = handlerContext.SqlTranslatingExpressionVisitorFactory
                     .Create(
                         handlerContext.QueryModelVisitor,
-                        handlerContext.SelectExpression);
+                        handlerContext.SelectExpression, 
+                        bindParentQueries: true);
 
             var itemResultOperator = (ContainsResultOperator)handlerContext.ResultOperator;
 
@@ -303,7 +304,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return TransformClientExpression<bool>(handlerContext);
             }
 
-            return handlerContext.EvalOnClient(requiresClientResultOperator: false);
+            return handlerContext.EvalOnClient();
         }
 
         private static Expression HandleCount(HandlerContext handlerContext)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -677,6 +677,33 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 1);
         }
 
+        [ConditionalFact]
+        public virtual void Where_subquery_on_navigation2()
+        {
+            AssertQuery<Product, OrderDetail, Product>(
+                (ps, ods) => from p in ps
+                             where p.OrderDetails.Contains(ods.OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID).FirstOrDefault())
+                             select p,
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_on_navigation_client_eval()
+        {
+            AssertQuery<Customer, Order, Customer>(
+                (cs, os) => from c in cs
+                            where c.Orders.Select(o => o.OrderID)
+                                .Contains(
+                                    os.OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())
+                            select c,
+                entryCount: 1);
+        }
+
+        private int ClientMethod(int argument)
+        {
+            return argument;
+        }
+
         // issue #4547
         ////[ConditionalFact]
         public virtual void Navigation_in_subquery_referencing_outer_query()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -759,6 +759,48 @@ WHERE EXISTS (
                 Sql);
         }
 
+        public override void Where_subquery_on_navigation2()
+        {
+            base.Where_subquery_on_navigation2();
+
+            Assert.Equal(
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        SELECT [o].[OrderID], [o].[ProductID]
+        FROM [Order Details] AS [o]
+        WHERE [p].[ProductID] = [o].[ProductID]
+    ) AS [t00]
+    INNER JOIN (
+        SELECT TOP(1) [o0].[OrderID], [o0].[ProductID]
+        FROM [Order Details] AS [o0]
+        ORDER BY [o0].[OrderID] DESC, [o0].[ProductID]
+    ) AS [t1] ON ([t00].[OrderID] = [t1].[OrderID]) AND ([t00].[ProductID] = [t1].[ProductID]))",
+                Sql);
+        }
+
+        public override void Where_subquery_on_navigation_client_eval()
+        {
+            base.Where_subquery_on_navigation_client_eval();
+
+            Assert.StartsWith(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+
+SELECT [o3].[OrderID]
+FROM [Orders] AS [o3]
+
+SELECT [o2].[CustomerID], [o2].[OrderID]
+FROM [Orders] AS [o2]
+
+SELECT [o3].[OrderID]
+FROM [Orders] AS [o3]",
+                Sql);
+
+        }
+
         public override void Navigation_in_subquery_referencing_outer_query()
         {
             base.Navigation_in_subquery_referencing_outer_query();


### PR DESCRIPTION
There are several issues around the area:
- in some cases we were forcing client evaluation too aggressively when trying to translate SubQueryExpression. Fix is to relax those criteria, so that more queries that we can translate to SQL will actually be translated.
- in other cases we were not translating expressions that could have been translated because we were not looking into queries processed by parent EntityQueryExpressionVisitor during binding,
- in general, if we were unable to translate the item expression of the contains, we were not applying client-side result operator, which would produce incorrect results when client evaluation was really needed,
- we were handling Contains in two places separately: RelationalResultOperatorHandler and SqlTranslatingExpressionVisitor -> VisitSubquery, now that the RelationalResultOperatorHandler logic has been improved, code in the the other place can be removed.