### PR TITLE
Update relationship snapshot when recording dangling entities

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -170,6 +170,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 && newTargetEntry == null)
             {
                 stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
+                entry.SetRelationshipSnapshotValue(navigation, newValue);
                 _attacher.AttachGraph(stateManager.GetOrCreateEntry(newValue), EntityState.Added);
             }
         }
@@ -247,8 +248,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                         // Set the inverse navigation to point to this principal
                         SetNavigation(newTargetEntry, inverse, entry.Entity);
-
-                        entry.AddToCollectionSnapshot(navigation, newValue);
                     }
                     finally
                     {
@@ -260,6 +259,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     stateManager.RecordReferencedUntrackedEntity(newValue, navigation, entry);
                     _attacher.AttachGraph(newTargetEntry, EntityState.Added);
                 }
+
+                entry.AddToCollectionSnapshot(navigation, newValue);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -27,11 +28,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -50,11 +56,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -72,11 +83,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -95,11 +111,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -117,11 +138,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -140,11 +166,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -162,11 +193,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -185,11 +221,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -208,11 +249,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -230,11 +276,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -253,11 +304,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -275,11 +331,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -298,11 +359,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -320,11 +386,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -342,10 +413,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -363,10 +439,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -385,10 +466,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -407,10 +493,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -429,10 +520,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -451,10 +547,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -472,10 +573,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -493,10 +599,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -514,10 +625,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -535,10 +651,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -556,10 +677,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -577,10 +703,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -598,9 +729,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -618,9 +754,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -639,11 +780,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -662,11 +808,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -684,11 +835,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -707,11 +863,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -729,11 +890,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -752,11 +918,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -774,11 +945,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -797,11 +973,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -820,11 +1001,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -842,11 +1028,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -865,11 +1056,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -887,11 +1083,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -910,11 +1111,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -932,11 +1138,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -954,10 +1165,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -975,10 +1191,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -997,10 +1218,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1019,10 +1245,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1041,10 +1272,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1063,10 +1299,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1084,10 +1325,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1105,10 +1351,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1126,10 +1377,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1147,10 +1403,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1168,10 +1429,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1189,10 +1455,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1210,9 +1481,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1230,9 +1506,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1255,11 +1536,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1281,11 +1567,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1306,11 +1597,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Empty(principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1332,11 +1628,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1358,11 +1659,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1383,11 +1689,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1408,11 +1719,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1435,11 +1751,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1461,11 +1782,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1486,11 +1812,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Empty(principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1512,11 +1843,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1538,11 +1874,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Empty(principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1564,11 +1905,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1589,11 +1935,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Empty(principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1614,10 +1965,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Empty(principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1638,10 +1994,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Empty(principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Empty(principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1663,10 +2024,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1687,10 +2053,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1712,10 +2083,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1736,10 +2112,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1760,10 +2141,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1785,10 +2171,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1809,10 +2200,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1833,10 +2229,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Null(dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Null(dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1858,10 +2259,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1882,10 +2288,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1906,9 +2317,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1929,9 +2345,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1954,11 +2375,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1980,11 +2406,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2005,11 +2436,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Null(principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2031,11 +2467,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2057,11 +2498,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2082,11 +2528,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2107,11 +2558,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2134,11 +2590,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2160,11 +2621,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2185,11 +2651,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Null(principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2211,11 +2682,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2237,11 +2713,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Null(principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2262,11 +2743,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2287,11 +2773,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Null(principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2312,10 +2803,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2336,10 +2832,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2361,10 +2862,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2385,10 +2891,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2410,10 +2921,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2434,10 +2950,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Added, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2458,10 +2979,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2483,10 +3009,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2507,10 +3038,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(EntityState.Added, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(EntityState.Added, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2531,10 +3067,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Null(dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Null(dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2556,10 +3097,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2580,10 +3126,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(0, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(0, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2604,9 +3155,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Equal(EntityState.Detached, context.Entry(principal).State);
-                Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Equal(EntityState.Detached, context.Entry(principal).State);
+                            Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -2627,9 +3183,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 context.ChangeTracker.DetectChanges();
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -3015,6 +3576,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase();
+        }
+
+        private void AssertFixup(DbContext context, Action asserts)
+        {
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
         }
 
         [Fact] // Issue #4853

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -19,9 +20,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = context.Set<Product>().Include(e => e.Category).Single();
                 var principal = dependent.Category;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                        });
             }
         }
 
@@ -35,9 +41,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = context.Set<Category>().Include(e => e.Products).Single();
                 var dependent = principal.Products.Single();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                        });
             }
         }
 
@@ -51,8 +62,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = context.Set<ProductDN>().Include(e => e.Category).Single();
                 var principal = dependent.Category;
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Same(principal, dependent.Category);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Same(principal, dependent.Category);
+                        });
             }
         }
 
@@ -66,8 +82,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = context.Set<CategoryPN>().Include(e => e.Products).Single();
                 var dependent = principal.Products.Single();
 
-                Assert.Equal(principal.Id, dependent.CategoryId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.CategoryId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                        });
             }
         }
 
@@ -81,9 +102,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = context.Set<Child>().Include(e => e.Parent).Single();
                 var principal = dependent.Parent;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                        });
             }
         }
 
@@ -97,9 +123,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = context.Set<Parent>().Include(e => e.Child).Single();
                 var dependent = principal.Child;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                        });
             }
         }
 
@@ -113,8 +144,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = context.Set<ChildDN>().Include(e => e.Parent).Single();
                 var principal = dependent.Parent;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(principal, dependent.Parent);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(principal, dependent.Parent);
+                        });
             }
         }
 
@@ -128,8 +164,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = context.Set<ParentPN>().Include(e => e.Child).Single();
                 var dependent = principal.Child;
 
-                Assert.Equal(principal.Id, dependent.ParentId);
-                Assert.Same(dependent, principal.Child);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentId);
+                            Assert.Same(dependent, principal.Child);
+                        });
             }
         }
 
@@ -144,9 +185,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Same(principal, dependent.ParentWidget);
-                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Same(principal, dependent.ParentWidget);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                        });
             }
         }
 
@@ -161,9 +207,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Same(principal, dependent.ParentWidget);
-                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Same(principal, dependent.ParentWidget);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                        });
             }
         }
 
@@ -178,9 +229,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Same(principal, dependent.ParentWidget);
-                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Same(principal, dependent.ParentWidget);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                        });
             }
         }
 
@@ -195,8 +251,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                        });
             }
         }
 
@@ -211,8 +272,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Same(principal, dependent.ParentWidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Same(principal, dependent.ParentWidget);
+                        });
             }
         }
 
@@ -227,8 +293,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Same(principal, dependent.ParentWidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Same(principal, dependent.ParentWidget);
+                        });
             }
         }
 
@@ -243,8 +314,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = widgets.Single(e => e.Id == 78);
                 var principal = widgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentWidgetId);
-                Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentWidgetId);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.ChildWidgets);
+                        });
             }
         }
 
@@ -259,9 +335,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(principal, dependent.ParentSmidget);
-                Assert.Same(dependent, principal.ChildSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(principal, dependent.ParentSmidget);
+                            Assert.Same(dependent, principal.ChildSmidget);
+                        });
             }
         }
 
@@ -276,9 +357,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(principal, dependent.ParentSmidget);
-                Assert.Same(dependent, principal.ChildSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(principal, dependent.ParentSmidget);
+                            Assert.Same(dependent, principal.ChildSmidget);
+                        });
             }
         }
 
@@ -293,9 +379,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(principal, dependent.ParentSmidget);
-                Assert.Same(dependent, principal.ChildSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(principal, dependent.ParentSmidget);
+                            Assert.Same(dependent, principal.ChildSmidget);
+                        });
             }
         }
 
@@ -310,8 +401,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(dependent, principal.ChildSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(dependent, principal.ChildSmidget);
+                        });
             }
         }
 
@@ -326,8 +422,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(principal, dependent.ParentSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(principal, dependent.ParentSmidget);
+                        });
             }
         }
 
@@ -342,8 +443,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(principal, dependent.ParentSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(principal, dependent.ParentSmidget);
+                        });
             }
         }
 
@@ -358,8 +464,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = smidgets.Single(e => e.Id == 78);
                 var principal = smidgets.Single(e => e.Id == 77);
 
-                Assert.Equal(principal.Id, dependent.ParentSmidgetId);
-                Assert.Same(dependent, principal.ChildSmidget);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.ParentSmidgetId);
+                            Assert.Same(dependent, principal.ChildSmidget);
+                        });
             }
         }
 
@@ -373,12 +484,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var dependent = context.Set<Post>().Include(e => e.Blog).Single();
                 var principal = dependent.Blog;
 
-                Assert.Equal(principal.Id, dependent.BlogId);
-                Assert.Same(principal, dependent.Blog);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.BlogId);
+                            Assert.Same(principal, dependent.Blog);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
 
-                Assert.Equal(dependent.Id, principal.TopPostId);
-                Assert.Same(dependent, principal.TopPost);
+                            Assert.Equal(dependent.Id, principal.TopPostId);
+                            Assert.Same(dependent, principal.TopPost);
+                        });
             }
         }
 
@@ -392,12 +508,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = context.Set<Blog>().Include(e => e.Posts).Single();
                 var dependent = principal.Posts.Single();
 
-                Assert.Equal(principal.Id, dependent.BlogId);
-                Assert.Same(principal, dependent.Blog);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, dependent.BlogId);
+                            Assert.Same(principal, dependent.Blog);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Posts);
 
-                Assert.Equal(dependent.Id, principal.TopPostId);
-                Assert.Same(dependent, principal.TopPost);
+                            Assert.Equal(dependent.Id, principal.TopPostId);
+                            Assert.Same(dependent, principal.TopPost);
+                        });
             }
         }
 
@@ -674,6 +795,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase("QueryFixup");
+        }
+
+        private void AssertFixup(DbContext context, Action asserts)
+        {
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -26,11 +27,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -49,11 +55,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -73,11 +84,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -98,11 +114,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -122,11 +143,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -145,11 +171,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -167,11 +198,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -192,11 +228,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -215,11 +256,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -239,11 +285,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -264,11 +315,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -288,11 +344,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -311,11 +372,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -333,11 +399,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -357,10 +428,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -380,10 +456,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -404,10 +485,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -426,10 +512,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -450,10 +541,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -472,10 +568,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(new[] { dependent }.ToList(), principal.Products);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -495,10 +596,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -518,10 +624,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -539,10 +650,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -562,10 +678,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -585,10 +706,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -606,10 +732,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Same(principal, dependent.Category);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Same(principal, dependent.Category);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -629,9 +760,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -651,9 +787,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -674,12 +815,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -698,11 +844,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -722,11 +873,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -747,11 +903,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -771,11 +932,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -794,11 +960,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -816,11 +987,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -841,11 +1017,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -864,11 +1045,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -888,11 +1074,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -913,11 +1104,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -937,11 +1133,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -960,11 +1161,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -982,11 +1188,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1006,10 +1217,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1029,10 +1245,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1053,10 +1274,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1075,10 +1301,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1099,10 +1330,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1121,10 +1357,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(dependent, principal.Child);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1144,10 +1385,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1167,10 +1413,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1188,10 +1439,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1211,10 +1467,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1234,10 +1495,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1255,10 +1521,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Same(principal, dependent.Parent);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1278,9 +1549,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1300,9 +1576,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
 
-                Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
-                Assert.Equal(entityState, context.Entry(principal).State);
-                Assert.Equal(entityState, context.Entry(dependent).State);
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
             }
         }
 
@@ -1482,6 +1763,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase();
+        }
+
+        private void AssertFixup(DbContext context, Action asserts)
+        {
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
         }
     }
 }


### PR DESCRIPTION
Issue #5734

When we encounter an untracked entity in a navigation we save it for later fixup, but we were not adding these entities to the snapshot for the navigation. This later caused change detection to be confused, which resulted in the entities being removed from the navigation.