### PR TITLE
Fix #5439 - Select null coalesce bool throws InvalidCastException

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -104,8 +104,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual string ConcatOperator => "+";
         protected virtual string TrueLiteral => "1";
         protected virtual string FalseLiteral => "0";
-        protected virtual string TypedTrueLiteral => "CAST(1 AS BIT)";
-        protected virtual string TypedFalseLiteral => "CAST(0 AS BIT)";
 
         public virtual Expression VisitSelect(SelectExpression selectExpression)
         {
@@ -824,31 +822,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 _relationalCommandBuilder.AppendLine();
                 _relationalCommandBuilder.Append("THEN ");
 
-                var constantIfTrue = expression.IfTrue as ConstantExpression;
-
-                if (constantIfTrue != null
-                    && constantIfTrue.Type == typeof(bool))
-                {
-                    _relationalCommandBuilder.Append((bool)constantIfTrue.Value ? TypedTrueLiteral : TypedFalseLiteral);
-                }
-                else
-                {
-                    Visit(expression.IfTrue);
-                }
+                Visit(expression.IfTrue);
 
                 _relationalCommandBuilder.Append(" ELSE ");
 
-                var constantIfFalse = expression.IfFalse as ConstantExpression;
-
-                if (constantIfFalse != null
-                    && constantIfFalse.Type == typeof(bool))
-                {
-                    _relationalCommandBuilder.Append((bool)constantIfFalse.Value ? TypedTrueLiteral : TypedFalseLiteral);
-                }
-                else
-                {
-                    Visit(expression.IfFalse);
-                }
+                Visit(expression.IfFalse);
 
                 _relationalCommandBuilder.AppendLine();
             }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -20,6 +20,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private const string DateTimeOffsetFormatConst = @"yyyy-MM-dd HH\:mm\:ss.fffffffzzz";
         private const string DateTimeOffsetFormatStringConst = "TIMESTAMP '{0:" + DateTimeOffsetFormatConst + "}'";
 
+        protected virtual string BoolTrueLiteral => "CAST(1 AS BIT)";
+        protected virtual string BoolFalseLiteral => "CAST(0 AS BIT)";
         protected virtual string FloatingPointFormatString => "{0}E0";
         protected virtual string DecimalFormat => DecimalFormatConst;
         protected virtual string DecimalFormatString => DecimalFormatStringConst;
@@ -174,10 +176,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => builder.AppendFormat(CultureInfo.InvariantCulture, FloatingPointFormatString, value);
 
         protected virtual string GenerateLiteralValue(bool value)
-            => value ? "1" : "0";
+            => value ? BoolTrueLiteral : BoolFalseLiteral;
 
         protected virtual void GenerateLiteralValue([NotNull] StringBuilder builder, bool value)
-            => builder.Append(value ? "1" : "0");
+            => builder.Append(value ? BoolTrueLiteral : BoolFalseLiteral);
 
         protected virtual string GenerateLiteralValue(char value)
             => $"'{value}'";

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/SqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/SqlGeneratorTestBase.cs
@@ -23,14 +23,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
         public virtual void GenerateLiteral_returns_bool_literal_when_true()
         {
             var literal = CreateSqlGenerationHelper().GenerateLiteral(true);
-            Assert.Equal("1", literal);
+            Assert.Equal("CAST(1 AS BIT)", literal);
         }
 
         [Fact]
         public virtual void GenerateLiteral_returns_bool_literal_when_false()
         {
             var literal = CreateSqlGenerationHelper().GenerateLiteral(false);
-            Assert.Equal("0", literal);
+            Assert.Equal("CAST(0 AS BIT)", literal);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -645,7 +645,7 @@ WHERE [w].[AmmunitionType] IS NULL",
 
             Assert.Equal(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[IsAutomatic] = 1
+    WHEN [w].[IsAutomatic] = CAST(1 AS BIT)
     THEN 1 ELSE 0
 END
 FROM [Weapon] AS [w]",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3445,7 +3445,7 @@ WHERE [c].[CustomerID] = N'ALFKI'",
             Assert.Contains(
                     @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE (@__flag_0 = 1 AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> 1) AND ([p].[UnitsInStock] < 20))",
+WHERE (@__flag_0 = 1 AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> CAST(1 AS BIT)) AND ([p].[UnitsInStock] < 20))",
                     Sql);
         }
 
@@ -3459,7 +3459,7 @@ WHERE (@__flag_0 = 1 AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> 1) AND ([
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[ProductID] < @__productId_0) AND ((@__flag_1 = 1 AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_1 <> 1) AND ([p].[UnitsInStock] < 20)))",
+WHERE ([p].[ProductID] < @__productId_0) AND ((@__flag_1 = 1 AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_1 <> CAST(1 AS BIT)) AND ([p].[UnitsInStock] < 20)))",
                     Sql);
         }
 


### PR DESCRIPTION
An exception was being thrown when projecting with null coalesce on a bool value on SQL Server because the generated SQL was not casting the numeric value back into a byte for materialization.
@maumar @anpete 