### PR TITLE
Fix to #5571 - RC2 Upgrade Eager Loading throw an exception

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -268,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
                     if (columnExpression != null
                         && subquery._projection.OfType<AliasExpression>()
-                            .Any(ae => ae.TryGetColumnExpression()?.Name == columnExpression.Name))
+                            .Any(ae => (ae.Alias ?? ae.TryGetColumnExpression()?.Name) == (aliasExpression.Alias ?? columnExpression.Name)))
                     {
                         aliasExpression.Alias = "c" + columnAliasCounter++;
                     }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -2435,5 +2435,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
             }
         }
+
+        [ConditionalFact]
+        public virtual void Complex_multi_include_with_order_by_and_paging()
+        {
+            List<string> expected;
+
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToOne_Required_FK).ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Required_FK).ThenInclude(e => e.OneToMany_Required)
+                    .ToList()
+                    .OrderBy(t => t.Name)
+                    .Skip(0).Take(10)
+                    .Select(e => e.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Include(e => e.OneToOne_Required_FK).ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Required_FK).ThenInclude(e => e.OneToMany_Required)
+                    .OrderBy(t => t.Name)
+                    .Skip(0).Take(10);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]?.Name));
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1218,6 +1218,59 @@ WHERE (
                 Sql);
         }
 
+
+        public override void Complex_multi_include_with_order_by_and_paging()
+        {
+            base.Complex_multi_include_with_order_by_and_paging();
+
+            Assert.Equal(
+                @"@__p_0: ?
+@__p_1: ?
+
+SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Required_Id] = [e].[Id]
+LEFT JOIN [Level2] AS [l2] ON [l2].[Level1_Required_Id] = [e].[Id]
+ORDER BY [e].[Name], [l].[Id], [l2].[Id]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+
+@__p_0: ?
+@__p_1: ?
+
+SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_InverseId], [l3].[OneToMany_Optional_Self_InverseId], [l3].[OneToMany_Required_InverseId], [l3].[OneToMany_Required_Self_InverseId], [l3].[OneToOne_Optional_PK_InverseId], [l3].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l3]
+INNER JOIN (
+    SELECT DISTINCT [t0].*
+    FROM (
+        SELECT [e].[Name], [l].[Id], [l2].[Id] AS [Id0]
+        FROM [Level1] AS [e]
+        LEFT JOIN [Level2] AS [l] ON [l].[Level1_Required_Id] = [e].[Id]
+        LEFT JOIN [Level2] AS [l2] ON [l2].[Level1_Required_Id] = [e].[Id]
+        ORDER BY [e].[Name], [l].[Id], [l2].[Id]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t0]
+) AS [l20] ON [l3].[OneToMany_Required_InverseId] = [l20].[Id]
+ORDER BY [l20].[Name], [l20].[Id], [l20].[Id0]
+
+@__p_0: ?
+@__p_1: ?
+
+SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l0]
+INNER JOIN (
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT [e].[Name], [l].[Id]
+        FROM [Level1] AS [e]
+        LEFT JOIN [Level2] AS [l] ON [l].[Level1_Required_Id] = [e].[Id]
+        ORDER BY [e].[Name], [l].[Id]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id]
+ORDER BY [l1].[Name], [l1].[Id]",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }


### PR DESCRIPTION
Fixes #5571

Problem was in the way that we were doing PushDownSubquery during complex includes. We were incorrectly overriding aliases of the projection elements from the outer query in some cases. Basically, we were looking at the aliased column name to determine whether it needs to be aliased again. Instead we should look at the alias first, and only if that is not set or it would be a duplicate, we should re-alias the column.