### PR TITLE
Remove dependency on Microsoft.DotNet.Cli.Utils

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/ConsoleCommandLogger.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/ConsoleCommandLogger.cs
@@ -1,32 +1,76 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.EntityFrameworkCore.Design.Internal;
+using Newtonsoft.Json;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Cli
 {
     public class ConsoleCommandLogger : CommandLogger
     {
+        private static object _lock = new object();
+        public static bool IsVerbose { get; set; }
+
+        public static void Output(string message)
+        {
+            lock (_lock)
+            {
+                Console.WriteLine(message);
+            }
+        }
+
+        public static void Error(string message)
+        {
+            lock (_lock)
+            {
+                Console.Error.WriteLine(message);
+            }
+        }
+
+        public static void Verbose(string message)
+        {
+            if (IsVerbose)
+            {
+                Output(message);
+            }
+        }
+
+        public static void Json(object result, bool delimited)
+        {
+            lock (_lock)
+            {
+                if (delimited)
+                {
+                    Console.WriteLine("//BEGIN");
+                }
+                Console.WriteLine(JsonConvert.SerializeObject(result, Formatting.Indented));
+                if (delimited)
+                {
+                    Console.WriteLine("//END");
+                }
+            }
+        }
+
         public ConsoleCommandLogger([NotNull] string name)
             : base(name)
         {
         }
 
-        protected override void WriteDebug(string message)
-            => Reporter.Verbose.WriteLine(message.Bold().Black());
+        protected override void WriteTrace(string message)
+            => Verbose(message.Bold().Black());
 
-        protected override void WriteError(string message)
-            => Reporter.Error.WriteLine(message.Bold().Red());
+        protected override void WriteDebug(string message)
+            => Verbose(message.Bold().Black());
 
         protected override void WriteInformation(string message)
-            => Reporter.Error.WriteLine(message);
-
-        protected override void WriteTrace(string message)
-            => Reporter.Verbose.WriteLine(message.Bold().Black());
+            => Output(message);
 
         protected override void WriteWarning(string message)
-            => Reporter.Error.WriteLine(message.Bold().Yellow());
+            => Output(message.Bold().Yellow());
+
+        protected override void WriteError(string message)
+            => Error(message.Bold().Red());
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DatabaseDropCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DatabaseDropCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Cli
@@ -48,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                             return true;
                         }
 
-                        Reporter.Output.WriteLine(
+                        ConsoleCommandLogger.Output(
                             $"Are you sure you want to drop the database '{database}' on server '{dataSource}'? (y/N)");
                         var readedKey = Console.ReadKey().KeyChar;
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DatabaseUpdateCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DatabaseUpdateCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using JetBrains.Annotations;
 using Microsoft.Extensions.CommandLineUtils;
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using JetBrains.Annotations;
 using Microsoft.Extensions.CommandLineUtils;
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextScaffoldCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextScaffoldCommand.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
-using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.CommandLineUtils;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Cli
 {
@@ -55,14 +55,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                 {
                     if (string.IsNullOrEmpty(connection.Value))
                     {
-                        Reporter.Error.WriteLine(("Missing required argument '" + connection.Name + "'").Bold().Red());
+                        ConsoleCommandLogger.Error(("Missing required argument '" + connection.Name + "'").Bold().Red());
                         command.ShowHelp();
 
                         return Task.FromResult(1);
                     }
                     if (string.IsNullOrEmpty(provider.Value))
                     {
-                        Reporter.Error.WriteLine(("Missing required argument '" + provider.Name + "'").Bold().Red());
+                        ConsoleCommandLogger.Error(("Missing required argument '" + provider.Name + "'").Bold().Red());
                         command.ShowHelp();
 
                         return Task.FromResult(1);
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                     dataAnnotations,
                     force);
 
-            Reporter.Error.WriteLine("Done");
+            ConsoleCommandLogger.Output("Done");
 
             return 0;
         }

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/AnsiColorExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/AnsiColorExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System
+{
+    internal static class AnsiColorExtensions
+    {
+        public static string Black(this string text)
+        {
+            return "\x1B[30m" + text + "\x1B[39m";
+        }
+
+        public static string Red(this string text)
+        {
+            return "\x1B[31m" + text + "\x1B[39m";
+        }
+        public static string Green(this string text)
+        {
+            return "\x1B[32m" + text + "\x1B[39m";
+        }
+
+        public static string Yellow(this string text)
+        {
+            return "\x1B[33m" + text + "\x1B[39m";
+        }
+
+        public static string Blue(this string text)
+        {
+            return "\x1B[34m" + text + "\x1B[39m";
+        }
+
+        public static string Magenta(this string text)
+        {
+            return "\x1B[35m" + text + "\x1B[39m";
+        }
+
+        public static string Cyan(this string text)
+        {
+            return "\x1B[36m" + text + "\x1B[39m";
+        }
+
+        public static string White(this string text)
+        {
+            return "\x1B[37m" + text + "\x1B[39m";
+        }
+
+        public static string Bold(this string text)
+        {
+            return "\x1B[1m" + text + "\x1B[22m";
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/CommandLineApplicationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/CommandLineApplicationExtensions.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Extensions.CommandLineUtils
         public static CommandOption JsonOption(this CommandLineApplication command)
             => command.Option("--json", "Use json output");
 
+        public static CommandOption JsonDelimitedOption(this CommandLineApplication command)
+            => command.Option("--json-delimited", "Use json output wrapped by '//BEGIN' and '//END'");
+
         public static CommandOption VersionOption(
             this CommandLineApplication command,
             Func<string> shortFormVersionGetter)

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsRemoveCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsRemoveCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using JetBrains.Annotations;
 using Microsoft.Extensions.CommandLineUtils;
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsScriptCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsScriptCommand.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Cli
@@ -61,15 +61,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
 
             if (string.IsNullOrEmpty(output))
             {
-                Reporter.Output.WriteLine(sql);
+                ConsoleCommandLogger.Output(sql);
             }
             else
             {
-                Reporter.Verbose.WriteLine("Writing SQL script to '" + output + "'".Bold().Black());
+                ConsoleCommandLogger.Verbose("Writing SQL script to '" + output + "'".Bold().Black());
                 File.WriteAllText(output, sql, Encoding.UTF8);
 
-                // TODO https://github.com/aspnet/EntityFramework/issues/4771
-                // Reporter.Error.WriteLine("Done");
+                ConsoleCommandLogger.Output("Done");
             }
 
             return 0;

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/project.json
@@ -12,7 +12,8 @@
     "compile": {
       "include": [
         "../Shared/CodeAnnotations.cs",
-        "../Shared/Check.cs"
+        "../Shared/Check.cs",
+        "../Shared/LoggingExtensions.cs"
       ]
     }
   },
@@ -24,14 +25,9 @@
     }
   },
   "dependencies": {
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Tools.Core": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
-    "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
-    }
+    "Newtonsoft.Json": "8.0.4-*"
   },
   "configurations": {
     "debug_x86": {

--- a/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.csproj
@@ -80,14 +80,16 @@
       <LastGenOutput>Resources.cs</LastGenOutput>
       <CustomToolNamespace>Microsoft.EntityFrameworkCore.Internal</CustomToolNamespace>
     </Content>
-    <Content Include="tools\about_EntityFramework.help.txt" />
+    <Content Include="tools\about_EntityFrameworkCore.help.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build\netcore50\Microsoft.EntityFrameworkCore.Tools.props" />
     <None Include="build\netcore50\Microsoft.EntityFrameworkCore.Tools.targets" />
     <None Include="project.json" />
-    <None Include="tools\EntityFramework.psd1" />
-    <None Include="tools\EntityFramework.psm1" />
+    <None Include="tools\EntityFrameworkCore.PowerShell2.psd1" />
+    <None Include="tools\EntityFrameworkCore.PowerShell2.psm1" />
+    <None Include="tools\EntityFrameworkCore.psd1" />
+    <None Include="tools\EntityFrameworkCore.psm1" />
     <None Include="tools\init.ps1" />
     <None Include="tools\install.ps1" />
   </ItemGroup>

--- a/src/Microsoft.EntityFrameworkCore.Tools/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools/project.json
@@ -15,8 +15,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Tools.Core": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
+    "Microsoft.EntityFrameworkCore.Tools.Core": "1.0.0-*"
   },
   "frameworks": {
     "netcoreapp1.0": {
@@ -27,10 +26,6 @@
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.EntityFrameworkCore.Tools.Cli": "1.0.0-*",
-        "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
-          "version": "1.0.0-*",
-          "type": "build"
-        },
         "Microsoft.NETCore.App": {
           "version": "1.0.0-*",
           "type": "platform"
@@ -40,11 +35,7 @@
     },
     "net451": {
       "dependencies": {
-        "Microsoft.EntityFrameworkCore.Tools.Cli": "1.0.0-*",
-        "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
-          "version": "1.0.0-*",
-          "type": "build"
-        }
+        "Microsoft.EntityFrameworkCore.Tools.Cli": "1.0.0-*"
       },
       "buildOptions": {
         "outputName": "Microsoft.EntityFrameworkCore.Tools",

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -670,14 +670,10 @@ function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
 
     $arguments += $args
 
-    # TODO better json output parsing so we don't need to suppress verbose output
     if ($json) {
-        $arguments += ,"--json"
+        $arguments += ,"--json-delimited"
     } 
-    else {
-        $arguments += ,"--verbose"
-    }
-    
+
     $arguments = $arguments | ? { $_ } | % { if  ($_ -like '* *') { "'$_'" } else { $_ } }
     
     $command = "ef $($arguments -join ' ')"
@@ -696,15 +692,15 @@ function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
             }
             throw $verboseOutput
         }
-        $output = $output -join [Environment]::NewLine
 
-        Write-Debug $output
         if ($json) {
             Write-Debug "Parsing json output"
-            # TODO trim the output of dotnet-build
-            $match = [regex]::Match($output, "\[|\{")
-            $output = $output.Substring($match.Index) | ConvertFrom-Json
+            Write-Debug $($output -join [Environment]::NewLine)
+            $startLine = $output.IndexOf("//BEGIN") + 1
+            $endLine = $output.IndexOf("//END") - 1
+            $output = $output[$startLine..$endLine] -join [Environment]::NewLine | ConvertFrom-Json
         } else {
+            $output = $output -join [Environment]::NewLine
             Write-Verbose $output
         }
 


### PR DESCRIPTION
Replace use of their console reporter with our own
Copy over a few of the command line helpers
Remove use of stderr for normal execution output from dotnet-ef

Fix #5012 
Incidentally fixes #5483 by removing dependency on Microsoft.Extensions.PlatformAbstractions

cc @bricelam 