### PR TITLE
Add R# StringFormatMethod to FromSql

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalQueryableExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalQueryableExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.EntityFrameworkCore
             = typeof(RelationalQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethod(nameof(FromSql));
 
+        [StringFormatMethod("sql")]
         public static IQueryable<TEntity> FromSql<TEntity>(
             [NotNull] this IQueryable<TEntity> source,
             [NotNull] [NotParameterized] string sql,

--- a/src/Shared/CodeAnnotations.cs
+++ b/src/Shared/CodeAnnotations.cs
@@ -79,6 +79,17 @@ namespace JetBrains.Annotations
         public ImplicitUseTargetFlags TargetFlags { get; private set; }
     }
 
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Delegate)]
+    internal sealed class StringFormatMethodAttribute : Attribute
+    {
+        public StringFormatMethodAttribute([NotNull] string formatParameterName)
+        {
+            FormatParameterName = formatParameterName;
+        }
+
+        [NotNull] public string FormatParameterName { get; private set; }
+    }
+
     [Flags]
     internal enum ImplicitUseKindFlags
     {


### PR DESCRIPTION
Add R# StringFormatMethod to FromSql

Will help users avoid parameter referencing and formatting issues in SQL queries passed to FromSql.

A good example is a user having curly braces somewhere in the SQL query, that will make `string.Format` bomb internally.