### PR TITLE
Use provider-specific truth literal in conditional

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -821,7 +821,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 if (expression.Test.IsSimpleExpression())
                 {
-                    _relationalCommandBuilder.Append(" = 1");
+                    _relationalCommandBuilder.Append(" = ");
+                    _relationalCommandBuilder.Append(TrueLiteral);
                 }
 
                 _relationalCommandBuilder.AppendLine();


### PR DESCRIPTION
DefaultQuerySqlGenerator contains the following code for rendering conditionals:

```c#
if (expression.Test.IsSimpleExpression())
{
    _relationalCommandBuilder.Append(" = 1");
}
```

This doesn't work for PostgreSQL. We already have TrueLiteral and TypedTrueLiteral which are used elsewhere, this PR replaces the `1` with TrueLiteral.

However, it's not clear to me why a condition is necessary at all. In other words, instead of rendering `WHEN x = 1 THEN y ELSE z END`, why not simply render `WHEN x THEN y ELSE z END`? At least for PostgreSQL all the GearsOfWar tests (where a lot of conditionals happen) pass in this way.

As a workaround, I've overridden `VisitConditional` in Npgsql's QuerySqlGenerator.
