### PR TITLE
Culture resistence in JsonUtility

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Utilities/Internal/JsonUtility.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Utilities/Internal/JsonUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -56,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Core.Utilities.Internal
                 || obj is float
                 || obj is double)
             {
-                sb.Append(obj);
+                sb.Append(Convert.ToString(obj, CultureInfo.InvariantCulture));
                 return;
             }
             if (obj is IEnumerable)

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/Utilities/JsonUtilityTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/Utilities/JsonUtilityTest.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Design.Core.Utilities.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Utilities
         }
 
         [Fact]
+        [UseCulture("")] // Invariant culture
         public void SerializesAnonymousType()
         {
             var t = new
@@ -84,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Utilities
             var actual = JsonUtility.Serialize(t);
             _output?.WriteLine(actual);
             Assert.Equal(
-@"{
+                @"{
     ""id"": ""Microsoft.EntityFrameworkCore.EFCore10"",
     ""escapedChars"": ""EFCore\\" + "\\\"" + @"\t\f\b\r\n"",
     ""floatNo"": 1.89,
@@ -100,7 +103,50 @@ namespace Microsoft.EntityFrameworkCore.Tests.Utilities
     ""emptyArray"": [
     ]
 }"
-              , actual);
+                , actual);
+            Assert.NotNull(JsonConvert.DeserializeObject(actual));
+        }
+
+        [Fact]
+        [UseCulture("pt-BR")]
+        public void SerializesAnonymousTypeDiffernetSeparatorsCulture()
+        {
+            var t = new
+            {
+                id = "Microsoft.EntityFrameworkCore.EFCore10",
+                escapedChars = "EFCore\\\"\t\f\b\r\n",
+                floatNo = 1.89f,
+                decimalNo = 48.1m,
+                doubleNo = 48d,
+                uintNo = 12u,
+                intNo = -23,
+                ulongNo = 123UL,
+                longNo = -123L,
+                trueType = true,
+                falseType = false,
+                nullProp = (object)null,
+                emptyArray = new object[] { }
+            };
+            var actual = JsonUtility.Serialize(t);
+            _output?.WriteLine(actual);
+            Assert.Equal(
+                @"{
+    ""id"": ""Microsoft.EntityFrameworkCore.EFCore10"",
+    ""escapedChars"": ""EFCore\\" + "\\\"" + @"\t\f\b\r\n"",
+    ""floatNo"": 1.89,
+    ""decimalNo"": 48.1,
+    ""doubleNo"": 48,
+    ""uintNo"": 12,
+    ""intNo"": -23,
+    ""ulongNo"": 123,
+    ""longNo"": -123,
+    ""trueType"": true,
+    ""falseType"": false,
+    ""nullProp"": null,
+    ""emptyArray"": [
+    ]
+}"
+                , actual);
             Assert.NotNull(JsonConvert.DeserializeObject(actual));
         }
     }


### PR DESCRIPTION
- If the entity framework is used in some culture that use another kind of decimal separator the JsonUtility test fail
- Forced invariant culture when doing serialization and add specific test forcing another culture

Fixes #5821 

**Please check if the PR fulfills these requirements**

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.