### PR TITLE
Create design-time abstractions

### DIFF
--- a/EntityFramework.sln
+++ b/EntityFramework.sln
@@ -65,6 +65,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests", "src\Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests\Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.csproj", "{A0B496FE-1E59-4262-A5F5-101CBBA42738}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.EntityFrameworkCore.Design.Core", "src\Microsoft.EntityFrameworkCore.Design.Core\Microsoft.EntityFrameworkCore.Design.Core.csproj", "{D3D0A8E8-EC2F-4E01-8650-8554E186A66F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.EntityFrameworkCore.Design.Abstractions", "src\Microsoft.EntityFrameworkCore.Design.Abstractions\Microsoft.EntityFrameworkCore.Design.Abstractions.csproj", "{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}"
+EndProject
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.EntityFrameworkCore.Tools.Core.Tests", "test\Microsoft.EntityFrameworkCore.Tools.Core.Tests\Microsoft.EntityFrameworkCore.Tools.Core.Tests.csproj", "{7583E3F0-8B29-4BEA-A55E-E8B66E6FD508}"
 EndProject
@@ -204,6 +206,10 @@ Global
 		{93F36377-39C6-48A2-8C01-FD72373A34A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93F36377-39C6-48A2-8C01-FD72373A34A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93F36377-39C6-48A2-8C01-FD72373A34A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/IOperationLogHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/IOperationLogHandler.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public interface IOperationLogHandler
+    {
+        int Version { get; }
+        void WriteError(string message);
+        void WriteWarning(string message);
+        void WriteInformation(string message);
+        void WriteDebug(string message);
+        void WriteTrace(string message);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/IOperationResultHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/IOperationResultHandler.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public interface IOperationResultHandler
+    {
+        int Version { get; }
+        void OnResult(object value);
+        void OnError(string type, string message, string stackTrace);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IConnectionStringDiscovered.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IConnectionStringDiscovered.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IConnectionStringDiscovered : IOperationResult
+    {
+        string DatabaseName { get; }
+        string DataSource { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IContextTypeDiscovered.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IContextTypeDiscovered.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IContextTypeDiscovered : IOperationResult
+    {
+        string Name { get; }
+        string FullName { get; }
+        string AssemblyQualifiedName { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IFileCreated.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IFileCreated.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IFileCreated : IOperationResult
+    {
+        string Id { get; }
+        string FilePath { get; }
+        string ContentType { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IFileDeleted.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IFileDeleted.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IFileDeleted : IOperationResult
+    {
+        string FilePath { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IMigrationDiscovered.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IMigrationDiscovered.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IMigrationDiscovered : IOperationResult
+    {
+        string Id { get; }
+        string Name { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IMigrationScriptGenerated.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IMigrationScriptGenerated.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IMigrationScriptGenerated : IOperationResult
+    {
+        string Sql { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IOperationResult.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Internal/IOperationResult.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public interface IOperationResult
+    {
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Microsoft.EntityFrameworkCore.Design.Abstractions.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Microsoft.EntityFrameworkCore.Design.Abstractions.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\tools\EntityFramework.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AF5EA360-4AB2-422A-9EBF-58EA094E17B5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.EntityFrameworkCore.Design</RootNamespace>
+    <AssemblyName>Microsoft.EntityFrameworkCore.Design.Abstractions</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="IOperationLogHandler.cs" />
+    <Compile Include="IOperationResultHandler.cs" />
+    <Compile Include="Internal\IContextTypeDiscovered.cs" />
+    <Compile Include="Internal\IFileCreated.cs" />
+    <Compile Include="Internal\IFileDeleted.cs" />
+    <Compile Include="Internal\IOperationResult.cs" />
+    <Compile Include="Internal\IMigrationDiscovered.cs" />
+    <Compile Include="Internal\IMigrationScriptGenerated.cs" />
+    <Compile Include="Internal\IConnectionStringDiscovered.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Microsoft.EntityFrameworkCore.Design.Abstractions.xproj
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Microsoft.EntityFrameworkCore.Design.Abstractions.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>661c26a1-3a5e-4cb7-b101-c0c59767881e</ProjectGuid>
+    <RootNamespace>Microsoft.EntityFrameworkCore.Design.Abstractions</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+[assembly: AssemblyMetadata("Serviceable", "True")]
+[assembly: AssemblyCompany("Microsoft Corporation.")]
+[assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: AssemblyProduct("Microsoft EntityFramework Core")]

--- a/src/Microsoft.EntityFrameworkCore.Design.Abstractions/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Design.Abstractions/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0-preview3-*",
+  "description": "Abstractions for Entity Framework Core design-time tools.",
+  "packOptions": {
+    "tags": [
+      "Entity Framework Core",
+      "entity-framework-core",
+      "EF",
+      "Data",
+      "O/RM"
+    ]
+  },
+  "buildOptions": {
+    "warningsAsErrors": true, 
+    "keyFile": "../../tools/Key.snk"
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Collections": "4.0.11-*"
+      }
+    }
+  }
+}


### PR DESCRIPTION
NB: merging into a feature branch instead of dev.

Part of #5334

In order to create "ef.exe", we will need to unify types on both sides of the app domain. Currently, we do this in powershell by including "OperationHandlers.cs" which is compiled into the powershell host. Although we could continue to use transparent proxies to remote calls between types that are almost the same, if we can settle on abstractions that work, we can use ef.exe on .NET Standard libraries.

In addition, I'm adding strong types for results.

TODO: xmldocs

cc @bricelam 
