### PR TITLE
Change optimistic concurrency tests to use a shadow property

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
@@ -16,17 +16,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             // TODO: Uncomment when complex types are supported
             //builder.ComplexType<Location>();
+
             modelBuilder.Entity<Chassis>(b =>
                 {
                     b.HasKey(c => c.TeamId);
-                    b.Property(e => e.Version)
+                    b.Property<byte[]>("Version")
                         .ValueGeneratedOnAddOrUpdate()
                         .IsConcurrencyToken();
                 });
 
             modelBuilder.Entity<Driver>(b =>
                 {
-                    b.Property(e => e.Version)
+                    b.Property<byte[]>("Version")
                         .ValueGeneratedOnAddOrUpdate()
                         .IsConcurrencyToken();
                 });
@@ -39,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             // TODO: Complex type
             // .Property(c => c.StorageLocation);
+
             modelBuilder.Ignore<Location>();
 
             modelBuilder.Entity<EngineSupplier>();
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             modelBuilder.Entity<Sponsor>(b =>
                 {
-                    b.Property(e => e.Version)
+                    b.Property<byte[]>("Version")
                         .ValueGeneratedOnAddOrUpdate()
                         .IsConcurrencyToken();
                 });
@@ -75,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             modelBuilder.Entity<Team>(b =>
                 {
-                    b.Property(t => t.Version)
+                    b.Property<byte[]>("Version")
                         .ValueGeneratedOnAddOrUpdate()
                         .IsConcurrencyToken();
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
@@ -5,8 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
 {
     public class Chassis
     {
-        public byte[] Version { get; set; }
-
         public int TeamId { get; set; }
 
         public string Name { get; set; }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
@@ -5,8 +5,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
 {
     public class Driver
     {
-        public byte[] Version { get; set; }
-
         public int Id { get; set; }
 
         public string Name { get; set; }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
@@ -10,9 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
     public class Sponsor
     {
         private readonly ObservableCollection<Team> _teams = new ObservableCollection<Team>();
-
-        public byte[] Version { get; set; }
-
+        
         public int Id { get; set; }
         public string Name { get; set; }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -11,9 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
     {
         private readonly ObservableCollection<Driver> _drivers = new ObservableCollection<Driver>();
         private readonly ObservableCollection<Sponsor> _sponsors = new ObservableCollection<Sponsor>();
-
-        public byte[] Version { get; set; }
-
+        
         public int Id { get; set; }
 
         public string Name { get; set; }


### PR DESCRIPTION
This allows other providers to use different concurrency tokens in the model