### PR TITLE
Fix build break introduced PR #5555

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -79,15 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
                 Sql);
         }
 
-        public override void AddColumnOperation_with_maxLength_overridden()
-        {
-            base.AddColumnOperation_with_maxLength_overridden();
-
-            Assert.Equal(
-                "ALTER TABLE \"Person\" ADD \"Name\" nvarchar(32);" + EOL,
-                Sql);
-        }
-
         public override void AddColumnOperation_with_maxLength_on_derived()
         {
             base.AddColumnOperation_with_maxLength_on_derived();

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -150,6 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
                     Table = "Person",
                     Name = "Name",
                     ClrType = typeof(string),
+                    MaxLength = 30,
                     IsNullable = true
                 });
 
@@ -362,18 +363,21 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
                         new AddColumnOperation
                         {
                             Name = "Id",
+                            Table = "People",
                             ClrType = typeof(int),
                             IsNullable = false
                         },
                         new AddColumnOperation
                         {
                             Name = "EmployerId",
+                            Table = "People",
                             ClrType = typeof(int),
                             IsNullable = true
                         },
                         new AddColumnOperation
                         {
                             Name = "SSN",
+                            Table = "People",
                             ClrType = typeof(string),
                             ColumnType = "char(11)",
                             IsNullable = true

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -106,6 +106,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Migrations
                 Sql);
         }
 
+        public override void AddColumnOperation_with_maxLength_overridden()
+        {
+            base.AddColumnOperation_with_maxLength_overridden();
+
+            Assert.Equal(
+                "ALTER TABLE [Person] ADD [Name] nvarchar(32);" + EOL,
+                Sql);
+        }
+
         public override void AddColumnOperation_with_maxLength_on_derived()
         {
             base.AddColumnOperation_with_maxLength_on_derived();

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -215,6 +215,16 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Migrations
                 Sql);
         }
 
+        public override void AddColumnOperation_with_maxLength_overridden()
+        {
+            base.AddColumnOperation_with_maxLength_overridden();
+
+            // See issue #3698
+            Assert.Equal(
+                "ALTER TABLE \"Person\" ADD \"Name\" TEXT;" + EOL,
+                Sql);
+        }
+
         public override void AddColumnOperation_with_maxLength_on_derived()
         {
             base.AddColumnOperation_with_maxLength_on_derived();


### PR DESCRIPTION
Issues:
1. Missing Table property values in `AddColumnOperation`
2. No `StringTypeMapper` in test code.
3. Use property to get type when property is not null and maxlength is absent or same as max length annotation.