### PR TITLE
Propagate type mapping from principal property to dependent property

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
@@ -121,6 +121,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static IProperty FindPrincipal([NotNull] this IProperty property)
+        {
+            var concreteProperty = property.AsProperty();
+            if (concreteProperty.ForeignKeys != null)
+            {
+                foreach (var foreignKey in concreteProperty.ForeignKeys)
+                {
+                    for (var propertyIndex = 0; propertyIndex < foreignKey.Properties.Count; propertyIndex++)
+                    {
+                        if (property == foreignKey.Properties[propertyIndex])
+                        {
+                            return foreignKey.PrincipalKey.Properties[propertyIndex];
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static Property AsProperty([NotNull] this IProperty property, [NotNull] [CallerMemberName] string methodName = "")
             => property.AsConcreteMetadataType<IProperty, Property>(methodName);
     }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Storage\RelationalSqlGeneratorTest.cs" />
     <Compile Include="Storage\RelationalTransactionExtensionsTest.cs" />
     <Compile Include="Storage\RelationalTypeMapperTest.cs" />
+    <Compile Include="Storage\RelationalTypeMapperTestBase.cs" />
     <Compile Include="Storage\RelationalTypeMappingTest.cs" />
     <Compile Include="Storage\SqlGeneratorTestBase.cs" />
     <Compile Include="Storage\TypedRelationalValueBufferFactoryFactoryTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
+{
+    public class RelationalTypeMapperTestBase
+    {
+        protected static EntityType CreateEntityType()
+            => (EntityType)CreateModel().FindEntityType(typeof(MyType));
+
+        protected static IModel CreateModel()
+        {
+            var builder = TestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<MyType>().Property(e => e.Id).HasColumnType("money");
+            builder.Entity<MyRelatedType1>().Property(e => e.Id).HasMaxLength(200);
+            builder.Entity<MyRelatedType1>().Property(e => e.Relationship2Id).HasColumnType("dec");
+            builder.Entity<MyRelatedType2>().Property(e => e.Id).HasMaxLength(100);
+            builder.Entity<MyRelatedType2>().Property(e => e.Relationship2Id).HasMaxLength(787);
+            builder.Entity<MyRelatedType3>().Property(e => e.Relationship2Id).HasMaxLength(767);
+
+            return builder.Model;
+        }
+
+        protected class MyType
+        {
+            public decimal Id { get; set; }
+        }
+
+        protected class MyRelatedType1
+        {
+            public string Id { get; set; }
+
+            public decimal Relationship1Id { get; set; }
+            public MyType Relationship1 { get; set; }
+
+            public decimal Relationship2Id { get; set; }
+            public MyType Relationship2 { get; set; }
+        }
+
+        protected class MyRelatedType2
+        {
+            public byte[] Id { get; set; }
+
+            public string Relationship1Id { get; set; }
+            public MyRelatedType1 Relationship1 { get; set; }
+
+            public string Relationship2Id { get; set; }
+            public MyRelatedType1 Relationship2 { get; set; }
+        }
+
+        protected class MyRelatedType3
+        {
+            public string Id { get; set; }
+
+            public byte[] Relationship1Id { get; set; }
+            public MyRelatedType2 Relationship1 { get; set; }
+
+            public byte[] Relationship2Id { get; set; }
+            public MyRelatedType2 Relationship2 { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         private static readonly RelationalTypeMapping _rowversion = new RelationalTypeMapping("rowversion", typeof(byte[]), DbType.Binary, unicode: true, size: 8);
         private static readonly RelationalTypeMapping _defaultIntMapping = new RelationalTypeMapping("default_int_mapping", typeof(int));
         private static readonly RelationalTypeMapping _someIntMapping = new RelationalTypeMapping("some_int_mapping", typeof(int));
+        private static readonly RelationalTypeMapping _decimal = new RelationalTypeMapping("decimal(18, 2)", typeof(decimal));
 
         protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
@@ -35,7 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             {
                 { "some_int_mapping", _someIntMapping },
                 { "some_string(max)", _string },
-                { "some_binary(max)", _binary }
+                { "some_binary(max)", _binary },
+                { "money", _decimal },
+                { "dec", _decimal }
             };
 
         public override IByteArrayRelationalTypeMapper ByteArrayMapper { get; }


### PR DESCRIPTION
So that if the type mapping for a primary key is changed, then the type mapping for referencing foreign keys will also change.

Issue #2455