### PR TITLE
Throw on multiple relationships using one navigation instead of letting the last one win

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -404,17 +404,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             {
                 var entityTypeBuilder = entityType.Builder;
                 var navigationCandidates = GetNavigationCandidates(entityTypeBuilder);
+                var targetType = navigation.GetTargetType().ClrType;
                 var candidate = navigationCandidates.Keys.FirstOrDefault(p => p.Name == navigation.Name);
-                if (candidate == null)
+                if (candidate != null)
                 {
-                    continue;
+                    navigationCandidates = navigationCandidates.Remove(candidate);
+                    SetNavigationCandidates(entityTypeBuilder, navigationCandidates);
                 }
 
-                var candidateTarget = navigationCandidates[candidate];
-                navigationCandidates = navigationCandidates.Remove(candidate);
-                SetNavigationCandidates(entityTypeBuilder, navigationCandidates);
                 // Only run the convention if an ambiguity might have been removed
-                if (navigationCandidates.ContainsValue(candidateTarget))
+                if (navigationCandidates.ContainsValue(targetType))
                 {
                     Apply(entityTypeBuilder);
                 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1220,6 +1220,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("LogIgnoredInclude", "navigation"), navigation);
         }
 
+        /// <summary>
+        /// Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship.
+        /// </summary>
+        public static string ConflictingRelationshipNavigation([CanBeNull] object newPrincipalEntityType, [CanBeNull] object newPrincipalNavigation, [CanBeNull] object newDependentEntityType, [CanBeNull] object newDependentNavigation, [CanBeNull] object existingPrincipalEntityType, [CanBeNull] object existingPrincipalNavigation, [CanBeNull] object existingDependentEntityType, [CanBeNull] object existingDependentNavigation)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingRelationshipNavigation", "newPrincipalEntityType", "newPrincipalNavigation", "newDependentEntityType", "newDependentNavigation", "existingPrincipalEntityType", "existingPrincipalNavigation", "existingDependentEntityType", "existingDependentNavigation"), newPrincipalEntityType, newPrincipalNavigation, newDependentEntityType, newDependentNavigation, existingPrincipalEntityType, existingPrincipalNavigation, existingDependentEntityType, existingDependentNavigation);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -570,4 +570,7 @@
   <data name="LogIgnoredInclude" xml:space="preserve">
     <value>The Include operation for navigation: '{navigation}' was ignored because the target navigation is not reachable in the final query results.</value>
   </data>
+  <data name="ConflictingRelationshipNavigation" xml:space="preserve">
+    <value>Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship.</value>
+  </data>
 </root>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1491,11 +1491,36 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
-            public virtual void Finds_and_removes_existing_one_to_one_relationship()
+            public virtual void Throws_on_existing_one_to_one_relationship()
             {
                 var modelBuilder = HobNobBuilder();
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
+
+                var dependentType = model.FindEntityType(typeof(Hob));
+                var principalType = model.FindEntityType(typeof(Nob));
+
+                Assert.Equal(CoreStrings.ConflictingRelationshipNavigation(
+                    principalType.DisplayName(),
+                    nameof(Nob.Hobs),
+                    dependentType.DisplayName(),
+                    nameof(Hob.Nob),
+                    dependentType.DisplayName(),
+                    nameof(Hob.Nob),
+                    principalType.DisplayName(),
+                    nameof(Nob.Hob)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        modelBuilder.Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)).Message);
+            }
+
+            [Fact]
+            public virtual void Removes_existing_unidirectional_one_to_one_relationship()
+            {
+                var modelBuilder = HobNobBuilder();
+                var model = modelBuilder.Model;
+                modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
+
+                modelBuilder.Entity<Nob>().HasOne<Hob>().WithOne(e => e.Nob);
 
                 var dependentType = model.FindEntityType(typeof(Hob));
                 var principalType = model.FindEntityType(typeof(Nob));


### PR DESCRIPTION
Throw when configuring a bidirectional relationship that conflicts with a previously configured biderectional relationship on one of the navigations.

Fixes #5344