### PR TITLE
Correctly map SQL Server datetime columns

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -66,6 +66,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private readonly SqlServerMaxLengthMapping _binary 
             = new SqlServerMaxLengthMapping("binary", typeof(byte[]), dbType: DbType.Binary);
 
+        private readonly RelationalTypeMapping _date
+            = new RelationalTypeMapping("date", typeof(DateTime), dbType: DbType.Date);
+
+        private readonly RelationalTypeMapping _datetime
+            = new RelationalTypeMapping("datetime", typeof(DateTime), dbType: DbType.DateTime);
+
         private readonly RelationalTypeMapping _datetime2 
             = new RelationalTypeMapping("datetime2", typeof(DateTime), dbType: DbType.DateTime2);
 
@@ -107,8 +113,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { "char", _char },
                     { "character varying", _varchar },
                     { "character", _char },
-                    { "date", _datetime2 },
-                    { "datetime", _datetime2 },
+                    { "date", _date },
+                    { "datetime", _datetime },
                     { "datetime2", _datetime2 },
                     { "datetimeoffset", _datetimeoffset },
                     { "dec", _decimal },
@@ -126,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { "nvarchar", _nvarchar },
                     { "real", _real },
                     { "rowversion", _rowversion },
-                    { "smalldatetime", _datetime2 },
+                    { "smalldatetime", _datetime },
                     { "smallint", _smallint },
                     { "smallmoney", _decimal },
                     { "text", _varchar },

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -317,8 +317,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p3: True
 @p4: Your (Nullable = false) (Size = 8000) (DbType = AnsiString)
 @p5: strong (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p6: 01/02/2015 10:11:12
-@p7: 01/02/2019 14:11:12
+@p6: 01/02/2015 10:11:12 (DbType = DateTime)
+@p7: 01/02/2019 14:11:12 (DbType = DateTime)
 @p8: 01/02/2017 12:11:12
 @p9: 01/02/2016 11:11:12 +00:00
 @p10: 102.2
@@ -333,7 +333,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19: 103.3
 @p20: don't (Nullable = false) (Size = 4000)
 @p21: 84.4
-@p22: 01/02/2018 13:11:12
+@p22: 01/02/2018 13:11:12 (DbType = DateTime)
 @p23: 79
 @p24: 82.2
 @p25: Gumball Rules! (Nullable = false) (Size = 8000) (DbType = AnsiString)
@@ -443,8 +443,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p3: True (Nullable = true)
 @p4: Your (Size = 8000) (DbType = AnsiString)
 @p5: strong (Size = 8000) (DbType = AnsiString)
-@p6: 01/02/2015 10:11:12 (Nullable = true)
-@p7: 01/02/2019 14:11:12 (Nullable = true)
+@p6: 01/02/2015 10:11:12 (Nullable = true) (DbType = DateTime)
+@p7: 01/02/2019 14:11:12 (Nullable = true) (DbType = DateTime)
 @p8: 01/02/2017 12:11:12 (Nullable = true)
 @p9: 01/02/2016 11:11:12 +00:00 (Nullable = true)
 @p10: 102.2 (Nullable = true)
@@ -459,7 +459,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19: 103.3 (Nullable = true)
 @p20: don't (Size = 4000)
 @p21: 84.4 (Nullable = true)
-@p22: 01/02/2018 13:11:12 (Nullable = true)
+@p22: 01/02/2018 13:11:12 (Nullable = true) (DbType = DateTime)
 @p23: 79 (Nullable = true)
 @p24: 82.2 (Nullable = true)
 @p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
@@ -563,8 +563,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p3:  (DbType = String)
 @p4:  (Size = 8000)
 @p5:  (Size = 8000)
-@p6:  (DbType = DateTime2)
-@p7:  (DbType = DateTime2)
+@p6:  (DbType = DateTime)
+@p7:  (DbType = DateTime)
 @p8:  (DbType = DateTime2)
 @p9:  (DbType = String)
 @p10:  (DbType = String)
@@ -579,7 +579,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19:  (DbType = String)
 @p20:  (Size = 4000) (DbType = String)
 @p21:  (DbType = String)
-@p22:  (DbType = DateTime2)
+@p22:  (DbType = DateTime)
 @p23:  (DbType = Int16)
 @p24:  (DbType = String)
 @p25:  (Size = 8000)
@@ -868,8 +868,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p2: True
 @p3: Your (Size = 8000) (DbType = AnsiString)
 @p4: strong (Size = 8000) (DbType = AnsiString)
-@p5: 01/02/2015 10:11:12
-@p6: 01/02/2019 14:11:12
+@p5: 01/02/2015 10:11:12 (DbType = DateTime)
+@p6: 01/02/2019 14:11:12 (DbType = DateTime)
 @p7: 01/02/2017 12:11:12
 @p8: 01/02/2016 11:11:12 +00:00
 @p9: 102.2
@@ -885,7 +885,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19: 103.3
 @p20: don't (Size = 4000)
 @p21: 84.4
-@p22: 01/02/2018 13:11:12
+@p22: 01/02/2018 13:11:12 (DbType = DateTime)
 @p23: 79
 @p24: 82.2
 @p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
@@ -988,8 +988,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p2: True (Nullable = true)
 @p3: Your (Size = 8000) (DbType = AnsiString)
 @p4: strong (Size = 8000) (DbType = AnsiString)
-@p5: 01/02/2015 10:11:12 (Nullable = true)
-@p6: 01/02/2019 14:11:12 (Nullable = true)
+@p5: 01/02/2015 10:11:12 (Nullable = true) (DbType = DateTime)
+@p6: 01/02/2019 14:11:12 (Nullable = true) (DbType = DateTime)
 @p7: 01/02/2017 12:11:12 (Nullable = true)
 @p8: 01/02/2016 11:11:12 +00:00 (Nullable = true)
 @p9: 102.2 (Nullable = true)
@@ -1005,7 +1005,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19: 103.3 (Nullable = true)
 @p20: don't (Size = 4000)
 @p21: 84.4 (Nullable = true)
-@p22: 01/02/2018 13:11:12 (Nullable = true)
+@p22: 01/02/2018 13:11:12 (Nullable = true) (DbType = DateTime)
 @p23: 79 (Nullable = true)
 @p24: 82.2 (Nullable = true)
 @p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
@@ -1108,8 +1108,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p2:  (DbType = String)
 @p3:  (Size = 8000)
 @p4:  (Size = 8000)
-@p5:  (DbType = DateTime2)
-@p6:  (DbType = DateTime2)
+@p5:  (DbType = DateTime)
+@p6:  (DbType = DateTime)
 @p7:  (DbType = DateTime2)
 @p8:  (DbType = String)
 @p9:  (DbType = String)
@@ -1125,7 +1125,7 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19:  (DbType = String)
 @p20:  (Size = 4000) (DbType = String)
 @p21:  (DbType = String)
-@p22:  (DbType = DateTime2)
+@p22:  (DbType = DateTime)
 @p23:  (DbType = Int16)
 @p24:  (DbType = String)
 @p25:  (Size = 8000)


### PR DESCRIPTION
Issue #5715

SQL Server was mapping "datetime" to DbType.DataTime2 parameters. This breaks SQL Server 2005 and also the always encrypted feature of later versions where the automatic conversions from datetime2 don't work.