### PR TITLE
Use short, readable type names consistently in exception messages

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Design/DbContextOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Design/DbContextOperations.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         private DbContext CreateContext(Func<DbContext> factory)
         {
             var context = factory();
-            _logger.Value.LogDebug(DesignCoreStrings.LogUseContext(context.GetType().Name));
+            _logger.Value.LogDebug(DesignCoreStrings.LogUseContext(context.GetType().ShortDisplayName()));
 
             var loggerFactory = context.GetService<ILoggerFactory>();
             loggerFactory.AddProvider(_loggerProvider);

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Design/Internal/StartupInvoker.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Design/Internal/StartupInvoker.cs
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 }
 
                 _logger.Value.LogWarning(
-                    DesignCoreStrings.InvokeStartupMethodFailed(method.Name, type.DisplayName(), ex.Message));
+                    DesignCoreStrings.InvokeStartupMethodFailed(method.Name, type.ShortDisplayName(), ex.Message));
                 _logger.Value.LogDebug(ex.ToString());
 
                 return null;

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/CSharpHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/CSharpHelper.cs
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     .Append(".");
             }
 
-            builder.Append(type.DisplayName(fullName: false));
+            builder.Append(type.ShortDisplayName());
 
             return builder.ToString();
         }

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/MigrationsScaffolder.cs
@@ -235,7 +235,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     }
                     else
                     {
-                        _logger.Value.LogWarning(DesignCoreStrings.NoMigrationFile(migrationFileName, migration.GetType().FullName));
+                        _logger.Value.LogWarning(
+                            DesignCoreStrings.NoMigrationFile(migrationFileName, migration.GetType().ShortDisplayName()));
                     }
 
                     var migrationMetadataFileName = migration.GetId() + ".Designer" + language;
@@ -274,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 else
                 {
                     _logger.Value.LogWarning(
-                        DesignCoreStrings.NoSnapshotFile(modelSnapshotFileName, modelSnapshot.GetType().FullName));
+                        DesignCoreStrings.NoSnapshotFile(modelSnapshotFileName, modelSnapshot.GetType().ShortDisplayName()));
                 }
             }
             else
@@ -341,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 var lastNamespace = siblingType.Namespace;
                 if (lastNamespace != defaultNamespace)
                 {
-                    _logger.Value.LogDebug(DesignCoreStrings.ReusingNamespace(siblingType.Name));
+                    _logger.Value.LogDebug(DesignCoreStrings.ReusingNamespace(siblingType.ShortDisplayName()));
 
                     return lastNamespace;
                 }

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Scaffolding/Internal/ReverseEngineeringGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Scaffolding/Internal/ReverseEngineeringGenerator.cs
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 throw new InvalidOperationException(
                     RelationalDesignStrings.ProviderReturnedNullModel(
-                        _factory.GetType().FullName));
+                        _factory.GetType().ShortDisplayName()));
             }
 
             return metadataModel;

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Utilities/Internal/JsonUtility.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Utilities/Internal/JsonUtility.cs
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Core.Utilities.Internal
                 return;
             }
 
-            throw new ArgumentException(DesignCoreStrings.CouldNotSerialize(obj, obj.GetType().FullName));
+            throw new ArgumentException(DesignCoreStrings.CouldNotSerialize(obj, obj.GetType().ShortDisplayName()));
         }
 
         private static void SerializeEnumerable(IEnumerable en, IndentedStringBuilder sb)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Action<MigrationsSqlGenerator, MigrationOperation, IModel, MigrationCommandListBuilder> generateAction;
             if (!_generateActions.TryGetValue(operationType, out generateAction))
             {
-                throw new InvalidOperationException(RelationalStrings.UnknownOperation(GetType().Name, operationType));
+                throw new InvalidOperationException(RelationalStrings.UnknownOperation(GetType().ShortDisplayName(), operationType));
             }
 
             generateAction(this, operation, model, builder);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -174,6 +174,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         [UsedImplicitly]
         private static Exception CreateUnableToDiscriminateException(IEntityType entityType)
-            => new InvalidOperationException(RelationalStrings.UnableToDiscriminate(entityType.Name));
+            => new InvalidOperationException(RelationalStrings.UnableToDiscriminate(entityType.DisplayName()));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var propertiesList = properties.ToList();
                     var appendAction = propertiesList.Count > 2 ? AppendLine : Append;
 
-                    appendAction(stringBuilder, value.GetType().DisplayName(fullName: false) + " ");
+                    appendAction(stringBuilder, value.GetType().ShortDisplayName() + " ");
                     appendAction(stringBuilder, "{ ");
 
                     stringBuilder.IncrementIndent();

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1312,7 +1312,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (typeMapping == null)
             {
-                throw new InvalidOperationException(RelationalStrings.UnsupportedType(explicitCastExpression.Type.Name));
+                throw new InvalidOperationException(RelationalStrings.UnsupportedType(explicitCastExpression.Type.ShortDisplayName()));
             }
 
             _relationalCommandBuilder.Append(typeMapping.StoreType);

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1401,7 +1401,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             var modelBuilder = CreateModelBuilder();
 
-            Assert.Equal(CoreStrings.InvalidRelationshipUsingDataAnnotations("B", typeof(A).DisplayName(), "A", typeof(B).DisplayName()),
+            Assert.Equal(CoreStrings.InvalidRelationshipUsingDataAnnotations("B", nameof(A), "A", nameof(B)),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.Entity<A>()).Message);
         }
 
@@ -1410,7 +1410,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             var modelBuilder = CreateModelBuilder();
 
-            Assert.Equal(CoreStrings.InvalidRelationshipUsingDataAnnotations("C", typeof(D).DisplayName(), "D", typeof(C).DisplayName()),
+            Assert.Equal(CoreStrings.InvalidRelationshipUsingDataAnnotations("C", nameof(D), "D", nameof(C)),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.Entity<D>()).Message);
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "String", "Int32"),
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
                     Assert.Throws<ArgumentException>(() => context.IntKeys.Find("77")).Message);
             }
         }
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "Int32", "String"),
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "int", "string"),
                     Assert.Throws<ArgumentException>(() => context.CompositeKeys.Find(77, 88)).Message);
             }
         }
@@ -583,7 +583,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "String", "Int32"),
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
                     (await Assert.ThrowsAsync<ArgumentException>(() => context.IntKeys.FindAsync("77"))).Message);
             }
         }
@@ -593,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "Int32", "String"),
+                Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "int", "string"),
                     (await Assert.ThrowsAsync<ArgumentException>(() => context.CompositeKeys.FindAsync(77, 88))).Message);
             }
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -264,7 +264,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             column.DisplayName,
                             column.DefaultValue,
                             propertyBuilder.Metadata.Name,
-                            propertyBuilder.Metadata.DeclaringEntityType.Name));
+                            propertyBuilder.Metadata.DeclaringEntityType.DisplayName()));
                 }
             }
         }
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             column.DisplayName,
                             column.ComputedValue,
                             propertyBuilder.Metadata.Name,
-                            propertyBuilder.Metadata.DeclaringEntityType.Name));
+                            propertyBuilder.Metadata.DeclaringEntityType.DisplayName()));
                 }
             }
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -109,14 +109,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                         || propertyType == typeof(byte?)))
                 {
                     throw new ArgumentException(SqlServerStrings.IdentityBadType(
-                        Property.Name, Property.DeclaringEntityType.Name, propertyType.Name));
+                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
                 }
 
                 if ((value == SqlServerValueGenerationStrategy.SequenceHiLo)
                     && !propertyType.IsInteger())
                 {
                     throw new ArgumentException(SqlServerStrings.SequenceBadType(
-                        Property.Name, Property.DeclaringEntityType.Name, propertyType.Name));
+                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -153,52 +153,52 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         // These operations can be accomplished instead with a table-rebuild
         protected override void Generate(AddForeignKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(AddPrimaryKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(AddUniqueConstraintOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(DropColumnOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(DropForeignKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(DropPrimaryKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(DropUniqueConstraintOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(RenameColumnOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(RenameIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         protected override void Generate(AlterColumnOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().Name));
+            throw new NotSupportedException(SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
         }
 
         #endregion

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
@@ -74,7 +75,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             if ((property != null)
                 && (property.ClrType != typeof(TProperty)))
             {
-                throw new ArgumentException(CoreStrings.WrongGenericPropertyType(propertyName, property.DeclaringEntityType.Name, property.ClrType.Name, typeof(TProperty).Name));
+                throw new ArgumentException(
+                    CoreStrings.WrongGenericPropertyType(
+                        propertyName, 
+                        property.DeclaringEntityType.DisplayName(), 
+                        property.ClrType.ShortDisplayName(), 
+                        typeof(TProperty).ShortDisplayName()));
             }
 
             return new PropertyEntry<TEntity, TProperty>(this.GetInfrastructure(), propertyName);

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.ChangeTrackingInterfaceMissing(
-                        entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanged).Name));
+                        entityType.DisplayName(), changeTrackingStrategy, nameof(INotifyPropertyChanged)));
             }
 
             return changed;
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.ChangeTrackingInterfaceMissing(
-                        entityType.DisplayName(), changeTrackingStrategy, typeof(INotifyPropertyChanging).Name));
+                        entityType.DisplayName(), changeTrackingStrategy, nameof(INotifyPropertyChanging)));
             }
 
             return changing;

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (entityType == null)
                 {
-                    throw new InvalidOperationException(CoreStrings.EntityTypeNotFound(entity.GetType().DisplayName(false)));
+                    throw new InvalidOperationException(CoreStrings.EntityTypeNotFound(entity.GetType().ShortDisplayName()));
                 }
 
                 entry = _factory.Create(this, entityType, entity);
@@ -297,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (entry.StateManager != this)
             {
-                throw new InvalidOperationException(CoreStrings.WrongStateManager(entityType.Name));
+                throw new InvalidOperationException(CoreStrings.WrongStateManager(entityType.DisplayName()));
             }
 
             var mapKey = entry.Entity ?? entry;
@@ -310,7 +310,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
             else
             {
-                throw new InvalidOperationException(CoreStrings.MultipleEntries(entityType.Name));
+                throw new InvalidOperationException(CoreStrings.MultipleEntries(entityType.DisplayName()));
             }
 
             foreach (var key in entityType.GetKeys())

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore
 
             if (!options.ContextType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
             {
-                throw new InvalidOperationException(CoreStrings.NonGenericOptions(GetType().DisplayName()));
+                throw new InvalidOperationException(CoreStrings.NonGenericOptions(GetType().ShortDisplayName()));
             }
 
             _options = options;
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 if (_disposed)
                 {
-                    throw new ObjectDisposedException(GetType().Name, CoreStrings.ContextDisposed);
+                    throw new ObjectDisposedException(GetType().ShortDisplayName(), CoreStrings.ContextDisposed);
                 }
                 return (_contextServices ?? (_contextServices = InitializeServices())).InternalServiceProvider;
             }
@@ -791,7 +791,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (Model.FindEntityType(typeof(TEntity)) == null)
             {
-                throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TEntity).Name));
+                throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TEntity).ShortDisplayName()));
             }
 
             return (_setInitializer

--- a/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore
             var extension = FindExtension<TExtension>();
             if (extension == null)
             {
-                throw new InvalidOperationException(CoreStrings.OptionsExtensionNotFound(typeof(TExtension).Name));
+                throw new InvalidOperationException(CoreStrings.OptionsExtensionNotFound(typeof(TExtension).ShortDisplayName()));
             }
             return extension;
         }

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
@@ -48,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var service = accessor.Instance.GetService<TService>();
             if (service == null)
             {
-                throw new InvalidOperationException(CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).FullName));
+                throw new InvalidOperationException(
+                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).DisplayName()));
             }
 
             return service;

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -109,10 +109,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 if (keyProperties.Count == 1)
                 {
                     throw new ArgumentException(
-                        CoreStrings.FindNotCompositeKey(typeof(TEntity).Name, keyValues.Length));
+                        CoreStrings.FindNotCompositeKey(typeof(TEntity).ShortDisplayName(), keyValues.Length));
                 }
                 throw new ArgumentException(
-                    CoreStrings.FindValueCountMismatch(typeof(TEntity).Name, keyProperties.Count, keyValues.Length));
+                    CoreStrings.FindValueCountMismatch(typeof(TEntity).ShortDisplayName(), keyProperties.Count, keyValues.Length));
             }
 
             for (var i = 0; i < keyValues.Length; i++)
@@ -127,7 +127,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 if (valueType != propertyType)
                 {
                     throw new ArgumentException(
-                        CoreStrings.FindValueTypeMismatch(i, typeof(TEntity).Name, valueType.Name, propertyType.Name));
+                        CoreStrings.FindValueTypeMismatch(
+                            i, typeof(TEntity).ShortDisplayName(), valueType.ShortDisplayName(), propertyType.ShortDisplayName()));
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Internal/ModelValidator.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/ModelValidator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var firstShadowEntity = model.GetEntityTypes().FirstOrDefault(entityType => !entityType.HasClrType());
             if (firstShadowEntity != null)
             {
-                ShowError(CoreStrings.ShadowEntity(firstShadowEntity.Name));
+                ShowError(CoreStrings.ShadowEntity(firstShadowEntity.DisplayName()));
             }
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var entityTypeWithNullPk = model.GetEntityTypes().FirstOrDefault(et => et.FindPrimaryKey() == null);
             if (entityTypeWithNullPk != null)
             {
-                ShowError(CoreStrings.EntityRequiresKey(entityTypeWithNullPk.Name));
+                ShowError(CoreStrings.EntityRequiresKey(entityTypeWithNullPk.DisplayName()));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Internal/TypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/TypeExtensions.cs
@@ -46,6 +46,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static string ShortDisplayName([NotNull] this Type type)
+            => type.DisplayName(fullName: false);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static string DisplayName([NotNull] this Type type, bool fullName = true)
         {
             var sb = new StringBuilder();

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 throw new InvalidOperationException(CoreStrings.DependentEntityTypeNotInRelationship(
                     _declaringEntityType.DisplayName(),
                     _relatedEntityType.DisplayName(),
-                    dependentEntityType.DisplayName()));
+                    dependentEntityType.ShortDisplayName()));
             }
 
             return Builder.RelatedEntityTypes(GetOtherEntityType(entityType), entityType, ConfigurationSource.Explicit);
@@ -328,7 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 throw new InvalidOperationException(CoreStrings.DependentEntityTypeNotInRelationship(
                     _declaringEntityType.DisplayName(),
                     _relatedEntityType.DisplayName(),
-                    principalEntityType.DisplayName()));
+                    principalEntityType.ShortDisplayName()));
             }
 
             return Builder.RelatedEntityTypes(entityType, GetOtherEntityType(entityType), ConfigurationSource.Explicit);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -154,9 +154,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 // Relationship is joined by InversePropertyAttribute
                 throw new InvalidOperationException(CoreStrings.InvalidRelationshipUsingDataAnnotations(
                     dependentToPrincipalNavigationName,
-                    foreignKey.DeclaringEntityType.Name,
+                    foreignKey.DeclaringEntityType.DisplayName(),
                     principalToDepedentNavigationName,
-                    foreignKey.PrincipalEntityType.Name));
+                    foreignKey.PrincipalEntityType.DisplayName()));
             }
 
             var dependentEntityTypebuilder = foreignKey.DeclaringEntityType.Builder;
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             if (candidateProperties.Count > 1)
             {
-                throw new InvalidOperationException(CoreStrings.CompositeFkOnProperty(navigationName, entityType.Name));
+                throw new InvalidOperationException(CoreStrings.CompositeFkOnProperty(navigationName, entityType.DisplayName()));
             }
 
             if (candidateProperties.Count == 1)
@@ -225,7 +225,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 if ((fkAttributeOnNavigation != null)
                     && (fkAttributeOnNavigation.Name != candidateProperties.First()))
                 {
-                    throw new InvalidOperationException(CoreStrings.FkAttributeOnPropertyNavigationMismatch(candidateProperties.First(), navigationName, entityType.Name));
+                    throw new InvalidOperationException(
+                        CoreStrings.FkAttributeOnPropertyNavigationMismatch(
+                            candidateProperties.First(), navigationName, entityType.DisplayName()));
                 }
             }
 
@@ -259,7 +261,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
                 if (properties.Any(string.IsNullOrWhiteSpace))
                 {
-                    throw new InvalidOperationException(CoreStrings.InvalidPropertyListOnNavigation(navigation.Name, navigation.DeclaringEntityType.Name));
+                    throw new InvalidOperationException(
+                        CoreStrings.InvalidPropertyListOnNavigation(navigation.Name, navigation.DeclaringEntityType.DisplayName()));
                 }
 
                 var navigationPropertyTargetType = navigation.DeclaringEntityType.ClrType.GetRuntimeProperties()
@@ -274,7 +277,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     if ((attribute != null)
                         && (attribute.Name == navigationFkAttribute.Name))
                     {
-                        throw new InvalidOperationException(CoreStrings.MultipleNavigationsSameFk(navigation.DeclaringEntityType.DisplayName(), attribute.Name));
+                        throw new InvalidOperationException(
+                            CoreStrings.MultipleNavigationsSameFk(navigation.DeclaringEntityType.DisplayName(), attribute.Name));
                     }
                 }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -70,7 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     .IsAssignableFrom(entityType.ClrType.GetTypeInfo()))
             {
                 throw new InvalidOperationException(
-                    CoreStrings.InvalidNavigationWithInverseProperty(navigationPropertyInfo.Name, entityType.Name, attribute.Property, targetClrType.FullName));
+                    CoreStrings.InvalidNavigationWithInverseProperty(
+					    navigationPropertyInfo.Name, entityType.DisplayName(), attribute.Property, targetClrType.ShortDisplayName()));
             }
 
             if (inverseNavigationPropertyInfo == navigationPropertyInfo)
@@ -78,9 +79,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 throw new InvalidOperationException(
                     CoreStrings.SelfReferencingNavigationWithInverseProperty(
                         navigationPropertyInfo.Name,
-                        entityType.Name,
+                        entityType.DisplayName(),
                         navigationPropertyInfo.Name,
-                        entityType.Name));
+                        entityType.DisplayName()));
             }
 
             // Check for InversePropertyAttribute on the inverseNavigation to verify that it matches.
@@ -91,9 +92,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 throw new InvalidOperationException(
                     CoreStrings.InversePropertyMismatch(
                         navigationPropertyInfo.Name,
-                        entityType.Name,
+                        entityType.DisplayName(),
                         inverseNavigationPropertyInfo.Name,
-                        targetEntityTypeBuilder.Metadata.Name));
+                        targetEntityTypeBuilder.Metadata.DisplayName()));
             }
 
             var inverseNavigationsList = AddInverseNavigation(

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 if (unmappedProperty != null)
                 {
                     throw new InvalidOperationException(CoreStrings.PropertyNotMapped(
-                        entityType.DisplayName(), unmappedProperty.Name, unmappedProperty.ClrType.DisplayName(fullName: false)));
+                        entityType.DisplayName(), unmappedProperty.Name, unmappedProperty.ClrType.ShortDisplayName()));
                 }
 
                 if (entityType.HasClrType())
@@ -63,24 +63,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                                 if (!modelBuilder.IsIgnored(targetType.DisplayName(), ConfigurationSource.Convention))
                                 {
                                     throw new InvalidOperationException(CoreStrings.NavigationNotAdded(
-                                        entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
+                                        entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                                 }
                             }
                             else if (propertyType.IsPrimitive())
                             {
                                 throw new InvalidOperationException(CoreStrings.PropertyNotMapped(
-                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                             }
                             else if (propertyType.GetTypeInfo().IsInterface
                                      || (targetSequenceType != null && targetSequenceType.GetTypeInfo().IsInterface))
                             {
                                 throw new InvalidOperationException(CoreStrings.InterfacePropertyNotAdded(
-                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                             }
                             else
                             {
                                 throw new InvalidOperationException(CoreStrings.PropertyNotAdded(
-                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                             }
                         }
                     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -46,13 +46,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.NavigationBadType(
-                        navigation.Name, navigation.DeclaringEntityType.Name, property.PropertyType.Name, navigation.GetTargetType().Name));
+                        navigation.Name, 
+                        navigation.DeclaringEntityType.DisplayName(), 
+                        property.PropertyType.ShortDisplayName(), 
+                        navigation.GetTargetType().DisplayName()));
             }
 
             if (property.PropertyType.IsArray)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.NavigationArray(navigation.Name, navigation.DeclaringEntityType.DisplayName(), property.PropertyType.Name));
+                    CoreStrings.NavigationArray(
+                        navigation.Name, 
+                        navigation.DeclaringEntityType.DisplayName(), 
+                        property.PropertyType.ShortDisplayName()));
             }
 
             if (property.GetMethod == null)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (_createCollection == null)
             {
                 throw new InvalidOperationException(CoreStrings.NavigationCannotCreateType(
-                    _propertyName, typeof(TEntity).Name, typeof(TCollection).Name));
+                    _propertyName, typeof(TEntity).ShortDisplayName(), typeof(TCollection).ShortDisplayName()));
             }
 
             var collection = (ICollection<TElement>)_createCollection();
@@ -115,13 +115,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 if (_setCollection == null)
                 {
-                    throw new InvalidOperationException(CoreStrings.NavigationNoSetter(_propertyName, typeof(TEntity).Name));
+                    throw new InvalidOperationException(CoreStrings.NavigationNoSetter(_propertyName, typeof(TEntity).ShortDisplayName()));
                 }
 
                 if (_createAndSetCollection == null)
                 {
                     throw new InvalidOperationException(CoreStrings.NavigationCannotCreateType(
-                        _propertyName, typeof(TEntity).Name, typeof(TCollection).Name));
+                        _propertyName, typeof(TEntity).ShortDisplayName(), typeof(TCollection).ShortDisplayName()));
                 }
 
                 collection = (ICollection<TElement>)_createAndSetCollection((TEntity)instance, _setCollection);
@@ -140,7 +140,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.NavigationBadType(
-                        _propertyName, typeof(TEntity).Name, enumerable.GetType().Name, typeof(TElement).Name));
+                        _propertyName, 
+                        typeof(TEntity).ShortDisplayName(), 
+                        enumerable.GetType().ShortDisplayName(), 
+                        typeof(TElement).ShortDisplayName()));
             }
 
             return collection;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (!entityType.HasClrType())
             {
-                throw new InvalidOperationException(CoreStrings.NoClrType(entityType.Name));
+                throw new InvalidOperationException(CoreStrings.NoClrType(entityType.DisplayName()));
             }
 
             if (entityType.IsAbstract())

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     if (!entityType.ClrType.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
                     {
-                        throw new InvalidOperationException(CoreStrings.NotAssignableClrBaseType(this.DisplayName(), entityType.DisplayName(), ClrType.DisplayName(fullName: false), entityType.ClrType.DisplayName(fullName: false)));
+                        throw new InvalidOperationException(CoreStrings.NotAssignableClrBaseType(this.DisplayName(), entityType.DisplayName(), ClrType.ShortDisplayName(), entityType.ClrType.ShortDisplayName()));
                     }
                 }
 
@@ -640,7 +640,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var foreignKey = key.GetReferencingForeignKeys().FirstOrDefault();
             if (foreignKey != null)
             {
-                throw new InvalidOperationException(CoreStrings.KeyInUse(Property.Format(key.Properties), Name, foreignKey.DeclaringEntityType.Name));
+                throw new InvalidOperationException(
+                    CoreStrings.KeyInUse(Property.Format(key.Properties), this.DisplayName(), foreignKey.DeclaringEntityType.DisplayName()));
             }
         }
 
@@ -1388,8 +1389,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         throw new InvalidOperationException(CoreStrings.PropertyWrongClrType(
                             name,
                             this.DisplayName(),
-                            clrProperty.PropertyType.DisplayName(fullName: false),
-                            propertyType.DisplayName(fullName: false)));
+                            clrProperty.PropertyType.ShortDisplayName(),
+                            propertyType.ShortDisplayName()));
                     }
 
                     return AddProperty(clrProperty, configurationSource, runConventions);
@@ -1436,7 +1437,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 || !propertyInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
             {
                 throw new ArgumentException(CoreStrings.PropertyWrongEntityClrType(
-                    propertyInfo.Name, this.DisplayName(), propertyInfo.DeclaringType?.Name));
+                    propertyInfo.Name, this.DisplayName(), propertyInfo.DeclaringType?.ShortDisplayName()));
             }
 
             return AddProperty(new Property(propertyInfo, this, configurationSource), runConventions);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string DisplayName([NotNull] this IEntityType entityType)
             => entityType.ClrType != null
-                ? entityType.ClrType.DisplayName(fullName: false)
+                ? entityType.ClrType.ShortDisplayName()
                 : entityType.Name;
 
         /// <summary>
@@ -326,14 +326,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (value != ChangeTrackingStrategy.Snapshot
                     && !typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.ClrType.GetTypeInfo()))
                 {
-                    return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, typeof(INotifyPropertyChanged).Name);
+                    return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, nameof(INotifyPropertyChanged));
                 }
 
                 if ((value == ChangeTrackingStrategy.ChangingAndChangedNotifications
                      || value == ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues)
                     && !typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(entityType.ClrType.GetTypeInfo()))
                 {
-                    return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, typeof(INotifyPropertyChanging).Name);
+                    return CoreStrings.ChangeTrackingInterfaceMissing(entityType.DisplayName(), value, nameof(INotifyPropertyChanging));
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
@@ -664,9 +664,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(
                         CoreStrings.ForeignKeyCountMismatch(
                             Property.Format(dependentProperties),
-                            dependentEntityType.Name,
+                            dependentEntityType.DisplayName(),
                             Property.Format(principalProperties),
-                            principalEntityType.Name));
+                            principalEntityType.DisplayName()));
                 }
                 return false;
             }
@@ -678,9 +678,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(
                         CoreStrings.ForeignKeyTypeMismatch(
                             Property.Format(dependentProperties),
-                            dependentEntityType.Name,
+                            dependentEntityType.DisplayName(),
                             Property.Format(principalProperties),
-                            principalEntityType.Name));
+                            principalEntityType.DisplayName()));
                 }
                 return false;
             }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
@@ -62,12 +62,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         FieldInfo fieldInfo;
                         if (!fields.TryGetValue(fieldName, out fieldInfo))
                         {
-                            throw new InvalidOperationException(CoreStrings.MissingBackingField(entityType.Name, propertyName, fieldName));
+                            throw new InvalidOperationException(
+                                CoreStrings.MissingBackingField(entityType.DisplayName(), propertyName, fieldName));
                         }
                         if (!fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(property.ClrType.GetTypeInfo()))
                         {
                             throw new InvalidOperationException(
-                                CoreStrings.BadBackingFieldType(fieldName, fieldInfo.FieldType.Name, entityType.Name, propertyName, property.ClrType.Name));
+                                CoreStrings.BadBackingFieldType(
+                                    fieldName, 
+                                    fieldInfo.FieldType.ShortDisplayName(), 
+                                    entityType.DisplayName(), 
+                                    propertyName, 
+                                    property.ClrType.ShortDisplayName()));
                         }
                         memberInfo = fieldInfo;
                     }
@@ -89,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (memberInfo == null)
                 {
-                    throw new InvalidOperationException(CoreStrings.NoFieldOrSetter(entityType.Name, propertyName));
+                    throw new InvalidOperationException(CoreStrings.NoFieldOrSetter(entityType.DisplayName(), propertyName));
                 }
 
                 propertyMappings.Add(Tuple.Create(property, memberInfo));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MetadataExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MetadataExtensions.cs
@@ -24,7 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (concrete == null)
             {
                 throw new NotSupportedException(
-                    CoreStrings.CustomMetadata(methodName, typeof(TInterface).Name, @interface.GetType().Name));
+                    CoreStrings.CustomMetadata(
+                        methodName, typeof(TInterface).ShortDisplayName(), @interface.GetType().ShortDisplayName()));
             }
 
             return concrete;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _entityTypes[entityType.Name] = entityType;
             if (previousLength == _entityTypes.Count)
             {
-                throw new InvalidOperationException(CoreStrings.DuplicateEntityType(entityType.Name));
+                throw new InvalidOperationException(CoreStrings.DuplicateEntityType(entityType.DisplayName()));
             }
 
             if (runConventions)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (shouldThrow)
                 {
                     throw new InvalidOperationException(CoreStrings.NoClrNavigation(
-                        navigationProperty.Name, sourceClrType.DisplayName(fullName: false)));
+                        navigationProperty.Name, sourceClrType.ShortDisplayName()));
                 }
                 return false;
             }
@@ -153,9 +153,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         throw new InvalidOperationException(CoreStrings.NavigationCollectionWrongClrType(
                             navigationProperty.Name,
-                            sourceClrType.DisplayName(fullName: false),
-                            navigationProperty.PropertyType.DisplayName(fullName: false),
-                            targetClrType.DisplayName(fullName: false)));
+                            sourceClrType.ShortDisplayName(),
+                            navigationProperty.PropertyType.ShortDisplayName(),
+                            targetClrType.ShortDisplayName()));
                     }
                     return false;
                 }
@@ -166,9 +166,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         throw new InvalidOperationException(CoreStrings.NavigationSingleWrongClrType(
                             navigationProperty.Name,
-                            sourceClrType.DisplayName(fullName: false),
-                            navigationProperty.PropertyType.DisplayName(fullName: false),
-                            targetClrType.DisplayName(fullName: false)));
+                            sourceClrType.ShortDisplayName(),
+                            navigationProperty.PropertyType.ShortDisplayName(),
+                            targetClrType.ShortDisplayName()));
                     }
                     return false;
                 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 if (!ClrType.IsNullableType())
                 {
-                    throw new InvalidOperationException(CoreStrings.CannotBeNullable(Name, DeclaringEntityType.DisplayName(), ClrType.Name));
+                    throw new InvalidOperationException(CoreStrings.CannotBeNullable(Name, DeclaringEntityType.DisplayName(), ClrType.ShortDisplayName()));
                 }
 
                 if (Keys != null)
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!readOnlyAfterSave
                 && Keys != null)
             {
-                throw new InvalidOperationException(CoreStrings.KeyPropertyMustBeReadOnly(Name, DeclaringEntityType.Name));
+                throw new InvalidOperationException(CoreStrings.KeyPropertyMustBeReadOnly(Name, DeclaringEntityType.DisplayName()));
             }
             SetFlag(readOnlyAfterSave, PropertyFlags.IsReadOnlyAfterSave);
             UpdateIsReadOnlyAfterSaveConfigurationSource(configurationSource);

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         protected override Expression VisitGoto(GotoExpression node)
         {
-            _stringBuilder.AppendLine("return (" + node.Target.Type.DisplayName(fullName: false) + ")" + node.Target + " {");
+            _stringBuilder.AppendLine("return (" + node.Target.Type.ShortDisplayName() + ")" + node.Target + " {");
             _stringBuilder.IncrementIndent();
 
             Visit(node.Value);
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             foreach (var parameter in node.Parameters)
             {
                 _parametersInScope.Add(parameter, parameter.Name);
-                _stringBuilder.Append(parameter.Type.DisplayName(fullName: false) + " " + parameter.Name);
+                _stringBuilder.Append(parameter.Type.ShortDisplayName() + " " + parameter.Name);
 
                 if (parameter != node.Parameters.Last())
                 {
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         protected override Expression VisitMemberInit(MemberInitExpression node)
         {
-            _stringBuilder.Append("new " + node.Type.DisplayName(fullName: false));
+            _stringBuilder.Append("new " + node.Type.ShortDisplayName());
 
             var appendAction = node.Bindings.Count > 1 ? AppendLine : Append;
             appendAction(_stringBuilder, "{ ");
@@ -446,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (node.Method.ReturnType != null)
             {
-                _stringBuilder.Append(node.Method.ReturnType.DisplayName(fullName: false) + " ");
+                _stringBuilder.Append(node.Method.ReturnType.ShortDisplayName() + " ");
             }
 
             if (node.Object != null)
@@ -495,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         protected override Expression VisitNew(NewExpression node)
         {
             _stringBuilder.Append("new ");
-            _stringBuilder.Append(node.Type.DisplayName(fullName: false));
+            _stringBuilder.Append(node.Type.ShortDisplayName());
 
             var appendAction = node.Arguments.Count > 1 ? AppendLine : Append;
             appendAction(_stringBuilder, "(");
@@ -520,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         protected override Expression VisitNewArray(NewArrayExpression node)
         {
             var appendAction = node.Expressions.Count > 1 ? AppendLine : Append;
-            appendAction(_stringBuilder, "new " + node.Type.GetElementType().DisplayName(fullName: false) + "[]");
+            appendAction(_stringBuilder, "new " + node.Type.GetElementType().ShortDisplayName() + "[]");
             appendAction(_stringBuilder, "{ ");
             _stringBuilder.IncrementIndent();
 
@@ -562,7 +562,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             if (node.NodeType == ExpressionType.Convert)
             {
-                _stringBuilder.Append("(" + node.Type.DisplayName(fullName: false) + ") ");
+                _stringBuilder.Append("(" + node.Type.ShortDisplayName() + ") ");
 
                 Visit(node.Operand);
 
@@ -633,7 +633,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     var appendAction = value is byte[] ? Append : AppendLine;
 
-                    appendAction(stringBuilder, value.GetType().DisplayName(fullName: false) + " ");
+                    appendAction(stringBuilder, value.GetType().ShortDisplayName() + " ");
                     appendAction(stringBuilder, "{ ");
                     stringBuilder.IncrementIndent();
                     foreach (var item in enumerable)

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             }
 
             throw new NotSupportedException(
-                CoreStrings.NoValueGenerator(property.Name, property.DeclaringEntityType.DisplayName(), propertyType.Name));
+                CoreStrings.NoValueGenerator(property.Name, property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             entityTypeBuilder.Property("LongProperty", typeof(long), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "LongProperty", typeof(long).DisplayName(fullName: false)),
+                typeof(NonPrimitiveAsPropertyEntity).ShortDisplayName(), "LongProperty", typeof(long).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             entityTypeBuilder.Property("LongProperty", typeof(long), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "LongProperty", typeof(long).DisplayName(fullName: false)),
+                typeof(NonPrimitiveAsPropertyEntity).ShortDisplayName(), "LongProperty", typeof(long).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -597,7 +597,9 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
 
                 var query4 = ctx.Customers.Select(c => c.Orders4);
 
-                Assert.Equal(CoreStrings.NavigationCannotCreateType("Orders4", typeof(Customer3758).Name, typeof(MyInvalidCollection3758<Order3758>).Name),
+                Assert.Equal(
+                    CoreStrings.NavigationCannotCreateType("Orders4", typeof(Customer3758).Name,
+                        typeof(MyInvalidCollection3758<Order3758>).ShortDisplayName()),
                     Assert.Throws<InvalidOperationException>(() => query4.ToList()).Message);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -714,7 +714,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Metadata;
 
             Assert.Equal(
-                SqlServerStrings.SequenceBadType("Name", typeof(Customer).FullName, "String"),
+                SqlServerStrings.SequenceBadType("Name", nameof(Customer), "string"),
                 Assert.Throws<ArgumentException>(
                     () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.SequenceHiLo).Message);
         }
@@ -730,7 +730,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Metadata;
 
             Assert.Equal(
-                SqlServerStrings.IdentityBadType("Name", typeof(Customer).FullName, "String"),
+                SqlServerStrings.IdentityBadType("Name", nameof(Customer), "string"),
                 Assert.Throws<ArgumentException>(
                     () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.IdentityColumn).Message);
         }
@@ -746,7 +746,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Metadata;
 
             Assert.Equal(
-                SqlServerStrings.IdentityBadType("Byte", typeof(Customer).FullName, "Byte"),
+                SqlServerStrings.IdentityBadType("Byte", nameof(Customer), "byte"),
                 Assert.Throws<ArgumentException>(
                     () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.IdentityColumn).Message);
         }
@@ -762,7 +762,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Metadata;
 
             Assert.Equal(
-                SqlServerStrings.IdentityBadType("NullableByte", typeof(Customer).FullName, "Nullable`1"),
+                SqlServerStrings.IdentityBadType("NullableByte", nameof(Customer), "Nullable<byte>"),
                 Assert.Throws<ArgumentException>(
                     () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.IdentityColumn).Message);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             {
                 var entity = context.Add(new Chunky()).Entity;
 
-                Assert.Equal(CoreStrings.WrongGenericPropertyType("Monkey", entity.GetType(), typeof(int).Name, typeof(string).Name),
+                Assert.Equal(CoreStrings.WrongGenericPropertyType("Monkey", entity.GetType().ShortDisplayName(), "int", "string"),
                     Assert.Throws<ArgumentException>(() => context.Entry(entity).Property<string>("Monkey")).Message);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(new Category());
 
             Assert.Equal(
-                CoreStrings.WrongStateManager(typeof(Category).FullName),
+                CoreStrings.WrongStateManager(nameof(Category)),
                 Assert.Throws<InvalidOperationException>(() => stateManager2.StartTracking(entry)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -4483,7 +4483,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 .Options;
 
             Assert.Equal(
-                CoreStrings.NonGenericOptions("Microsoft.EntityFrameworkCore.Tests.DbContextTest+NonGenericOptions2"),
+                CoreStrings.NonGenericOptions(nameof(NonGenericOptions2)),
                 Assert.Throws<InvalidOperationException>(() => new NonGenericOptions2(options)).Message);
         }
 
@@ -4500,7 +4500,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 .CreateScope())
             {
                 Assert.Equal(
-                    CoreStrings.NonGenericOptions("Microsoft.EntityFrameworkCore.Tests.DbContextTest+NonGenericOptions2"),
+                    CoreStrings.NonGenericOptions(nameof(NonGenericOptions2)),
                     Assert.Throws<InvalidOperationException>(() =>
                         {
                             serviceScope.ServiceProvider.GetService<NonGenericOptions1>();

--- a/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
             var model = new Model();
             model.AddEntityType(typeof(A));
 
-            VerifyError(CoreStrings.EntityRequiresKey(typeof(A).FullName), model);
+            VerifyError(CoreStrings.EntityRequiresKey(nameof(A)), model);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<SelfReferencingEntity>();
 
-            Assert.Equal(CoreStrings.SelfReferencingNavigationWithInverseProperty("AnotherEntity", typeof(SelfReferencingEntity).FullName, "AnotherEntity", typeof(SelfReferencingEntity).FullName),
+            Assert.Equal(CoreStrings.SelfReferencingNavigationWithInverseProperty("AnotherEntity", nameof(SelfReferencingEntity), "AnotherEntity", nameof(SelfReferencingEntity)),
                 Assert.Throws<InvalidOperationException>(() => new InversePropertyAttributeConvention().Apply(entityTypeBuilder)).Message);
         }
 
@@ -248,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<NonExistentNavigation>();
 
-            Assert.Equal(CoreStrings.InvalidNavigationWithInverseProperty("Principal", typeof(NonExistentNavigation).FullName, "WrongNavigation", typeof(Principal).FullName),
+            Assert.Equal(CoreStrings.InvalidNavigationWithInverseProperty("Principal", nameof(NonExistentNavigation), "WrongNavigation", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(() => new InversePropertyAttributeConvention().Apply(entityTypeBuilder)).Message);
         }
 
@@ -257,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<WrongNavigationType>();
 
-            Assert.Equal(CoreStrings.InvalidNavigationWithInverseProperty("Principal", typeof(WrongNavigationType).FullName, "Dependent", typeof(Principal).FullName),
+            Assert.Equal(CoreStrings.InvalidNavigationWithInverseProperty("Principal", nameof(WrongNavigationType), "Dependent", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(() => new InversePropertyAttributeConvention().Apply(entityTypeBuilder)).Message);
         }
 
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<MismatchedInverseProperty>();
 
             Assert.Equal(
-                CoreStrings.InversePropertyMismatch("Principal", typeof(MismatchedInverseProperty).FullName, "MismatchedInverseProperty", typeof(Principal).FullName),
+                CoreStrings.InversePropertyMismatch("Principal", nameof(MismatchedInverseProperty), "MismatchedInverseProperty", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(() => new InversePropertyAttributeConvention().Apply(entityTypeBuilder)).Message);
         }
 
@@ -449,7 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
                 null,
                 ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.FkAttributeOnPropertyNavigationMismatch("PrincipalId", "Principal", typeof(FkPropertyNavigationMismatch).FullName),
+            Assert.Equal(CoreStrings.FkAttributeOnPropertyNavigationMismatch("PrincipalId", "Principal", nameof(FkPropertyNavigationMismatch)),
                 Assert.Throws<InvalidOperationException>(() => new ForeignKeyAttributeConvention().Apply(relationshipBuilder)).Message);
         }
 
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
                 null,
                 ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.CompositeFkOnProperty("Principal", typeof(CompositeFkOnProperty).FullName),
+            Assert.Equal(CoreStrings.CompositeFkOnProperty("Principal", nameof(CompositeFkOnProperty)),
                 Assert.Throws<InvalidOperationException>(() => new ForeignKeyAttributeConvention().Apply(relationshipBuilder)).Message);
         }
 
@@ -481,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
                 null,
                 ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.InvalidPropertyListOnNavigation("Principal", typeof(InvalidPropertyListOnNavigation).FullName),
+            Assert.Equal(CoreStrings.InvalidPropertyListOnNavigation("Principal", nameof(InvalidPropertyListOnNavigation)),
                 Assert.Throws<InvalidOperationException>(() => new ForeignKeyAttributeConvention().Apply(relationshipBuilder)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -21,9 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             entityTypeBuilder.Property("Property", typeof(NavigationAsProperty), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false),
+                typeof(NonPrimitiveAsPropertyEntity).ShortDisplayName(),
                 "Property",
-                typeof(NavigationAsProperty).DisplayName(fullName: false)),
+                typeof(NavigationAsProperty).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             Assert.Equal(
                 CoreStrings.PropertyNotMapped(
-                    typeof(PrimitivePropertyEntity).DisplayName(fullName: false), "Property", typeof(int).DisplayName()),
+                    typeof(PrimitivePropertyEntity).ShortDisplayName(), "Property", typeof(int).DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             Assert.Equal(
                 CoreStrings.PropertyNotAdded(
-                    typeof(NonPrimitiveValueTypePropertyEntity).DisplayName(fullName: false), "Property", typeof(CancellationToken).Name),
+                    typeof(NonPrimitiveValueTypePropertyEntity).ShortDisplayName(), "Property", typeof(CancellationToken).Name),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.NavigationNotAdded(typeof(NavigationEntity).DisplayName(fullName: false), "Navigation", typeof(PrimitivePropertyEntity).Name),
+                CoreStrings.NavigationNotAdded(typeof(NavigationEntity).ShortDisplayName(), "Navigation", typeof(PrimitivePropertyEntity).Name),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -133,9 +133,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(InterfaceNavigationEntity), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.InterfacePropertyNotAdded(
-                typeof(InterfaceNavigationEntity).DisplayName(fullName: false),
+                typeof(InterfaceNavigationEntity).ShortDisplayName(),
                 "Navigation",
-                typeof(IList<INavigationEntity>).DisplayName(fullName: false)),
+                typeof(IList<INavigationEntity>).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             orderType.GetOrAddForeignKey(customerFk, customerKey, customerType);
 
             Assert.Equal(
-                CoreStrings.KeyInUse("{'" + Customer.IdProperty.Name + "'}", typeof(Customer).FullName, typeof(Order).FullName),
+                CoreStrings.KeyInUse("{'" + Customer.IdProperty.Name + "'}", nameof(Customer), nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => customerType.RemoveKey(customerKey.Properties)).Message);
         }
 
@@ -1506,7 +1506,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             nameProperty.IsReadOnlyAfterSave = true;
 
             Assert.Equal(
-                CoreStrings.KeyPropertyMustBeReadOnly(Customer.NameProperty.Name, typeof(Customer).FullName),
+                CoreStrings.KeyPropertyMustBeReadOnly(Customer.NameProperty.Name, nameof(Customer)),
                 Assert.Throws<InvalidOperationException>(() => nameProperty.IsReadOnlyAfterSave = false).Message);
 
             nameProperty.IsReadOnlyBeforeSave = true;
@@ -2078,7 +2078,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
                 CoreStrings.NavigationCollectionWrongClrType(
                     nameof(SpecialCustomer.DerivedOrders),
                     typeof(SpecialCustomer).Name,
-                    typeof(IEnumerable<SpecialOrder>).DisplayName(fullName: false),
+                    typeof(IEnumerable<SpecialOrder>).ShortDisplayName(),
                     typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => customerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty)).Message);
@@ -2387,7 +2387,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityType = new Model().AddEntityType(typeof(Customer));
 
             Assert.Equal(CoreStrings.PropertyWrongClrType(
-                nameof(Customer.Name), nameof(Customer), typeof(string).DisplayName(), typeof(int).DisplayName(fullName: false)),
+                nameof(Customer.Name), nameof(Customer), typeof(string).DisplayName(), typeof(int).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() =>
                     entityType.AddProperty(nameof(Customer.Name), typeof(int), shadow: false)).Message);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.False(builder.IsRequired(false, ConfigurationSource.DataAnnotation));
 
-            Assert.Equal(CoreStrings.CannotBeNullable(nameof(Customer.Id), typeof(Customer).Name, typeof(int).Name),
+            Assert.Equal(CoreStrings.CannotBeNullable(nameof(Customer.Id), typeof(Customer).Name, "int"),
                 Assert.Throws<InvalidOperationException>(() => builder.IsRequired(false, ConfigurationSource.Explicit)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/MemberMapperTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/MemberMapperTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             property["BackingField"] = "_speakToMe";
 
             Assert.Equal(
-                CoreStrings.MissingBackingField(typeof(TheDarkSide).FullName, "SpeakToMe", "_speakToMe"),
+                CoreStrings.MissingBackingField(nameof(TheDarkSide), "SpeakToMe", "_speakToMe"),
                 Assert.Throws<InvalidOperationException>(
                     () => new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType)).Message);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             property["BackingField"] = "_badFieldForSpeak";
 
             Assert.Equal(
-                CoreStrings.BadBackingFieldType("_badFieldForSpeak", typeof(string).Name, typeof(TheDarkSide).FullName, "SpeakToMe", typeof(int).Name),
+                CoreStrings.BadBackingFieldType("_badFieldForSpeak", "string", nameof(TheDarkSide), "SpeakToMe", "int"),
                 Assert.Throws<InvalidOperationException>(
                     () => new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType)).Message);
         }
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var property = entityType.AddProperty(TheDarkSide.TimeProperty);
 
             Assert.Equal(
-                CoreStrings.NoFieldOrSetter(typeof(TheDarkSide).FullName, "Time"),
+                CoreStrings.NoFieldOrSetter(nameof(TheDarkSide), "Time"),
                 Assert.Throws<InvalidOperationException>(
                     () => new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType)).Message);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             model.AddEntityType(typeof(Customer));
 
             Assert.Equal(
-                CoreStrings.DuplicateEntityType(typeof(Customer).FullName),
+                CoreStrings.DuplicateEntityType(nameof(Customer)),
                 Assert.Throws<InvalidOperationException>(() => model.AddEntityType(typeof(Customer))).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var intProperty = entityType.AddProperty("Name", typeof(int));
 
             Assert.Equal(
-                CoreStrings.CannotBeNullable("Name", "object", "Int32"),
+                CoreStrings.CannotBeNullable("Name", "object", "int"),
                 Assert.Throws<InvalidOperationException>(() => intProperty.IsNullable = true).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var orderEntityType = modelBuilder.Entity(typeof(Order));
 
                 Assert.Equal(
-                    CoreStrings.NavigationToShadowEntity("Customer", typeof(Order).DisplayName(fullName: false), "Customer"),
+                    CoreStrings.NavigationToShadowEntity("Customer", typeof(Order).ShortDisplayName(), "Customer"),
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne("Customer", "Customer")).Message);
             }
 
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var orderEntityType = modelBuilder.Entity(typeof(Order));
 
                 Assert.Equal(
-                    CoreStrings.NoClrNavigation("CustomerNavigation", typeof(Order).DisplayName(fullName: false)),
+                    CoreStrings.NoClrNavigation("CustomerNavigation", typeof(Order).ShortDisplayName()),
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(typeof(Customer), "CustomerNavigation")).Message);
             }
 
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var customerEntityType = modelBuilder.Entity(typeof(Customer));
 
                 Assert.Equal(
-                    CoreStrings.NavigationToShadowEntity("Orders", typeof(Customer).DisplayName(fullName: false), "Order"),
+                    CoreStrings.NavigationToShadowEntity("Orders", typeof(Customer).ShortDisplayName(), "Order"),
                     Assert.Throws<InvalidOperationException>(() => customerEntityType.HasMany("Order", "Orders")).Message);
             }
 
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var customerEntityType = modelBuilder.Entity(typeof(Customer));
 
                 Assert.Equal(
-                    CoreStrings.NoClrNavigation("OrdersNavigation", typeof(Customer).DisplayName(fullName: false)),
+                    CoreStrings.NoClrNavigation("OrdersNavigation", typeof(Customer).ShortDisplayName()),
                     Assert.Throws<InvalidOperationException>(() => customerEntityType.HasMany(typeof(Order), "OrdersNavigation")).Message);
             }
 
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var orderEntityType = modelBuilder.Entity(typeof(Order));
 
                 Assert.Equal(
-                    CoreStrings.NavigationToShadowEntity(nameof(Order.Details), typeof(Order).DisplayName(fullName: false), nameof(OrderDetails)),
+                    CoreStrings.NavigationToShadowEntity(nameof(Order.Details), typeof(Order).ShortDisplayName(), nameof(OrderDetails)),
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(nameof(OrderDetails), nameof(Order.Details))).Message);
             }
 
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var orderEntityType = modelBuilder.Entity(typeof(Order));
 
                 Assert.Equal(
-                    CoreStrings.NoClrNavigation("OrderDetailsNavigation", typeof(Order).DisplayName(fullName: false)),
+                    CoreStrings.NoClrNavigation("OrderDetailsNavigation", typeof(Order).ShortDisplayName()),
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(typeof(OrderDetails), "OrderDetailsNavigation")).Message);
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -451,15 +451,15 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<Quarks>(b =>
                     {
                         Assert.Equal(
-                            CoreStrings.CannotBeNullable("Up", "Quarks", "Int32"),
+                            CoreStrings.CannotBeNullable("Up", "Quarks", "int"),
                             Assert.Throws<InvalidOperationException>(() => b.Property(e => e.Up).IsRequired(false)).Message);
 
                         Assert.Equal(
-                            CoreStrings.CannotBeNullable("Charm", "Quarks", "Int32"),
+                            CoreStrings.CannotBeNullable("Charm", "Quarks", "int"),
                             Assert.Throws<InvalidOperationException>(() => b.Property<int>("Charm").IsRequired(false)).Message);
 
                         Assert.Equal(
-                            CoreStrings.CannotBeNullable("Top", "Quarks", "Int32"),
+                            CoreStrings.CannotBeNullable("Top", "Quarks", "int"),
                             Assert.Throws<InvalidOperationException>(() => b.Property<int>("Top").IsRequired(false)).Message);
                     });
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2333,7 +2333,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
                 modelBuilder.Ignore<Order>();
 
-                Assert.Equal(CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
+                Assert.Equal(CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
@@ -2373,7 +2373,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
                 modelBuilder.Ignore<Order>();
 
-                Assert.Equal(CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
+                Assert.Equal(CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
@@ -2414,7 +2414,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
                 modelBuilder.Ignore<Order>();
 
-                Assert.Equal(CoreStrings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
+                Assert.Equal(CoreStrings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
@@ -2454,7 +2454,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
                 modelBuilder.Ignore<Order>();
 
-                Assert.Equal(CoreStrings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
+                Assert.Equal(CoreStrings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/Design/Internal/StartupInvokerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.Tests/Design/Internal/StartupInvokerTest.cs
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Core.Tests.Design.Internal
             Assert.Equal(
                 DesignCoreStrings.InvokeStartupMethodFailed(
                     "ConfigureServices",
-                    typeof(BadStartup).DisplayName(),
+                    nameof(BadStartup),
                     "Something went wrong."),
                 log[0].Item2);
         }


### PR DESCRIPTION
Issue #734

Also used our name formatting methods, that did not exist when bug was filed, so that generic types are nicely formatted.