### PR TITLE
Perf improvement for adding graphs

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         void RecordReferencedUntrackedEntity([NotNull] object referencedEntity, [NotNull] INavigation navigation, [NotNull] InternalEntityEntry referencedFromEntry);
 
-        IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers([NotNull] object referencedEntity);
+        IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers([NotNull] object referencedEntity, bool clear);
 
         InternalEntityEntry GetPrincipal([NotNull] InternalEntityEntry dependentEntry, [NotNull] IForeignKey foreignKey);
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -241,6 +241,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
                 else
                 {
+                    stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
                     _attacher.AttachGraph(newTargetEntry, EntityState.Added);
                 }
             }
@@ -577,7 +578,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 // If the entity was previously referenced while it was still untracked, go back and do the fixup
                 // that we would have done then now that the entity is tracked.
-                foreach (var danglerEntry in stateManager.GetRecordedReferers(entry.Entity))
+                foreach (var danglerEntry in stateManager.GetRecordedReferers(entry.Entity, clear: true))
                 {
                     DelayedFixup(danglerEntry.Item2, danglerEntry.Item1, entry);
                 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -296,13 +296,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             danglers.Add(Tuple.Create(navigation, referencedFromEntry));
         }
 
-        public virtual IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers(object referencedEntity)
+        public virtual IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers(object referencedEntity, bool clear)
         {
             IList<Tuple<INavigation, InternalEntityEntry>> danglers;
             if (_referencedUntrackedEntities.HasValue
                 && _referencedUntrackedEntities.Value.TryGetValue(referencedEntity, out danglers))
             {
-                _referencedUntrackedEntities.Value.Remove(referencedEntity);
+                if (clear)
+                {
+                    _referencedUntrackedEntities.Value.Remove(referencedEntity);
+                }
                 return danglers;
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -321,7 +321,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers(object referencedEntity)
+            public IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers(object referencedEntity, bool clear)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Issue #4831

The problem was in the code that propagates FK values from principal values when adding dependents. It was doing expensive scanning with a TODO: Perf comment. :-) The fix is to reuse the look-aside indexes already created for fixup. For large graphs the perf is now orders of magnitude faster.