### PR TITLE
Move API into .Internal namespaces.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/Microsoft.EntityFrameworkCore.InMemory.csproj
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Microsoft.EntityFrameworkCore.InMemory.csproj
@@ -80,8 +80,8 @@
     <Compile Include="Query\Internal\InMemoryQueryModelVisitor.cs" />
     <Compile Include="Query\Internal\InMemoryQueryModelVisitorFactory.cs" />
     <Compile Include="Query\Internal\MaterializerFactory.cs" />
-    <Compile Include="Storage\InMemoryTransaction.cs" />
-    <Compile Include="Storage\InMemoryTransactionManager.cs" />
+    <Compile Include="Storage\Internal\InMemoryTransaction.cs" />
+    <Compile Include="Storage\Internal\InMemoryTransactionManager.cs" />
     <Compile Include="Storage\Internal\IInMemoryDatabase.cs" />
     <Compile Include="Storage\Internal\IInMemoryStore.cs" />
     <Compile Include="Storage\Internal\IInMemoryStoreSource.cs" />

--- a/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryTransaction.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryTransaction.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     public class InMemoryTransaction : IDbContextTransaction
     {

--- a/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     public class InMemoryTransactionManager : IDbContextTransactionManager
     {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -136,7 +136,7 @@
     <Compile Include="Query\Internal\SqlServerQueryModelVisitorFactory.cs" />
     <Compile Include="Query\Sql\Internal\SqlServerQuerySqlGenerator.cs" />
     <Compile Include="Query\Sql\Internal\SqlServerQuerySqlGeneratorFactory.cs" />
-    <Compile Include="Query\Sql\ISqlServerExpressionVisitor.cs" />
+    <Compile Include="Query\Sql\Internal\ISqlServerExpressionVisitor.cs" />
     <Compile Include="Storage\Internal\ISqlServerConnection.cs" />
     <Compile Include="Storage\Internal\SqlServerConnection.cs" />
     <Compile Include="Storage\Internal\SqlServerDatabaseCreator.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/DatePartExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/DatePartExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/ISqlServerExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/ISqlServerExpressionVisitor.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Query.Sql
+namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 {
     public interface ISqlServerExpressionVisitor
     {

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Infrastructure/SqliteServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Infrastructure/SqliteServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Update.Internal;

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
@@ -94,14 +94,14 @@
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimEndTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimStartTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringTrimTranslator.cs" />
-    <Compile Include="Query\Sql\SqliteQuerySqlGenerator.cs" />
-    <Compile Include="Query\Sql\SqliteQuerySqlGeneratorFactory.cs" />
+    <Compile Include="Query\Sql\Internal\SqliteQuerySqlGenerator.cs" />
+    <Compile Include="Query\Sql\Internal\SqliteQuerySqlGeneratorFactory.cs" />
     <Compile Include="SqliteDbContextOptionsBuilderExtensions.cs" />
     <Compile Include="Storage\Internal\SqliteDatabaseCreator.cs" />
     <Compile Include="Storage\Internal\SqliteRelationalConnection.cs" />
     <Compile Include="Storage\Internal\SqliteSqlGenerationHelper.cs" />
     <Compile Include="Storage\Internal\SqliteTypeMapper.cs" />
-    <Compile Include="Storage\SqliteDatabaseProviderServices.cs" />
+    <Compile Include="Storage\Internal\SqliteDatabaseProviderServices.cs" />
     <Compile Include="Update\Internal\SqliteModificationCommandBatchFactory.cs" />
     <Compile Include="Update\Internal\SqliteUpdateSqlGenerator.cs" />
     <Compile Include="ValueGeneration\Internal\SqliteValueGeneratorCache.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Sql
+namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 {
     public class SqliteQuerySqlGenerator : DefaultQuerySqlGenerator
     {

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Sql
+namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 {
     public class SqliteQuerySqlGeneratorFactory : QuerySqlGeneratorFactoryBase
     {

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteDatabaseProviderServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteDatabaseProviderServices.cs
@@ -15,13 +15,13 @@ using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     public class SqliteDatabaseProviderServices : RelationalDatabaseProviderServices
     {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.Logging;
 using Xunit;
 


### PR DESCRIPTION
Move the following classes to .Internal.

- InMemoryTransaction
- InMemoryTransactionManager
- SqliteDatabaseProviderServices
- SqliteQuerySqlGenerator
- SqliteQuerySqlGeneratorFactory
- ISqlServerExpressionVisitor

Fix #5761

cc @rowanmiller @anpete 