### PR TITLE
Enforce uniqueness of foreign keys in the database

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -24,6 +24,58 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             TestStore = Fixture.CreateTestStore();
         }
 
+        [ConditionalFact]
+        public virtual void Optional_One_to_one_relationships_are_one_to_one()
+        {
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Single();
+
+                root.OptionalSingle = new OptionalSingle1();
+
+                Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Required_One_to_one_relationships_are_one_to_one()
+        {
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Single();
+
+                root.RequiredSingle = new RequiredSingle1();
+
+                Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_One_to_one_with_AK_relationships_are_one_to_one()
+        {
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Single();
+
+                root.OptionalSingleAk = new OptionalSingleAk1();
+
+                Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Required_One_to_one_with_AK_relationships_are_one_to_one()
+        {
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Single();
+
+                root.RequiredSingleAk = new RequiredSingleAk1();
+
+                Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            }
+        }
+
         [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         [InlineData((int)ChangeMechanism.Principal, true)]

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -800,6 +800,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (Metadata.IsUnique == unique)
             {
                 Metadata.SetIsUnique(unique, configurationSource);
+                Metadata.DeclaringEntityType.FindIndex(Metadata.Properties)?.SetIsUnique(unique, configurationSource);
+
                 return this;
             }
 
@@ -825,6 +827,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             builder.Metadata.SetIsUnique(unique, configurationSource);
+            Metadata.DeclaringEntityType.FindIndex(Metadata.Properties)?.SetIsUnique(unique, configurationSource);
             return builder;
         }
 

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -17,6 +17,30 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         {
         }
 
+        [ConditionalFact]
+        public override void Optional_One_to_one_relationships_are_one_to_one()
+        {
+            // FK uniqueness not enforced in in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_One_to_one_relationships_are_one_to_one()
+        {
+            // FK uniqueness not enforced in in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Optional_One_to_one_with_AK_relationships_are_one_to_one()
+        {
+            // FK uniqueness not enforced in in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_One_to_one_with_AK_relationships_are_one_to_one()
+        {
+            // FK uniqueness not enforced in in-memory database
+        }
+
         [ConditionalTheory]
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {


### PR DESCRIPTION
Issue #5623

The index created to go alongside the relationship was not getting its uniqueness from the relationship, and hence the database created by Migrations did not have a unique index for the FK column. The fix is to propagate uniqueness from the relationship metadata to the index.