### PR TITLE
Make RelationalLoggerExtensions namespace internal instead of really internal.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TestSqlLoggerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TestSqlLoggerFactory.cs
@@ -3,21 +3,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
-using System.Reflection;
 #if !NETSTANDARD1_3
 using System.Runtime.Remoting.Messaging;
 
 #endif
-
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public class TestSqlLoggerFactory : ILoggerFactory
@@ -70,20 +66,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 #if NET451
             [NonSerialized]
 #endif
-            public readonly IndentedStringBuilder _log = new IndentedStringBuilder();
+                public readonly IndentedStringBuilder _log = new IndentedStringBuilder();
+
             public readonly List<string> _sqlStatements = new List<string>();
 #if NET451
             [NonSerialized]
 #endif
-            public readonly List<DbCommandLogData> _logData = new List<DbCommandLogData>();
+                public readonly List<DbCommandLogData> _logData = new List<DbCommandLogData>();
+
 #if NET451
             [NonSerialized]
 #endif
-            public ITestOutputHelper _testOutputHelper;
+                public ITestOutputHelper _testOutputHelper;
+
 #if NET451
             [NonSerialized]
 #endif
-            public CancellationTokenSource _cancellationTokenSource;
+                public CancellationTokenSource _cancellationTokenSource;
+
             // ReSharper restore InconsistentNaming
         }
 
@@ -152,8 +152,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                                 = string.Join(
                                     EOL,
                                     commandLogData.Parameters
-                                        .Select(p => $"{p.Name}: {FormatParameter(p)}"))
-                                    + EOL + EOL;
+                                        .Select(p => $"{p.Name}: {p.FormatParameter(quoteValues: false)}"))
+                                  + EOL + EOL;
                         }
 
                         sqlLoggerData._sqlStatements.Add(parameters + commandLogData.CommandText);
@@ -170,7 +170,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
             }
 
-
             public bool IsEnabled(LogLevel logLevel) => true;
 
             public IDisposable BeginScope<TState>(TState state) => SqlLoggerData._log.Indent();
@@ -183,175 +182,5 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 CallContext.LogicalSetData(ContextName, null);
 #endif
         }
-
-        public static string FormatParameter(DbParameterLogData parameterData)
-        {
-            var builder = new StringBuilder();
-
-            var value = parameterData.Value;
-            var clrType = value?.GetType();
-
-            FormatParameterValue(builder, value);
-
-            if (parameterData.IsNullable
-                && value != null
-                && !IsNullableType(clrType))
-            {
-                builder.Append(" (Nullable = true)");
-            }
-            else
-            {
-                if (!parameterData.IsNullable
-                    && parameterData.HasValue
-                    && (value == null
-                        || IsNullableType(clrType)))
-                {
-                    builder.Append(" (Nullable = false)");
-                }
-            }
-
-            if (parameterData.Size != 0)
-            {
-                builder
-                    .Append(" (Size = ")
-                    .Append(parameterData.Size)
-                    .Append(')');
-            }
-
-            if (parameterData.Precision != 0)
-            {
-                builder
-                    .Append(" (Precision = ")
-                    .Append(parameterData.Precision)
-                    .Append(')');
-            }
-
-            if (parameterData.Scale != 0)
-            {
-                builder
-                    .Append(" (Scale = ")
-                    .Append(parameterData.Scale)
-                    .Append(')');
-            }
-
-            if (parameterData.Direction != ParameterDirection.Input)
-            {
-                builder
-                    .Append(" (Direction = ")
-                    .Append(parameterData.Direction)
-                    .Append(')');
-            }
-
-            if (parameterData.HasValue
-                && !IsNormalDbType(parameterData.DbType, clrType))
-            {
-                builder
-                    .Append(" (DbType = ")
-                    .Append(parameterData.DbType)
-                    .Append(')');
-            }
-
-            return builder.ToString();
-        }
-
-        private static void FormatParameterValue(StringBuilder builder, object parameterValue)
-        {
-            if (parameterValue.GetType() != typeof(byte[]))
-            {
-                builder.Append(Convert.ToString(parameterValue, CultureInfo.InvariantCulture));
-                return;
-            }
-
-            var buffer = (byte[])parameterValue;
-            builder.Append("0x");
-
-            for (var i = 0; i < buffer.Length; i++)
-            {
-                if (i > 31)
-                {
-                    builder.Append("...");
-                    break;
-                }
-                builder.Append(buffer[i].ToString("X2", CultureInfo.InvariantCulture));
-            }
-        }
-
-        private static bool IsNullableType(Type type)
-        {
-            var typeInfo = type.GetTypeInfo();
-
-            return !typeInfo.IsValueType
-                   || (typeInfo.IsGenericType
-                       && (typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>)));
-        }
-
-        private static bool IsNormalDbType(DbType dbType, Type clrType)
-        {
-            if (clrType == null)
-            {
-                return false;
-            }
-
-            clrType = UnwrapEnumType(UnwrapNullableType(clrType));
-
-            switch (dbType)
-            {
-                case DbType.AnsiString: // Zero
-                    return clrType != typeof(string);
-                case DbType.Binary:
-                    return clrType == typeof(byte[]);
-                case DbType.Byte:
-                    return clrType == typeof(byte);
-                case DbType.Boolean:
-                    return clrType == typeof(bool);
-                case DbType.Decimal:
-                    return clrType == typeof(decimal);
-                case DbType.Double:
-                    return clrType == typeof(double);
-                case DbType.Guid:
-                    return clrType == typeof(Guid);
-                case DbType.Int16:
-                    return clrType == typeof(short);
-                case DbType.Int32:
-                    return clrType == typeof(int);
-                case DbType.Int64:
-                    return clrType == typeof(long);
-                case DbType.Object:
-                    return clrType == typeof(object);
-                case DbType.SByte:
-                    return clrType == typeof(sbyte);
-                case DbType.Single:
-                    return clrType == typeof(float);
-                case DbType.String:
-                    return clrType == typeof(string);
-                case DbType.Time:
-                    return clrType == typeof(TimeSpan);
-                case DbType.UInt16:
-                    return clrType == typeof(ushort);
-                case DbType.UInt32:
-                    return clrType == typeof(uint);
-                case DbType.UInt64:
-                    return clrType == typeof(ulong);
-                case DbType.DateTime2:
-                    return clrType == typeof(DateTime);
-                case DbType.DateTimeOffset:
-                    return clrType == typeof(DateTimeOffset);
-                //case DbType.VarNumeric:
-                //case DbType.AnsiStringFixedLength:
-                //case DbType.StringFixedLength:
-                //case DbType.Xml:
-                //case DbType.Currency:
-                //case DbType.Date:
-                //case DbType.DateTime:
-                default:
-                    return false;
-            }
-        }
-
-        private static Type UnwrapNullableType(Type type)
-            => Nullable.GetUnderlyingType(type) ?? type;
-
-        private static Type UnwrapEnumType(Type type)
-            => !type.GetTypeInfo().IsEnum ? type : Enum.GetUnderlyingType(type);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -67,7 +67,6 @@
     <Compile Include="Extensions\DbCommandLogData.cs" />
     <Compile Include="Extensions\DbParameterLogData.cs" />
     <Compile Include="Extensions\RelationalExpressionExtensions.cs" />
-    <Compile Include="Extensions\RelationalLoggerExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Infrastructure\Internal\RelationalModelSource.cs" />
     <Compile Include="Infrastructure\ModelSnapshot.cs" />
@@ -303,11 +302,13 @@
     <Compile Include="Storage\DbContextTransactionExtensions.cs" />
     <Compile Include="Storage\IByteArrayRelationalTypeMapper.cs" />
     <Compile Include="Storage\Internal\CompositeRelationalParameter.cs" />
+    <Compile Include="Storage\Internal\DbParameterLogDataExtensions.cs" />
     <Compile Include="Storage\Internal\DynamicRelationalParameter.cs" />
     <Compile Include="Storage\Internal\RawSqlCommandBuilder.cs" />
     <Compile Include="Storage\Internal\RelationalCommand.cs" />
     <Compile Include="Storage\Internal\RelationalCommandBuilder.cs" />
     <Compile Include="Storage\Internal\RelationalCommandBuilderFactory.cs" />
+    <Compile Include="Storage\Internal\RelationalLoggerExtensions.cs" />
     <Compile Include="Storage\Internal\RelationalParameterBuilder.cs" />
     <Compile Include="Storage\Internal\RemappingUntypedRelationalValueBufferFactory.cs" />
     <Compile Include="Storage\Internal\TypedRelationalValueBufferFactory.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -18,6 +18,7 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/DbParameterLogDataExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/DbParameterLogDataExtensions.cs
@@ -3,89 +3,32 @@
 
 using System;
 using System.Data;
-using System.Data.Common;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
-using Microsoft.Extensions.Logging;
 
-// ReSharper disable once CheckNamespace
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
-    internal static class RelationalLoggerExtensions
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class DbParameterLogDataExtensions
     {
-        public static void LogCommandExecuted(
-            [NotNull] this ISensitiveDataLogger logger,
-            [NotNull] DbCommand command,
-            long startTimestamp,
-            long currentTimestamp)
-        {
-            Check.NotNull(logger, nameof(logger));
-            Check.NotNull(command, nameof(command));
-
-            if (logger.IsEnabled(LogLevel.Information))
-            {
-                var logParameterValues
-                    = command.Parameters.Count > 0
-                      && logger.LogSensitiveData;
-
-                var logData = new DbCommandLogData(
-                    command.CommandText.TrimEnd(),
-                    command.CommandType,
-                    command.CommandTimeout,
-                    command.Parameters
-                        .Cast<DbParameter>()
-                        .Select(
-                            p => new DbParameterLogData(
-                                p.ParameterName,
-                                logParameterValues ? p.Value : "?",
-                                logParameterValues,
-                                p.Direction,
-                                p.DbType,
-                                p.IsNullable,
-                                p.Size,
-                                p.Precision,
-                                p.Scale))
-                        .ToList(),
-                    DeriveTimespan(startTimestamp, currentTimestamp));
-
-                logger.Log(
-                    LogLevel.Information,
-                    (int)RelationalEventId.ExecutedCommand,
-                    logData,
-                    null,
-                    (state, _) =>
-                        {
-                            var elapsedMilliseconds = DeriveTimespan(startTimestamp, currentTimestamp);
-
-                            return RelationalStrings.RelationalLoggerExecutedCommand(
-                                string.Format(
-                                    CultureInfo.InvariantCulture, 
-                                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", elapsedMilliseconds)),
-                                state.Parameters
-                                    // Interpolation okay here because value is always a string.
-                                    .Select(p => $"{p.Name}={FormatParameter(p)}")
-                                    .Join(),
-                                state.CommandType,
-                                state.CommandTimeout,
-                                Environment.NewLine,
-                                state.CommandText);
-                        });
-            }
-        }
-
-        public static string FormatParameter(DbParameterLogData parameterData)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string FormatParameter(
+            [NotNull] this DbParameterLogData parameterData,
+            bool quoteValues = true)
         {
             var builder = new StringBuilder();
 
             var value = parameterData.Value;
             var clrType = value?.GetType();
 
-            FormatParameterValue(builder, value);
+            FormatParameterValue(builder, value, quoteValues);
 
             if (parameterData.IsNullable
                 && value != null
@@ -146,12 +89,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
             }
 
             return builder.ToString();
-
         }
 
-        public static void FormatParameterValue([NotNull] StringBuilder builder, [CanBeNull] object parameterValue)
+        private static void FormatParameterValue(StringBuilder builder, object parameterValue, bool quoteValues)
         {
-            builder.Append('\'');
+            if (quoteValues)
+            {
+                builder.Append('\'');
+            }
 
             if (parameterValue?.GetType() != typeof(byte[]))
             {
@@ -173,7 +118,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 }
             }
 
-            builder.Append('\'');
+            if (quoteValues)
+            {
+                builder.Append('\'');
+            }
         }
 
         private static bool IsNormalDbType(DbType dbType, Type clrType)
@@ -238,42 +186,5 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     return false;
             }
         }
-
-        public static void LogInformation<TState>(
-            this ILogger logger, RelationalEventId eventId, TState state, Func<TState, string> formatter)
-        {
-            if (logger.IsEnabled(LogLevel.Information))
-            {
-                logger.Log(LogLevel.Information, (int)eventId, state, null, (s, _) => formatter(s));
-            }
-        }
-
-        public static void LogDebug(
-            this ILogger logger, RelationalEventId eventId, Func<string> formatter)
-        {
-            if (logger.IsEnabled(LogLevel.Debug))
-            {
-                logger.Log<object>(LogLevel.Debug, (int)eventId, null, null, (_, __) => formatter());
-            }
-        }
-
-        public static void LogDebug<TState>(
-            this ILogger logger, RelationalEventId eventId, TState state, Func<TState, string> formatter)
-        {
-            if (logger.IsEnabled(LogLevel.Debug))
-            {
-                logger.Log(LogLevel.Debug, (int)eventId, state, null, (s, __) => formatter(s));
-            }
-        }
-
-        public static void LogWarning(this ILogger logger, RelationalEventId eventId, Func<string> formatter)
-        {
-            // Always call Log for Warnings because Warnings as Errors should work even
-            // if LogLevel.Warning is not enabled.
-            logger.Log<object>(LogLevel.Warning, (int)eventId, eventId, null, (_, __) => formatter());
-        }
-
-        private static long DeriveTimespan(long startTimestamp, long currentTimestamp)
-            => (currentTimestamp - startTimestamp) / TimeSpan.TicksPerMillisecond;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Globalization;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class RelationalLoggerExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void LogCommandExecuted(
+            [NotNull] this ISensitiveDataLogger logger,
+            [NotNull] DbCommand command,
+            long startTimestamp,
+            long currentTimestamp)
+        {
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(command, nameof(command));
+
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var logParameterValues
+                    = command.Parameters.Count > 0
+                      && logger.LogSensitiveData;
+
+                var logData = new DbCommandLogData(
+                    command.CommandText.TrimEnd(),
+                    command.CommandType,
+                    command.CommandTimeout,
+                    command.Parameters
+                        .Cast<DbParameter>()
+                        .Select(
+                            p => new DbParameterLogData(
+                                p.ParameterName,
+                                logParameterValues ? p.Value : "?",
+                                logParameterValues,
+                                p.Direction,
+                                p.DbType,
+                                p.IsNullable,
+                                p.Size,
+                                p.Precision,
+                                p.Scale))
+                        .ToList(),
+                    DeriveTimespan(startTimestamp, currentTimestamp));
+
+                logger.Log(
+                    LogLevel.Information,
+                    (int)RelationalEventId.ExecutedCommand,
+                    logData,
+                    null,
+                    (state, _) =>
+                        {
+                            var elapsedMilliseconds = DeriveTimespan(startTimestamp, currentTimestamp);
+
+                            return RelationalStrings.RelationalLoggerExecutedCommand(
+                                string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", elapsedMilliseconds)),
+                                state.Parameters
+                                    // Interpolation okay here because value is always a string.
+                                    .Select(p => $"{p.Name}={p.FormatParameter()}")
+                                    .Join(),
+                                state.CommandType,
+                                state.CommandTimeout,
+                                Environment.NewLine,
+                                state.CommandText);
+                        });
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void LogDebug(
+            [NotNull] this ILogger logger,
+            RelationalEventId eventId,
+            [NotNull] Func<string> formatter)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.Log<object>(LogLevel.Debug, (int)eventId, null, null, (_, __) => formatter());
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void LogDebug<TState>(
+            [NotNull] this ILogger logger,
+            RelationalEventId eventId,
+            [CanBeNull] TState state,
+            [NotNull] Func<TState, string> formatter)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.Log(LogLevel.Debug, (int)eventId, state, null, (s, __) => formatter(s));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void LogWarning(
+            [NotNull] this ILogger logger,
+            RelationalEventId eventId,
+            [NotNull] Func<string> formatter)
+        {
+            // Always call Log for Warnings because Warnings as Errors should work even
+            // if LogLevel.Warning is not enabled.
+            logger.Log<object>(LogLevel.Warning, (int)eventId, eventId, null, (_, __) => formatter());
+        }
+
+        private static long DeriveTimespan(long startTimestamp, long currentTimestamp)
+            => (currentTimestamp - startTimestamp) / TimeSpan.TicksPerMillisecond;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 using IsolationLevel = System.Data.IsolationLevel;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTransaction.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Data;
 using System.Linq;
-using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
@@ -18,15 +18,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
             var shortArray = new Guid("21EC2020-3AEA-4069-A2DD-08002B30309D").ToByteArray();
             var longerShortArray = shortArray.Concat(shortArray).ToArray();
 
-            var builder = new StringBuilder();
-            RelationalLoggerExtensions.FormatParameterValue(builder, shortArray);
+            Assert.Equal(
+                "'0x2020EC21EA3A6940A2DD08002B30309D'",
+                new DbParameterLogData(
+                    "@param", shortArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0).FormatParameter());
 
-            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D'", builder.ToString());
-
-            builder.Clear();
-            RelationalLoggerExtensions.FormatParameterValue(builder, longerShortArray);
-
-            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D'", builder.ToString());
+            Assert.Equal(
+                "'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D'",
+                new DbParameterLogData(
+                    "@param", longerShortArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -35,10 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
             var shortArray = new Guid("21EC2020-3AEA-4069-A2DD-08002B30309D").ToByteArray();
             var longArray = shortArray.Concat(shortArray).Concat(shortArray).ToArray();
 
-            var builder = new StringBuilder();
-            RelationalLoggerExtensions.FormatParameterValue(builder, longArray);
-
-            Assert.Equal("'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...'", builder.ToString());
+            Assert.Equal(
+                "'0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...'",
+                new DbParameterLogData(
+                    "@param", longArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -46,8 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -55,8 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin' (Direction = Output)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Output, DbType.String, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Output, DbType.String, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -64,8 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin' (Nullable = false)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.String, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -73,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin' (DbType = AnsiString)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -82,8 +82,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin' (Nullable = false) (DbType = AnsiString)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -91,8 +91,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'Muffin' (Nullable = false) (Size = 100) (DbType = AnsiString)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 100, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 100, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -100,8 +100,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'' (DbType = String)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", null, true, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.String, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -109,8 +109,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'' (DbType = AnsiString)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", null, true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -118,8 +118,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'?'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "?", false, ParameterDirection.Input, DbType.String, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.String, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -127,8 +127,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'?'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "?", false, ParameterDirection.Input, DbType.String, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.String, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -136,8 +136,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -145,8 +145,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (Nullable = true)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -154,8 +154,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", 777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -163,8 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", 777, true, ParameterDirection.Input, 0, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", 777, true, ParameterDirection.Input, 0, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -172,8 +172,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'' (DbType = Int32)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", null, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", null, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -181,8 +181,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'?'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -190,8 +190,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'?'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", "?", false, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -199,8 +199,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (short)777, true, ParameterDirection.Input, DbType.Int16, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (short)777, true, ParameterDirection.Input, DbType.Int16, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -208,8 +208,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (short)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (short)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -217,8 +217,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (long)777, true, ParameterDirection.Input, DbType.Int64, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (long)777, true, ParameterDirection.Input, DbType.Int64, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -226,8 +226,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (long)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (long)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -235,8 +235,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (byte)77, true, ParameterDirection.Input, DbType.Byte, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (byte)77, true, ParameterDirection.Input, DbType.Byte, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -244,8 +244,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (byte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (byte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -253,8 +253,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (uint)777, true, ParameterDirection.Input, DbType.UInt32, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (uint)777, true, ParameterDirection.Input, DbType.UInt32, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -262,8 +262,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (uint)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (uint)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -271,8 +271,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.UInt16, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.UInt16, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -280,8 +280,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (ushort)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -289,8 +289,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.UInt64, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.UInt64, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -298,8 +298,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (ulong)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -307,8 +307,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.SByte, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.SByte, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -316,8 +316,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (sbyte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -325,8 +325,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'0x0102'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -334,8 +334,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'0x0102' (DbType = Object)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -343,8 +343,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'True'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", true, true, ParameterDirection.Input, DbType.Boolean, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", true, true, ParameterDirection.Input, DbType.Boolean, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -352,8 +352,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'True' (DbType = Int32)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", true, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", true, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -361,8 +361,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -370,8 +370,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (decimal)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -379,8 +379,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77.7' (Precision = 18)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 0)));
+                new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 0).FormatParameter());
         }
 
         [Fact]
@@ -388,8 +388,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77.7' (Scale = 2)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 2)));
+                new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 2).FormatParameter());
         }
 
         [Fact]
@@ -397,8 +397,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'77.7' (Precision = 18) (Scale = 2)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 2)));
+                new DbParameterLogData(
+                    "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 2).FormatParameter());
         }
 
         [Fact]
@@ -406,8 +406,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (double)777, true, ParameterDirection.Input, DbType.Double, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (double)777, true, ParameterDirection.Input, DbType.Double, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -415,8 +415,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (double)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (double)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -424,8 +424,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (float)777, true, ParameterDirection.Input, DbType.Single, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (float)777, true, ParameterDirection.Input, DbType.Single, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -433,8 +433,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'777' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", (float)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", (float)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -442,9 +442,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'304afb2a-8b8c-49ac-996e-8561f7559a3f'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                new DbParameterLogData(
                     "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
-                    true, ParameterDirection.Input, DbType.Guid, false, 0, 0, 0)));
+                    true, ParameterDirection.Input, DbType.Guid, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -452,9 +452,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'304afb2a-8b8c-49ac-996e-8561f7559a3f' (DbType = Binary)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                new DbParameterLogData(
                     "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
-                    true, ParameterDirection.Input, DbType.Binary, false, 0, 0, 0)));
+                    true, ParameterDirection.Input, DbType.Binary, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -462,8 +462,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'System.Object'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new object(), true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new object(), true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -471,8 +471,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'System.Object' (DbType = VarNumeric)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new object(), true, ParameterDirection.Input, DbType.VarNumeric, true, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new object(), true, ParameterDirection.Input, DbType.VarNumeric, true, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -480,8 +480,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'09/03/1973 00:00:00'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime2, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime2, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -489,8 +489,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'09/03/1973 00:00:00' (DbType = DateTime)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -498,9 +498,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'09/03/1973 00:00:00 -08:00'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                new DbParameterLogData(
                     "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
-                    true, ParameterDirection.Input, DbType.DateTimeOffset, false, 0, 0, 0)));
+                    true, ParameterDirection.Input, DbType.DateTimeOffset, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -508,9 +508,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'09/03/1973 00:00:00 -08:00' (DbType = Date)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
+                new DbParameterLogData(
                     "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
-                    true, ParameterDirection.Input, DbType.Date, false, 0, 0, 0)));
+                    true, ParameterDirection.Input, DbType.Date, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -518,8 +518,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'-08:00:00'",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.Time, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.Time, false, 0, 0, 0).FormatParameter());
         }
 
         [Fact]
@@ -527,8 +527,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Utilities
         {
             Assert.Equal(
                 "'-08:00:00' (DbType = DateTime)",
-                RelationalLoggerExtensions.FormatParameter(new DbParameterLogData(
-                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0)));
+                new DbParameterLogData(
+                    "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0).FormatParameter());
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Xunit;
 // ReSharper disable UnusedParameter.Local
 // ReSharper disable PossibleInvalidOperationException
@@ -359,7 +360,7 @@ WHERE [e].[Time] = @__timeSpan_0",
             => string.Join(
                 FileLineEnding, 
                 TestSqlLoggerFactory.CommandLogData.Single().Parameters
-                .Select(p => p.Name + ": " + TestSqlLoggerFactory.FormatParameter(p)));
+                .Select(p => p.Name + ": " + p.FormatParameter(quoteValues: false)));
 
         private static void AssertMappedDataTypes(MappedDataTypes entity, int id)
         {


### PR DESCRIPTION
This enables re-use of parameter formatting code in tests.

Issue #5472