### PR TITLE
Query: Reuse projections for properties in derived types mapped to sa…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -430,9 +430,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             if (projectionIndex == -1)
             {
-                projectionIndex = _projection.Count;
-
-                AddAliasToProjection(
+                projectionIndex = AddAliasToProjection(
                     alias: null,
                     expression: new ColumnExpression(column, property, GetTableForQuerySource(querySource)));
             }
@@ -516,13 +514,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                             var ae = e as AliasExpression;
                             var ce = e.TryGetColumnExpression();
 
-                            return ce != null && ce.Property == columnExpression?.Property
-                                   && ce.TableAlias == columnExpression?.TableAlias
-                                   || ae?.Expression == expression;
+                            return (ce != null
+                                    && columnExpression != null
+                                    && (ce.Property == columnExpression.Property || ce.Name == columnExpression.Name)
+                                    && ce.TableAlias == columnExpression.TableAlias)
+                                || ae?.Expression == expression;
                         });
 
             if (projectionIndex == -1)
             {
+                // Alias != null means SelectExpression in subquery which needs projections to have unique aliases
                 if (Alias != null
                     || columnExpression == null)
                 {
@@ -580,15 +581,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                         {
                             var ce = e.TryGetColumnExpression();
 
-                            return ce?.Property == columnExpression.Property
-                                   && ce?.Type == columnExpression.Type
-                                   && ce.TableAlias == columnExpression.TableAlias;
+                            return ce != null
+                                && ce.Property == columnExpression.Property
+                                && ce.Name == columnExpression.Name
+                                && ce.TableAlias == columnExpression.TableAlias;
                         });
 
             if (projectionIndex == -1)
             {
                 var aliasExpression = new AliasExpression(columnExpression);
 
+                // Alias != null means SelectExpression in subquery which needs projections to have unique aliases
                 if (Alias != null)
                 {
                     var currentAlias = columnExpression.Name;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -57,7 +57,7 @@ WHERE [d].[Discriminator] = N'Tea'",
             base.Can_query_all_types_when_shared_column();
 
             Assert.Equal(
-                @"SELECT [d].[Id], [d].[Discriminator], [d].[CaffeineGrams], [d].[CokeCO2], [d].[SugarGrams], [d].[LiltCO2], [d].[SugarGrams], [d].[CaffeineGrams], [d].[HasMilk]
+                @"SELECT [d].[Id], [d].[Discriminator], [d].[CaffeineGrams], [d].[CokeCO2], [d].[SugarGrams], [d].[LiltCO2], [d].[HasMilk]
 FROM [Drink] AS [d]
 WHERE [d].[Discriminator] IN (N'Tea', N'Lilt', N'Coke', N'Drink')",
                 Sql);


### PR DESCRIPTION
Resolves #5909 