### PR TITLE
Implement DbSet.Find

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
@@ -1,0 +1,708 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class FindTestBase<TFixture> : IClassFixture<TFixture>, IDisposable
+        where TFixture : FindTestBase<TFixture>.FindFixtureBase, new()
+    {
+        protected FindTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            fixture.Initialize();
+        }
+
+        [Fact]
+        public virtual void Find_int_key_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new IntKey { Id = 88 }).Entity;
+
+                Assert.Same(entity, context.IntKeys.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_int_key_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Smokey", context.IntKeys.Find(77).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_int_key_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.IntKeys.Find(99));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_string_key_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new StringKey { Id = "Rabbit" }).Entity;
+
+                Assert.Same(entity, context.StringKeys.Find("Rabbit"));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_string_key_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alice", context.StringKeys.Find("Cat").Foo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_string_key_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.StringKeys.Find("Fox"));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_composite_key_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new CompositeKey { Id1 = 88, Id2 = "Rabbit" }).Entity;
+
+                Assert.Same(entity, context.CompositeKeys.Find(88, "Rabbit"));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_composite_key_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Olive", context.CompositeKeys.Find(77, "Dog").Foo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_composite_key_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.CompositeKeys.Find(77, "Fox"));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_base_type_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new BaseType { Id = 88 }).Entity;
+
+                Assert.Same(entity, context.BaseTypes.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_base_type_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Baxter", context.BaseTypes.Find(77).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_base_type_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.BaseTypes.Find(99));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_derived_type_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
+
+                Assert.Same(entity, context.DerivedTypes.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_derived_type_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                var derivedType = context.DerivedTypes.Find(78);
+                Assert.Equal("Strawberry", derivedType.Foo);
+                Assert.Equal("Cheesecake", derivedType.Boo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_derived_type_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.DerivedTypes.Find(99));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_base_type_using_derived_set_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                context.Attach(new BaseType { Id = 88 });
+
+                Assert.Null(context.DerivedTypes.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_base_type_using_derived_set_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.DerivedTypes.Find(77));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_derived_type_using_base_set_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
+
+                Assert.Same(entity, context.BaseTypes.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_derived_using_base_set_type_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                var derivedType = context.BaseTypes.Find(78);
+                Assert.Equal("Strawberry", derivedType.Foo);
+                Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
+            }
+        }
+
+        [Fact]
+        public virtual void Find_shadow_key_tracked()
+        {
+            using (var context = CreateContext())
+            {
+                var entry = context.Entry(new ShadowKey());
+                entry.Property("Id").CurrentValue = 88;
+                entry.State = EntityState.Unchanged;
+
+                Assert.Same(entry.Entity, context.ShadowKeys.Find(88));
+            }
+        }
+
+        [Fact]
+        public virtual void Find_shadow_key_from_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Clippy", context.ShadowKeys.Find(77).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual void Returns_null_for_shadow_key_not_in_store()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(context.ShadowKeys.Find(99));
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_null_key_values_array()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    Assert.Throws<ArgumentNullException>(() => context.CompositeKeys.Find(null)).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_null_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    Assert.Throws<ArgumentNullException>(() => context.IntKeys.Find(new object[] { null })).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_null_in_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    Assert.Throws<ArgumentNullException>(() => context.CompositeKeys.Find(77, null)).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_multiple_values_passed_for_simple_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindNotCompositeKey("IntKey", 2),
+                    Assert.Throws<ArgumentException>(() => context.IntKeys.Find(77, 88)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_wrong_number_of_values_for_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueCountMismatch("CompositeKey", 2, 1),
+                    Assert.Throws<ArgumentException>(() => context.CompositeKeys.Find(77)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_bad_type_for_simple_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "String", "Int32"),
+                    Assert.Throws<ArgumentException>(() => context.IntKeys.Find("77")).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_bad_type_for_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "Int32", "String"),
+                    Assert.Throws<ArgumentException>(() => context.CompositeKeys.Find(77, 88)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_int_key_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new IntKey { Id = 88 }).Entity;
+
+                Assert.Same(entity, await context.IntKeys.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_int_key_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Smokey", (await context.IntKeys.FindAsync(77)).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_int_key_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.IntKeys.FindAsync(99));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_string_key_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new StringKey { Id = "Rabbit" }).Entity;
+
+                Assert.Same(entity, await context.StringKeys.FindAsync("Rabbit"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_string_key_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alice", (await context.StringKeys.FindAsync("Cat")).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_string_key_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.StringKeys.FindAsync("Fox"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_composite_key_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new CompositeKey { Id1 = 88, Id2 = "Rabbit" }).Entity;
+
+                Assert.Same(entity, await context.CompositeKeys.FindAsync(88, "Rabbit"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_composite_key_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Olive", (await context.CompositeKeys.FindAsync(77, "Dog")).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_composite_key_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.CompositeKeys.FindAsync(77, "Fox"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_base_type_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new BaseType { Id = 88 }).Entity;
+
+                Assert.Same(entity, await context.BaseTypes.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_base_type_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Baxter", (await context.BaseTypes.FindAsync(77)).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_base_type_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.BaseTypes.FindAsync(99));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_derived_type_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
+
+                Assert.Same(entity, await context.DerivedTypes.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_derived_type_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                var derivedType = await context.DerivedTypes.FindAsync(78);
+                Assert.Equal("Strawberry", derivedType.Foo);
+                Assert.Equal("Cheesecake", derivedType.Boo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_derived_type_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.DerivedTypes.FindAsync(99));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_base_type_using_derived_set_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                context.Attach(new BaseType { Id = 88 });
+
+                Assert.Null(await context.DerivedTypes.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_base_type_using_derived_set_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.DerivedTypes.FindAsync(77));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_derived_type_using_base_set_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
+
+                Assert.Same(entity, await context.BaseTypes.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_derived_using_base_set_type_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                var derivedType = await context.BaseTypes.FindAsync(78);
+                Assert.Equal("Strawberry", derivedType.Foo);
+                Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_shadow_key_tracked_async()
+        {
+            using (var context = CreateContext())
+            {
+                var entry = context.Entry(new ShadowKey());
+                entry.Property("Id").CurrentValue = 88;
+                entry.State = EntityState.Unchanged;
+
+                Assert.Same(entry.Entity, await context.ShadowKeys.FindAsync(88));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Find_shadow_key_from_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Clippy", (await context.ShadowKeys.FindAsync(77)).Foo);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Returns_null_for_shadow_key_not_in_store_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Null(await context.ShadowKeys.FindAsync(99));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_null_key_values_array_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.CompositeKeys.FindAsync(null))).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_null_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.IntKeys.FindAsync(new object[] { null }))).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_null_in_composite_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("keyValues",
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.CompositeKeys.FindAsync(77, null))).ParamName);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_multiple_values_passed_for_simple_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindNotCompositeKey("IntKey", 2),
+                    (await Assert.ThrowsAsync<ArgumentException>(() => context.IntKeys.FindAsync(77, 88))).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_wrong_number_of_values_for_composite_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueCountMismatch("CompositeKey", 2, 1),
+                    (await Assert.ThrowsAsync<ArgumentException>(() => context.CompositeKeys.FindAsync(77))).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_bad_type_for_simple_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "String", "Int32"),
+                    (await Assert.ThrowsAsync<ArgumentException>(() => context.IntKeys.FindAsync("77"))).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_bad_type_for_composite_key_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "Int32", "String"),
+                    (await Assert.ThrowsAsync<ArgumentException>(() => context.CompositeKeys.FindAsync(77, 88))).Message);
+            }
+        }
+
+        protected class BaseType
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+
+            public string Foo { get; set; }
+        }
+
+        protected class DerivedType : BaseType
+        {
+            public string Boo { get; set; }
+        }
+
+        protected class IntKey
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id { get; set; }
+
+            public string Foo { get; set; }
+        }
+
+        protected class StringKey
+        {
+            public string Id { get; set; }
+
+            public string Foo { get; set; }
+        }
+
+        protected class CompositeKey
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+            public string Foo { get; set; }
+        }
+
+        protected class ShadowKey
+        {
+            public string Foo { get; set; }
+        }
+
+        protected class FindContext : DbContext
+        {
+            public FindContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<IntKey> IntKeys { get; set; }
+            public DbSet<StringKey> StringKeys { get; set; }
+            public DbSet<CompositeKey> CompositeKeys { get; set; }
+            public DbSet<BaseType> BaseTypes { get; set; }
+            public DbSet<DerivedType> DerivedTypes { get; set; }
+            public DbSet<ShadowKey> ShadowKeys { get; set; }
+        }
+
+        protected FindContext CreateContext() => (FindContext)Fixture.CreateContext();
+
+        protected TFixture Fixture { get; }
+
+        public virtual void Dispose()
+        {
+        }
+
+        public abstract class FindFixtureBase
+        {
+            private static readonly object _lock = new object();
+            private static bool _initialized;
+
+            public virtual void Initialize()
+            {
+                lock (_lock)
+                {
+                    if (!_initialized)
+                    {
+                        CreateTestStore();
+                        _initialized = true;
+                    }
+                }
+            }
+
+            public abstract void CreateTestStore();
+
+            public abstract DbContext CreateContext();
+
+            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<CompositeKey>().HasKey(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<ShadowKey>().Property(typeof(int), "Id").ValueGeneratedNever();
+            }
+
+            protected virtual void Seed(DbContext context)
+            {
+                context.AddRange(
+                    new IntKey { Id = 77, Foo = "Smokey" },
+                    new StringKey { Id = "Cat", Foo = "Alice" },
+                    new CompositeKey { Id1 = 77, Id2 = "Dog", Foo = "Olive" },
+                    new BaseType { Id = 77, Foo = "Baxter" },
+                    new DerivedType { Id = 78, Foo = "Strawberry", Boo = "Cheesecake" });
+
+                var entry = context.Entry(new ShadowKey { Foo = "Clippy" });
+                entry.Property("Id").CurrentValue = 77;
+                entry.State = EntityState.Added;
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="DataAnnotationFixtureBase.cs" />
     <Compile Include="DataAnnotationTestBase.cs" />
     <Compile Include="F1FixtureBase.cs" />
+    <Compile Include="FindTestBase.cs" />
     <Compile Include="GearsOfWarQueryFixtureBase.cs" />
     <Compile Include="GearsOfWarQueryTestBase.cs" />
     <Compile Include="GraphUpdatesTestBase.cs" />

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
@@ -40,6 +40,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual object CreateFromKeyValues(object[] keyValues)
+            => keyValues.Any(v => v == null) ? null : keyValues;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual object CreateFromBuffer(ValueBuffer valueBuffer)
         {
             var values = new object[_properties.Count];

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IIdentityMap.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IIdentityMap.cs
@@ -35,6 +35,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        InternalEntityEntry TryGetEntry([NotNull] object[] keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         InternalEntityEntry TryGetEntry(ValueBuffer valueBuffer, bool throwOnNullKey);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IPrincipalKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IPrincipalKeyValueFactory.cs
@@ -17,6 +17,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        object CreateFromKeyValues([NotNull] object[] keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         object CreateFromBuffer(ValueBuffer valueBuffer);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -39,6 +39,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        InternalEntityEntry TryGetEntry([NotNull] IKey key, [NotNull] object[] keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         InternalEntityEntry TryGetEntry([NotNull] IKey key, ValueBuffer valueBuffer, bool throwOnNullKey);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IdentityMap.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IdentityMap.cs
@@ -81,6 +81,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual InternalEntityEntry TryGetEntry(object[] keyValues)
+        {
+            InternalEntityEntry entry;
+            var key = PrincipalKeyValueFactory.CreateFromKeyValues(keyValues);
+            return key != null && _identityMap.TryGetValue((TKey)key, out entry) ? entry : null;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalEntityEntry TryGetEntry(ValueBuffer valueBuffer, bool throwOnNullKey)
         {
             InternalEntityEntry entry;

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SimplePrincipalKeyValueFactory.cs
@@ -35,6 +35,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual object CreateFromKeyValues(object[] keyValues)
+            => keyValues[0];
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual object CreateFromBuffer(ValueBuffer valueBuffer)
             => _propertyAccessors.ValueBufferGetter(valueBuffer);
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     // This is lower-level change tracking services used by the ChangeTracker and other parts of the system
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class StateManager : IStateManager
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly IConcurrencyDetector _concurrencyDetector;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public StateManager(
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsSingleQueryMode(IEntityType entityType)
@@ -97,25 +97,25 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void EndSingleQueryMode() => _singleQueryMode = false;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IInternalEntityEntryNotifier Notify { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IValueGenerationManager ValueGeneration { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry GetOrCreateEntry(object entity)
@@ -140,13 +140,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void BeginTrackingQuery() => _singleQueryMode = _singleQueryMode == null;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry StartTrackingFromQuery(
@@ -186,14 +186,21 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalEntityEntry TryGetEntry(IKey key, object[] keyValues)
+            => FindIdentityMap(key)?.TryGetEntry(keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry TryGetEntry(IKey key, ValueBuffer valueBuffer, bool throwOnNullKey)
             => GetOrCreateIdentityMap(key).TryGetEntry(valueBuffer, throwOnNullKey);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry TryGetEntry(object entity)
@@ -272,13 +279,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> Entries => _entityReferenceMap.Values;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry StartTracking(InternalEntityEntry entry)
@@ -317,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void StopTracking(InternalEntityEntry entry)
@@ -359,7 +366,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Unsubscribe()
@@ -374,7 +381,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void RecordReferencedUntrackedEntity(
@@ -390,7 +397,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<Tuple<INavigation, InternalEntityEntry>> GetRecordedReferers(object referencedEntity, bool clear)
@@ -410,21 +417,21 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry GetPrincipal(InternalEntityEntry dependentEntry, IForeignKey foreignKey)
             => FindIdentityMap(foreignKey.PrincipalKey)?.TryGetEntry(foreignKey, dependentEntry);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry GetPrincipalUsingRelationshipSnapshot(InternalEntityEntry dependentEntry, IForeignKey foreignKey)
             => FindIdentityMap(foreignKey.PrincipalKey)?.TryGetEntryUsingRelationshipSnapshot(foreignKey, dependentEntry);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void UpdateIdentityMap(InternalEntityEntry entry, IKey key)
@@ -445,7 +452,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void UpdateDependentMap(InternalEntityEntry entry, IForeignKey foreignKey)
@@ -461,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> GetDependents(
@@ -474,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot(
@@ -487,7 +494,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<InternalEntityEntry> GetDependentsFromNavigation(InternalEntityEntry principalEntry, IForeignKey foreignKey)
@@ -517,7 +524,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual int SaveChanges(bool acceptAllChangesOnSuccess)
@@ -572,7 +579,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual async Task<int> SaveChangesAsync(
@@ -606,7 +613,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual int SaveChanges(
@@ -619,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual async Task<int> SaveChangesAsync(
@@ -633,7 +640,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void AcceptAllChanges()
@@ -656,7 +663,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual DbContext Context { get; }

--- a/src/Microsoft.EntityFrameworkCore/DbSet`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbSet`.cs
@@ -6,6 +6,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -43,6 +45,49 @@ namespace Microsoft.EntityFrameworkCore
         : IQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IInfrastructure<IServiceProvider>
         where TEntity : class
     {
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual TEntity Find([NotNull] params object[] keyValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<TEntity> FindAsync([NotNull] params object[] keyValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<TEntity> FindAsync([NotNull] object[] keyValues, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         ///     Begins tracking the given entity, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Added" /> state such that they will

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -713,6 +713,30 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// Entity type '{entityType}' is defined with a single key property, but {valuesCount} values were passed to the 'DbSet.Find' method.
+        /// </summary>
+        public static string FindNotCompositeKey([CanBeNull] object entityType, [CanBeNull] object valuesCount)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FindNotCompositeKey", "entityType", "valuesCount"), entityType, valuesCount);
+        }
+
+        /// <summary>
+        /// Entity type '{entityType}' is defined with a {propertiesCount}-part composite key, but {valuesCount} values were passed to the 'DbSet.Find' method.
+        /// </summary>
+        public static string FindValueCountMismatch([CanBeNull] object entityType, [CanBeNull] object propertiesCount, [CanBeNull] object valuesCount)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FindValueCountMismatch", "entityType", "propertiesCount", "valuesCount"), entityType, propertiesCount, valuesCount);
+        }
+
+        /// <summary>
+        /// The key value at position {index} of the call to 'DbSet&lt;{entityType}&gt;.Find' was of type '{valueType}', which does not match the property type of '{propertyType}'.
+        /// </summary>
+        public static string FindValueTypeMismatch([CanBeNull] object index, [CanBeNull] object entityType, [CanBeNull] object valueType, [CanBeNull] object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FindValueTypeMismatch", "index", "entityType", "valueType", "propertyType"), index, entityType, valueType, propertyType);
+        }
+
+        /// <summary>
         /// The provided principal entity key '{principalKey}' is not a key on the entity type '{principalEntityType}'.
         /// </summary>
         public static string ForeignKeyReferencedEntityKeyMismatch([CanBeNull] object principalKey, [CanBeNull] object principalEntityType)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -378,6 +378,15 @@
   <data name="CannotMaterializeAbstractType" xml:space="preserve">
     <value>Unable to create an instance of type entity type '{entityType}' because it is abstract. Either make it non-abstract or consider mapping at least one derived type.</value>
   </data>
+  <data name="FindNotCompositeKey" xml:space="preserve">
+    <value>Entity type '{entityType}' is defined with a single key property, but {valuesCount} values were passed to the 'DbSet.Find' method.</value>
+  </data>
+  <data name="FindValueCountMismatch" xml:space="preserve">
+    <value>Entity type '{entityType}' is defined with a {propertiesCount}-part composite key, but {valuesCount} values were passed to the 'DbSet.Find' method.</value>
+  </data>
+  <data name="FindValueTypeMismatch" xml:space="preserve">
+    <value>The key value at position {index} of the call to 'DbSet&lt;{entityType}&gt;.Find' was of type '{valueType}', which does not match the property type of '{propertyType}'.</value>
+  </data>
   <data name="ForeignKeyReferencedEntityKeyMismatch" xml:space="preserve">
     <value>The provided principal entity key '{principalKey}' is not a key on the entity type '{principalEntityType}'.</value>
   </data>

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FindInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FindInMemoryTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class FindInMemoryTest
+        : FindTestBase<FindInMemoryTest.FindInMemoryFixture>
+    {
+        public FindInMemoryTest(FindInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class FindInMemoryFixture : FindFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public FindInMemoryFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override void CreateTestStore()
+            {
+                using (var context = CreateContext())
+                {
+                    Seed(context);
+                }
+            }
+
+            public override DbContext CreateContext()
+                => new FindContext(new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase("FindTest")
+                    .UseInternalServiceProvider(_serviceProvider).Options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="DataAnnotationInMemoryFixture.cs" />
     <Compile Include="DataAnnotationInMemoryTest.cs" />
     <Compile Include="DatabaseInMemoryTest.cs" />
+    <Compile Include="FindInMemoryTest.cs" />
     <Compile Include="WarningsTest.cs" />
     <Compile Include="EndToEndTest.cs" />
     <Compile Include="GearsOfWarQueryInMemoryFixture.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -1,0 +1,268 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class FindSqlServerTest
+        : FindTestBase<FindSqlServerTest.FindSqlServerFixture>
+    {
+        public FindSqlServerTest(FindSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [Fact]
+        public override void Find_int_key_tracked()
+        {
+            base.Find_int_key_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_int_key_from_store()
+        {
+            base.Find_int_key_from_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [IntKey] AS [e]
+WHERE [e].[Id] = 77", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_int_key_not_in_store()
+        {
+            base.Returns_null_for_int_key_not_in_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [IntKey] AS [e]
+WHERE [e].[Id] = 99", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_string_key_tracked()
+        {
+            base.Find_string_key_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_string_key_from_store()
+        {
+            base.Find_string_key_from_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [StringKey] AS [e]
+WHERE [e].[Id] = N'Cat'", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_string_key_not_in_store()
+        {
+            base.Returns_null_for_string_key_not_in_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [StringKey] AS [e]
+WHERE [e].[Id] = N'Fox'", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_composite_key_tracked()
+        {
+            base.Find_composite_key_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_composite_key_from_store()
+        {
+            base.Find_composite_key_from_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
+FROM [CompositeKey] AS [e]
+WHERE ([e].[Id1] = 77) AND ([e].[Id2] = N'Dog')", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_composite_key_not_in_store()
+        {
+            base.Returns_null_for_composite_key_not_in_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
+FROM [CompositeKey] AS [e]
+WHERE ([e].[Id1] = 77) AND ([e].[Id2] = N'Fox')", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_base_type_tracked()
+        {
+            base.Find_base_type_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_base_type_from_store()
+        {
+            base.Find_base_type_from_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = 77)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_base_type_not_in_store()
+        {
+            base.Returns_null_for_base_type_not_in_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = 99)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_derived_type_tracked()
+        {
+            base.Find_derived_type_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_derived_type_from_store()
+        {
+            base.Find_derived_type_from_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = 78)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_derived_type_not_in_store()
+        {
+            base.Returns_null_for_derived_type_not_in_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = 99)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_base_type_using_derived_set_tracked()
+        {
+            base.Find_base_type_using_derived_set_tracked();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = 88)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_base_type_using_derived_set_from_store()
+        {
+            base.Find_base_type_using_derived_set_from_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = 77)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_derived_type_using_base_set_tracked()
+        {
+            base.Find_derived_type_using_base_set_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_derived_using_base_set_type_from_store()
+        {
+            base.Find_derived_using_base_set_type_from_store();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
+FROM [BaseType] AS [e]
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = 78)", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_shadow_key_tracked()
+        {
+            base.Find_shadow_key_tracked();
+
+            Assert.Equal("", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Find_shadow_key_from_store()
+        {
+            base.Find_shadow_key_from_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [ShadowKey] AS [e]
+WHERE [e].[Id] = 77", TestSqlLoggerFactory.Sql);
+        }
+
+        [Fact]
+        public override void Returns_null_for_shadow_key_not_in_store()
+        {
+            base.Returns_null_for_shadow_key_not_in_store();
+
+            Assert.Equal(@"SELECT TOP(1) [e].[Id], [e].[Foo]
+FROM [ShadowKey] AS [e]
+WHERE [e].[Id] = 99", TestSqlLoggerFactory.Sql);
+        }
+
+        public override void Dispose() => TestSqlLoggerFactory.Reset();
+
+        public class FindSqlServerFixture : FindFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public FindSqlServerFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkSqlServer()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .AddSingleton<ILoggerFactory, TestSqlLoggerFactory>()
+                    .BuildServiceProvider();
+            }
+
+            public override void CreateTestStore()
+            {
+                using (var context = CreateContext())
+                {
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
+                    Seed(context);
+                    TestSqlLoggerFactory.Reset();
+                }
+            }
+
+            public override DbContext CreateContext()
+                => new FindContext(new DbContextOptionsBuilder()
+                    .UseSqlServer(SqlServerTestStore.CreateConnectionString("FindTest"))
+                    .UseInternalServiceProvider(_serviceProvider).Options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />
     <Compile Include="F1SqlServerFixture.cs" />
+    <Compile Include="FindSqlServerTest.cs" />
     <Compile Include="FromSqlQuerySqlServerTest.cs" />
     <Compile Include="FromSqlSprocQuerySqlServerTest.cs" />
     <Compile Include="GearsOfWarFromSqlQuerySqlServerTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -45,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 {
                     Assert.Same(
                         entity,
-                        stateManager.TryGetEntry(key, new ValueBuffer(new object[] { entity.Id, entity.Name }), false).Entity);
+                        stateManager.TryGetEntry(key, new object[] { entity.Id }).Entity);
                 }
 
                 Assert.Throws<DbUpdateException>(() => context.SaveChanges());
@@ -59,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 {
                     Assert.Same(
                         entity,
-                        stateManager.TryGetEntry(key, new ValueBuffer(new object[] { entity.Id, entity.Name }), false).Entity);
+                        stateManager.TryGetEntry(key, new object[] { entity.Id }).Entity);
                 }
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class FindSqliteTest
+        : FindTestBase<FindSqliteTest.FindSqliteFixture>
+    {
+        public FindSqliteTest(FindSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class FindSqliteFixture : FindFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public FindSqliteFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkSqlite()
+                    .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override void CreateTestStore()
+            {
+                using (var context = CreateContext())
+                {
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
+                    Seed(context);
+                }
+            }
+
+            public override DbContext CreateContext()
+                => new FindContext(new DbContextOptionsBuilder()
+                    .UseSqlite(SqliteTestStore.CreateConnectionString("FindTest"))
+                    .UseInternalServiceProvider(_serviceProvider).Options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="DataAnnotationSqliteTest.cs" />
     <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="F1SqliteFixture.cs" />
+    <Compile Include="FindSqliteTest.cs" />
     <Compile Include="FromSqlQuerySqliteTest.cs" />
     <Compile Include="GearsOfWarFromSqlQuerySqliteTest.cs" />
     <Compile Include="GearsOfWarQuerySqliteFixture.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -289,6 +289,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 throw new NotImplementedException();
             }
 
+            public InternalEntityEntry TryGetEntry(IKey key, object[] keyValues)
+            {
+                throw new NotImplementedException();
+            }
+
             public InternalEntityEntry TryGetEntry(IKey key, ValueBuffer valueBuffer, bool throwOnNullKey)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Issue #797

Semantics are essentially the same as EF6:
- If entity with given key is being tracked, then return it without a database query
- Otherwise, query the database and track and return entity if found
- Otherwise, return null