### PR TITLE
Query: Apply search condition conversions outside of ConvertExpression

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/NullSemanticsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/NullSemanticsQueryTestBase.cs
@@ -444,6 +444,39 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
+        public virtual void Where_nullable_bool()
+        {
+            using (var context = CreateContext())
+            {
+                context.Entities1
+                    .Where(e => e.NullableBoolA.Value)
+                    .Select(e => e.Id).ToList();
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_bool_equal_with_constant()
+        {
+            using (var context = CreateContext())
+            {
+                context.Entities1
+                    .Where(e => e.NullableBoolA == true)
+                    .Select(e => e.Id).ToList();
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_bool_with_null_check()
+        {
+            using (var context = CreateContext())
+            {
+                context.Entities1
+                    .Where(e => e.NullableBoolA != null && e.NullableBoolA.Value)
+                    .Select(e => e.Id).ToList();
+            }
+        }
+
+        [Fact]
         public virtual void Where_equal_using_relational_null_semantics_with_parameter()
         {
             using (var context = CreateContext(useRelationalNulls: true))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -917,6 +917,39 @@ WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
                 Sql);
         }
 
+        public override void Where_nullable_bool()
+        {
+            base.Where_nullable_bool();
+
+            Assert.Equal(
+    @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] = 1",
+                Sql);
+        }
+
+        public override void Where_nullable_bool_equal_with_constant()
+        {
+            base.Where_nullable_bool_equal_with_constant();
+
+            Assert.Equal(
+    @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] = 1",
+                Sql);
+        }
+
+        public override void Where_nullable_bool_with_null_check()
+        {
+            base.Where_nullable_bool_with_null_check();
+
+            Assert.Equal(
+    @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)",
+                Sql);
+        }
+
         public override void Where_equal_using_relational_null_semantics_with_parameter()
         {
             base.Where_equal_using_relational_null_semantics_with_parameter();


### PR DESCRIPTION
Resolves #5877 
The issue: We had `UnaryExpression` to convert values from `bool?` to `bool` in predicates for nullable columns. While visiting the `UnaryExpression.Operand` we tried to convert it to search condition by comparing it to true but `Operand` is of `bool?` type hence throwing exception.
The fix: For `UnaryExpression` with `Convert` node type, the operand is not search condition, we compare the whole expression to make a search condition if needed.