### PR TITLE
Issue warning when EF6 commands are also installed in solution

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
@@ -44,6 +44,6 @@ function Enable-Migrations {
 
 function Hint-Upgrade ($name) {
     if (Get-Module | Where { $_.Name -eq 'EntityFramework' }) {
-        Write-Warning "Executing the Entity Framework Core version of '$name'. Run 'EntityFramework\$name' to execute for EF 6 and earlier."
+        Write-Warning "Both Entity Framework Core and Entity Framework 6.x commands are installed. The Entity Framework Core version is executing. You can fully qualify the command to select which one to execute, 'EntityFramework\$name' for EF6.x and 'EntityFrameworkCore\$name' for EF Core."
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
@@ -1,31 +1,49 @@
 $ErrorActionPreference = 'Stop'
 
-$versionErrorMessage = "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+$versionErrorMessage = "EF Core commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
 
 function Add-Migration {
-    throw $versionErrorMessage 
-}
-
-function Enable-Migrations {
-    throw $versionErrorMessage 
+    Hint-Upgrade $MyInvocation.MyCommand
+    throw $versionErrorMessage
 }
 
 function Remove-Migration {
-    throw $versionErrorMessage 
+    throw $versionErrorMessage
 }
 
 function Scaffold-DbContext {
-    throw $versionErrorMessage 
+    throw $versionErrorMessage
 }
 
 function Script-Migration {
-    throw $versionErrorMessage 
+    throw $versionErrorMessage
 }
 
 function Update-Database {
-    throw $versionErrorMessage 
+    Hint-Upgrade $MyInvocation.MyCommand
+    throw $versionErrorMessage
 }
 
 function Use-DbContext {
     throw $versionErrorMessage
+}
+
+#
+# Enable-Migrations (Obsolete)
+#
+
+function Enable-Migrations {
+    # TODO: Link to some docs on the changes to Migrations
+    Hint-Upgrade $MyInvocation.MyCommand
+    Write-Warning 'Enable-Migrations is obsolete. Use Add-Migration to start using Migrations.'
+}
+
+#
+# Private functions
+#
+
+function Hint-Upgrade ($name) {
+    if (Get-Module | Where { $_.Name -eq 'EntityFramework' }) {
+        Write-Warning "Executing the Entity Framework Core version of '$name'. Run 'EntityFramework\$name' to execute for EF 6 and earlier."
+    }
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -119,6 +119,7 @@ function Add-Migration {
         [string] $StartupProject,
         [string] $Environment)
 
+    Hint-Upgrade $MyInvocation.MyCommand
     $values = ProcessCommonParameters $StartupProject $Project $Context
     $dteStartupProject = $values.StartupProject
     $dteProject = $values.Project
@@ -203,6 +204,7 @@ function Update-Database {
         [string] $StartupProject,
         [string] $Environment)
 
+    Hint-Upgrade $MyInvocation.MyCommand
     $values = ProcessCommonParameters $StartupProject $Project $Context
     $dteStartupProject = $values.StartupProject
     $dteProject = $values.Project
@@ -512,6 +514,7 @@ function Scaffold-DbContext {
 
 function Enable-Migrations {
     # TODO: Link to some docs on the changes to Migrations
+    Hint-Upgrade $MyInvocation.MyCommand
     Write-Warning 'Enable-Migrations is obsolete. Use Add-Migration to start using Migrations.'
 }
 
@@ -997,3 +1000,8 @@ function GetProviders($projectName) {
     return Get-Package -ProjectName $projectName | select -ExpandProperty Id
 }
 
+function Hint-Upgrade ($name) {
+    if (Get-Module | ? Name -eq EntityFramework) {
+        Write-Warning "Executing the Entity Framework Core version of '$name'. Run 'EntityFramework\$name' to execute for EF 6 and earlier."
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1002,6 +1002,6 @@ function GetProviders($projectName) {
 
 function Hint-Upgrade ($name) {
     if (Get-Module | ? Name -eq EntityFramework) {
-        Write-Warning "Executing the Entity Framework Core version of '$name'. Run 'EntityFramework\$name' to execute for EF 6 and earlier."
+        Write-Warning "Both Entity Framework Core and Entity Framework 6.x commands are installed. The Entity Framework Core version is executing. You can fully qualify the command to select which one to execute, 'EntityFramework\$name' for EF6.x and 'EntityFrameworkCore\$name' for EF Core."
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/init.ps1
@@ -8,7 +8,7 @@ if ($PSVersionTable.PSVersion.Major -lt 3) {
     # import a "dummy" module that contains matching functions that throw on PS2
     Import-Module ([System.IO.Path]::Combine($toolsPath, "EntityFrameworkCore.PowerShell2.psd1")) -DisableNameChecking
     
-    throw "EF commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
+    throw "EF Core commands do not support PowerShell version $($PSVersionTable.PSVersion). Please upgrade PowerShell to 3.0 or greater and restart Visual Studio."
 } else {
     
     if (Get-Module | ? Name -eq EntityFrameworkCore) {


### PR DESCRIPTION
cc @rowanmiller @bricelam 

When executing any command that also exist in EF6 powershell commands AND the EF6 commands are installed, users will see a warning.

![image](https://cloud.githubusercontent.com/assets/2696087/15623530/90954dac-2429-11e6-9df2-14df5f9669ad.png)

Fix #5145
