### PR TITLE
Implement IsUnicode API

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -552,7 +552,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                                           // TODO: Detect type narrowing
                                           || columnTypeChanged;
 
-                // TODO: Set IsUnicode with #3420
                 var alterColumnOperation = new AlterColumnOperation
                 {
                     Schema = sourceEntityTypeAnnotations.Schema,
@@ -561,6 +560,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     ClrType = target.ClrType.UnwrapNullableType().UnwrapEnumType(),
                     ColumnType = targetAnnotations.ColumnType,
                     MaxLength = target.GetMaxLength(),
+                    IsUnicode = target.IsUnicode(),
                     IsRowVersion = target.ClrType == typeof(byte[])
                         && target.IsConcurrencyToken
                         && target.ValueGenerated == ValueGenerated.OnAddOrUpdate,
@@ -589,7 +589,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var targetEntityTypeAnnotations = Annotations.For(
                 diffContext.FindSource(target.DeclaringEntityType.RootType()));
 
-            // TODO: Set IsUnicode with #3420
             var operation = new AddColumnOperation
             {
                 Schema = targetEntityTypeAnnotations.Schema,
@@ -598,6 +597,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 ClrType = target.ClrType.UnwrapNullableType().UnwrapEnumType(),
                 ColumnType = targetAnnotations.ColumnType,
                 MaxLength = target.GetMaxLength(),
+                IsUnicode = target.IsUnicode(),
                 IsRowVersion = target.ClrType == typeof(byte[])
                     && target.IsConcurrencyToken
                     && target.ValueGenerated == ValueGenerated.OnAddOrUpdate,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -677,8 +677,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var property = FindProperty(model, schema, table, name);
             if (property != null)
             {
-                // TODO: Allow unicode to be overridden with #3420
-                if (maxLength == property.GetMaxLength()
+                if (unicode == property.IsUnicode()
+                    && maxLength == property.GetMaxLength()
                     && rowVersion == (property.IsConcurrencyToken && (property.ValueGenerated == ValueGenerated.OnAddOrUpdate)))
                 {
                     return TypeMapper.GetMapping(property).StoreType;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
@@ -197,11 +197,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(property, nameof(property));
 
-            // TODO: Use unicode-ness defined in property metadata
+            var principal = property.FindPrincipal();
+
             return StringMapper?.FindMapping(
-                true,
+                property.IsUnicode() ?? principal?.IsUnicode() ?? true,
                 RequiresKeyMapping(property),
-                property.GetMaxLength() ?? property.FindPrincipal()?.GetMaxLength());
+                property.GetMaxLength() ?? principal?.GetMaxLength());
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/BuiltInDataTypesFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/BuiltInDataTypesFixtureBase.cs
@@ -33,6 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     b.Property(e => e.ByteArray9000).HasMaxLength(9000);
                     b.Property(e => e.String9000).HasMaxLength(9000);
                 });
+
+            modelBuilder.Entity<UnicodeDataTypes>(b =>
+            {
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.Property(e => e.StringAnsi).IsUnicode(false);
+                b.Property(e => e.StringAnsi3).HasMaxLength(3).IsUnicode(false);
+                b.Property(e => e.StringAnsi9000).IsUnicode(false).HasMaxLength(9000);
+                b.Property(e => e.StringUnicode).IsUnicode();
+            });
         }
 
         protected static void MakeRequired<TEntity>(ModelBuilder modelBuilder) where TEntity : class
@@ -105,6 +114,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public byte[] ByteArray5 { get; set; }
         public string String9000 { get; set; }
         public byte[] ByteArray9000 { get; set; }
+    }
+
+    public class UnicodeDataTypes
+    {
+        public int Id { get; set; }
+        public string StringDefault { get; set; }
+        public string StringAnsi { get; set; }
+        public string StringAnsi3 { get; set; }
+        public string StringAnsi9000 { get; set; }
+        public string StringUnicode { get; set; }
     }
 
     public class BinaryKeyDataType

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -55,6 +55,55 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.NotNull(context.Set<MaxLengthDataTypes>().SingleOrDefault(e => e.Id == 799 && e.String9000 == longString));
                 Assert.NotNull(context.Set<MaxLengthDataTypes>().SingleOrDefault(e => e.Id == 799 && e.ByteArray9000 == longBinary));
+            }
+        }
+
+        public virtual void Can_perform_query_with_ansi_strings(bool supportsAnsi)
+        {
+            var shortString = "Ϩky";
+            var longString = new string('Ϩ', 9000);
+
+            using (var context = CreateContext())
+            {
+                context.Set<UnicodeDataTypes>().Add(
+                    new UnicodeDataTypes
+                    {
+                        Id = 799,
+                        StringDefault = shortString,
+                        StringAnsi = shortString,
+                        StringAnsi3 = shortString,
+                        StringAnsi9000 = longString,
+                        StringUnicode = shortString
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.NotNull(context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799 && e.StringDefault == shortString));
+                Assert.NotNull(context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799 && e.StringAnsi == shortString));
+                Assert.NotNull(context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799 && e.StringAnsi3 == shortString));
+                Assert.NotNull(context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799 && e.StringAnsi9000 == longString));
+                Assert.NotNull(context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799 && e.StringUnicode == shortString));
+
+                var entity = context.Set<UnicodeDataTypes>().SingleOrDefault(e => e.Id == 799);
+
+                Assert.Equal(shortString, entity.StringDefault);
+                Assert.Equal(shortString, entity.StringUnicode);
+
+                if (supportsAnsi)
+                {
+                    Assert.NotEqual(shortString, entity.StringAnsi);
+                    Assert.NotEqual(shortString, entity.StringAnsi3);
+                    Assert.NotEqual(longString, entity.StringAnsi9000);
+                }
+                else
+                {
+                    Assert.Equal(shortString, entity.StringAnsi);
+                    Assert.Equal(shortString, entity.StringAnsi3);
+                    Assert.Equal(longString, entity.StringAnsi9000);
+                }
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
@@ -37,6 +37,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Sets a value indicating whether or not this property can persist unicode characters.
+        /// </summary>
+        /// <param name="property"> The property to set the value for. </param>
+        /// <param name="unicode"> True if the property accepts unicode characters, false if it does not, null to clear the setting. </param>
+        public static void IsUnicode([NotNull] this IMutableProperty property, bool? unicode)
+        {
+            Check.NotNull(property, nameof(property));
+
+            property[CoreAnnotationNames.UnicodeAnnotation] = unicode;
+        }
+
+        /// <summary>
         ///     Gets all foreign keys that use this property (including composite foreign keys in which this property
         ///     is included).
         /// </summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
@@ -30,6 +30,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Gets a value indicating whether or not the property can persist unicode characters.
+        /// </summary>
+        /// <param name="property"> The property to get the unicode setting for. </param>
+        /// <returns> The unicode setting, or null if none if defined. </returns>
+        public static bool? IsUnicode([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, nameof(property));
+
+            return (bool?)property[CoreAnnotationNames.UnicodeAnnotation];
+        }
+
+        /// <summary>
         ///     Gets a value indicating whether this property is used as a foreign key (or part of a composite foreign key).
         /// </summary>
         /// <param name="property"> The property to check. </param>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
@@ -90,6 +90,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     Configures the property as capable of persisting unicode characters or not.
+        ///     Can only be set on <see cref="string" /> properties.
+        /// </summary>
+        /// <param name="unicode"> A value indicating whether the property can contain unicode characters or not. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder IsUnicode(bool unicode = true)
+        {
+            Builder.IsUnicode(unicode, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
         ///     Configures whether this property should be used as a concurrency token. When a property is configured
         ///     as a concurrency token the value in the database will be checked when an instance of this entity type
         ///     is updated or deleted during <see cref="DbContext.SaveChanges()" /> to ensure it has not changed since

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
@@ -56,6 +56,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (PropertyBuilder<TProperty>)base.HasMaxLength(maxLength);
 
         /// <summary>
+        ///     Configures the property as capable of persisting unicode characters or not.
+        ///     Can only be set on <see cref="string" /> properties.
+        /// </summary>
+        /// <param name="unicode"> A value indicating whether the property can contain unicode characters or not. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> IsUnicode(bool unicode = true)
+            => (PropertyBuilder<TProperty>)base.IsUnicode(unicode);
+
+        /// <summary>
         ///     Configures whether this property should be used as a concurrency token. When a property is configured
         ///     as a concurrency token the value in the database will be checked when an instance of this entity type
         ///     is updated or deleted during <see cref="DbContext.SaveChanges()" /> to ensure it has not changed since

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -14,7 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string MaxLengthAnnotation = "MaxLength";
-        
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string UnicodeAnnotation = "Unicode";
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -71,6 +71,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool IsUnicode(bool unicode, ConfigurationSource configurationSource)
+            => HasAnnotation(CoreAnnotationNames.UnicodeAnnotation, unicode, configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool IsConcurrencyToken(bool concurrencyToken, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetIsConcurrencyTokenConfigurationSource())

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
@@ -10,6 +11,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         public BuiltInDataTypesInMemoryTest(BuiltInDataTypesInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [Fact]
+        public virtual void Can_perform_query_with_ansi_strings()
+        {
+            Can_perform_query_with_ansi_strings(supportsAnsi: false);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -604,6 +604,37 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
         }
 
         [Fact]
+        public void Alter_column_unicode()
+        {
+            Execute(
+                source => source.Entity(
+                    "Toad",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Name");
+                    }),
+                target => target.Entity(
+                    "Toad",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Name")
+                            .IsUnicode(false);
+                    }),
+                operations =>
+                {
+                    Assert.Equal(1, operations.Count);
+
+                    var operation = Assert.IsType<AlterColumnOperation>(operations[0]);
+                    Assert.Equal("Toad", operation.Table);
+                    Assert.Equal("Name", operation.Name);
+                    Assert.False(operation.IsUnicode);
+                    Assert.True(operation.IsDestructiveChange);
+                });
+        }
+
+        [Fact]
         public void Alter_column_default()
         {
             Execute(

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -50,8 +50,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                     : base.FindMapping(clrType);
 
             protected override RelationalTypeMapping FindCustomMapping(IProperty property)
-                => property.ClrType == typeof(string) && property.GetMaxLength().HasValue
-                    ? new RelationalTypeMapping("nvarchar(" + property.GetMaxLength() + ")", typeof(string), dbType: null, unicode: false, size: property.GetMaxLength())
+                => property.ClrType == typeof(string) && (property.GetMaxLength().HasValue || property.IsUnicode().HasValue)
+                    ? new RelationalTypeMapping(((property.IsUnicode() ?? true) ? "n" : "") + "varchar(" + (property.GetMaxLength() ?? 767) + ")", typeof(string), dbType: null, unicode: false, size: property.GetMaxLength())
                     : base.FindCustomMapping(property);
 
             private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTestBase.cs
@@ -69,15 +69,28 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
                 });
 
         [Fact]
-        public virtual void AddColumnOperation_with_unicode_overridden()
+        public virtual void AddColumnOperation_with_unicode()
             => Generate(
-                modelBuilder => modelBuilder.Entity("Person").Property<string>("Name"),
+                modelBuilder => modelBuilder.Entity("Person").Property<string>("Name").IsUnicode(false),
                 new AddColumnOperation
                 {
                     Table = "Person",
                     Name = "Name",
                     ClrType = typeof(string),
                     IsUnicode = false,
+                    IsNullable = true
+                });
+
+        [Fact]
+        public virtual void AddColumnOperation_with_unicode_overridden()
+            => Generate(
+                modelBuilder => modelBuilder.Entity("Person").Property<string>("Name").IsUnicode(false),
+                new AddColumnOperation
+                {
+                    Table = "Person",
+                    Name = "Name",
+                    ClrType = typeof(string),
+                    IsUnicode = true,
                     IsNullable = true
                 });
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
@@ -172,6 +172,21 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
         }
 
         [Fact]
+        public void String_key_with_unicode_is_picked_up_by_FK()
+        {
+            var model = CreateModel();
+            var mapper = new TestRelationalTypeMapper();
+
+            Assert.Equal(
+                "ansi_string(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Id")).StoreType);
+
+            Assert.Equal(
+                "ansi_string(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType4)).FindProperty("Relationship1Id")).StoreType);
+        }
+
+        [Fact]
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
@@ -214,6 +229,21 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(
                 "just_binary(767)",
                 mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Relationship2Id")).StoreType);
+        }
+
+        [Fact]
+        public void String_FK_unicode_is_preferred_if_specified()
+        {
+            var model = CreateModel();
+            var mapper = new TestRelationalTypeMapper();
+
+            Assert.Equal(
+                "ansi_string(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Id")).StoreType);
+
+            Assert.Equal(
+                "just_string(450)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType4)).FindProperty("Relationship2Id")).StoreType);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
@@ -21,7 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             builder.Entity<MyRelatedType1>().Property(e => e.Relationship2Id).HasColumnType("dec");
             builder.Entity<MyRelatedType2>().Property(e => e.Id).HasMaxLength(100);
             builder.Entity<MyRelatedType2>().Property(e => e.Relationship2Id).HasMaxLength(787);
+            builder.Entity<MyRelatedType3>().Property(e => e.Id).IsUnicode(false);
             builder.Entity<MyRelatedType3>().Property(e => e.Relationship2Id).HasMaxLength(767);
+            builder.Entity<MyRelatedType4>().Property(e => e.Relationship2Id).IsUnicode();
 
             return builder.Model;
         }
@@ -62,6 +64,17 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
 
             public byte[] Relationship2Id { get; set; }
             public MyRelatedType2 Relationship2 { get; set; }
+        }
+
+        protected class MyRelatedType4
+        {
+            public string Id { get; set; }
+
+            public string Relationship1Id { get; set; }
+            public MyRelatedType3 Relationship1 { get; set; }
+
+            public string Relationship2Id { get; set; }
+            public MyRelatedType3 Relationship2 { get; set; }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestRelationalTypeMapper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         private static readonly RelationalTypeMapping _string = new RelationalTypeMapping("just_string(2000)", typeof(string));
         private static readonly RelationalTypeMapping _unboundedString = new RelationalTypeMapping("just_string(max)", typeof(string));
         private static readonly RelationalTypeMapping _stringKey = new RelationalTypeMapping("just_string(450)", typeof(string), dbType: null, unicode: true, size: 450);
+        private static readonly RelationalTypeMapping _ansiStringKey = new RelationalTypeMapping("ansi_string(900)", typeof(string), dbType: null, unicode: true, size: 450);
         private static readonly RelationalTypeMapping _unboundedBinary = new RelationalTypeMapping("just_binary(max)", typeof(byte[]), DbType.Binary);
         private static readonly RelationalTypeMapping _binary = new RelationalTypeMapping("just_binary(max)", typeof(byte[]), DbType.Binary);
         private static readonly RelationalTypeMapping _binaryKey = new RelationalTypeMapping("just_binary(900)", typeof(byte[]), DbType.Binary, unicode: true, size: 900);
@@ -61,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 2000,
                 _string,
                 _unboundedString,
-                _stringKey,
+                _ansiStringKey,
                 size => new RelationalTypeMapping(
                     "just_string(" + size + ")",
                     typeof(string),

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -20,6 +20,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_perform_query_with_ansi_strings()
+        {
+            Can_perform_query_with_ansi_strings(supportsAnsi: true);
+        }
+
+        [Fact]
         public void Sql_translation_uses_type_mapper_when_constant()
         {
             using (var context = CreateContext())
@@ -2005,6 +2011,12 @@ MaxLengthDataTypes.String9000 ---> [nullable nvarchar] [MaxLength = -1]
 StringForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
 StringForeignKeyDataType.StringKeyDataTypeId ---> [nullable nvarchar] [MaxLength = 450]
 StringKeyDataType.Id ---> [nvarchar] [MaxLength = 450]
+UnicodeDataTypes.Id ---> [int] [Precision = 10 Scale = 0]
+UnicodeDataTypes.StringAnsi ---> [nullable varchar] [MaxLength = -1]
+UnicodeDataTypes.StringAnsi3 ---> [nullable varchar] [MaxLength = 3]
+UnicodeDataTypes.StringAnsi9000 ---> [nullable varchar] [MaxLength = -1]
+UnicodeDataTypes.StringDefault ---> [nullable nvarchar] [MaxLength = -1]
+UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 ";
 
             Assert.Equal(expected, actual);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -6,8 +6,6 @@ using System.Data;
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Relational.Tests;
 using Microsoft.EntityFrameworkCore.Relational.Tests.Storage;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -129,10 +127,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal("decimal(18, 2)", typeMapping.StoreType);
         }
 
-        [Fact]
-        public void Does_non_key_SQL_Server_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_non_key_SQL_Server_string_mapping(bool? unicode)
         {
-            var typeMapping = GetTypeMapping(typeof(string));
+            var typeMapping = GetTypeMapping(typeof(string), unicode: unicode);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
@@ -141,10 +141,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(4000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_non_key_SQL_Server_string_mapping_with_max_length()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_non_key_SQL_Server_string_mapping_with_max_length(bool? unicode)
         {
-            var typeMapping = GetTypeMapping(typeof(string), null, 3);
+            var typeMapping = GetTypeMapping(typeof(string), null, 3, unicode: unicode);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(3)", typeMapping.StoreType);
@@ -153,10 +155,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_non_key_SQL_Server_string_mapping_with_long_string()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_non_key_SQL_Server_string_mapping_with_long_string(bool? unicode)
         {
-            var typeMapping = GetTypeMapping(typeof(string));
+            var typeMapping = GetTypeMapping(typeof(string), unicode: unicode);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
@@ -165,10 +169,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 4001)).Size);
         }
 
-        [Fact]
-        public void Does_non_key_SQL_Server_string_mapping_with_max_length_with_long_string()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_non_key_SQL_Server_string_mapping_with_max_length_with_long_string(bool? unicode)
         {
-            var typeMapping = GetTypeMapping(typeof(string), null, 3);
+            var typeMapping = GetTypeMapping(typeof(string), null, 3, unicode: unicode);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(3)", typeMapping.StoreType);
@@ -177,10 +183,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 4001)).Size);
         }
 
-        [Fact]
-        public void Does_non_key_SQL_Server_required_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_non_key_SQL_Server_required_string_mapping(bool? unicode)
         {
-            var typeMapping = GetTypeMapping(typeof(string), isNullable: false);
+            var typeMapping = GetTypeMapping(typeof(string), nullable: false, unicode: unicode);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
@@ -189,11 +197,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(4000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_key_SQL_Server_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_key_SQL_Server_string_mapping(bool? unicode)
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string));
             property.IsNullable = false;
+            property.IsUnicode(unicode);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
             var typeMapping = new SqlServerTypeMapper().GetMapping(property);
@@ -205,11 +216,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_foreign_key_SQL_Server_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_foreign_key_SQL_Server_string_mapping(bool? unicode)
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string));
             property.IsNullable = false;
+            property.IsUnicode(unicode);
             var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
@@ -223,11 +237,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_required_foreign_key_SQL_Server_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_required_foreign_key_SQL_Server_string_mapping(bool? unicode)
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string));
             property.IsNullable = false;
+            property.IsUnicode(unicode);
             var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
@@ -242,11 +259,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
-        [Fact]
-        public void Does_indexed_column_SQL_Server_string_mapping()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void Does_indexed_column_SQL_Server_string_mapping(bool? unicode)
         {
             var entityType = CreateEntityType();
             var property = entityType.AddProperty("MyProp", typeof(string));
+            property.IsUnicode(unicode);
             entityType.AddIndex(property);
 
             var typeMapping = new SqlServerTypeMapper().GetMapping(property);
@@ -256,6 +276,139 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(450, typeMapping.Size);
             Assert.True(typeMapping.IsUnicode);
             Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_string_mapping_ansi()
+        {
+            var typeMapping = GetTypeMapping(typeof(string), unicode: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(max)", typeMapping.StoreType);
+            Assert.Equal(8000, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_string_mapping_with_max_length_ansi()
+        {
+            var typeMapping = GetTypeMapping(typeof(string), null, 3, unicode: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(3)", typeMapping.StoreType);
+            Assert.Equal(3, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_string_mapping_with_long_string_ansi()
+        {
+            var typeMapping = GetTypeMapping(typeof(string), unicode: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(max)", typeMapping.StoreType);
+            Assert.Equal(8000, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 8001)).Size);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_string_mapping_with_max_length_with_long_string_ansi()
+        {
+            var typeMapping = GetTypeMapping(typeof(string), null, 3, unicode: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(3)", typeMapping.StoreType);
+            Assert.Equal(3, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 8001)).Size);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_required_string_mapping_ansi()
+        {
+            var typeMapping = GetTypeMapping(typeof(string), nullable: false, unicode: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(max)", typeMapping.StoreType);
+            Assert.Equal(8000, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_key_SQL_Server_string_mapping_ansi()
+        {
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
+            property.IsNullable = false;
+            property.IsUnicode(false);
+            property.DeclaringEntityType.SetPrimaryKey(property);
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(property);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(900)", typeMapping.StoreType);
+            Assert.Equal(900, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(900, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_foreign_key_SQL_Server_string_mapping_ansi()
+        {
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
+            property.IsUnicode(false);
+            property.IsNullable = false;
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(fkProperty);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(900)", typeMapping.StoreType);
+            Assert.Equal(900, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(900, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_required_foreign_key_SQL_Server_string_mapping_ansi()
+        {
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
+            property.IsUnicode(false);
+            property.IsNullable = false;
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
+            fkProperty.IsNullable = false;
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(fkProperty);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(900)", typeMapping.StoreType);
+            Assert.Equal(900, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(900, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
+        public void Does_indexed_column_SQL_Server_string_mapping_ansi()
+        {
+            var entityType = CreateEntityType();
+            var property = entityType.AddProperty("MyProp", typeof(string));
+            property.IsUnicode(false);
+            entityType.AddIndex(property);
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(property);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(900)", typeMapping.StoreType);
+            Assert.Equal(900, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.Equal(900, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
 
         [Fact]
@@ -281,7 +434,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
-        public void Does_non_key_SQL_Server_binary_mapping_with_long_string()
+        public void Does_non_key_SQL_Server_binary_mapping_with_long_array()
         {
             var typeMapping = GetTypeMapping(typeof(byte[]));
 
@@ -292,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
-        public void Does_non_key_SQL_Server_binary_mapping_with_max_length_with_long_string()
+        public void Does_non_key_SQL_Server_binary_mapping_with_max_length_with_long_array()
         {
             var typeMapping = GetTypeMapping(typeof(byte[]), null, 3);
 
@@ -305,7 +458,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         [Fact]
         public void Does_non_key_SQL_Server_required_binary_mapping()
         {
-            var typeMapping = GetTypeMapping(typeof(byte[]), isNullable: false);
+            var typeMapping = GetTypeMapping(typeof(byte[]), nullable: false);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
@@ -429,18 +582,27 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
         }
 
-        private static RelationalTypeMapping GetTypeMapping(Type propertyType, bool? isNullable = null, int? maxLength = null)
+        private static RelationalTypeMapping GetTypeMapping(
+            Type propertyType,
+            bool? nullable = null,
+            int? maxLength = null,
+            bool? unicode = null)
         {
             var property = CreateEntityType().AddProperty("MyProp", propertyType);
 
-            if (isNullable.HasValue)
+            if (nullable.HasValue)
             {
-                property.IsNullable = isNullable.Value;
+                property.IsNullable = nullable.Value;
             }
 
             if (maxLength.HasValue)
             {
                 property.SetMaxLength(maxLength);
+            }
+
+            if (unicode.HasValue)
+            {
+                property.IsUnicode(unicode);
             }
 
             return new SqlServerTypeMapper().GetMapping(property);
@@ -608,6 +770,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
+        public void String_key_with_unicode_is_picked_up_by_FK()
+        {
+            var model = CreateModel();
+            var mapper = new SqlServerTypeMapper();
+
+            Assert.Equal(
+                "varchar(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Id")).StoreType);
+
+            Assert.Equal(
+                "varchar(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType4)).FindProperty("Relationship1Id")).StoreType);
+        }
+
+        [Fact]
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
@@ -650,6 +827,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.Equal(
                 "varbinary(767)",
                 mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Relationship2Id")).StoreType);
+        }
+
+        [Fact]
+        public void String_FK_unicode_is_preferred_if_specified()
+        {
+            var model = CreateModel();
+            var mapper = new SqlServerTypeMapper();
+
+            Assert.Equal(
+                "varchar(900)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType3)).FindProperty("Id")).StoreType);
+
+            Assert.Equal(
+                "nvarchar(450)",
+                mapper.FindMapping(model.FindEntityType(typeof(MyRelatedType4)).FindProperty("Relationship2Id")).StoreType);
         }
 
         private enum LongEnum : long

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -16,6 +16,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_perform_query_with_ansi_strings()
+        {
+            Can_perform_query_with_ansi_strings(supportsAnsi: false);
+        }
+
+        [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_data_types()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -156,6 +156,37 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
+        public void Can_only_override_lower_or_equal_source_unicode()
+        {
+            var builder = CreateInternalPropertyBuilder();
+            var metadata = builder.Metadata;
+
+            Assert.True(builder.IsUnicode(true, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsUnicode(false, ConfigurationSource.DataAnnotation));
+
+            Assert.False(metadata.IsUnicode().Value);
+
+            Assert.False(builder.IsUnicode(true, ConfigurationSource.Convention));
+            Assert.False(metadata.IsUnicode().Value);
+        }
+
+        [Fact]
+        public void Can_only_override_existing_unicode_value_explicitly()
+        {
+            var metadata = CreateProperty();
+            metadata.IsUnicode(true);
+            var builder = CreateInternalPropertyBuilder(metadata);
+
+            Assert.True(builder.IsUnicode(true, ConfigurationSource.DataAnnotation));
+            Assert.False(builder.IsUnicode(false, ConfigurationSource.DataAnnotation));
+
+            Assert.True(metadata.IsUnicode().Value);
+
+            Assert.True(builder.IsUnicode(false, ConfigurationSource.Explicit));
+            Assert.False(metadata.IsUnicode().Value);
+        }
+
+        [Fact]
         public void Can_only_override_lower_or_equal_source_Required()
         {
             var builder = CreateInternalPropertyBuilder();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -199,6 +199,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
                 => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasMaxLength(maxLength));
 
+            public override TestPropertyBuilder<TProperty> IsUnicode(bool unicode = true)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsUnicode(unicode));
+
             public override TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true)
                 => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsConcurrencyToken(isConcurrencyToken));
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -156,6 +156,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
                 => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasMaxLength(maxLength));
 
+            public override TestPropertyBuilder<TProperty> IsUnicode(bool unicode = true)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsUnicode(unicode));
+
             public override TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true)
                 => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsConcurrencyToken(isConcurrencyToken));
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -206,6 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public abstract TestPropertyBuilder<TProperty> HasAnnotation(string annotation, object value);
             public abstract TestPropertyBuilder<TProperty> IsRequired(bool isRequired = true);
             public abstract TestPropertyBuilder<TProperty> HasMaxLength(int maxLength);
+            public abstract TestPropertyBuilder<TProperty> IsUnicode(bool unicode = true);
             public abstract TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true);
 
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedNever();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -617,6 +617,33 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
+            public virtual void Can_set_unicode_for_properties()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Quarks>(b =>
+                    {
+                        b.Property(e => e.Up).IsUnicode();
+                        b.Property(e => e.Down).IsUnicode(false);
+                        b.Property<int>("Charm").IsUnicode();
+                        b.Property<string>("Strange").IsUnicode(false);
+                        b.Property<int>("Top").IsUnicode();
+                        b.Property<string>("Bottom").IsUnicode(false);
+                    });
+
+                var entityType = model.FindEntityType(typeof(Quarks));
+
+                Assert.Null(entityType.FindProperty(Customer.IdProperty.Name).IsUnicode());
+                Assert.Equal(true, entityType.FindProperty("Up").IsUnicode());
+                Assert.Equal(false, entityType.FindProperty("Down").IsUnicode());
+                Assert.Equal(true, entityType.FindProperty("Charm").IsUnicode());
+                Assert.Equal(false, entityType.FindProperty("Strange").IsUnicode());
+                Assert.Equal(true, entityType.FindProperty("Top").IsUnicode());
+                Assert.Equal(false, entityType.FindProperty("Bottom").IsUnicode());
+            }
+
+            [Fact]
             public virtual void PropertyBuilder_methods_can_be_chained()
             {
                 CreateModelBuilder()
@@ -628,6 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     .ValueGeneratedNever()
                     .ValueGeneratedOnAdd()
                     .ValueGeneratedOnAddOrUpdate()
+                    .IsUnicode()
                     .HasMaxLength(100)
                     .IsRequired();
             }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -807,6 +807,28 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrat
         }
 
         [ConditionalFact]
+        public void Property_unicodeness_is_stored_in_snapshot()
+        {
+            Test(
+                builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").IsUnicode(false); },
+                @"
+builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
+    {
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.Property<string>(""Name"")
+            .HasAnnotation(""Unicode"", false);
+
+        b.HasKey(""Id"");
+
+        b.ToTable(""EntityWithStringProperty"");
+    });
+",
+                o => { Assert.False(o.GetEntityTypes().First().FindProperty("Name").IsUnicode()); });
+        }
+
+        [ConditionalFact]
         public void Property_RequiresValueGenerator_is_not_stored_in_snapshot()
         {
             Test(


### PR DESCRIPTION
Issue #3420

I think everything in the runtime and migrations areas is implemented. The ScaffoldingTypeMapper already supports unicode, but scaffolding will not make use of this until updated as described in issue #5410.

/cc @rowanmiller Can you look at the public API and doc comments?