### PR TITLE
[SMALL] Don't assume failed GetService means no provider

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var service = accessor.Instance.GetService<TService>();
             if (service == null)
             {
-                throw new InvalidOperationException(CoreStrings.NoProviderConfigured);
+                throw new InvalidOperationException(CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).FullName));
             }
 
             return service;

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1244,6 +1244,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("WarningLogTemplate", "message", "eventId"), message, eventId);
         }
 
+        /// <summary>
+        /// Unable to resolve service for type '{service}'. This is often because no database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions&lt;TContext&gt; object in its constructor and passes it to the base constructor for DbContext.
+        /// </summary>
+        public static string NoProviderConfiguredFailedToResolveService([CanBeNull] object service)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoProviderConfiguredFailedToResolveService", "service"), service);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -579,4 +579,7 @@
   <data name="WarningLogTemplate" xml:space="preserve">
     <value>{message} This warning can be configured using DbContextOptionsBuilder.ConfigureWarnings with event id '{eventId}'.</value>
   </data>
+  <data name="NoProviderConfiguredFailedToResolveService" xml:space="preserve">
+    <value>Unable to resolve service for type '{service}'. This is often because no database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions&lt;TContext&gt; object in its constructor and passes it to the base constructor for DbContext.</value>
+  </data>
 </root>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             using (var context = new ConstructorTestContext1A(options))
             {
                 Assert.Equal(
-                    CoreStrings.NoProviderConfigured,
+                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(IRelationalConnection).FullName),
                     Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
             }
         }
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
 
                 Assert.Equal(
-                    CoreStrings.NoProviderConfigured,
+                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(IRelationalConnection).FullName),
                     Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
             }
         }
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             using (var context = new ConstructorTestContextNoConfiguration())
             {
                 Assert.Equal(
-                    CoreStrings.NoProviderConfigured,
+                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(IRelationalConnection).FullName),
                     Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
             }
         }
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfiguration>();
 
                 Assert.Equal(
-                    CoreStrings.NoProviderConfigured,
+                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(IRelationalConnection).FullName),
                     Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
             }
         }


### PR DESCRIPTION
If you call an extension method such as
`DbContext.Database.GetDbConnection()` and we fail to resolve the
connection from DI, then we assumed this was because you did not
register a provider. This is often the case, but it's a misleading error
message if you are just trying to resolve some service that is not
present. Adding some pre-amble to this exception to explain this.

Note we still throw the existing message if we are trying to locate the
configured provider and there is none
(see `DatabaseProviderSelector.SelectServices()`) since we are sure that
is the problem in that case.

Fixes #5500