### PR TITLE
Make IsTypeMapped virtual

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalTypeMapper.cs
@@ -43,6 +43,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         RelationalTypeMapping FindMapping([NotNull] string storeType);
 
         /// <summary>
+        ///     Gets a value indicating whether the given .NET type is mapped.
+        /// </summary>
+        /// <param name="clrType"> The .NET type. </param>
+        /// <returns> True if the type can be mapped; otherwise false. </returns>
+        bool IsTypeMapped([NotNull] Type clrType);
+
+        /// <summary>
         ///     Ensures that the given type name is a valid type for the relational database.
         ///     An exception is thrown if it is not a valid type.
         /// </summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
@@ -116,6 +116,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Gets a value indicating whether the given .NET type is mapped.
+        /// </summary>
+        /// <param name="clrType"> The .NET type. </param>
+        /// <returns> True if the type can be mapped; otherwise false. </returns>
+        public virtual bool IsTypeMapped(Type clrType)
+        {
+            Check.NotNull(clrType, nameof(clrType));
+
+            return FindMapping(clrType) != null;
+        }
+
+        /// <summary>
         ///     Creates the mapping for the given database type.
         /// </summary>
         /// <param name="storeType">The type to create the mapping for.</param>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -94,21 +94,5 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             throw new InvalidOperationException(RelationalStrings.UnsupportedType(typeName));
         }
-
-        /// <summary>
-        ///     Gets a value indicating whether the given .NET type is mapped.
-        /// </summary>
-        /// <param name="typeMapper"> The type mapper. </param>
-        /// <param name="clrType"> The .NET type. </param>
-        /// <returns> True if the type can be mapped; otherwise false. </returns>
-        public static bool IsTypeMapped(
-            [NotNull] this IRelationalTypeMapper typeMapper,
-            [NotNull] Type clrType)
-        {
-            Check.NotNull(typeMapper, nameof(typeMapper));
-            Check.NotNull(clrType, nameof(clrType));
-
-            return typeMapper.FindMapping(clrType) != null;
-        }
     }
 }


### PR DESCRIPTION
Rather than an extension method. This allows it to be overridden by providers.

The use case is that in Npgsql, the same CLR type may correspond to several store types, without any of the store types being an obvious default. In this case, `FindMapping(Type clrType)` can't return an actual mapping (since there's no default), but the property should still be a candidate and the user should be able to specify the exact store type with the fluent API.