### PR TITLE
Query tells state manager which relationships have been fixed up

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IEntityStateListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IEntityStateListener.cs
@@ -26,7 +26,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         void StateChanged(
             [NotNull] InternalEntityEntry entry,
             EntityState oldState,
-            bool skipInitialFixup,
             bool fromQuery);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
@@ -23,7 +23,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState, bool skipInitialFixup, bool fromQuery);
+        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState, bool fromQuery);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void TrackedFromQuery(
+            [NotNull] InternalEntityEntry entry, 
+            [CanBeNull] ISet<IForeignKey> handledForeignKeys);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/INavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/INavigationFixer.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface INavigationFixer : IEntityStateListener, INavigationListener, IKeyListener
+    public interface INavigationFixer : IEntityStateListener, INavigationListener, IKeyListener, IQueryTrackingListener
     {
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IQueryTrackingListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IQueryTrackingListener.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IQueryTrackingListener
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void TrackedFromQuery(
+            [NotNull] InternalEntityEntry entry,
+            [CanBeNull] ISet<IForeignKey> handledForeignKeys);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -27,7 +27,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalEntityEntry StartTrackingFromQuery([NotNull] IEntityType baseEntityType, [NotNull] object entity, ValueBuffer valueBuffer);
+        InternalEntityEntry StartTrackingFromQuery(
+            [NotNull] IEntityType baseEntityType, 
+            [NotNull] object entity, 
+            ValueBuffer valueBuffer,
+            [CanBeNull] ISet<IForeignKey> handledForeignKeys);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -166,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        bool IsSingleQueryMode([NotNull] IEntityType entityType);
+        TrackingQueryMode GetTrackingQueryMode([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -391,13 +391,32 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual void TrackedFromQuery(
+            InternalEntityEntry entry, 
+            ISet<IForeignKey> handledForeignKeys)
+        {
+            try
+            {
+                _inFixup = true;
+
+                InitialFixup(entry, handledForeignKeys, fromQuery: true);
+            }
+            finally
+            {
+                _inFixup = false;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual void StateChanged(
             InternalEntityEntry entry,
             EntityState oldState,
-            bool skipInitialFixup,
             bool fromQuery)
         {
-            if (_inFixup)
+            if (fromQuery || _inFixup)
             {
                 return;
             }
@@ -406,12 +425,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 _inFixup = true;
 
-                if (oldState == EntityState.Detached
-                    && !skipInitialFixup)
+                if (oldState == EntityState.Detached)
                 {
-                    InitialFixup(entry, fromQuery);
+                    InitialFixup(entry, null, fromQuery: false);
                 }
-
                 else if (entry.EntityState == EntityState.Detached
                          && oldState == EntityState.Deleted)
                 {
@@ -470,60 +487,71 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
         }
 
-        private void InitialFixup(InternalEntityEntry entry, bool fromQuery)
+        private void InitialFixup(
+            InternalEntityEntry entry,
+            ISet<IForeignKey> handledForeignKeys, 
+            bool fromQuery)
         {
             var entityType = entry.EntityType;
             var stateManager = entry.StateManager;
 
             foreach (var foreignKey in entityType.GetForeignKeys())
             {
-                var principalEntry = stateManager.GetPrincipal(entry, foreignKey);
-                if (principalEntry != null)
+                if (handledForeignKeys == null
+                    || !handledForeignKeys.Contains(foreignKey))
                 {
-                    // Set navigation to principal based on FK properties
-                    SetNavigation(entry, foreignKey.DependentToPrincipal, principalEntry.Entity);
-
-                    // Add this entity to principal's collection, or set inverse for 1:1
-                    var principalToDependent = foreignKey.PrincipalToDependent;
-                    if (principalToDependent != null)
+                    var principalEntry = stateManager.GetPrincipal(entry, foreignKey);
+                    if (principalEntry != null)
                     {
-                        SetReferenceOrAddToCollection(
-                            principalEntry,
-                            principalToDependent,
-                            principalToDependent.IsCollection() ? principalToDependent.GetCollectionAccessor() : null,
-                            entry.Entity);
+                        // Set navigation to principal based on FK properties
+                        SetNavigation(entry, foreignKey.DependentToPrincipal, principalEntry.Entity);
+
+                        // Add this entity to principal's collection, or set inverse for 1:1
+                        var principalToDependent = foreignKey.PrincipalToDependent;
+                        if (principalToDependent != null)
+                        {
+                            SetReferenceOrAddToCollection(
+                                principalEntry,
+                                principalToDependent,
+                                principalToDependent.IsCollection() ? principalToDependent.GetCollectionAccessor() : null,
+                                entry.Entity);
+                        }
                     }
                 }
             }
 
             foreach (var foreignKey in entityType.GetReferencingForeignKeys())
             {
-                var dependents = stateManager.GetDependents(entry, foreignKey).ToList();
-                if (dependents.Any())
+                if (handledForeignKeys == null
+                    || !handledForeignKeys.Contains(foreignKey))
                 {
-                    var dependentToPrincipal = foreignKey.DependentToPrincipal;
-                    var principalToDependent = foreignKey.PrincipalToDependent;
-
-                    if (foreignKey.IsUnique)
+                    var dependents = stateManager.GetDependents(entry, foreignKey).ToList();
+                    if (dependents.Any())
                     {
-                        var dependentEntry = dependents.First();
+                        var dependentToPrincipal = foreignKey.DependentToPrincipal;
+                        var principalToDependent = foreignKey.PrincipalToDependent;
 
-                        // Set navigations to and from principal entity that is indicated by FK
-                        SetNavigation(entry, principalToDependent, dependentEntry.Entity);
-                        SetNavigation(dependentEntry, dependentToPrincipal, entry.Entity);
-                    }
-                    else
-                    {
-                        var collectionAccessor = principalToDependent?.GetCollectionAccessor();
-
-                        foreach (var dependentEntry in dependents)
+                        if (foreignKey.IsUnique)
                         {
-                            var dependentEntity = dependentEntry.Entity;
+                            var dependentEntry = dependents.First();
 
-                            // Add to collection on principal indicated by FK and set inverse navigation
-                            AddToCollection(entry, principalToDependent, collectionAccessor, dependentEntity);
-
+                            // Set navigations to and from principal entity that is indicated by FK
+                            SetNavigation(entry, principalToDependent, dependentEntry.Entity);
                             SetNavigation(dependentEntry, dependentToPrincipal, entry.Entity);
+                        }
+                        else
+                        {
+                            var collectionAccessor = principalToDependent?.GetCollectionAccessor();
+
+                            foreach (var dependentEntry in dependents)
+                            {
+                                var dependentEntity = dependentEntry.Entity;
+
+                                // Add to collection on principal indicated by FK and set inverse navigation
+                                AddToCollection(entry, principalToDependent, collectionAccessor, dependentEntity);
+
+                                SetNavigation(dependentEntry, dependentToPrincipal, entry.Entity);
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/TrackingQueryMode.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/TrackingQueryMode.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public enum TrackingQueryMode
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        ///     The state manager is tracking for a single query for one entity type and no self-refs.
+        /// </summary>
+        Simple,
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        ///     The state manager is tracking for a single query, but with multiple entity types and/or self refs.
+        /// </summary>
+        Single,
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        ///     The state manager is tracking for multiple queries and/or with other tracked entities.
+        /// </summary>
+        Multiple
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped<IEntityStateListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
                 .AddScoped<INavigationListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
                 .AddScoped<IKeyListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
+                .AddScoped<IQueryTrackingListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
                 .AddScoped<IPropertyListener, IChangeDetector>(p => p.GetService<IChangeDetector>()));
 
             serviceCollection.TryAdd(new ServiceCollection()

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -100,6 +100,7 @@
     <Compile Include="ChangeTracking\Internal\InternalShadowEntityEntry.cs" />
     <Compile Include="ChangeTracking\Internal\IPrincipalKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IPropertyListener.cs" />
+    <Compile Include="ChangeTracking\Internal\IQueryTrackingListener.cs" />
     <Compile Include="ChangeTracking\Internal\ISnapshot.cs" />
     <Compile Include="ChangeTracking\Internal\IStateManager.cs" />
     <Compile Include="ChangeTracking\Internal\IValueGenerationManager.cs" />
@@ -124,6 +125,7 @@
     <Compile Include="ChangeTracking\Internal\StateData.cs" />
     <Compile Include="ChangeTracking\Internal\StateManager.cs" />
     <Compile Include="ChangeTracking\Internal\StoreGeneratedValues.cs" />
+    <Compile Include="ChangeTracking\Internal\TrackingQueryMode.cs" />
     <Compile Include="ChangeTracking\Internal\ValueGenerationManager.cs" />
     <Compile Include="ChangeTracking\ObservableHashSet.cs" />
     <Compile Include="ChangeTracking\PropertyEntry.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -3244,34 +3244,34 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }), null);
+                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }), null);
+                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }), null);
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
+                stateManager.StartTrackingFromQuery(productType, new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
+                stateManager.StartTrackingFromQuery(productType, new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
+                stateManager.StartTrackingFromQuery(productType, new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
+                stateManager.StartTrackingFromQuery(productType, new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
+                stateManager.StartTrackingFromQuery(productType, new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }), null);
                 AssertAllFixedUp(context);
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }), null);
 
                 AssertAllFixedUp(context);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
 
             var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(principalEntry, EntityState.Detached, skipInitialFixup: false, fromQuery: false);
+            fixer.StateChanged(principalEntry, EntityState.Detached, fromQuery: false);
 
             Assert.Same(dependent1.Category, principal);
             Assert.Null(dependent2.Category);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -61,9 +61,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var category = new Category { Id = 77, PrincipalId = 777 };
             var valueBuffer = new ValueBuffer(new object[] { 77, "Bjork", 777 });
 
-            var entry = stateManager.StartTrackingFromQuery(categoryType, category, valueBuffer);
+            var entry = stateManager.StartTrackingFromQuery(categoryType, category, valueBuffer, null);
 
-            Assert.Same(entry, stateManager.StartTrackingFromQuery(categoryType, category, valueBuffer));
+            Assert.Same(entry, stateManager.StartTrackingFromQuery(categoryType, category, valueBuffer, null));
         }
 
         [Fact]
@@ -87,36 +87,36 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
-                new ValueBuffer(new object[] { 77, "Bjork", 777 }));
+                new ValueBuffer(new object[] { 77, "Bjork", 777 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
-                new ValueBuffer(new object[] { 78, "Beck", 778 }));
+                new ValueBuffer(new object[] { 78, "Beck", 778 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Multiple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 79, PrincipalId = 779 },
-                new ValueBuffer(new object[] { 79, "Bush", 779 }));
+                new ValueBuffer(new object[] { 79, "Bush", 779 }), null);
 
-            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Multiple, stateManager.GetTrackingQueryMode(categoryType));
         }
 
         [Fact]
@@ -126,11 +126,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var widgetType = model.FindEntityType(typeof(Widget));
             var stateManager = CreateStateManager(model);
 
-            Assert.False(stateManager.IsSingleQueryMode(widgetType));
+            Assert.Equal(TrackingQueryMode.Single, stateManager.GetTrackingQueryMode(widgetType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.False(stateManager.IsSingleQueryMode(widgetType));
+            Assert.Equal(TrackingQueryMode.Single, stateManager.GetTrackingQueryMode(widgetType));
         }
 
         [Fact]
@@ -141,15 +141,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
-            Assert.False(stateManager.IsSingleQueryMode(productType));
+            Assert.Equal(TrackingQueryMode.Single, stateManager.GetTrackingQueryMode(productType));
 
-            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Single, stateManager.GetTrackingQueryMode(categoryType));
         }
 
         [Fact]
@@ -159,29 +159,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
-                new ValueBuffer(new object[] { 77, "Bjork", 777 }));
+                new ValueBuffer(new object[] { 77, "Bjork", 777 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
-                new ValueBuffer(new object[] { 78, "Beck", 778 }));
+                new ValueBuffer(new object[] { 78, "Beck", 778 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             entry.SetEntityState(EntityState.Modified);
 
-            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Multiple, stateManager.GetTrackingQueryMode(categoryType));
         }
 
         [Fact]
@@ -191,29 +191,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
-                new ValueBuffer(new object[] { 77, "Bjork", null }));
+                new ValueBuffer(new object[] { 77, "Bjork", null }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
-                new ValueBuffer(new object[] { 78, "Beck", 778 }));
+                new ValueBuffer(new object[] { 78, "Beck", 778 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             entry.SetEntityState(EntityState.Added);
 
-            Assert.False(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Multiple, stateManager.GetTrackingQueryMode(categoryType));
         }
 
         [Fact]
@@ -223,29 +223,29 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.BeginTrackingQuery();
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             var entry = stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 77, PrincipalId = 777 },
-                new ValueBuffer(new object[] { 77, "Bjork", 777 }));
+                new ValueBuffer(new object[] { 77, "Bjork", 777 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.StartTrackingFromQuery(
                 categoryType,
                 new Category { Id = 78, PrincipalId = 778 },
-                new ValueBuffer(new object[] { 78, "Beck", 778 }));
+                new ValueBuffer(new object[] { 78, "Beck", 778 }), null);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
 
             stateManager.GetOrCreateEntry(entry.Entity);
 
-            Assert.True(stateManager.IsSingleQueryMode(categoryType));
+            Assert.Equal(TrackingQueryMode.Simple, stateManager.GetTrackingQueryMode(categoryType));
         }
 
         [Fact]
@@ -422,10 +422,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             foreach (var listener in listeners)
             {
                 listener.Verify(m => m.StateChanging(entry, It.IsAny<EntityState>()), Times.Once);
-                listener.Verify(m => m.StateChanged(entry, It.IsAny<EntityState>(), false, false), Times.Once);
+                listener.Verify(m => m.StateChanged(entry, It.IsAny<EntityState>(), false), Times.Once);
 
                 listener.Verify(m => m.StateChanging(entry, EntityState.Added), Times.Once);
-                listener.Verify(m => m.StateChanged(entry, EntityState.Detached, false, false), Times.Once);
+                listener.Verify(m => m.StateChanged(entry, EntityState.Detached, false), Times.Once);
             }
 
             entry.SetEntityState(EntityState.Modified);
@@ -433,10 +433,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             foreach (var listener in listeners)
             {
                 listener.Verify(m => m.StateChanging(entry, It.IsAny<EntityState>()), Times.Exactly(2));
-                listener.Verify(m => m.StateChanged(entry, It.IsAny<EntityState>(), false, false), Times.Exactly(2));
+                listener.Verify(m => m.StateChanged(entry, It.IsAny<EntityState>(), false), Times.Exactly(2));
 
                 listener.Verify(m => m.StateChanging(entry, EntityState.Modified), Times.Once);
-                listener.Verify(m => m.StateChanged(entry, EntityState.Detached, false, false), Times.Once);
+                listener.Verify(m => m.StateChanged(entry, EntityState.Detached, false), Times.Once);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -218,7 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public bool SaveChangesCalled { get; set; }
             public bool SaveChangesAsyncCalled { get; set; }
 
-            public bool IsSingleQueryMode(IEntityType entityType) => false;
+            public TrackingQueryMode GetTrackingQueryMode(IEntityType entityType) => TrackingQueryMode.Multiple;
 
             public void EndSingleQueryMode()
             {
@@ -278,7 +278,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public InternalEntityEntry StartTrackingFromQuery(
                 IEntityType baseEntityType,
                 object entity,
-                ValueBuffer valueBuffer)
+                ValueBuffer valueBuffer,
+                ISet<IForeignKey> handledForeignKeys)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Issue #5688

Query code will take care of fixing up entities within the query when Include is used. This means that the state manager does not need to do fixup for these relationships in cases where there are no entities tracked other than those that have come from query. This change allows query to communicate this to the state manager so that it can avoid unneeded work. The change also preserves the very simple case of a single query for a single entity type with no self-refs, in which case the state manager does not need to do work at all.