### PR TITLE
Query: Convert boolean value to search condition in sql predicates

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -169,31 +169,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (selectExpression.Predicate != null)
             {
-                var nullSemanticsPredicate = ApplyNullSemantics(selectExpression.Predicate);
-                var constantExpression = nullSemanticsPredicate as ConstantExpression;
-
-                if (constantExpression == null
-                    || !(bool)constantExpression.Value)
+                var optimizedPredicate = ApplyOptimizations(selectExpression.Predicate, searchCondition: true);
+                if (optimizedPredicate != null)
                 {
                     _relationalCommandBuilder.AppendLine()
                         .Append("WHERE ");
 
-                    if (constantExpression != null)
-                    {
-                        _relationalCommandBuilder.Append("1 = 0");
-                    }
-                    else
-                    {
-                        Visit(nullSemanticsPredicate);
-
-                        if (selectExpression.Predicate is ParameterExpression
-                            || selectExpression.Predicate.IsAliasWithColumnExpression()
-                            || selectExpression.Predicate is SelectExpression)
-                        {
-                            _relationalCommandBuilder.Append(" = ");
-                            _relationalCommandBuilder.Append(TrueLiteral);
-                        }
-                    }
+                    Visit(optimizedPredicate);
                 }
             }
 
@@ -223,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             return selectExpression;
         }
 
-        private Expression ApplyNullSemantics(Expression expression)
+        private Expression ApplyOptimizations(Expression expression, bool searchCondition)
         {
             var newExpression
                 = new NullComparisonTransformingVisitor(_parametersValues)
@@ -240,13 +222,26 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             newExpression = new PredicateReductionExpressionOptimizer().Visit(newExpression);
             newExpression = new PredicateNegationExpressionOptimizer().Visit(newExpression);
             newExpression = new ReducingExpressionVisitor().Visit(newExpression);
+            var searchConditionTranslatingVisitor = new SearchConditionTranslatingVisitor(searchCondition);
+            newExpression = searchConditionTranslatingVisitor.Visit(newExpression);
+
+            if (searchCondition && !searchConditionTranslatingVisitor.IsSearchCondition(newExpression))
+            {
+                var constantExpression = newExpression as ConstantExpression;
+                if ((constantExpression != null)
+                    && (bool)constantExpression.Value)
+                {
+                    return null;
+                }
+                return Expression.Equal(newExpression, Expression.Constant(true, typeof(bool)));
+            }
 
             return newExpression;
         }
 
         protected virtual void VisitProjection([NotNull] IReadOnlyList<Expression> projections) => VisitJoin(
             projections
-                .Select(ApplyNullSemantics)
+                .Select(e => ApplyOptimizations(e, searchCondition: false))
                 .ToList());
 
         protected virtual void GenerateOrderBy([NotNull] IReadOnlyList<Ordering> orderings)
@@ -438,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _relationalCommandBuilder.AppendLines(sql);
         }
 
-        private RelationalTypeMapping GetTypeMapping(object value) 
+        private RelationalTypeMapping GetTypeMapping(object value)
             => _typeMapping ?? _relationalTypeMapper.GetMappingForValue(value);
 
         public virtual Expression VisitTable(TableExpression tableExpression)
@@ -573,7 +568,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 }
                 else
                 {
-                    _relationalCommandBuilder.Append("1 = 0");
+                    _relationalCommandBuilder.Append("0 = 1");
                 }
             }
             else
@@ -935,12 +930,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     switch (expression.NodeType)
                     {
                         case ExpressionType.Add:
-                            op = expression.Type == typeof(string)
-                                ? " " + ConcatOperator + " "
-                                : " + ";
-                            break;
+                        op = expression.Type == typeof(string)
+                            ? " " + ConcatOperator + " "
+                            : " + ";
+                        break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                        throw new ArgumentOutOfRangeException();
                     }
                 }
 
@@ -1112,24 +1107,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                         return expression;
                     }
 
-                    if (!(expression.Operand is ColumnExpression
-                          || expression.Operand is ParameterExpression
-                          || expression.Operand.IsAliasWithColumnExpression()
-                          || expression.Operand is SelectExpression))
-                    {
-                        _relationalCommandBuilder.Append("NOT (");
+                    _relationalCommandBuilder.Append("NOT (");
 
-                        Visit(expression.Operand);
+                    Visit(expression.Operand);
 
-                        _relationalCommandBuilder.Append(")");
-                    }
-                    else
-                    {
-                        Visit(expression.Operand);
-
-                        _relationalCommandBuilder.Append(" = ");
-                        _relationalCommandBuilder.Append(FalseLiteral);
-                    }
+                    _relationalCommandBuilder.Append(")");
 
                     return expression;
                 }
@@ -1179,7 +1161,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
         public virtual Expression VisitPropertyParameter(PropertyParameterExpression propertyParameterExpression)
         {
-            var parameterName 
+            var parameterName
                 = _sqlGenerationHelper.GenerateParameterName(
                     propertyParameterExpression.PropertyParameterName);
 
@@ -1200,8 +1182,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual RelationalTypeMapping InferTypeMappingFromColumn([NotNull] Expression expression)
         {
             var column = expression.TryGetColumnExpression();
-            return column?.Property != null 
-                ? _relationalTypeMapper.FindMapping(column.Property) 
+            return column?.Property != null
+                ? _relationalTypeMapper.FindMapping(column.Property)
                 : null;
         }
 
@@ -1246,7 +1228,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                             if (columnExpression != null)
                             {
-                                return 
+                                return
                                     expression.NodeType == ExpressionType.Equal
                                         ? (Expression)new IsNullExpression(columnExpression)
                                         : Expression.Not(new IsNullExpression(columnExpression));
@@ -1280,6 +1262,159 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 }
 
                 return base.VisitBinary(expression);
+            }
+        }
+
+        private class SearchConditionTranslatingVisitor : RelinqExpressionVisitor
+        {
+            private bool _isSearchCondition;
+
+            public SearchConditionTranslatingVisitor(bool isSearchCondition)
+            {
+                _isSearchCondition = isSearchCondition;
+            }
+
+            public bool IsSearchCondition(Expression expression)
+            {
+                expression = expression.RemoveConvert();
+
+                if (!(expression is BinaryExpression)
+                    && (expression.NodeType != ExpressionType.Not)
+                    && (expression.NodeType != ExpressionType.Extension))
+                {
+                    return false;
+                }
+
+                if (expression.IsComparisonOperation()
+                    || expression.IsLogicalOperation()
+                    || expression is LikeExpression
+                    || expression is IsNullExpression
+                    || expression is InExpression
+                    || expression is ExistsExpression
+                    || expression is StringCompareExpression)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            protected override Expression VisitBinary(BinaryExpression expression)
+            {
+                if (_isSearchCondition)
+                {
+                    if (expression.IsComparisonOperation())
+                    {
+                        var parentIsSearchCondition = _isSearchCondition;
+                        _isSearchCondition = false;
+                        var left = Visit(expression.Left);
+                        var right = Visit(expression.Right);
+                        _isSearchCondition = parentIsSearchCondition;
+
+                        return Expression.MakeBinary(expression.NodeType, left, right);
+                    }
+                }
+                else
+                {
+                    if (expression.IsLogicalOperation())
+                    {
+                        var parentIsSearchCondition = _isSearchCondition;
+                        _isSearchCondition = true;
+                        var left = Visit(expression.Left);
+                        var right = Visit(expression.Right);
+                        _isSearchCondition = parentIsSearchCondition;
+
+                        return Expression.MakeBinary(expression.NodeType, left, right);
+                    }
+
+                    if (IsSearchCondition(expression))
+                    {
+                        return Expression.Condition(
+                            expression,
+                            Expression.Constant(true, typeof(bool)),
+                            Expression.Constant(false, typeof(bool)));
+                    }
+                }
+
+                return base.VisitBinary(expression);
+            }
+
+            protected override Expression VisitConditional(ConditionalExpression node)
+            {
+                var parentIsSearchCondition = _isSearchCondition;
+                _isSearchCondition = true;
+                var test = Visit(node.Test);
+                _isSearchCondition = false;
+                var ifTrue = Visit(node.IfTrue);
+                var ifFalse = Visit(node.IfFalse);
+                _isSearchCondition = parentIsSearchCondition;
+
+                var newExpression = Expression.Condition(test, ifTrue, ifFalse);
+
+                if (_isSearchCondition)
+                {
+                    return Expression.MakeBinary(
+                        ExpressionType.Equal,
+                        newExpression,
+                        Expression.Constant(true, typeof(bool)));
+                }
+                return newExpression;
+            }
+
+            protected override Expression VisitUnary(UnaryExpression expression)
+            {
+                var operand = Visit(expression.Operand);
+
+                if (_isSearchCondition)
+                {
+                    if (expression.NodeType == ExpressionType.Not
+                        && expression.Operand.IsSimpleExpression())
+                    {
+                        return Expression.Equal(expression.Operand, Expression.Constant(false, typeof(bool)));
+                    }
+                }
+                else
+                {
+                    if (IsSearchCondition(expression))
+                    {
+                        if (expression.NodeType == ExpressionType.Not)
+                        {
+                            return Expression.Condition(
+                                operand,
+                                Expression.Constant(false, typeof(bool)),
+                                Expression.Constant(true, typeof(bool)));
+                        }
+
+                        if (expression.NodeType == ExpressionType.Convert
+                            || expression.NodeType == ExpressionType.ConvertChecked)
+                        {
+                            return Expression.MakeUnary(expression.NodeType, operand, expression.Type);
+                        }
+
+                        return Expression.Condition(
+                            Expression.MakeUnary(expression.NodeType, operand, expression.Type),
+                            Expression.Constant(true, typeof(bool)),
+                            Expression.Constant(false, typeof(bool)));
+                    }
+                }
+
+                return base.VisitUnary(expression);
+            }
+
+            protected override Expression VisitExtension(Expression expression)
+            {
+                if (_isSearchCondition)
+                {
+                    var parentIsSearchCondition = _isSearchCondition;
+                    _isSearchCondition = false;
+                    var newExpression = base.VisitExtension(expression);
+                    _isSearchCondition = parentIsSearchCondition;
+                    return expression is AliasExpression
+                        ? Expression.Equal(newExpression, Expression.Constant(true, typeof(bool)))
+                        : newExpression;
+                }
+
+                return base.VisitExtension(expression);
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1456,6 +1456,39 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Coalesce_operator_in_predicate()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Weapons.Where(w => (bool?)w.IsAutomatic ?? false).ToList();
+
+                Assert.Equal(3, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Coalesce_operator_in_predicate_with_other_conditions()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Weapons.Where(w => w.AmmunitionType == AmmunitionType.Cartridge && ((bool?)w.IsAutomatic ?? false)).ToList();
+
+                Assert.Equal(3, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Coalesce_operator_in_projection_with_other_conditions()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Weapons.Select(w => w.AmmunitionType == AmmunitionType.Cartridge && ((bool?)w.IsAutomatic ?? false)).ToList();
+
+                Assert.Equal(10, query.Count);
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -1851,7 +1851,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Select_anonymous_bool_constant_in_expression()
+        public virtual void Select_anonymous_constant_in_expression()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.CustomerID, Expression = c.CustomerID.Length + 5 }));
@@ -5012,6 +5012,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertQuery<Customer>(customer => customer
                 // ReSharper disable once ConvertConditionalTernaryToNullCoalescing
                 .OrderBy(c => c.Region == null ? "ZZ" : c.Region),
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_comparison_operator()
+        {
+            AssertQuery<Customer>(customer => customer
+                // ReSharper disable once ConvertConditionalTernaryToNullCoalescing
+                .OrderBy(c => c.Region == "ASK"),
                 entryCount: 91);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -827,7 +827,7 @@ FROM [Weapon] AS [w]",
 
             Assert.Equal(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[IsAutomatic] = 0 AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL)
+    WHEN ([w].[IsAutomatic] = 0) AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL)
     THEN N'Yes' ELSE N'No'
 END
 FROM [Weapon] AS [w]",
@@ -840,7 +840,7 @@ FROM [Weapon] AS [w]",
 
             Assert.Equal(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[IsAutomatic] = 0 AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL)
+    WHEN ([w].[IsAutomatic] = 0) AND (([w].[SynergyWithId] = 1) AND [w].[SynergyWithId] IS NOT NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
 FROM [Weapon] AS [w]",
@@ -1455,6 +1455,41 @@ INNER JOIN (
     WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t0] ON [w0].[OwnerFullName] = [t0].[FullName0]
 ORDER BY [t0].[LeaderNickname], [t0].[FullName], [t0].[FullName0]",
+                Sql);
+        }
+
+        public override void Coalesce_operator_in_predicate()
+        {
+            base.Coalesce_operator_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE COALESCE([w].[IsAutomatic], 0) = 1",
+                Sql);
+        }
+
+        public override void Coalesce_operator_in_predicate_with_other_conditions()
+        {
+            base.Coalesce_operator_in_predicate_with_other_conditions();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE ([w].[AmmunitionType] = 1) AND (COALESCE([w].[IsAutomatic], 0) = 1)",
+                Sql);
+        }
+
+        public override void Coalesce_operator_in_projection_with_other_conditions()
+        {
+            base.Coalesce_operator_in_projection_with_other_conditions();
+
+            Assert.Equal(
+                @"SELECT CASE
+    WHEN ([w].[AmmunitionType] = 1) AND (COALESCE([w].[IsAutomatic], 0) = 1)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Weapon] AS [w]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -901,7 +901,7 @@ END) OR [e].[NullableStringC] IS NULL",
             Assert.Equal(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] LIKE (N'%' + [e].[NullableStringB]) + N'%' AND [e].[BoolA] = 1",
+WHERE [e].[NullableStringA] LIKE (N'%' + [e].[NullableStringB]) + N'%' AND ([e].[BoolA] = 1)",
                 Sql);
         }
 
@@ -985,7 +985,7 @@ FROM [NullSemanticsEntity1] AS [e]
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
         }
 
@@ -996,7 +996,7 @@ WHERE 1 = 0",
             Assert.Equal(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 1 = 0
+WHERE 0 = 1
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]",
@@ -1010,7 +1010,7 @@ FROM [NullSemanticsEntity1] AS [e]",
             Assert.Equal(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 1 = 0
+WHERE 0 = 1
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]",
@@ -1056,7 +1056,7 @@ WHERE @__prm_0 = N'Foo'
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
 
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1637,9 +1637,9 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
-        public override void Select_anonymous_bool_constant_in_expression()
+        public override void Select_anonymous_constant_in_expression()
         {
-            base.Select_anonymous_bool_constant_in_expression();
+            base.Select_anonymous_constant_in_expression();
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], LEN([c].[CustomerID]) + 5
@@ -1925,7 +1925,7 @@ WHERE [e].[EmployeeID] = 1",
             Assert.Equal(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
 
             Assert.True(TestSqlLoggerFactory.Log.Contains(
@@ -1971,11 +1971,11 @@ WHERE @__intPrm_0 = [e].[ReportsTo]",
             Assert.Equal(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE 1 = 0
+WHERE 0 = 1
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
 
             Assert.True(TestSqlLoggerFactory.Log.Contains(
@@ -1992,11 +1992,11 @@ WHERE 1 = 0",
             Assert.Equal(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE 1 = 0
+WHERE 0 = 1
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
 
             Assert.True(TestSqlLoggerFactory.Log.Contains(
@@ -2220,7 +2220,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
         }
 
@@ -2231,7 +2231,7 @@ WHERE 1 = 0",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
         }
 
@@ -3417,7 +3417,7 @@ ORDER BY [e1].[EmployeeID]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
         }
 
@@ -3619,7 +3619,7 @@ WHERE [p].[Discontinued] = 1",
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE (([p].[ProductID] > 100) AND [p].[Discontinued] = 1) OR [p].[Discontinued] = 1",
+WHERE (([p].[ProductID] > 100) AND ([p].[Discontinued] = 1)) OR ([p].[Discontinued] = 1)",
                 Sql);
         }
 
@@ -3721,7 +3721,7 @@ END",
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE [p].[Discontinued] = 0 AND ([p].[ProductID] >= 20)",
+WHERE ([p].[Discontinued] = 0) AND ([p].[ProductID] >= 20)",
                 Sql);
         }
 
@@ -3732,7 +3732,7 @@ WHERE [p].[Discontinued] = 0 AND ([p].[ProductID] >= 20)",
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE [p].[Discontinued] = 0 OR ([p].[ProductID] >= 20)",
+WHERE ([p].[Discontinued] = 0) OR ([p].[ProductID] >= 20)",
                 Sql);
         }
 
@@ -3743,7 +3743,7 @@ WHERE [p].[Discontinued] = 0 OR ([p].[ProductID] >= 20)",
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[Discontinued] = 0 AND ([p].[ProductID] < 60)) AND ([p].[ProductID] > 30)",
+WHERE (([p].[Discontinued] = 0) AND ([p].[ProductID] < 60)) AND ([p].[ProductID] > 30)",
                 Sql);
         }
 
@@ -4803,6 +4803,20 @@ END",
                 Sql);
         }
 
+        public override void OrderBy_comparison_operator()
+        {
+            base.OrderBy_comparison_operator();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY CASE
+    WHEN [c].[Region] = N'ASK'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
         public override void Contains_with_subquery()
         {
             base.Contains_with_subquery();
@@ -4978,7 +4992,7 @@ WHERE [c].[CustomerID] IN (N'ALFKI', N'ABC'')); GO; DROP TABLE Orders; GO; --', 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE 1 = 0",
+WHERE 0 = 1",
                 Sql);
         }
 


### PR DESCRIPTION
resolves #5652 
Issue: In Sql bool values and conditions are different concept and implicit conversion is not done. Therefore we need to append `= 1` to where predicate for certain expression. So far we had a list of expression which needed it. `Coalesce` was not part of the list hence incorrect SQL generated.
Solution: Instead of adding another special case for `Coalesce` here we generalized kind of expression which are valid to be used as search condition and generated `= 1` for all the rest. The CFG was taken from T-SQL which covers all cases. (supposedly)
@anpete @maumar @divega 