### PR TITLE
order by subquery and using theninclude throws exception

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -16,6 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static bool IsAliasWithColumnExpression([NotNull] this Expression expression)
             => (expression as AliasExpression)?.Expression is ColumnExpression;
 
+        public static bool IsAliasWithSelectExpression([NotNull] this Expression expression)
+            => (expression as AliasExpression)?.Expression is SelectExpression;
+
         public static bool HasColumnExpression([CanBeNull] this AliasExpression aliasExpression)
             => aliasExpression?.Expression is ColumnExpression;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -428,7 +428,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var needOrderingChanges
                 = innerJoinSelectExpression.OrderBy
-                .Any(x => x.Expression is SelectExpression || x.Expression.IsAliasWithColumnExpression());
+                .Any(x => x.Expression is SelectExpression
+                || x.Expression.IsAliasWithColumnExpression()
+                || x.Expression.IsAliasWithSelectExpression());
 
             var orderings = innerJoinSelectExpression.OrderBy.ToList();
             if (needOrderingChanges)
@@ -445,7 +447,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 if (aliasExpression?.Alias != null)
                 {
                     var columnExpression = aliasExpression.TryGetColumnExpression();
-
                     if (columnExpression != null)
                     {
                         orderingExpression

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -66,7 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
         protected virtual bool Equals([NotNull] ColumnExpression other)
-            => _property.Equals(other._property)
+            => ((_property == null && other._property == null) || (_property != null && _property.Equals(other._property)))
+               && Type == other.Type
                && _tableExpression.Equals(other._tableExpression);
 
         public override bool Equals([CanBeNull] object obj)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -788,22 +788,27 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             if (columnExpression != null)
             {
-                return new ColumnExpression(columnExpression.Name, columnExpression.Property, tableExpression);
+                return columnExpression.Property == null
+                    ? new ColumnExpression(columnExpression.Name, columnExpression.Type, tableExpression)
+                    : new ColumnExpression(columnExpression.Name, columnExpression.Property, tableExpression);
             }
 
             var aliasExpression = expression as AliasExpression;
 
             if (aliasExpression != null)
             {
-                var newAliasExpression
-                    = new AliasExpression(
-                        aliasExpression.Alias,
-                        UpdateColumnExpression(aliasExpression.Expression, tableExpression))
-                    {
-                        SourceMember = aliasExpression.SourceMember
-                    };
+                var selectExpression = aliasExpression.Expression as SelectExpression;
+                if (selectExpression != null)
+                {
+                    return new ColumnExpression(aliasExpression.Alias, selectExpression.Type, tableExpression);
+                }
 
-                return newAliasExpression;
+                return new AliasExpression(
+                    aliasExpression.Alias,
+                    UpdateColumnExpression(aliasExpression.Expression, tableExpression))
+                {
+                    SourceMember = aliasExpression.SourceMember
+                };
             }
 
             switch (expression.NodeType)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -75,6 +75,30 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
+        public virtual void Then_include_collection_order_by_collection_column()
+        {
+            using (var context = CreateContext())
+            {
+                var customer
+                    = context.Set<Customer>()
+                        .Include(c => c.Orders)
+                        .ThenInclude(o => o.OrderDetails)
+                        .Where(c => c.CustomerID.StartsWith("W"))
+                        .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault().OrderDate)
+                        .FirstOrDefault();
+
+                Assert.NotNull(customer);
+                Assert.Equal("WHITC", customer.CustomerID);
+                Assert.NotNull(customer.Orders);
+                Assert.Equal(14, customer.Orders.Count);
+                Assert.NotNull(customer.Orders.First().OrderDetails);
+                Assert.Equal(2, customer.Orders.First().OrderDetails.Count);
+                Assert.NotNull(customer.Orders.Last().OrderDetails);
+                Assert.Equal(3, customer.Orders.Last().OrderDetails.Count);
+            }
+        }
+
+        [Fact]
         public virtual void Then_include_property_expression_invalid()
         {
             var anonymousType = new { Customer = default(Customer), OrderDetails = default(ICollection<OrderDetail>) }.GetType();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -228,7 +228,7 @@ INNER JOIN (
     WHERE [c].[CustomerID] LIKE N'W' + N'%'
     ORDER BY [c0_0] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0_0] DESC, [c0].[CustomerID]",
+ORDER BY [c0].[c0_0] DESC, [c0].[CustomerID]",
                 Sql);
         }
 
@@ -374,8 +374,8 @@ INNER JOIN (
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = N'ALFKI'
     ORDER BY [c0_0], [c].[CustomerID]
-) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0_0], [c0].[CustomerID]",
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[c0_0], [c0].[CustomerID]", 
                 Sql);
         }
 
@@ -1177,6 +1177,56 @@ INNER JOIN (
 ORDER BY [c0].[ContactName], [c0].[CustomerID]",
                     Sql);
             }
+        }
+
+        public override void Then_include_collection_order_by_collection_column()
+        {
+            base.Then_include_collection_order_by_collection_column();
+            Assert.Equal(
+    @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'W' + N'%'
+ORDER BY (
+    SELECT TOP(1) [oo].[OrderDate]
+    FROM [Orders] AS [oo]
+    WHERE [c].[CustomerID] = [oo].[CustomerID]
+    ORDER BY [oo].[OrderDate] DESC
+) DESC, [c].[CustomerID]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT TOP(1) (
+        SELECT TOP(1) [oo].[OrderDate]
+        FROM [Orders] AS [oo]
+        WHERE [c].[CustomerID] = [oo].[CustomerID]
+        ORDER BY [oo].[OrderDate] DESC
+    ) AS [c0_0], [c].[CustomerID]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] LIKE N'W' + N'%'
+    ORDER BY [c0_0] DESC, [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[c0_0] DESC, [c0].[CustomerID], [o].[OrderID]
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+INNER JOIN (
+    SELECT DISTINCT [c0].[c0_0], [c0].[CustomerID], [o].[OrderID]
+    FROM [Orders] AS [o]
+    INNER JOIN (
+        SELECT DISTINCT TOP(1) (
+            SELECT TOP(1) [oo].[OrderDate]
+            FROM [Orders] AS [oo]
+            WHERE [c].[CustomerID] = [oo].[CustomerID]
+            ORDER BY [oo].[OrderDate] DESC
+        ) AS [c0_0], [c].[CustomerID]
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] LIKE N'W' + N'%'
+        ORDER BY [c0_0] DESC, [c].[CustomerID]
+    ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+ORDER BY [o1].[c0_0] DESC, [o1].[CustomerID], [o1].[OrderID]",
+    Sql);
         }
 
         private static string Sql => TestSqlLoggerFactory.Sql;


### PR DESCRIPTION
This contains test case and fix for #5519. This also contains the fixes from #5443.

Fixes bug #5519, #5421, #5038 
Potential fix for #4695

@smitpatel Didn't get any answer on I should include in previous PR or create a new one so created a new one. If I should include them in the other one I will merge and squash them, otherwise I will squash the commits here after #5543 is merged to get a clean PR for the theninclude bug.

ping @anpete 