### PR TITLE
Migrations: Make MigrationsSqlGenerator.EndStatement batching-friendly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -117,6 +117,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(" ADD ");
 
             ColumnDefinition(operation, model, builder);
+
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             EndStatement(builder);
         }
 
@@ -134,6 +137,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(" ADD ");
 
             ForeignKeyConstraint(operation, model, builder);
+
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             EndStatement(builder);
         }
 
@@ -150,6 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" ADD ");
             PrimaryKeyConstraint(operation, model, builder);
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
             EndStatement(builder);
         }
 
@@ -166,6 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" ADD ");
             UniqueConstraint(operation, model, builder);
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
             EndStatement(builder);
         }
 
@@ -198,6 +206,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema));
 
             SequenceOptions(operation, model, builder);
+
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             EndStatement(builder);
         }
 
@@ -244,6 +255,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (terminate)
             {
+                builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
                 EndStatement(builder);
             }
         }
@@ -280,6 +293,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(SqlGenerationHelper.GenerateLiteral(operation.StartValue));
 
             SequenceOptions(operation, model, builder);
+
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             EndStatement(builder);
         }
 
@@ -330,7 +346,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder.AppendLine();
             }
 
-            builder.Append(")");
+            builder
+                .Append(")")
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -347,7 +365,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER TABLE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" DROP COLUMN ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -364,7 +383,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER TABLE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" DROP CONSTRAINT ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -389,7 +409,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER TABLE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" DROP CONSTRAINT ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -404,7 +425,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .Append("DROP SCHEMA ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -419,7 +441,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .Append("DROP SEQUENCE ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -434,7 +457,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .Append("DROP TABLE ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -451,7 +475,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER TABLE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                 .Append(" DROP CONSTRAINT ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -484,7 +509,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER SEQUENCE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema))
                 .Append(" RESTART WITH ")
-                .Append(SqlGenerationHelper.GenerateLiteral(operation.StartValue));
+                .Append(SqlGenerationHelper.GenerateLiteral(operation.StartValue))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -497,7 +523,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            builder.Append(operation.Sql);
+            builder
+                .Append(operation.Sql)
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder, operation.SuppressTransaction);
         }
@@ -840,9 +868,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             Check.NotNull(builder, nameof(builder));
 
-            builder
-                .AppendLine(SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction);
+            builder.EndCommand(suppressTransaction);
         }
 
         private string ColumnList(string[] columns) => string.Join(", ", columns.Select(SqlGenerationHelper.DelimitIdentifier));

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -80,18 +80,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 model,
                 builder);
 
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             if ((operation.DefaultValue != null)
                 || (operation.DefaultValueSql != null))
             {
                 builder
-                    .AppendLine(";")
                     .Append("ALTER TABLE ")
                     .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                     .Append(" ADD");
                 DefaultValue(operation.DefaultValue, operation.DefaultValueSql, builder);
                 builder
                     .Append(" FOR ")
-                    .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                    .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                    .AppendLine(SqlGenerationHelper.StatementTerminator);
             }
 
             EndStatement(builder);
@@ -126,7 +128,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            var separate = false;
             var name = operation.Name;
             if (operation.NewName != null)
             {
@@ -141,17 +142,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 Rename(qualifiedName.ToString(), operation.NewName, builder);
 
-                separate = true;
                 name = operation.NewName;
             }
 
             if (operation.NewSchema != null)
             {
-                if (separate)
-                {
-                    builder.AppendLine(SqlGenerationHelper.StatementTerminator);
-                }
-
                 Transfer(operation.NewSchema, operation.Schema, name, builder);
             }
 
@@ -166,7 +161,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            var separate = false;
             var name = operation.Name;
             if (operation.NewName != null)
             {
@@ -181,17 +175,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 Rename(qualifiedName.ToString(), operation.NewName, builder);
 
-                separate = true;
                 name = operation.NewName;
             }
 
             if (operation.NewSchema != null)
             {
-                if (separate)
-                {
-                    builder.AppendLine(SqlGenerationHelper.StatementTerminator);
-                }
-
                 Transfer(operation.NewSchema, operation.Schema, name, builder);
             }
 
@@ -223,6 +211,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 }
             }
 
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
+
             EndStatement(builder);
         }
 
@@ -241,7 +231,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(SqlGenerationHelper.GenerateLiteral(operation.Name))
                 .Append(") IS NULL EXEC(N'CREATE SCHEMA ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                .Append("')");
+                .Append("')")
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -262,7 +253,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .EndCommand(suppressTransaction: true)
                 .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                .Append(" SET READ_COMMITTED_SNAPSHOT ON')");
+                .Append(" SET READ_COMMITTED_SNAPSHOT ON')")
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder, suppressTransaction: true);
         }
@@ -283,7 +275,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .AppendLine(SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true)
                 .Append("DROP DATABASE ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder, suppressTransaction: true);
         }
@@ -300,7 +293,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("DROP INDEX ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .Append(" ON ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema));
+                .Append(SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
 
             EndStatement(builder);
         }
@@ -463,6 +457,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     .Append(", ")
                     .Append(SqlGenerationHelper.GenerateLiteral(type));
             }
+
+            builder.AppendLine(SqlGenerationHelper.StatementTerminator);
         }
 
         protected virtual void Transfer(
@@ -479,7 +475,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("ALTER SCHEMA ")
                 .Append(SqlGenerationHelper.DelimitIdentifier(newSchema))
                 .Append(" TRANSFER ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(name, schema));
+                .Append(SqlGenerationHelper.DelimitIdentifier(name, schema))
+                .AppendLine(SqlGenerationHelper.StatementTerminator);
         }
 
         protected override void IndexTraits(MigrationOperation operation, IModel model, MigrationCommandListBuilder builder)


### PR DESCRIPTION
This decouples statement termination from `SqlCommand` creation, and enables us to implement #3928 later.