### PR TITLE
Do state manager fixup for for more single queries

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -160,7 +160,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        bool? SingleQueryMode { get; set; }
+        bool IsSingleQueryMode([NotNull] IEntityType entityType);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void EndSingleQueryMode();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             // can happen without constraints on changing read-only values kicking in
             _stateData.EntityState = EntityState.Detached;
 
-            StateManager.SingleQueryMode = false;
+            StateManager.EndSingleQueryMode();
 
             return true;
         }
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                 }
 
-                StateManager.SingleQueryMode = false;
+                StateManager.EndSingleQueryMode();
             }
 
             if (oldState == newState)
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 StateManager.StopTracking(this);
             }
 
-            StateManager.Notify.StateChanged(this, oldState, StateManager.SingleQueryMode == true, fromQuery: false);
+            StateManager.Notify.StateChanged(this, oldState, StateManager.IsSingleQueryMode(EntityType), fromQuery: false);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             StateManager.Notify.StateChanging(this, EntityState.Unchanged);
             _stateData.EntityState = EntityState.Unchanged;
-            StateManager.Notify.StateChanged(this, EntityState.Detached, StateManager.SingleQueryMode == true, fromQuery: true);
+            StateManager.Notify.StateChanged(this, EntityState.Detached, StateManager.IsSingleQueryMode(EntityType), fromQuery: true);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     _stateData.EntityState = EntityState.Modified;
                 }
 
-                StateManager.SingleQueryMode = false;
+                StateManager.EndSingleQueryMode();
 
                 if (changeState)
                 {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2681,9 +2681,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 var stateManager = context.ChangeTracker.GetInfrastructure();
 
+                stateManager.BeginTrackingQuery();
+
                 stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
                 stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
                 stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+
+                stateManager.BeginTrackingQuery();
 
                 stateManager.StartTrackingFromQuery(productType, new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
                 AssertAllFixedUp(context);
@@ -2695,6 +2699,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 AssertAllFixedUp(context);
                 stateManager.StartTrackingFromQuery(productType, new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
                 AssertAllFixedUp(context);
+
+                stateManager.BeginTrackingQuery();
 
                 stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
                 AssertAllFixedUp(context);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
@@ -1,0 +1,679 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class QueryFixupTest
+    {
+        [Fact]
+        public void Query_dependent_include_principal()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var dependent = context.Set<Product>().Include(e => e.Category).Single();
+                var principal = dependent.Category;
+
+                Assert.Equal(principal.Id, dependent.CategoryId);
+                Assert.Same(principal, dependent.Category);
+                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var principal = context.Set<Category>().Include(e => e.Products).Single();
+                var dependent = principal.Products.Single();
+
+                Assert.Equal(principal.Id, dependent.CategoryId);
+                Assert.Same(principal, dependent.Category);
+                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var dependent = context.Set<ProductDN>().Include(e => e.Category).Single();
+                var principal = dependent.Category;
+
+                Assert.Equal(principal.Id, dependent.CategoryId);
+                Assert.Same(principal, dependent.Category);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var principal = context.Set<CategoryPN>().Include(e => e.Products).Single();
+                var dependent = principal.Products.Single();
+
+                Assert.Equal(principal.Id, dependent.CategoryId);
+                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var dependent = context.Set<Child>().Include(e => e.Parent).Single();
+                var principal = dependent.Parent;
+
+                Assert.Equal(principal.Id, dependent.ParentId);
+                Assert.Same(principal, dependent.Parent);
+                Assert.Same(dependent, principal.Child);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var principal = context.Set<Parent>().Include(e => e.Child).Single();
+                var dependent = principal.Child;
+
+                Assert.Equal(principal.Id, dependent.ParentId);
+                Assert.Same(principal, dependent.Parent);
+                Assert.Same(dependent, principal.Child);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_unidirectional_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var dependent = context.Set<ChildDN>().Include(e => e.Parent).Single();
+                var principal = dependent.Parent;
+
+                Assert.Equal(principal.Id, dependent.ParentId);
+                Assert.Same(principal, dependent.Parent);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_unidirectional_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var principal = context.Set<ParentPN>().Include(e => e.Child).Single();
+                var dependent = principal.Child;
+
+                Assert.Equal(principal.Id, dependent.ParentId);
+                Assert.Same(dependent, principal.Child);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<Widget>().ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Same(principal, dependent.ParentWidget);
+                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_self_ref()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<Widget>().Include(e => e.ParentWidget).ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Same(principal, dependent.ParentWidget);
+                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_self_ref()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<Widget>().Include(e => e.ChildWidgets).ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Same(principal, dependent.ParentWidget);
+                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref_prinipal_nav_only()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<WidgetPN>().ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref_dependent_nav_only()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<WidgetDN>().ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Same(principal, dependent.ParentWidget);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_self_ref_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<WidgetDN>().Include(e => e.ParentWidget).ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Same(principal, dependent.ParentWidget);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_self_ref_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var widgets = context.Set<WidgetPN>().Include(e => e.ChildWidgets).ToList();
+                var dependent = widgets.Single(e => e.Id == 78);
+                var principal = widgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<Smidget>().ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(principal, dependent.ParentSmidget);
+                Assert.Same(dependent, principal.ChildSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_self_ref_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<Smidget>().Include(e => e.ParentSmidget).ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(principal, dependent.ParentSmidget);
+                Assert.Same(dependent, principal.ChildSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_self_ref_one_to_one()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<Smidget>().Include(e => e.ChildSmidget).ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(principal, dependent.ParentSmidget);
+                Assert.Same(dependent, principal.ChildSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref_one_to_one_principal_nav_only()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<SmidgetPN>().ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(dependent, principal.ChildSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_self_ref_one_to_one_dependent_nav_only()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<SmidgetDN>().ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(principal, dependent.ParentSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_self_ref_one_to_one_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<SmidgetDN>().Include(e => e.ParentSmidget).ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(principal, dependent.ParentSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_self_ref_one_to_one_unidirectional()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var smidgets = context.Set<SmidgetPN>().Include(e => e.ChildSmidget).ToList();
+                var dependent = smidgets.Single(e => e.Id == 78);
+                var principal = smidgets.Single(e => e.Id == 77);
+
+                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                Assert.Same(dependent, principal.ChildSmidget);
+            }
+        }
+
+        [Fact]
+        public void Query_dependent_include_principal_multiple_relationsships()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var dependent = context.Set<Post>().Include(e => e.Blog).Single();
+                var principal = dependent.Blog;
+
+                Assert.Equal(principal.Id, dependent.BlogId);
+                Assert.Same(principal, dependent.Blog);
+                Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
+
+                Assert.Equal(dependent.Id, principal.TopPostId);
+                Assert.Same(dependent, principal.TopPost);
+            }
+        }
+
+        [Fact]
+        public void Query_principal_include_dependent_multiple_relationsships()
+        {
+            Seed();
+
+            using (var context = new QueryFixupContext())
+            {
+                var principal = context.Set<Blog>().Include(e => e.Posts).Single();
+                var dependent = principal.Posts.Single();
+
+                Assert.Equal(principal.Id, dependent.BlogId);
+                Assert.Same(principal, dependent.Blog);
+                Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
+
+                Assert.Equal(dependent.Id, principal.TopPostId);
+                Assert.Same(dependent, principal.TopPost);
+            }
+        }
+
+        private static void Seed()
+        {
+            using (var context = new QueryFixupContext())
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                context.AddRange(
+                    new Blog { Id = 77, TopPostId = 78 },
+                    new Post { Id = 78, BlogId = 77 },
+                    new Widget { Id = 77 },
+                    new Widget { Id = 78, ParentWidgetId = 77 },
+                    new WidgetPN { Id = 77 },
+                    new WidgetPN { Id = 78, ParentWidgetId = 77 },
+                    new WidgetDN { Id = 77 },
+                    new WidgetDN { Id = 78, ParentWidgetId = 77 },
+                    new Smidget { Id = 77 },
+                    new Smidget { Id = 78, ParentSmidgetId = 77 },
+                    new SmidgetPN { Id = 77 },
+                    new SmidgetPN { Id = 78, ParentSmidgetId = 77 },
+                    new SmidgetDN { Id = 77 },
+                    new SmidgetDN { Id = 78, ParentSmidgetId = 77 },
+                    new Category { Id = 77 },
+                    new Product { Id = 78, CategoryId = 77 },
+                    new CategoryPN { Id = 77 },
+                    new ProductPN { Id = 78, CategoryId = 77 },
+                    new CategoryDN { Id = 77 },
+                    new ProductDN { Id = 78, CategoryId = 77 },
+                    new Parent { Id = 77 },
+                    new Child { Id = 78, ParentId = 77 },
+                    new ParentPN { Id = 77 },
+                    new ChildPN { Id = 78, ParentId = 77 },
+                    new ParentDN { Id = 77 },
+                    new ChildDN { Id = 78, ParentId = 77 });
+
+                context.SaveChanges();
+            }
+        }
+
+        private class Parent
+        {
+            public int Id { get; set; }
+
+            public Child Child { get; set; }
+        }
+
+        private class Child
+        {
+            public int Id { get; set; }
+            public int ParentId { get; set; }
+
+            public Parent Parent { get; set; }
+        }
+
+        private class ParentPN
+        {
+            public int Id { get; set; }
+
+            public ChildPN Child { get; set; }
+        }
+
+        private class ChildPN
+        {
+            public int Id { get; set; }
+
+            public int ParentId { get; set; }
+        }
+
+        private class ParentDN
+        {
+            public int Id { get; set; }
+        }
+
+        private class ChildDN
+        {
+            public int Id { get; set; }
+            public int ParentId { get; set; }
+
+            public ParentDN Parent { get; set; }
+        }
+
+        private class CategoryDN
+        {
+            public int Id { get; set; }
+        }
+
+        private class ProductDN
+        {
+            public int Id { get; set; }
+            public int CategoryId { get; set; }
+
+            public CategoryDN Category { get; set; }
+        }
+
+        private class CategoryPN
+        {
+            public int Id { get; set; }
+
+            public ICollection<ProductPN> Products { get; } = new List<ProductPN>();
+        }
+
+        private class ProductPN
+        {
+            public int Id { get; set; }
+            public int CategoryId { get; set; }
+        }
+
+        private class Category
+        {
+            public int Id { get; set; }
+
+            public ICollection<Product> Products { get; } = new List<Product>();
+        }
+
+        private class Product
+        {
+            public int Id { get; set; }
+            public int CategoryId { get; set; }
+
+            public Category Category { get; set; }
+        }
+
+        private class Blog
+        {
+            public int Id { get; set; }
+
+            public ICollection<Post> Posts { get; } = new List<Post>();
+
+            public int TopPostId { get; set; }
+            public Post TopPost { get; set; }
+        }
+
+        private class Post
+        {
+            public int Id { get; set; }
+            public int BlogId { get; set; }
+
+            public Blog Blog { get; set; }
+        }
+
+        public class Widget
+        {
+            public int Id { get; set; }
+
+            public int? ParentWidgetId { get; set; }
+            public Widget ParentWidget { get; set; }
+
+            public List<Widget> ChildWidgets { get; set; }
+        }
+
+        public class WidgetPN
+        {
+            public int Id { get; set; }
+
+            public int? ParentWidgetId { get; set; }
+
+            public List<WidgetPN> ChildWidgets { get; set; }
+        }
+
+        public class WidgetDN
+        {
+            public int Id { get; set; }
+
+            public int? ParentWidgetId { get; set; }
+            public WidgetDN ParentWidget { get; set; }
+        }
+
+        public class Smidget
+        {
+            public int Id { get; set; }
+
+            public int? ParentSmidgetId { get; set; }
+            public Smidget ParentSmidget { get; set; }
+            public Smidget ChildSmidget { get; set; }
+        }
+
+        public class SmidgetPN
+        {
+            public int Id { get; set; }
+
+            public int? ParentSmidgetId { get; set; }
+            public SmidgetPN ChildSmidget { get; set; }
+        }
+
+        public class SmidgetDN
+        {
+            public int Id { get; set; }
+
+            public int? ParentSmidgetId { get; set; }
+            public SmidgetDN ParentSmidget { get; set; }
+        }
+
+        private class QueryFixupContext : DbContext
+        {
+            public QueryFixupContext()
+            {
+                ChangeTracker.AutoDetectChangesEnabled = false;
+            }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Widget>()
+                    .HasMany(e => e.ChildWidgets)
+                    .WithOne(e => e.ParentWidget)
+                    .HasForeignKey(e => e.ParentWidgetId);
+
+                modelBuilder.Entity<WidgetPN>()
+                    .HasMany(e => e.ChildWidgets)
+                    .WithOne()
+                    .HasForeignKey(e => e.ParentWidgetId);
+
+                modelBuilder.Entity<WidgetDN>()
+                    .HasOne(e => e.ParentWidget)
+                    .WithMany()
+                    .HasForeignKey(e => e.ParentWidgetId);
+
+                modelBuilder.Entity<Smidget>()
+                    .HasOne(e => e.ParentSmidget)
+                    .WithOne(e => e.ChildSmidget)
+                    .HasForeignKey<Smidget>(e => e.ParentSmidgetId);
+
+                modelBuilder.Entity<SmidgetPN>()
+                    .HasOne<SmidgetPN>()
+                    .WithOne(e => e.ChildSmidget)
+                    .HasForeignKey<SmidgetPN>(e => e.ParentSmidgetId);
+
+                modelBuilder.Entity<SmidgetDN>()
+                    .HasOne(e => e.ParentSmidget)
+                    .WithOne()
+                    .HasForeignKey<SmidgetDN>(e => e.ParentSmidgetId);
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(e => e.Products)
+                    .WithOne(e => e.Category);
+
+                modelBuilder.Entity<CategoryPN>()
+                    .HasMany(e => e.Products)
+                    .WithOne()
+                    .HasForeignKey(e => e.CategoryId);
+
+                modelBuilder.Entity<ProductDN>()
+                    .HasOne(e => e.Category)
+                    .WithMany()
+                    .HasForeignKey(e => e.CategoryId);
+
+                modelBuilder.Entity<Parent>()
+                    .HasOne(e => e.Child)
+                    .WithOne(e => e.Parent)
+                    .HasForeignKey<Child>(e => e.ParentId);
+
+                modelBuilder.Entity<ParentPN>()
+                    .HasOne(e => e.Child)
+                    .WithOne()
+                    .HasForeignKey<ChildPN>(e => e.ParentId);
+
+                modelBuilder.Entity<ChildDN>()
+                    .HasOne(e => e.Parent)
+                    .WithOne()
+                    .HasForeignKey<ChildDN>(e => e.ParentId);
+
+                modelBuilder.Entity<Blog>()
+                    .HasMany(e => e.Posts)
+                    .WithOne(e => e.Blog)
+                    .HasForeignKey(e => e.BlogId);
+
+                modelBuilder.Entity<Blog>()
+                    .HasOne(e => e.TopPost)
+                    .WithOne()
+                    .HasForeignKey<Blog>(e => e.TopPostId);
+            }
+
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase("QueryFixup");
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -87,36 +87,69 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.Null(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
                 new ValueBuffer(new object[] { 77, "Bjork", 777 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
                 new ValueBuffer(new object[] { 78, "Beck", 778 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.False(stateManager.SingleQueryMode);
+            Assert.False(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 79, PrincipalId = 779 },
                 new ValueBuffer(new object[] { 79, "Bush", 779 }));
 
-            Assert.False(stateManager.SingleQueryMode);
+            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+        }
+
+        [Fact]
+        public void State_manager_switches_out_of_single_query_mode_when_entity_has_self_refs()
+        {
+            var model = BuildModel();
+            var widgetType = model.FindEntityType(typeof(Widget));
+            var stateManager = CreateStateManager(model);
+
+            Assert.False(stateManager.IsSingleQueryMode(widgetType));
+
+            stateManager.BeginTrackingQuery();
+
+            Assert.False(stateManager.IsSingleQueryMode(widgetType));
+        }
+
+        [Fact]
+        public void State_manager_switches_out_of_single_query_mode_when_entity_included()
+        {
+            var model = BuildModel();
+            var productType = model.FindEntityType(typeof(Product));
+            var categoryType = model.FindEntityType(typeof(Category));
+            var stateManager = CreateStateManager(model);
+
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+
+            stateManager.BeginTrackingQuery();
+
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+
+            Assert.False(stateManager.IsSingleQueryMode(productType));
+
+            Assert.False(stateManager.IsSingleQueryMode(categoryType));
         }
 
         [Fact]
@@ -126,29 +159,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.Null(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
                 new ValueBuffer(new object[] { 77, "Bjork", 777 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
                 new ValueBuffer(new object[] { 78, "Beck", 778 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             entry.SetEntityState(EntityState.Modified);
 
-            Assert.False(stateManager.SingleQueryMode);
+            Assert.False(stateManager.IsSingleQueryMode(categoryType));
         }
 
         [Fact]
@@ -158,29 +191,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.Null(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
                 new ValueBuffer(new object[] { 77, "Bjork", null }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
                 new ValueBuffer(new object[] { 78, "Beck", 778 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             entry.SetEntityState(EntityState.Added);
 
-            Assert.False(stateManager.SingleQueryMode);
+            Assert.False(stateManager.IsSingleQueryMode(categoryType));
         }
 
         [Fact]
@@ -190,29 +223,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.Null(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
                 new ValueBuffer(new object[] { 77, "Bjork", 777 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
                 new ValueBuffer(new object[] { 78, "Beck", 778 }));
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
 
             stateManager.GetOrCreateEntry(entry.Entity);
 
-            Assert.True(stateManager.SingleQueryMode);
+            Assert.True(stateManager.IsSingleQueryMode(categoryType));
         }
 
         [Fact]
@@ -519,9 +552,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Throws<InvalidOperationException>(() => stateManager.GetOrCreateEntry(new SpecialProduct())).Message);
         }
 
-        private static IStateManager CreateStateManager(IModel model)
+        private static IStateManager CreateStateManager(IModel model) 
+            => TestHelpers.Instance.CreateContextServices(model).GetRequiredService<IStateManager>();
+
+        public class Widget
         {
-            return TestHelpers.Instance.CreateContextServices(model).GetRequiredService<IStateManager>();
+            public int Id { get; set; }
+
+            public int? ParentWidgetId { get; set; }
+            public Widget ParentWidget { get; set; }
+
+            public List<Widget> ChildWidgets { get; set; }
         }
 
         private class Category
@@ -556,8 +597,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             builder.Entity<Product>().HasOne<Category>().WithOne()
                 .HasForeignKey<Product>(e => e.DependentId)
                 .HasPrincipalKey<Category>(e => e.PrincipalId);
+
+            builder.Entity<Widget>()
+                .HasOne(e => e.ParentWidget)
+                .WithMany(e => e.ChildWidgets)
+                .HasForeignKey(e => e.ParentWidgetId);
+
             builder.Entity<Category>();
+
             builder.Entity<Dogegory>();
+
             builder.Entity("Location", eb =>
                 {
                     eb.Property<int>("Id");

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -218,7 +218,12 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public IEnumerable<InternalEntityEntry> InternalEntries { get; set; }
             public bool SaveChangesCalled { get; set; }
             public bool SaveChangesAsyncCalled { get; set; }
-            public virtual bool? SingleQueryMode { get; set; }
+
+            public bool IsSingleQueryMode(IEntityType entityType) => false;
+
+            public void EndSingleQueryMode()
+            {
+            }
 
             public void Unsubscribe()
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ChangeTracking\Internal\InternalShadowEntityEntryTest.cs" />
     <Compile Include="ChangeTracking\Internal\KeyPropagatorTest.cs" />
     <Compile Include="ChangeTracking\Internal\NavigationFixerTest.cs" />
+    <Compile Include="ChangeTracking\Internal\QueryFixupTest.cs" />
     <Compile Include="ChangeTracking\Internal\ShadowFkFixupTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateDataTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateManagerTest.cs" />


### PR DESCRIPTION
Issue #5674

The state manager was assuming the query would take care of fixup for all single queries. However, this is only true when the relationships are explicitly included in the query. For some cases such as self references and multiple relationships between entity types, fixup is needed that will not be performed by query. Therefore we will now drop out of single query mode for any query with self refs and any time multiple entities are returned. This will have a perf impact, but super simple queries will still run in single query mode. Post RTM we will try to do something better.