### PR TITLE
CLI commands: always wrap JSON output with begin/end markers

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/ConsoleCommandLogger.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/ConsoleCommandLogger.cs
@@ -37,19 +37,13 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
             }
         }
 
-        public static void Json(object result, bool delimited)
+        public static void Json(object result)
         {
             lock (_lock)
             {
-                if (delimited)
-                {
-                    Console.WriteLine("//BEGIN");
-                }
+                Console.WriteLine("//BEGIN");
                 Console.WriteLine(JsonUtility.Serialize(result));
-                if (delimited)
-                {
-                    Console.WriteLine("//END");
-                }
+                Console.WriteLine("//END");
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextListCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/DbContextListCommand.cs
@@ -19,7 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                 "-e|--environment <environment>",
                 "The environment to use. If omitted, \"Development\" is used.");
             var json = command.JsonOption();
-            var jsonDelimited = command.JsonDelimitedOption();
 
             command.HelpOption();
             command.VerboseOption();
@@ -27,8 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
             command.OnExecute(
                 () => Execute(commonOptions.Value(),
                     environment.Value(),
-                    json.HasValue() || jsonDelimited.HasValue()
-                        ? ReportJsonResults(jsonDelimited.HasValue())
+                    json.HasValue()
+                        ? (Action<IEnumerable<Type>>)ReportJsonResults
                         : ReportResults)
                 );
         }
@@ -45,13 +44,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
             return 0;
         }
 
-        private static Action<IEnumerable<Type>> ReportJsonResults(bool delimited)
-            => contextTypes =>
-            {
-                var typeNames = contextTypes.Select(t => new { fullName = t.FullName }).ToArray();
+        private static void ReportJsonResults(IEnumerable<Type> contextTypes)
+        {
+            var typeNames = contextTypes.Select(t => new { fullName = t.FullName }).ToArray();
 
-                ConsoleCommandLogger.Json(typeNames, delimited);
-            };
+            ConsoleCommandLogger.Json(typeNames);
+        }
 
         private static void ReportResults(IEnumerable<Type> contextTypes)
         {

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/CommandLineApplicationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/Extensions/CommandLineApplicationExtensions.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Extensions.CommandLineUtils
             => command.Option("-v|--verbose", "Enable verbose output");
 
         public static CommandOption JsonOption(this CommandLineApplication command)
-            => command.Option("--json", "Use json output");
-
-        public static CommandOption JsonDelimitedOption(this CommandLineApplication command)
-            => command.Option("--json-delimited", "Use json output wrapped by '//BEGIN' and '//END'");
+            => command.Option("--json", "Use json output. JSON is wrapped by '//BEGIN' and '//END'");
 
         public static CommandOption VersionOption(
             this CommandLineApplication command,

--- a/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsAddCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Cli/MigrationsAddCommand.cs
@@ -26,7 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                 "-e|--environment <environment>",
                 "The environment to use. If omitted, \"Development\" is used.");
             var json = command.JsonOption();
-            var jsonDelimited = command.JsonDelimitedOption();
 
             command.HelpOption();
             command.VerboseOption();
@@ -47,8 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
                         outputDir.Value(),
                         context.Value(),
                         environment.Value(),
-                        json.HasValue() || jsonDelimited.HasValue()
-                            ? ReportJson(jsonDelimited.HasValue())
+                        json.HasValue()
+                            ? (Action<MigrationFiles>)ReportJson
                             : null);
                 });
         }
@@ -70,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Cli
             return 0;
         }
 
-        private static Action<MigrationFiles> ReportJson(bool delimited)
-            => files => ConsoleCommandLogger.Json(files, delimited);
+        private static void ReportJson(MigrationFiles files)
+            => ConsoleCommandLogger.Json(files);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -674,7 +674,7 @@ function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
     $arguments += $args
 
     if ($json) {
-        $arguments += ,"--json-delimited"
+        $arguments += ,"--json"
     } 
 
     $arguments = $arguments | ? { $_ } | % { if  ($_ -like '* *') { "'$_'" } else { $_ } }
@@ -704,7 +704,6 @@ function InvokeDotNetEf($project, [switch] $json, [switch] $skipBuild) {
             $output = $output[$startLine..$endLine] -join [Environment]::NewLine | ConvertFrom-Json
         } else {
             $output = $output -join [Environment]::NewLine
-            Write-Verbose $output
         }
 
         # dotnet commands log verbose output to stderr


### PR DESCRIPTION
After further review, it appears anyone scripting dotnet-ef with json output always needs to parse out other stdout output anyways. When we trigger a dotnet-build or when we add a migration, there is now other output on stdout. We might as well always log "//BEGIN" and "//END" for json output.

cc @bricelam 