### PR TITLE
One-to-many relationships are not ambiguous

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -366,6 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => relatedEntityType.Builder
                 .Relationship(Builder, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Explicit)
+                .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
                 .PrincipalToDependent(navigationName, ConfigurationSource.Explicit);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -50,7 +50,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
 
             if (ConfigurationSource.Convention.Overrides(foreignKey.GetPrincipalEndConfigurationSource())
-                && !foreignKey.IsSelfReferencing())
+                && !foreignKey.IsSelfReferencing()
+                && (foreignKey.PrincipalToDependent?.IsCollection() != true))
             {
                 var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(foreignKey, onDependent: false);
                 if (candidatePropertiesOnPrincipal != null

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (shouldBeUnique.HasValue)
             {
-                builder = builder.IsUnique(shouldBeUnique.Value, configurationSource.Value, false);
+                builder = builder.IsUnique(shouldBeUnique.Value, configurationSource.Value, runConventions: false);
             }
 
             if (navigationToPrincipal != null)

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder=dependentEntityBuilder.Relationship(
+            var relationshipBuilder = dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
                 null,
                 Customer.OrdersProperty.Name,
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.Property("CustomerId", typeof(string), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new [] { "CustomerId"}, ConfigurationSource.Explicit);
+            principalEntityBuilder.PrimaryKey(new[] { "CustomerId" }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
@@ -1307,7 +1307,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Null(derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(string), ConfigurationSource.DataAnnotation));
 
             Assert.Null(entityBuilder.Metadata.FindPrimaryKey());
-            Assert.NotNull(entityBuilder.PrimaryKey(new [] { propertyBuilder.Metadata.Name}, ConfigurationSource.Explicit));
+            Assert.NotNull(entityBuilder.PrimaryKey(new[] { propertyBuilder.Metadata.Name }, ConfigurationSource.Explicit));
             propertyBuilder = derivedEntityBuilder.Property(nameof(SpecialOrder.Specialty), typeof(string), ConfigurationSource.Explicit);
 
             Assert.Same(typeof(string), propertyBuilder.Metadata.ClrType);
@@ -1952,100 +1952,53 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_set_base_type_if_keys_of_lower_or_equal_source()
+        public void Can_only_set_base_type_if_keys_of_data_annotation_or_lower_source()
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.DataAnnotation);
+            derivedEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
 
             Assert.Null(derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedEntityBuilder.Metadata.BaseType);
             Assert.Equal(1, derivedEntityBuilder.Metadata.GetDeclaredKeys().Count());
 
             Assert.Same(derivedEntityBuilder,
-                derivedEntityBuilder.HasBaseType(typeof(Order), ConfigurationSource.DataAnnotation));
+                derivedEntityBuilder.HasBaseType(typeof(Order), ConfigurationSource.Explicit));
             Assert.Same(entityBuilder.Metadata, derivedEntityBuilder.Metadata.BaseType);
             Assert.Equal(0, derivedEntityBuilder.Metadata.GetDeclaredKeys().Count());
         }
 
         [Fact]
-        public void Can_only_set_base_type_if_relationship_with_conflicting_navigation_of_lower_or_equal_source()
+        public void Can_only_set_base_type_if_relationship_with_conflicting_navigation_of_data_annotation_or_lower_source()
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.Relationship(
-                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedDependentEntityBuilder.Relationship(
-                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
             Assert.Equal(1, derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
 
             Assert.Same(derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
+                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit));
             Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
             Assert.Equal(1, dependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
             Assert.Equal(0, derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
         }
 
         [Fact]
-        public void Can_only_set_base_type_if_relationship_with_conflicting_navigation_of_lower_or_equal_source_on_base_type()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.Relationship(
-                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation)
-                .RelatedEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
-
-            var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedDependentEntityBuilder.Relationship(
-                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit)
-                .RelatedEntityTypes(derivedDependentEntityBuilder.Metadata, principalEntityBuilder.Metadata, ConfigurationSource.Explicit);
-
-            Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
-            Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Equal(1, dependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
-
-            Assert.Same(derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
-            Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Equal(0, dependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
-            Assert.Equal(1, derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Count());
-        }
-
-        [Fact]
-        public void Can_only_set_base_type_if_relationship_with_conflicting_foreign_key_of_lower_or_equal_source()
+        public void Can_only_set_base_type_if_relationship_with_conflicting_foreign_key_of_data_annotation_or_lower_source()
         {
             var modelBuilder = CreateModelBuilder();
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
-
-            var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedDependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
-
-            Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
-            Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Equal(1, derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
-
-            Assert.Same(derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
-            Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Equal(1, dependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
-            Assert.Equal(0, derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
-        }
-
-        [Fact]
-        public void Can_only_set_base_type_if_relationship_with_conflicting_foreign_key_of_lower_or_equal_source_on_base_type()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
+            dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Explicit);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedDependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Explicit);
@@ -2055,10 +2008,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(1, derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
 
             Assert.Same(derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
+                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit));
             Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Equal(0, dependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
-            Assert.Equal(1, derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
+            Assert.Equal(1, dependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
+            Assert.Equal(0, derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Count());
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -1636,6 +1636,16 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.False(property.RequiresValueGenerator);
                 Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
             }
+
+            [Fact]
+            public virtual void One_to_many_relationship_has_no_ambiguity_explicit()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<Kappa>().Ignore(e => e.Omegas);
+                modelBuilder.Entity<Kappa>().HasMany<Omega>().WithOne(e => e.Kappa);
+
+                Assert.Equal("KappaId", modelBuilder.Model.FindEntityType(typeof(Omega)).FindNavigation(nameof(Omega.Kappa)).ForeignKey.Properties.Single().Name);
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1975,6 +1975,26 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal(typeof(int?), modelBuilder.Model.FindEntityType(typeof(Order)).FindProperty("MyShadowFk").ClrType);
             }
 
+            [Fact]
+            public virtual void One_to_many_relationship_has_no_ambiguity_convention()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<Alpha>();
+                modelBuilder.Entity<Kappa>();
+
+                Assert.Equal("KappaId", modelBuilder.Model.FindEntityType(typeof(Kappa)).FindNavigation(nameof(Kappa.Omegas)).ForeignKey.Properties.Single().Name);
+            }
+
+            [Fact]
+            public virtual void One_to_many_relationship_has_no_ambiguity_explicit()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<Kappa>().Ignore(e => e.Omegas);
+                modelBuilder.Entity<Omega>().HasOne(e => e.Kappa).WithMany();
+
+                Assert.Equal("KappaId", modelBuilder.Model.FindEntityType(typeof(Omega)).FindNavigation(nameof(Omega.Kappa)).ForeignKey.Properties.Single().Name);
+            }
+
             [Fact] // Issue #3376
             public virtual void Can_use_self_referencing_overlapping_FK_PK()
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
 
@@ -520,6 +521,25 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             [NotMapped]
             public OneToOnePrincipalEntityWithAnnotation NavOneToOnePrincipalEntityWithAnnotation { get; set; }
+        }
+
+        protected class BaseTypeWithKeyAnnotation
+        {
+            [Key]
+            public int MyPrimaryKey { get; set; }
+            public int AnotherKey { get; set; }
+
+            public int ForeignKeyProperty { get; set; }
+
+            [ForeignKey("ForeignKeyProperty")]
+            public PrincipalTypeWithKeyAnnotation Navigation { get; set; }
+        }
+
+        protected class DerivedTypeWithKeyAnnotation : BaseTypeWithKeyAnnotation { }
+
+        protected class PrincipalTypeWithKeyAnnotation
+        {
+            public int Id { get; set; }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -441,8 +441,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
         protected class Kappa
         {
             public int KappaId { get; set; }
+            public int OmegaId { get; set; }
 
             public Alpha Alpha { get; set; }
+            public IList<Omega> Omegas { get; set; }
         }
 
         protected class Iota
@@ -451,6 +453,14 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public Theta FirstTheta { get; set; }
             public Theta SecondTheta { get; set; }
+        }
+
+        protected class Omega
+        {
+            public int Id { get; set; }
+            public int KappaId { get; set; }
+
+            public Kappa Kappa { get; set; }
         }
 
         protected interface IEntityBase


### PR DESCRIPTION
Fix #5406 
Set principal end correctly for explicit
For relationships which has collection navigation, don't check for matching property on principal side.