### PR TITLE
Make relationship discovery more flexible

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -37,7 +37,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public const string AmbiguousNavigationsAnnotationName = "RelationshipDiscoveryConvention:AmbiguousNavigations";
 
-        private InternalEntityTypeBuilder DiscoverRelationships(InternalEntityTypeBuilder entityTypeBuilder)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual InternalEntityTypeBuilder DiscoverRelationships(InternalEntityTypeBuilder entityTypeBuilder)
         {
             if (!entityTypeBuilder.Metadata.HasClrType()
                 || entityTypeBuilder.ModelBuilder.IsIgnored(entityTypeBuilder.Metadata.ClrType, ConfigurationSource.Convention))


### PR DESCRIPTION
Am not sure if this PR is the right way, here's what I'm trying to accomplish.

PostgreSQL supports arrays as a database type. In other words, a single column can be a an array of ints, etc. This is a much more lightweight one-to-many solution than another table with a relationship, and there are built-in operators and functions which deal with the array.

Npgsql fully supports arrays on the ADO.NET level, and I'd like to add support to the EFCore level as well. The main issue is that EFCore identifies CLR array types as relationship/navigation properties. My approach is to add an attribute `[MapAsArray]`, which would let EFCore know to leave the property alone and let it be mapped as a "scalar" (as far as EFCore is concerned). However, RelationshipDiscoveryConvention, doesn't seem to be very extensible (most of the logic is private) - this PR makes the main DiscoverRelationships method overridable.

Does the approach seem valid? Do you foresee other issues?