### PR TITLE
[SMALL] Fix to #5499 - Local variable null check incorrectly translates to SQL

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/NullSemanticsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/NullSemanticsQueryTestBase.cs
@@ -504,6 +504,37 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
+        public virtual void Where_comparison_null_constant_and_null_parameter()
+        {
+            string prm = null;
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => prm == null));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => prm != null));
+        }
+
+        [Fact]
+        public virtual void Where_comparison_null_constant_and_nonnull_parameter()
+        {
+            string prm = "Foo";
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => null == prm));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => null != prm));
+        }
+
+        [Fact]
+        public virtual void Where_comparison_nonnull_constant_and_null_parameter()
+        {
+            string prm = null;
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => "Foo" == prm));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => "Foo" != prm));
+        }
+
+        [Fact]
+        public virtual void Where_comparison_null_semantics_optimization_works_with_complex_predicates()
+        {
+            string prm = null;
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => null == prm && e.NullableStringA == prm));
+        }
+
+        [Fact]
         public virtual void Switching_null_semantics_produces_different_cache_entry()
         {
             List<int> results1, results2;
@@ -527,6 +558,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
 
             Assert.True(results1.Count != results2.Count);
+        }
+
+        [Fact]
+        public virtual void Switching_parameter_value_to_null_produces_different_cache_entry()
+        {
+            using (var context = CreateContext())
+            {
+                var prm = "Foo";
+                var query = context.Entities1
+                    .Where(e => prm == "Foo")
+                    .Select(e => e.Id);
+
+                var results1 = query.ToList();
+
+                prm = null;
+
+                var results2 = query.ToList();
+
+                Assert.True(results1.Count != results2.Count);
+            }
         }
 
         [Fact]

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -169,8 +169,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (selectExpression.Predicate != null)
             {
-
-                var constantExpression = selectExpression.Predicate as ConstantExpression;
+                var nullSemanticsPredicate = ApplyNullSemantics(selectExpression.Predicate);
+                var constantExpression = nullSemanticsPredicate as ConstantExpression;
 
                 if (constantExpression == null
                     || !(bool)constantExpression.Value)
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     }
                     else
                     {
-                        Visit(ApplyNullSemantics(selectExpression.Predicate));
+                        Visit(nullSemanticsPredicate);
 
                         if (selectExpression.Predicate is ParameterExpression
                             || selectExpression.Predicate.IsAliasWithColumnExpression()
@@ -237,6 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     ? optimizedExpression
                     : new RelationalNullsExpandingVisitor().Visit(newExpression);
 
+            newExpression = new PredicateReductionExpressionOptimizer().Visit(newExpression);
             newExpression = new PredicateNegationExpressionOptimizer().Visit(newExpression);
             newExpression = new ReducingExpressionVisitor().Visit(newExpression);
 
@@ -823,6 +824,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 Visit(expression.Test);
 
+                if (expression.Test.IsSimpleExpression())
+                {
+                    _relationalCommandBuilder.Append(" = 1");
+                }
+
                 _relationalCommandBuilder.AppendLine();
                 _relationalCommandBuilder.Append("THEN ");
 
@@ -1240,19 +1246,45 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                     object parameterValue;
                     if (parameter != null
-                        && _parameterValues.TryGetValue(parameter.Name, out parameterValue)
-                        && parameterValue == null)
+                        && _parameterValues.TryGetValue(parameter.Name, out parameterValue))
                     {
-                        var columnExpression
-                            = leftExpression.TryGetColumnExpression()
-                              ?? rightExpression.TryGetColumnExpression();
-
-                        if (columnExpression != null)
+                        if (parameterValue == null)
                         {
-                            return
-                                expression.NodeType == ExpressionType.Equal
-                                    ? (Expression)new IsNullExpression(columnExpression)
-                                    : Expression.Not(new IsNullExpression(columnExpression));
+                            var columnExpression
+                                = leftExpression.TryGetColumnExpression()
+                                  ?? rightExpression.TryGetColumnExpression();
+
+                            if (columnExpression != null)
+                            {
+                                return 
+                                    expression.NodeType == ExpressionType.Equal
+                                        ? (Expression)new IsNullExpression(columnExpression)
+                                        : Expression.Not(new IsNullExpression(columnExpression));
+                            }
+                        }
+
+                        var constantExpression
+                            = leftExpression as ConstantExpression
+                                ?? rightExpression as ConstantExpression;
+
+                        if (constantExpression != null)
+                        {
+                            if (parameterValue == null && constantExpression.Value == null)
+                            {
+                                return
+                                    expression.NodeType == ExpressionType.Equal
+                                    ? Expression.Constant(true)
+                                    : Expression.Constant(false);
+                            }
+
+                            if ((parameterValue == null && constantExpression.Value != null)
+                                || (parameterValue != null && constantExpression.Value == null))
+                            {
+                                return
+                                    expression.NodeType == ExpressionType.Equal
+                                    ? Expression.Constant(false)
+                                    : Expression.Constant(true);
+                            }
                         }
                     }
                 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -975,6 +975,59 @@ WHERE ([e].[NullableBoolA] <> [e].[NullableBoolB]) OR @__prm_0 = 1",
                 Sql);
         }
 
+        public override void Where_comparison_null_constant_and_null_parameter()
+        {
+            base.Where_comparison_null_constant_and_null_parameter();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE 1 = 0",
+                Sql);
+        }
+
+        public override void Where_comparison_null_constant_and_nonnull_parameter()
+        {
+            base.Where_comparison_null_constant_and_nonnull_parameter();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE 1 = 0
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]",
+                Sql);
+        }
+
+        public override void Where_comparison_nonnull_constant_and_null_parameter()
+        {
+            base.Where_comparison_nonnull_constant_and_null_parameter();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE 1 = 0
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]",
+                Sql);
+
+        }
+        public override void Where_comparison_null_semantics_optimization_works_with_complex_predicates()
+        {
+            base.Where_comparison_null_semantics_optimization_works_with_complex_predicates();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
         public override void Switching_null_semantics_produces_different_cache_entry()
         {
             base.Switching_null_semantics_produces_different_cache_entry();
@@ -988,6 +1041,24 @@ SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
                 Sql);
+        }
+
+        public override void Switching_parameter_value_to_null_produces_different_cache_entry()
+        {
+            base.Switching_parameter_value_to_null_produces_different_cache_entry();
+
+            Assert.Equal(
+                @"@__prm_0: Foo (Size = 4000)
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE @__prm_0 = N'Foo'
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE 1 = 0",
+                Sql);
+
         }
 
         public override void From_sql_composed_with_relational_null_comparison()


### PR DESCRIPTION
Problem was that during null semantics rewrite we were only looking at constant and column expressions, never taking parameter expressions into account. Those can be optimized out in some cases as we know the value of the parameter during sql generation. Added another pass of PredicateReductionExpressionOptimizer after null semantics is applied to get rid of redundant true/false constants that may now be produced.