### PR TITLE
[TINY] Revert "Fixing build break"

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -45,6 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         For example, when using Microsoft.EntityFrameworkCore.SqlServer you would call
         ///         <c>collection.AddEntityFrameworkSqlServer()</c>.
         ///     </para>
+        ///     <para>
+        ///         For derived contexts to be registered in the <see cref="IServiceProvider" /> and resolve their services
+        ///         from the <see cref="IServiceProvider" /> you must chain a call to the
+        ///         <see
+        ///             cref="Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}, ServiceLifetime)" />
+        ///         method on the returned <see cref="IServiceCollection" />.
+        ///     </para>
         /// </remarks>
         /// <example>
         ///     <code>


### PR DESCRIPTION
This reverts commit 242d53cfc49dd40932ff3b5cdc0639893d729ad6.

Adding in the missing "Microsoft." that caused the build to break. Not really sure why this only started failing recently since the code has been like this for a while.