### PR TITLE
Document constructors that take internal types as internal

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Builders/DiscriminatorBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Builders/DiscriminatorBuilder.cs
@@ -10,6 +10,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
     public class DiscriminatorBuilder
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public DiscriminatorBuilder([NotNull] RelationalAnnotationsBuilder annotationsBuilder,
             [NotNull] Func<InternalEntityTypeBuilder, RelationalEntityTypeBuilderAnnotations> getRelationalEntityTypeBuilderAnnotations)
         {

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/HistoryRepository.cs
@@ -32,6 +32,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         private readonly LazyRef<string> _migrationIdColumnName;
         private readonly LazyRef<string> _productVersionColumnName;
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected HistoryRepository(
             [NotNull] IDatabaseCreator databaseCreator,
             [NotNull] IRawSqlCommandBuilder rawSqlCommandBuilder,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -23,6 +23,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         private const string SystemAliasPrefix = "t";
         private readonly ISet<string> _tableAliasSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public RelationalQueryCompilationContext(
             [NotNull] IModel model,
             [NotNull] ISensitiveDataLogger logger,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContextFactory.cs
@@ -15,6 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class RelationalQueryCompilationContextFactory : QueryCompilationContextFactory
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public RelationalQueryCompilationContextFactory(
             [NotNull] IModel model,
             [NotNull] ISensitiveDataLogger<RelationalQueryCompilationContextFactory> logger,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryContext.cs
@@ -22,6 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private int _activeIncludeQueryOffset;
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public RelationalQueryContext(
             [NotNull] Func<IQueryBuffer> queryBufferFactory,
             [NotNull] IRelationalConnection connection,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitorFactory.cs
@@ -14,6 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class RelationalQueryModelVisitorFactory : EntityQueryModelVisitorFactory
     {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public RelationalQueryModelVisitorFactory(
             [NotNull] IQueryOptimizer queryOptimizer,
             [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ChangeTracker.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ChangeTracker.cs
@@ -24,14 +24,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private readonly IEntityEntryGraphIterator _graphIterator;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ChangeTracker" /> class. Instances of this class are typically
-        ///     obtained from <see cref="DbContext.ChangeTracker" /> and it is not designed to be directly constructed
-        ///     in your application code.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="stateManager"> The internal state manager being used to store information about tracked entities. </param>
-        /// <param name="changeDetector"> The internal change detector used to identify changes in tracked entities. </param>
-        /// <param name="graphIterator"> The internal graph iterator used to traverse graphs of entities. </param>
-        /// <param name="context"> The context this change tracker belongs to. </param>
         public ChangeTracker(
             [NotNull] IStateManager stateManager,
             [NotNull] IChangeDetector changeDetector,

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry.cs
@@ -30,11 +30,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private readonly InternalEntityEntry _internalEntityEntry;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="EntityEntry" /> class. Instances of this class are returned from
-        ///     methods when using the <see cref="ChangeTracker" /> API and it is not designed to be directly constructed in
-        ///     your application code.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="internalEntry"> The internal entry tracking information about this entity. </param>
         public EntityEntry([NotNull] InternalEntityEntry internalEntry)
         {
             Check.NotNull(internalEntry, nameof(internalEntry));

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntryGraphNode.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntryGraphNode.cs
@@ -18,12 +18,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private readonly InternalEntityEntry _internalEntityEntry;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="EntityEntryGraphNode" /> class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="internalEntityEntry"> The internal entry tracking information about this entity. </param>
-        /// <param name="inboundNavigation">
-        ///     The navigation property that is being traversed to reach this node in the graph.
-        /// </param>
         public EntityEntryGraphNode(
             [NotNull] InternalEntityEntry internalEntityEntry,
             [CanBeNull] INavigation inboundNavigation)

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
@@ -25,11 +25,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         where TEntity : class
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="EntityEntry{TEntity}" /> class. Instances of this class are returned
-        ///     from methods when using the <see cref="ChangeTracker" /> API and it is not designed to be directly
-        ///     constructed in your application code.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="internalEntry"> The internal entry tracking information about this entity. </param>
         public EntityEntry([NotNull] InternalEntityEntry internalEntry)
             : base(internalEntry)
         {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry.cs
@@ -26,16 +26,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private readonly InternalEntityEntry _internalEntry;
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="PropertyEntry" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
-        ///         not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="internalEntry">  The internal entry tracking information about the entity the property belongs to. </param>
-        /// <param name="name"> The name of the property. </param>
         public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
         {
             Check.NotNull(internalEntry, nameof(internalEntry));

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry`.cs
@@ -22,16 +22,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         where TEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="PropertyEntry{TEntity, TProperty}" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
-        ///         not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="internalEntry">  The internal entry tracking information about the entity the property belongs to. </param>
-        /// <param name="name"> The name of the property. </param>
         public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
             : base(internalEntry, name)
         {

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/ModelSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/ModelSource.cs
@@ -51,24 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         protected virtual IModelCacheKeyFactory ModelCacheKeyFactory { get; }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelSource"/> class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="setFinder">
-        ///     The <see cref="IDbSetFinder"/> that will locate the <see cref="DbSet{TEntity}"/> properties
-        ///     on the derived context.
-        /// </param>
-        /// <param name="coreConventionSetBuilder">
-        ///     The <see cref="ICoreConventionSetBuilder"/> that will build the conventions to be used 
-        ///     to build the model.
-        /// </param>
-        /// <param name="modelCustomizer">
-        ///     The <see cref="IModelCustomizer"/> that will perform additional configuration of the model
-        ///     in addition to what is discovered by convention.
-        /// </param>
-        /// <param name="modelCacheKeyFactory">
-        ///     The <see cref="IModelCacheKeyFactory"/> that will create keys used to store and lookup models
-        ///     the model cache.
-        /// </param>
         protected ModelSource([NotNull] IDbSetFinder setFinder, [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder, [NotNull] IModelCustomizer modelCustomizer, [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
         {
             Check.NotNull(setFinder, nameof(setFinder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -24,15 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class CollectionNavigationBuilder : IInfrastructure<InternalRelationshipBuilder>
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure the relationship. </param>
         public CollectionNavigationBuilder([NotNull] InternalRelationshipBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -27,15 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder{TEntity, TRelatedEntity}" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure the relationship. </param>
         public CollectionNavigationBuilder(
             [NotNull] InternalRelationshipBuilder builder)
             : base(builder)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -23,16 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class EntityTypeBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalEntityTypeBuilder>
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="EntityTypeBuilder" /> class to configure a given
-        ///         entity type.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal builder for the entity type being configured. </param>
         public EntityTypeBuilder([NotNull] InternalEntityTypeBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -26,16 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="EntityTypeBuilder{TEntity}" /> class to configure a
-        ///         given entity type.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal typeBuilder for the entity type being configured. </param>
         public EntityTypeBuilder([NotNull] InternalEntityTypeBuilder builder)
             : base(builder)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/IndexBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/IndexBuilder.cs
@@ -22,15 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         private readonly InternalIndexBuilder _builder;
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="IndexBuilder" /> class to configure a given index.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal builder for the index being configured. </param>
         public IndexBuilder([NotNull] InternalIndexBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/KeyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/KeyBuilder.cs
@@ -22,15 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         private readonly InternalKeyBuilder _builder;
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="KeyBuilder" /> class to configure a given key.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal builder for the key being configured. </param>
         public KeyBuilder([NotNull] InternalKeyBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
@@ -20,16 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class PropertyBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalPropertyBuilder>
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="PropertyBuilder" /> class to configure a given
-        ///         property.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal builder for the property being configured. </param>
         public PropertyBuilder([NotNull] InternalPropertyBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
@@ -18,16 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class PropertyBuilder<TProperty> : PropertyBuilder
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="PropertyBuilder" /> class to configure a given
-        ///         property.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> Internal builder for the property being configured. </param>
         public PropertyBuilder([NotNull] InternalPropertyBuilder builder)
             : base(builder)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -26,15 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         private readonly bool? _required;
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceCollectionBuilder" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
         public ReferenceCollectionBuilder([NotNull] InternalRelationshipBuilder builder)
             : this(builder, null)
         {
@@ -42,21 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceCollectionBuilder" /> class.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="oldBuilder"> A builder to copy configuration from. </param>
-        /// <param name="foreignKeySet">
-        ///     A value indicating whether the foreign key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="principalKeySet">
-        ///     A value indicating whether the principal key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="requiredSet">
-        ///     A value indicating whether required/optional has been configured in this chain of configuration calls.
-        /// </param>
         protected ReferenceCollectionBuilder(InternalRelationshipBuilder builder,
             ReferenceCollectionBuilder oldBuilder,
             bool foreignKeySet = false,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -27,38 +27,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TDependentEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceCollectionBuilder{TPrincipalEntity, TDependentEntity}" />
-        ///         class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
         public ReferenceCollectionBuilder([NotNull] InternalRelationshipBuilder builder)
             : base(builder)
         {
         }
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceCollectionBuilder{TPrincipalEntity, TDependentEntity}" />
-        ///         class.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="oldBuilder"> A builder to copy configuration from. </param>
-        /// <param name="foreignKeySet">
-        ///     A value indicating whether the foreign key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="principalKeySet">
-        ///     A value indicating whether the principal key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="requiredSet">
-        ///     A value indicating whether required/optional has been configured in this chain of configuration calls.
-        /// </param>
         protected ReferenceCollectionBuilder(InternalRelationshipBuilder builder,
             ReferenceCollectionBuilder oldBuilder,
             bool foreignKeySet = false,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -24,21 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class ReferenceNavigationBuilder : IInfrastructure<InternalRelationshipBuilder>
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="declaringEntityType"> The entity type that the reference is declared on. </param>
-        /// <param name="relatedEntityType"> The entity type that the reference points to. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on the end of the relationship that configuration began
-        ///     on. If null, there is no navigation property on this end of the relationship.
-        /// </param>
-        /// <param name="builder"> The internal builder being used to configure the relationship. </param>
         public ReferenceNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -28,21 +28,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder{TEntity, TRelatedEntity}" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="declaringEntityType"> The entity type that the reference is declared on. </param>
-        /// <param name="relatedEntityType"> The entity type that the reference points to. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on the end of the relationship that configuration began
-        ///     on. If null, there is no navigation property on this end of the relationship.
-        /// </param>
-        /// <param name="builder"> The internal builder being used to configure the relationship. </param>
         public ReferenceNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -31,17 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         private readonly bool? _required;
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceReferenceBuilder" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="declaringEntityType"> The first entity type in the relationship. </param>
-        /// <param name="relatedEntityType"> The second entity type in the relationship. </param>
         public ReferenceReferenceBuilder(
             [NotNull] InternalRelationshipBuilder builder,
             [NotNull] EntityType declaringEntityType,
@@ -54,24 +46,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceReferenceBuilder" /> class.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="oldBuilder"> A builder to copy configuration from. </param>
-        /// <param name="inverted">
-        ///     A value indicating whether to reverse the direction of the relationship.
-        /// </param>
-        /// <param name="foreignKeySet">
-        ///     A value indicating whether the foreign key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="principalKeySet">
-        ///     A value indicating whether the principal key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="requiredSet">
-        ///     A value indicating whether required/optional has been configured in this chain of configuration calls.
-        /// </param>
         protected ReferenceReferenceBuilder(
             InternalRelationshipBuilder builder,
             ReferenceReferenceBuilder oldBuilder,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -26,17 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceReferenceBuilder{TEntity, TRelatedEntity}" /> class.
-        ///     </para>
-        ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
-        ///         and it is not designed to be directly constructed in your application code.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="declaringEntityType"> The first entity type in the relationship. </param>
-        /// <param name="relatedEntityType"> The second entity type in the relationship. </param>
         public ReferenceReferenceBuilder(
             [NotNull] InternalRelationshipBuilder builder,
             [NotNull] EntityType declaringEntityType,
@@ -46,24 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     <para>
-        ///         Initializes a new instance of the <see cref="ReferenceReferenceBuilder{TEntity, TRelatedEntity}" /> class.
-        ///     </para>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        /// <param name="oldBuilder"> A builder to copy configuration from. </param>
-        /// <param name="inverted">
-        ///     A value indicating whether to reverse the direction of the relationship.
-        /// </param>
-        /// <param name="foreignKeySet">
-        ///     A value indicating whether the foreign key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="principalKeySet">
-        ///     A value indicating whether the principal key properties have been configured in this chain of configuration calls.
-        /// </param>
-        /// <param name="requiredSet">
-        ///     A value indicating whether required/optional has been configured in this chain of configuration calls.
-        /// </param>
         protected ReferenceReferenceBuilder(InternalRelationshipBuilder builder,
             ReferenceReferenceBuilder oldBuilder,
             bool inverted = false,

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitorFactory.cs
@@ -22,22 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class EntityQueryModelVisitorFactory : IEntityQueryModelVisitorFactory
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="EntityQueryModelVisitorFactory"/> class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="queryOptimizer"> The <see cref="IQueryOptimizer"/> to be used when processing a query. </param>
-        /// <param name="navigationRewritingExpressionVisitorFactory"> The <see cref="INavigationRewritingExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="subQueryMemberPushDownExpressionVisitor"> The <see cref="ISubQueryMemberPushDownExpressionVisitor"/> to be used when processing a query. </param>
-        /// <param name="querySourceTracingExpressionVisitorFactory"> The <see cref="IQuerySourceTracingExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="entityResultFindingExpressionVisitorFactory"> The <see cref="IEntityResultFindingExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="taskBlockingExpressionVisitor"> The <see cref="ITaskBlockingExpressionVisitor"/> to be used when processing a query. </param>
-        /// <param name="memberAccessBindingExpressionVisitorFactory"> The <see cref="IMemberAccessBindingExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="orderingExpressionVisitorFactory"> The <see cref="IOrderingExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="projectionExpressionVisitorFactory"> The <see cref="IProjectionExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="entityQueryableExpressionVisitorFactory"> The <see cref="IEntityQueryableExpressionVisitorFactory"/> to be used when processing a query. </param>
-        /// <param name="queryAnnotationExtractor"> The <see cref="IQueryAnnotationExtractor"/> to be used when processing a query. </param>
-        /// <param name="resultOperatorHandler"> The <see cref="IResultOperatorHandler"/> to be used when processing a query. </param>
-        /// <param name="entityMaterializerSource"> The <see cref="IEntityMaterializerSource"/> to be used when processing a query. </param>
-        /// <param name="expressionPrinter"> The <see cref="IExpressionPrinter"/> to be used when processing a query. </param>
         protected EntityQueryModelVisitorFactory(
             [NotNull] IQueryOptimizer queryOptimizer,
             [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryCompilationContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryCompilationContext.cs
@@ -35,15 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         private ISet<IQuerySource> _querySourcesRequiringMaterialization;
 
         /// <summary>
-        ///     Initializes a new instance of the Microsoft.EntityFrameworkCore.Query.QueryCompilationContext class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="model"> The model. </param>
-        /// <param name="logger"> The logger. </param>
-        /// <param name="entityQueryModelVisitorFactory"> The entity query model visitor factory. </param>
-        /// <param name="requiresMaterializationExpressionVisitorFactory"> The requires materialization expression visitor factory. </param>
-        /// <param name="linqOperatorProvider"> The linq operator provider. </param>
-        /// <param name="contextType"> Type of the context. </param>
-        /// <param name="trackQueryResults"> The default configured tracking behavior. </param>
         public QueryCompilationContext(
             [NotNull] IModel model,
             [NotNull] ILogger logger,

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryContext.cs
@@ -25,11 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         private IQueryBuffer _queryBuffer;
 
         /// <summary>
-        ///     Initializes a new instance of the Microsoft.EntityFrameworkCore.Query.QueryContext class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="queryBufferFactory"> The query buffer factory. </param>
-        /// <param name="stateManager"> The state manager. </param>
-        /// <param name="concurrencyDetector"> The concurrency detector. </param>
         public QueryContext(
             [NotNull] Func<IQueryBuffer> queryBufferFactory,
             [NotNull] IStateManager stateManager,

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
@@ -15,11 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class QueryContextFactory : IQueryContextFactory
     {
         /// <summary>
-        ///     Initializes a new instance of the Microsoft.EntityFrameworkCore.Query.QueryContextFactory class.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="stateManager"> The state manager. </param>
-        /// <param name="concurrencyDetector"> The concurrency detector. </param>
-        /// <param name="changeDetector"> The change detector. </param>
         protected QueryContextFactory(
             [NotNull] IStateManager stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector,


### PR DESCRIPTION
Issue #5725

These typically would have been internal constructors in the old world. They are now public, often for D.I. or for fluent API builders. When we break internal stuff these as conceptually internal members may also get broken, so document as such.