### PR TITLE
Remove imports

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Design/project.json
@@ -48,7 +48,6 @@
   "frameworks": {
     "net451": {},
     "netcoreapp1.0": {
-      "imports": "portable-net452+win81",
       "dependencies": {
         "Microsoft.NETCore.App": {
           "version": "1.0.0-*",

--- a/src/Microsoft.EntityFrameworkCore.InMemory/project.json
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/project.json
@@ -27,10 +27,6 @@
   },
   "frameworks": {
     "net451": { },
-    "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ]
-    }
+    "netstandard1.3": { }
   }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
@@ -30,7 +30,7 @@
     "netstandard1.6": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "System.Threading.Tasks.Parallel": "4.0.1-*"

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/project.json
@@ -26,10 +26,6 @@
   },
   "frameworks": {
     "net451": { },
-    "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ]
-    }
+    "netstandard1.3": { }
   }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
@@ -26,7 +26,7 @@
     "netstandard1.3": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ]
     },
     "net451": { }

--- a/src/Microsoft.EntityFrameworkCore.Relational/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational/project.json
@@ -47,9 +47,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ],
       "dependencies": {
         "Microsoft.CSharp": "4.0.1-*",
         "System.Data.Common": "4.1.0-*",

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -3187,8 +3187,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    (await Assert.ThrowsAsync<AggregateException>(
-                        async () => await context.Customers.FirstAsync())).InnerException.Message);
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        async () => await context.Customers.FirstAsync())).Message);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/project.json
@@ -31,7 +31,7 @@
     "netstandard1.3": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.CSharp": "4.0.1-*",

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/project.json
@@ -28,10 +28,6 @@
   },
   "frameworks": {
     "net451": { },
-    "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ]
-    }
+    "netstandard1.3": { }
   }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/project.json
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/project.json
@@ -31,9 +31,6 @@
   "frameworks": {
     "net451": { },
     "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ],
       "dependencies": {
         "System.Data.SqlClient": "4.1.0-*",
         "System.Threading.Thread": "4.0.0-*"

--- a/src/Microsoft.EntityFrameworkCore.Sqlite.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite.Design/project.json
@@ -28,10 +28,6 @@
   },
   "frameworks": {
     "net451": { },
-    "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ]
-    }
+    "netstandard1.3": { }
   }
 }

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/project.json
@@ -32,9 +32,6 @@
   "frameworks": {
     "net451": { },
     "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ],
       "dependencies": {
         "System.IO.FileSystem": "4.0.1-*"
       }

--- a/src/Microsoft.EntityFrameworkCore.Tools.Core/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools.Core/project.json
@@ -28,9 +28,6 @@
   "frameworks": {
     "net451": { },
     "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ],
       "dependencies": {
         "System.Collections.NonGeneric": "4.0.1-*",
         "System.IO": "4.1.0-*",

--- a/src/Microsoft.EntityFrameworkCore.Tools/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools/project.json
@@ -32,9 +32,6 @@
   },
   "frameworks": {
     "netcoreapp1.0": {
-      "imports": [
-        "portable-net451+win8"
-      ],
       "dependencies": {
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",

--- a/src/Microsoft.EntityFrameworkCore/project.json
+++ b/src/Microsoft.EntityFrameworkCore/project.json
@@ -25,7 +25,7 @@
     "Microsoft.Extensions.Caching.Memory": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.Logging": "1.0.0-*",
-    "Remotion.Linq": "2.0.2",
+    "Remotion.Linq": "2.1.0-*",
     "System.Collections.Immutable": "1.2.0-*",
     "System.Interactive.Async": "3.0.0-*"
   },

--- a/src/Microsoft.EntityFrameworkCore/project.json
+++ b/src/Microsoft.EntityFrameworkCore/project.json
@@ -22,12 +22,12 @@
     }
   },
   "dependencies": {
-    "Ix-Async": "1.2.5",
     "Microsoft.Extensions.Caching.Memory": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.Logging": "1.0.0-*",
     "Remotion.Linq": "2.0.2",
-    "System.Collections.Immutable": "1.2.0-*"
+    "System.Collections.Immutable": "1.2.0-*",
+    "System.Interactive.Async": "3.0.0-*"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.EntityFrameworkCore/project.json
+++ b/src/Microsoft.EntityFrameworkCore/project.json
@@ -39,9 +39,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "portable-net452+win81"
-      ],
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12-*",
         "System.ComponentModel.Annotations": "4.1.0-*",

--- a/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
@@ -19,7 +19,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
@@ -17,7 +17,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/project.json
@@ -16,7 +16,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
@@ -28,7 +28,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/project.json
@@ -14,7 +14,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
@@ -28,7 +28,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
@@ -21,7 +21,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/project.json
@@ -14,7 +14,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
@@ -21,7 +21,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/AspNetHostingPortableApp/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/AspNetHostingPortableApp/project.json.ignore
@@ -32,18 +32,9 @@
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "netcoreapp1.0": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopApp/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopApp/project.json.ignore
@@ -12,17 +12,12 @@
     "Microsoft.EntityFrameworkCore.Sqlite": {
       "target": "project"
     },
-    "Newtonsoft.Json": "8.0.4-*"
+    "Newtonsoft.Json": "9.0.1-*"
   },
   "frameworks": {
     "net451": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/DesktopClassLibrary/project.json.ignore
@@ -12,11 +12,6 @@
     "net451": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/LibraryUsingSqlite/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/LibraryUsingSqlite/project.json.ignore
@@ -1,16 +1,12 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.5.0-*",
+    "NETStandard.Library": "1.6.0-*",
     "Microsoft.EntityFrameworkCore.Sqlite": {
       "target": "project"
     }
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "netstandard1.5": { }
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/NetStandardClassLibrary/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/NetStandardClassLibrary/project.json.ignore
@@ -14,18 +14,9 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "netcoreapp1.0": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/PortableApp/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/PortableApp/project.json.ignore
@@ -21,18 +21,9 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "netcoreapp1.0": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/StandaloneApp/project.json.ignore
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/TestProjects/StandaloneApp/project.json.ignore
@@ -18,19 +18,10 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "netcoreapp1.0": { }
   },
   "tools": {
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "$toolVersion$",
-      "imports": [
-        "portable-net451+win8"
-      ]
-    }
+    "Microsoft.EntityFrameworkCore.Tools": "$toolVersion$"
   },
   "runtimes": {
     "win7-x86": {},

--- a/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Cli.FunctionalTests/project.json
@@ -24,7 +24,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/project.json
@@ -16,7 +16,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tools.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tools.FunctionalTests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Microsoft.EntityFrameworkCore.Tools.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Tests/project.json
@@ -13,7 +13,7 @@
     "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
-        "portable-net452+win81"
+        "portable-net45+win8"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {


### PR DESCRIPTION
Fix #5176.
Fix #2192.

We still need imports for test code (for xunit and moq.netcore).

~~:watch: Waiting on updates to package feeds, as well as the updates to Ix-Async and re-linq.~~ Ready now.

cc @divega @Eilon 
