### PR TITLE
Fix to #4739 - UseRowNumberPaging causes NRE in complex queries

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -140,13 +140,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     if (column != null)
                     {
-                        column = new ColumnExpression(column.Name, column.Property, subQuery);
+                        column = new ColumnExpression(alias.Alias ?? column.Name, column.Property, subQuery);
                         alias = new AliasExpression(alias.Alias, column);
                         selectExpression.AddToProjection(alias);
                     }
                     else
                     {
-                        column = new ColumnExpression(alias.Alias, alias.Expression.Type, subQuery);
+                        column = new ColumnExpression(alias?.Alias, alias.Expression.Type, subQuery);
                         selectExpression.AddToProjection(column);
                     }
                 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1001,8 +1001,6 @@ ORDER BY [l1].[Id], [l1].[Id0]",
                 Sql);
         }
 
-        // TODO remove condition when https://github.com/aspnet/EntityFramework/issues/4739 is resolved
-        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Include_with_groupjoin_skip_and_take()
         {
             base.Include_with_groupjoin_skip_and_take();


### PR DESCRIPTION
Fixes #4739 and #5641

Thanks to @sepplK for pointing out where the bug is.

Problem was that during query rewrite for RowNumberPaging, when copying projection elements from the inner query, we were not preserving aliases. Instead were using ColumnExpression (so it would be the projected element in the outer query) even in the alias was explicitly set in the inner SelectExpression. Fix is to try use alias first and only if alias is not set fall-back to using the column name.