### PR TITLE
Query: Navigations: Three bug fixes.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return _tables.FirstOrDefault(te
                 => te.QuerySource == querySource
                    || ((te as SelectExpression)?.HandlesQuerySource(querySource) ?? false))
-                   ?? _tables.Single();
+                   ?? _tables.Last();
         }
 
         /// <summary>
@@ -816,7 +816,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             Check.NotNull(orderings, nameof(orderings));
 
-            _orderBy.InsertRange(0, orderings);
+            var oldOrderBy = _orderBy.ToList();
+
+            _orderBy.Clear();
+            _orderBy.AddRange(orderings);
+
+            foreach (var ordering in oldOrderBy)
+            {
+                AddToOrderBy(ordering);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -416,6 +416,27 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(queryModel, nameof(queryModel));
 
             base.VisitAdditionalFromClause(fromClause, queryModel, index);
+            
+            var fromQuerySourceReferenceExpression 
+                = fromClause.FromExpression as QuerySourceReferenceExpression;
+
+            if (fromQuerySourceReferenceExpression != null)
+            {
+                var previousQuerySource = FindPreviousQuerySource(queryModel, index - 1);
+
+                if (previousQuerySource != null
+                    && !RequiresClientJoin)
+                {
+                    var previousSelectExpression = TryGetQuery(previousQuerySource);
+
+                    if (previousSelectExpression != null)
+                    {
+                        AddQuery(fromClause, previousSelectExpression);
+                    }
+                }
+
+                return;
+            }
 
             RequiresClientSelectMany = true;
 
@@ -582,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(operatorToFlatten, nameof(operatorToFlatten));
 
             RequiresClientJoin = true;
-
+            
             var previousQuerySource = FindPreviousQuerySource(queryModel, index);
 
             var previousSelectExpression
@@ -594,8 +615,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 = previousSelectExpression?.Projection.Count ?? -1;
 
             baseVisitAction();
-
-            if (previousSelectExpression != null)
+            
+            if (!RequiresClientSelectMany 
+                && previousSelectExpression != null)
             {
                 var selectExpression = TryGetQuery(joinClause);
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -985,8 +985,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
         {
             List<KeyValuePair<Guid, Guid>> expected;
@@ -1014,8 +1013,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
         {
             List<KeyValuePair<Guid, Guid>> expected;
@@ -1112,8 +1110,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Equals_Navigation()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -9,8 +9,13 @@ using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
+// ReSharper disable PossibleMultipleEnumeration
+// ReSharper disable ReplaceWithSingleCallToFirstOrDefault
+// ReSharper disable ReplaceWithSingleCallToAny
+// ReSharper disable ReplaceWithSingleCallToFirst
+// ReSharper disable StringStartsWithIsCultureSpecific
 // ReSharper disable UseCollectionCountProperty
-
 // ReSharper disable AccessToDisposedClosure
 // ReSharper disable PossibleUnintendedReferenceComparison
 
@@ -43,8 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
         {
             using (var context = CreateContext())
@@ -59,8 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
         {
             using (var context = CreateContext())
@@ -186,8 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 6);
         }
 
-        // issue 4539
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Equals_Navigation()
         {
             using (var context = CreateContext())
@@ -616,11 +618,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 );
         }
 
-        // #5427
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Collection_select_nav_prop_first_or_default_then_nav_prop_nested_with_orderby()
         {
             AssertQuery<Customer, Order, string>(
+                // ReSharper disable once StringStartsWithIsCultureSpecific
                 (cs, os) => cs.Where(e => e.CustomerID.StartsWith("A"))
                     .Select(c => os.OrderBy(o => o.CustomerID).FirstOrDefault(o =>o.CustomerID == "ALFKI").Customer.City));
         }
@@ -728,13 +730,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 1);
         }
 
-        private int ClientMethod(int argument)
-        {
-            return argument;
-        }
+        // ReSharper disable once MemberCanBeMadeStatic.Local
+        private int ClientMethod(int argument) => argument;
 
-        // issue #4547
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Navigation_in_subquery_referencing_outer_query()
         {
             using (var context = CreateContext())
@@ -794,15 +793,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     });
         }
 
-        // issue #3676
-        //// [ConditionalFact]
+        [ConditionalFact]
         public virtual void Let_group_by_nav_prop()
         {
             AssertQuery<OrderDetail, IGrouping<string, OrderDetail>>(
                 ods => from od in ods
                        let customer = od.Order.CustomerID
-                       group od by customer
-                       into odg
+                       group od by customer into odg
                        select odg,
                 asserter: (l2oItems, efItems) =>
                 {
@@ -836,10 +833,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             bool assertOrder = false,
             int entryCount = 0,
             Action<IList<object>, IList<object>> asserter = null)
-            where TItem : class
-        {
-            AssertQuery(query, query, assertOrder, entryCount, asserter);
-        }
+            where TItem : class 
+            => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> query,
@@ -847,21 +842,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             int entryCount = 0,
             Action<IList<TResult>, IList<TResult>> asserter = null)
             where TItem1 : class
-            where TItem2 : class
-        {
-            AssertQuery(query, query, assertOrder, entryCount, asserter);
-        }
-
+            where TItem2 : class 
+            => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem, TResult>(
             Func<IQueryable<TItem>, IQueryable<TResult>> query,
             bool assertOrder = false,
             int entryCount = 0,
             Action<IList<TResult>, IList<TResult>> asserter = null)
-            where TItem : class
-        {
-            AssertQuery(query, query, assertOrder, entryCount, asserter);
-        }
+            where TItem : class 
+            => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<object>> efQuery,

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -3153,7 +3153,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 select new { c, hasOrders });
         }
 
-        // TODO: Need to figure out how to do this 
+        // TODO: Need to figure out how to do this
         //        [ConditionalFact]
         //        public virtual void GroupBy_anonymous()
         //        {
@@ -4620,6 +4620,30 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 from c in cs.Take(1)
                 join o in os on c.CustomerID equals o.CustomerID into orders
                 from o in orders.DefaultIfEmpty()
+                select o);
+        }
+
+
+        [ConditionalFact]
+        public virtual void GroupJoin_Where()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                where o.CustomerID == "ALFKI"
+                select o);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_DefaultIfEmpty_Where_OrderBy()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                where o.CustomerID == "ALFKI" || c.CustomerID == "ANATR"
+                orderby c.City
                 select o);
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
@@ -209,16 +209,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IEnumerable<IGrouping<TKey, TOut>> _TrackGroupedEntities<TKey, TOut, TIn>(
-            IEnumerable<IGrouping<TKey, TOut>> groupings,
+        private static IEnumerable<IGrouping<TKey, TElement>> _TrackGroupedEntities<TKey, TElement>(
+            IEnumerable<IGrouping<TKey, TElement>> groupings,
             QueryContext queryContext,
             IList<EntityTrackingInfo> entityTrackingInfos,
-            IList<Func<TIn, object>> entityAccessors)
-            where TIn : class
+            IList<Func<TElement, object>> entityAccessors)
         {
             return groupings
                 .Select(g =>
-                    new TrackingGrouping<TKey, TOut, TIn>(
+                    new TrackingGrouping<TKey, TElement>(
                         g,
                         queryContext,
                         entityTrackingInfos,
@@ -231,19 +230,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual MethodInfo TrackGroupedEntities => _trackGroupedEntities;
 
-        private class TrackingGrouping<TKey, TOut, TIn> : IGrouping<TKey, TOut>
-            where TIn : class
+        private class TrackingGrouping<TKey, TElement> : IGrouping<TKey, TElement>
         {
-            private readonly IGrouping<TKey, TOut> _grouping;
+            private readonly IGrouping<TKey, TElement> _grouping;
             private readonly QueryContext _queryContext;
             private readonly IList<EntityTrackingInfo> _entityTrackingInfos;
-            private readonly IList<Func<TIn, object>> _entityAccessors;
+            private readonly IList<Func<TElement, object>> _entityAccessors;
 
             public TrackingGrouping(
-                IGrouping<TKey, TOut> grouping,
+                IGrouping<TKey, TElement> grouping,
                 QueryContext queryContext,
                 IList<EntityTrackingInfo> entityTrackingInfos,
-                IList<Func<TIn, object>> entityAccessors)
+                IList<Func<TElement, object>> entityAccessors)
             {
                 _grouping = grouping;
                 _queryContext = queryContext;
@@ -253,7 +251,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public TKey Key => _grouping.Key;
 
-            public IEnumerator<TOut> GetEnumerator()
+            public IEnumerator<TElement> GetEnumerator()
             {
                 _queryContext.BeginTrackingQuery();
 
@@ -263,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         for (var i = 0; i < _entityTrackingInfos.Count; i++)
                         {
-                            var entity = _entityAccessors[i](result as TIn);
+                            var entity = _entityAccessors[i](result);
 
                             if (entity != null)
                             {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -956,10 +956,21 @@ WHERE ([g1].[Discriminator] = N'Officer') OR ([g1].[Discriminator] = N'Gear')",
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar();
+#if NET451
+            Assert.StartsWith(
+                @"SELECT [ct2.Gear].[Nickname], [ct2.Gear].[SquadId], [ct2.Gear].[AssignedCityName], [ct2.Gear].[CityOrBirthName], [ct2.Gear].[Discriminator], [ct2.Gear].[FullName], [ct2.Gear].[HasSoulPatch], [ct2.Gear].[LeaderNickname], [ct2.Gear].[LeaderSquadId], [ct2.Gear].[Rank]
+FROM [Gear] AS [ct2.Gear]
+WHERE [ct2.Gear].[Discriminator] IN (N'Officer', N'Gear')
 
-            Assert.Equal(
-                @"",
+SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [ct1.Gear].[Nickname], [ct1.Gear].[SquadId], [ct1.Gear].[AssignedCityName], [ct1.Gear].[CityOrBirthName], [ct1.Gear].[Discriminator], [ct1.Gear].[FullName], [ct1.Gear].[HasSoulPatch], [ct1.Gear].[LeaderNickname], [ct1.Gear].[LeaderSquadId], [ct1.Gear].[Rank]
+FROM [CogTag] AS [ct1]
+LEFT JOIN [Gear] AS [ct1.Gear] ON ([ct1].[GearNickName] = [ct1.Gear].[Nickname]) AND ([ct1].[GearSquadId] = [ct1.Gear].[SquadId])
+ORDER BY [ct1].[GearNickName], [ct1].[GearSquadId]
+
+SELECT [ct2].[Id], [ct2].[GearNickName], [ct2].[GearSquadId], [ct2].[Note]
+FROM [CogTag] AS [ct2]",
                 Sql);
+#endif
         }
 
         public override void Select_Singleton_Navigation_With_Member_Access()
@@ -1002,13 +1013,21 @@ ORDER BY [o].[GearNickName], [o].[GearSquadId]",
         public override void Select_Where_Navigation_Equals_Navigation()
         {
             base.Select_Where_Navigation_Equals_Navigation();
+#if NET451
+            Assert.StartsWith(
+                @"SELECT [ct2.Gear].[Nickname], [ct2.Gear].[SquadId], [ct2.Gear].[AssignedCityName], [ct2.Gear].[CityOrBirthName], [ct2.Gear].[Discriminator], [ct2.Gear].[FullName], [ct2.Gear].[HasSoulPatch], [ct2.Gear].[LeaderNickname], [ct2.Gear].[LeaderSquadId], [ct2.Gear].[Rank]
+FROM [Gear] AS [ct2.Gear]
+WHERE [ct2.Gear].[Discriminator] IN (N'Officer', N'Gear')
 
-            Assert.Equal(
-                @"SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [ct2].[Id], [ct2].[GearNickName], [ct2].[GearSquadId], [ct2].[Note]
+SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [ct1.Gear].[Nickname], [ct1.Gear].[SquadId], [ct1.Gear].[AssignedCityName], [ct1.Gear].[CityOrBirthName], [ct1.Gear].[Discriminator], [ct1.Gear].[FullName], [ct1.Gear].[HasSoulPatch], [ct1.Gear].[LeaderNickname], [ct1.Gear].[LeaderSquadId], [ct1.Gear].[Rank]
 FROM [CogTag] AS [ct1]
-CROSS JOIN [CogTag] AS [ct2]
-WHERE (([ct1].[GearNickName] = [ct2].[GearNickName]) OR ([ct1].[GearNickName] IS NULL AND [ct2].[GearNickName] IS NULL)) AND (([ct1].[GearSquadId] = [ct2].[GearSquadId]) OR ([ct1].[GearSquadId] IS NULL AND [ct2].[GearSquadId] IS NULL))",
+LEFT JOIN [Gear] AS [ct1.Gear] ON ([ct1].[GearNickName] = [ct1.Gear].[Nickname]) AND ([ct1].[GearSquadId] = [ct1.Gear].[SquadId])
+ORDER BY [ct1].[GearNickName], [ct1].[GearSquadId]
+
+SELECT [ct2].[Id], [ct2].[GearNickName], [ct2].[GearSquadId], [ct2].[Note]
+FROM [CogTag] AS [ct2]",
                 Sql);
+#endif
         }
 
         public override void Select_Where_Navigation_Null()
@@ -1036,17 +1055,21 @@ WHERE [ct].[GearNickName] IS NULL AND [ct].[GearSquadId] IS NULL",
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected();
-
+#if NET451
             Assert.StartsWith(
-                @"SELECT [ct2.Gear].[Nickname], [ct2.Gear].[SquadId], [ct2.Gear].[AssignedCityName], [ct2.Gear].[CityOrBirthName], [ct2.Gear].[Discriminator], [ct2.Gear].[FullName], [ct2.Gear].[LeaderNickname], [ct2.Gear].[LeaderSquadId], [ct2.Gear].[Rank]
+                @"SELECT [ct2.Gear].[Nickname], [ct2.Gear].[SquadId], [ct2.Gear].[AssignedCityName], [ct2.Gear].[CityOrBirthName], [ct2.Gear].[Discriminator], [ct2.Gear].[FullName], [ct2.Gear].[HasSoulPatch], [ct2.Gear].[LeaderNickname], [ct2.Gear].[LeaderSquadId], [ct2.Gear].[Rank]
 FROM [Gear] AS [ct2.Gear]
-WHERE ([ct2.Gear].[Discriminator] = N'Officer') OR ([ct2.Gear].[Discriminator] = N'Gear')
+WHERE [ct2.Gear].[Discriminator] IN (N'Officer', N'Gear')
 
-SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [ct1.Gear].[Nickname], [ct1.Gear].[SquadId], [ct1.Gear].[AssignedCityName], [ct1.Gear].[CityOrBirthName], [ct1.Gear].[Discriminator], [ct1.Gear].[FullName], [ct1.Gear].[LeaderNickname], [ct1.Gear].[LeaderSquadId], [ct1.Gear].[Rank]
+SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [ct1.Gear].[Nickname], [ct1.Gear].[SquadId], [ct1.Gear].[AssignedCityName], [ct1.Gear].[CityOrBirthName], [ct1.Gear].[Discriminator], [ct1.Gear].[FullName], [ct1.Gear].[HasSoulPatch], [ct1.Gear].[LeaderNickname], [ct1.Gear].[LeaderSquadId], [ct1.Gear].[Rank]
 FROM [CogTag] AS [ct1]
 LEFT JOIN [Gear] AS [ct1.Gear] ON ([ct1].[GearNickName] = [ct1.Gear].[Nickname]) AND ([ct1].[GearSquadId] = [ct1.Gear].[SquadId])
-ORDER BY [ct1].[GearNickName], [ct1].[GearSquadId]",
+ORDER BY [ct1].[GearNickName], [ct1].[GearSquadId]
+
+SELECT [ct2].[Id], [ct2].[GearNickName], [ct2].[GearSquadId], [ct2].[Note]
+FROM [CogTag] AS [ct2]",
                 Sql);
+#endif
         }
 
         public override void Optional_Navigation_Null_Coalesce_To_Clr_Type()
@@ -1631,11 +1654,6 @@ LEFT JOIN [Gear] AS [t.Gear] ON ([t].[GearNickName] = [t.Gear].[Nickname]) AND (
 WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
 ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
-        }
-
-        public override void Optional_navigation_type_compensation_throws_rasonable_exception_for_nullable_values()
-        {
-            base.Optional_navigation_type_compensation_throws_rasonable_exception_for_nullable_values();
         }
 
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -275,19 +275,41 @@ ORDER BY [o].[CustomerID]",
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar();
-
+#if NET451
             Assert.StartsWith(
-                @"",
+                @"SELECT [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
+FROM [Customers] AS [o.Customer0]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE [o].[OrderID] < 10300
+ORDER BY [o].[CustomerID]
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]",
                 Sql);
+#endif
         }
 
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected();
-
+#if NET451
             Assert.StartsWith(
-                @"",
+                @"SELECT [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
+FROM [Customers] AS [o.Customer0]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE [o].[OrderID] < 10300
+ORDER BY [o].[CustomerID]
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]",
                 Sql);
+#endif
         }
 
         public override void Select_Where_Navigation_Equals_Navigation()
@@ -762,8 +784,16 @@ ORDER BY [oo].[CustomerID]",
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop_nested_with_orderby();
 
-            Assert.Equal(
-                @"",
+            Assert.StartsWith(
+                @"SELECT 1
+FROM [Customers] AS [e]
+WHERE [e].[CustomerID] LIKE N'A' + N'%'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -884,17 +914,17 @@ FROM [Orders] AS [o3]",
         {
             base.Navigation_in_subquery_referencing_outer_query();
 
-            Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[Country]
+            Assert.StartsWith(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
-INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE (
-    SELECT COUNT(*)
-    FROM [Order Details] AS [od]
-    INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
-    INNER JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
-    WHERE ([o.Customer].[Country] = [od.Order.Customer].[Country]) OR ([o.Customer].[Country] IS NULL AND [od.Order.Customer].[Country] IS NULL)
-) > 0",
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [o].[CustomerID]
+
+SELECT [od.Order0].[OrderID], [od.Order0].[CustomerID], [od.Order0].[EmployeeID], [od.Order0].[OrderDate], [od.Order.Customer0].[CustomerID], [od.Order.Customer0].[Address], [od.Order.Customer0].[City], [od.Order.Customer0].[CompanyName], [od.Order.Customer0].[ContactName], [od.Order.Customer0].[ContactTitle], [od.Order.Customer0].[Country], [od.Order.Customer0].[Fax], [od.Order.Customer0].[Phone], [od.Order.Customer0].[PostalCode], [od.Order.Customer0].[Region]
+FROM [Order Details] AS [od0]
+INNER JOIN [Orders] AS [od.Order0] ON [od0].[OrderID] = [od.Order0].[OrderID]
+LEFT JOIN [Customers] AS [od.Order.Customer0] ON [od.Order0].[CustomerID] = [od.Order.Customer0].[CustomerID]
+ORDER BY [od.Order0].[CustomerID]",
                 Sql);
         }
 
@@ -928,7 +958,10 @@ ORDER BY [od].[Quantity]",
             base.Let_group_by_nav_prop();
 
             Assert.Equal(
-                @"",
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[CustomerID]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+ORDER BY [od.Order].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2974,6 +2974,32 @@ ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
+        public override void GroupJoin_Where()
+        {
+            base.GroupJoin_Where();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupJoin_DefaultIfEmpty_Where_OrderBy()
+        {
+            base.GroupJoin_DefaultIfEmpty_Where_OrderBy();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE ([o].[CustomerID] = N'ALFKI') OR ([c].[CustomerID] = N'ANATR')
+ORDER BY [c].[City], [c].[CustomerID]",
+                Sql);
+        }
+
         public override void GroupJoin_simple()
         {
             base.GroupJoin_simple();


### PR DESCRIPTION
```
Fix: #3676 - Usage of the "let" keyword breaks grouping.
 - Fixed compiler bug in tracked, grouped queries.
Fix: #5427 - A column has been specified more than once in the order by list thrown for a complex query with orderby and navigation.
 - Fixed bug in SelectExpression.PrependToOrderBy
Fix: #4539 - Query :: Join flattening fails for some complex cases involving SelectMany
 - SelectMany after GroupJoin should not cause client-eval.
```
Also addressed most of the R# warnings in nav. rewriter.