### PR TITLE
Making tracking more pay-per-play in query

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public InMemoryQueryContext(
             [NotNull] Func<IQueryBuffer> queryBufferFactory,
             [NotNull] IInMemoryStore store,
-            [NotNull] IStateManager stateManager,
+            [NotNull] LazyRef<IStateManager> stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector)
             : base(
                 Check.NotNull(queryBufferFactory, nameof(queryBufferFactory)),

--- a/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -23,12 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InMemoryQueryContextFactory(
-            [NotNull] IStateManager stateManager,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IConcurrencyDetector concurrencyDetector,
             [NotNull] IInMemoryStoreSource storeSource,
-            [NotNull] IChangeDetector changeDetector,
             [NotNull] IDbContextOptions contextOptions)
-            : base(stateManager, concurrencyDetector, changeDetector)
+            : base(currentContext, concurrencyDetector)
         {
             _store = storeSource.GetStore(contextOptions);
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             if (IsTrackingQuery)
             {
-                var entry = queryContext.StateManager.TryGetEntry(Key, valueBuffer, !AllowNullResult);
+                var entry = queryContext.StateManager.Value.TryGetEntry(Key, valueBuffer, !AllowNullResult);
 
                 if (entry != null)
                 {

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalQueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalQueryContextFactory.cs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class RelationalQueryContextFactory : QueryContextFactory
@@ -17,21 +16,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly IRelationalConnection _connection;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalQueryContextFactory(
-            [NotNull] IStateManager stateManager,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IConcurrencyDetector concurrencyDetector,
-            [NotNull] IRelationalConnection connection,
-            [NotNull] IChangeDetector changeDetector)
-            : base(stateManager, concurrencyDetector, changeDetector)
+            [NotNull] IRelationalConnection connection)
+            : base(currentContext, concurrencyDetector)
         {
             _connection = connection;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override QueryContext Create()

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public RelationalQueryContext(
             [NotNull] Func<IQueryBuffer> queryBufferFactory,
             [NotNull] IRelationalConnection connection,
-            [NotNull] IStateManager stateManager,
+            [NotNull] LazyRef<IStateManager> stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector)
             : base(
                 Check.NotNull(queryBufferFactory, nameof(queryBufferFactory)),

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsNoTrackingTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsNoTrackingTestBase.cs
@@ -2,17 +2,59 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable AccessToDisposedClosure
-
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public abstract class AsNoTrackingTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
+        [ConditionalFact]
+        public virtual void State_manager_not_loaded()
+        {
+            StateManagerProxy.IsInitialized = false;
+
+            using (var context = new NorthwindContext(
+                Fixture.BuildOptions(
+                    new ServiceCollection()
+                        .AddScoped<IStateManager, StateManagerProxy>())))
+            {
+                context.Set<Customer>().AsNoTracking().ToList();
+                Assert.False(StateManagerProxy.IsInitialized);
+
+                context.GetService<IStateManager>();
+                Assert.True(StateManagerProxy.IsInitialized);
+            }
+        }
+
+        private class StateManagerProxy : StateManager
+        {
+            public static bool IsInitialized { get; set; }
+
+            public StateManagerProxy(
+                IInternalEntityEntryFactory factory,
+                IInternalEntityEntrySubscriber subscriber,
+                IInternalEntityEntryNotifier notifier,
+                IValueGenerationManager valueGeneration,
+                IModel model,
+                IDatabase database,
+                IConcurrencyDetector concurrencyDetector,
+                ICurrentDbContext currentContext)
+                : base(factory, subscriber, notifier, valueGeneration, model, database, concurrencyDetector, currentContext)
+            {
+                IsInitialized = true;
+            }
+        }
+
         [ConditionalFact]
         public virtual void Entity_not_added_to_state_manager()
         {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/NorthwindQueryFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/NorthwindQueryFixtureBase.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public abstract class NorthwindQueryFixtureBase
     {
+        public abstract DbContextOptions BuildOptions(IServiceCollection additionalServices = null);
+
         public virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Customer>();

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeTrackerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeTrackerFactory.cs
@@ -7,37 +7,27 @@ using Microsoft.EntityFrameworkCore.Internal;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ChangeTrackerFactory : IChangeTrackerFactory
     {
-        private readonly IStateManager _stateManager;
-        private readonly IChangeDetector _changeDetector;
-        private readonly IEntityEntryGraphIterator _graphIterator;
         private readonly DbContext _context;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ChangeTrackerFactory(
-            [NotNull] IStateManager stateManager,
-            [NotNull] IChangeDetector changeDetector,
-            [NotNull] IEntityEntryGraphIterator graphIterator,
-            [NotNull] ICurrentDbContext currentContext)
+        public ChangeTrackerFactory([NotNull] ICurrentDbContext currentContext)
         {
-            _stateManager = stateManager;
-            _changeDetector = changeDetector;
-            _graphIterator = graphIterator;
             _context = currentContext.Context;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ChangeTracker Create()
-            => new ChangeTracker(_stateManager, _changeDetector, _graphIterator, _context);
+            => new ChangeTracker(_context);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         public QueryContext(
             [NotNull] Func<IQueryBuffer> queryBufferFactory,
-            [NotNull] IStateManager stateManager,
+            [NotNull] LazyRef<IStateManager> stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector)
         {
             Check.NotNull(queryBufferFactory, nameof(queryBufferFactory));
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <value>
         ///     The state manager.
         /// </value>
-        public virtual IStateManager StateManager { get; }
+        public virtual LazyRef<IStateManager> StateManager { get; }
 
         /// <summary>
         ///     Gets the concurrency detector.
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     Notify the state manager that a tracking query is starting.
         /// </summary>
-        public virtual void BeginTrackingQuery() => StateManager.BeginTrackingQuery();
+        public virtual void BeginTrackingQuery() => StateManager.Value.BeginTrackingQuery();
 
         /// <summary>
         ///     Start tracking an entity.
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             else
             {
-                entityTrackingInfo.StartTracking(StateManager, entity, ValueBuffer.Empty);
+                entityTrackingInfo.StartTracking(StateManager.Value, entity, ValueBuffer.Empty);
             }
         }
     }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
@@ -18,21 +18,23 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
         public NorthwindQueryInMemoryFixture()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
-                .AddSingleton<ILoggerFactory>(_testLoggerFactory)
-                .BuildServiceProvider();
-
-            _options = new DbContextOptionsBuilder()
-                .UseInMemoryDatabase()
-                .UseInternalServiceProvider(serviceProvider).Options;
+            _options = BuildOptions();
 
             using (var context = CreateContext())
             {
                 NorthwindData.Seed(context);
             }
         }
+
+        public override DbContextOptions BuildOptions(IServiceCollection serviceCollection = null)
+            => new DbContextOptionsBuilder()
+                .UseInMemoryDatabase()
+                .UseInternalServiceProvider(
+                    (serviceCollection ?? new ServiceCollection())
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                        .AddSingleton<ILoggerFactory>(_testLoggerFactory)
+                        .BuildServiceProvider()).Options;
 
         public override NorthwindContext CreateContext()
             => new NorthwindContext(_options);
@@ -46,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
         private class TestLogger : ILogger
         {
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) 
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
                 => TestOutputHelper?.WriteLine(formatter(state, exception));
 
             public bool IsEnabled(LogLevel logLevel) => TestOutputHelper != null;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -15,7 +15,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class NorthwindQuerySqlServerFixture : NorthwindQueryRelationalFixture, IDisposable
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly DbContextOptions _options;
 
         private readonly SqlServerTestStore _testStore = SqlServerNorthwindContext.GetSharedStore();
@@ -23,21 +22,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         public NorthwindQuerySqlServerFixture()
         {
-            _serviceProvider
-                = new ServiceCollection()
-                    .AddEntityFrameworkSqlServer()
-                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
-                    .AddSingleton<ILoggerFactory>(_testSqlLoggerFactory)
-                    .BuildServiceProvider();
-
             _options = BuildOptions();
         }
 
-        protected DbContextOptions BuildOptions()
+        public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
             => ConfigureOptions(
                 new DbContextOptionsBuilder()
                     .EnableSensitiveDataLogging()
-                    .UseInternalServiceProvider(_serviceProvider))
+                    .UseInternalServiceProvider((additionalServices ?? new ServiceCollection())
+                        .AddEntityFrameworkSqlServer()
+                        .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                        .AddSingleton<ILoggerFactory>(_testSqlLoggerFactory)
+                        .BuildServiceProvider()))
                 .UseSqlServer(
                     _testStore.ConnectionString,
                     b =>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
@@ -20,19 +20,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             _testStore = SqlServerNorthwindContext.GetSharedStore();
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFrameworkSqlServer()
-                .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
-                .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
-                .BuildServiceProvider();
-
-            _options = new DbContextOptionsBuilder()
-                .EnableSensitiveDataLogging()
-                .UseInternalServiceProvider(serviceProvider)
-                .UseSqlServer(_testStore.ConnectionString).Options;
-
-            serviceProvider.GetRequiredService<ILoggerFactory>();
+            _options = BuildOptions();
         }
+
+        public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
+            => new DbContextOptionsBuilder()
+                .EnableSensitiveDataLogging()
+                .UseInternalServiceProvider((additionalServices ?? new ServiceCollection())
+                    .AddEntityFrameworkSqlServer()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
+                    .BuildServiceProvider())
+                .UseSqlServer(_testStore.ConnectionString).Options;
 
         public override NorthwindContext CreateContext()
         {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
@@ -14,7 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
     public class NorthwindQuerySqliteFixture : NorthwindQueryRelationalFixture, IDisposable
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly DbContextOptions _options;
 
         private readonly SqliteTestStore _testStore = SqliteNorthwindContext.GetSharedStore();
@@ -22,22 +21,17 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
         public NorthwindQuerySqliteFixture()
         {
-            _serviceProvider
-                = new ServiceCollection()
-                    .AddEntityFrameworkSqlite()
-                    .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
-                    .AddSingleton<ILoggerFactory>(_testSqlLoggerFactory)
-                    .BuildServiceProvider();
-
             _options = BuildOptions();
-
-            _serviceProvider.GetRequiredService<ILoggerFactory>();
         }
 
-        protected DbContextOptions BuildOptions()
+        public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
             => ConfigureOptions(
                 new DbContextOptionsBuilder()
-                    .UseInternalServiceProvider(_serviceProvider))
+                    .UseInternalServiceProvider((additionalServices ?? new ServiceCollection())
+                        .AddEntityFrameworkSqlite()
+                        .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                        .AddSingleton<ILoggerFactory>(_testSqlLoggerFactory)
+                        .BuildServiceProvider()))
                 .UseSqlite(
                     _testStore.ConnectionString,
                     b => ConfigureOptions(b).SuppressForeignKeyEnforcement())


### PR DESCRIPTION
Lazily resolve services related to tracking from query such that they will not be loaded when only no-tracking queries are used.