### PR TITLE
Close connection only if opened by QueryingEnumerables

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/AsyncFromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/AsyncFromSqlQueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
@@ -340,6 +341,23 @@ FROM ""Customers""")
                     .ToArrayAsync();
 
                 Assert.Equal(0, actual.Length);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Include_does_not_close_user_opened_connection_for_empty_result()
+        {
+            using (var ctx = CreateContext())
+            {
+                ctx.Database.OpenConnection();
+
+                var query = await ctx.Customers
+                        .Include(v => v.Orders)
+                        .Where(v => v.CustomerID == "MAMRFC")
+                        .ToListAsync();
+
+                Assert.Empty(query);
+                Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
@@ -446,6 +447,23 @@ AND ((UnitsInStock + UnitsOnOrder) < ReorderLevel)")
                 Assert.Equal(3, actual.Length);
                 Assert.True(actual.All(c => c.City == "London"));
                 Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_does_not_close_user_opened_connection_for_empty_result()
+        {
+            using (var ctx = CreateContext())
+            {
+                ctx.Database.OpenConnection();
+
+                var query = ctx.Customers
+                        .Include(v => v.Orders)
+                        .Where(v => v.CustomerID == "MAMRFC")
+                        .ToList();
+
+                Assert.Empty(query);
+                Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -141,12 +141,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (!_disposed)
                 {
-                    _dataReader?.Dispose();
-
                     lock (_queryingEnumerable._relationalQueryContext)
                     {
                         _queryingEnumerable._relationalQueryContext.DeregisterValueBufferCursor(this);
-                        _queryingEnumerable._relationalQueryContext.Connection?.Close();
+                        if (_dataReader != null)
+                        {
+                            _dataReader.Dispose();
+                            _queryingEnumerable._relationalQueryContext.Connection?.Close();
+                        }
                     }
 
                     _disposed = true;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -129,9 +129,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (!_disposed)
                 {
-                    _dataReader?.Dispose();
                     _queryingEnumerable._relationalQueryContext.DeregisterValueBufferCursor(this);
-                    _queryingEnumerable._relationalQueryContext.Connection?.Close();
+                    if (_dataReader != null)
+                    {
+                        _dataReader.Dispose();
+                        _queryingEnumerable._relationalQueryContext.Connection?.Close();
+                    }
 
                     _disposed = true;
                 }


### PR DESCRIPTION
Resolves #5628 
Close the connection only if it was opened by `QueryingEnumerable`