### PR TITLE
Make it easy to set a custom value generator

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -254,6 +254,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             GenerateFluentApiForAnnotation(ref annotations, CoreAnnotationNames.MaxLengthAnnotation, nameof(PropertyBuilder.HasMaxLength), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, CoreAnnotationNames.UnicodeAnnotation, nameof(PropertyBuilder.IsUnicode), stringBuilder);
 
+            IgnoreAnnotations(annotations, CoreAnnotationNames.ValueGeneratorFactoryAnnotation);
+
             GenerateAnnotations(annotations, stringBuilder);
         }
 
@@ -423,14 +425,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 annotations.Remove(discriminatorValueAnnotation);
             }
 
-            foreach (var annotationToRemove in annotations.Where(a =>
-                a.Name == RelationshipDiscoveryConvention.NavigationCandidatesAnnotationName
-                || a.Name == RelationshipDiscoveryConvention.AmbiguousNavigationsAnnotationName
-                || a.Name == InversePropertyAttributeConvention.InverseNavigationsAnnotationName)
-                .ToList())
-            {
-                annotations.Remove(annotationToRemove);
-            }
+            IgnoreAnnotations(
+                annotations,
+                RelationshipDiscoveryConvention.NavigationCandidatesAnnotationName,
+                RelationshipDiscoveryConvention.AmbiguousNavigationsAnnotationName,
+                InversePropertyAttributeConvention.InverseNavigationsAnnotationName);
 
             if (annotations.Any())
             {
@@ -584,6 +583,23 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             GenerateAnnotations(annotations, stringBuilder);
         }
+
+        protected virtual void IgnoreAnnotations(
+            [NotNull] IList<IAnnotation> annotations, [NotNull] params string[] annotationNames)
+        {
+            Check.NotNull(annotations, nameof(annotations));
+            Check.NotNull(annotationNames, nameof(annotationNames));
+
+            foreach (var annotationName in annotationNames)
+            {
+                var annotation = annotations.FirstOrDefault(a => a.Name == annotationName);
+                if (annotation != null)
+                {
+                    annotations.Remove(annotation);
+                }
+            }
+        }
+
 
         protected virtual void GenerateAnnotations(
             [NotNull] IReadOnlyList<IAnnotation> annotations, [NotNull] IndentedStringBuilder stringBuilder)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
@@ -52,9 +52,10 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
             Check.NotNull(property, nameof(property));
             Check.NotNull(entityType, nameof(entityType));
 
-            return property.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
+            return property.GetValueGeneratorFactory() == null
+                   && property.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
                 ? _sequenceFactory.Create(property, Cache.GetOrAddSequenceState(property), _connection)
-                : Cache.GetOrAdd(property, entityType, Create);
+                : base.Select(property, entityType);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -17,6 +18,30 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class MutablePropertyExtensions
     {
+        /// <summary>
+        ///     <para>
+        ///         Sets the factory to use for generating values for this property, or null to clear any previously set factory.
+        ///     </para>
+        ///     <para>
+        ///         Setting null does not disable value generation for this property, it just clears any generator explicitly
+        ///         configured for this property. The database provider may still have a value generator for the property type.
+        ///     </para>
+        /// </summary>
+        /// <param name="property"> The property to set the value generator for. </param>
+        /// <param name="valueGeneratorFactory">
+        ///     A factory that will be used to create the value generator, or null to
+        ///     clear any previously set factory.
+        /// </param>
+        public static void SetValueGeneratorFactory(
+            [NotNull] this IMutableProperty property,
+            [NotNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory)
+        {
+            Check.NotNull(property, nameof(property));
+            Check.NotNull(valueGeneratorFactory, nameof(valueGeneratorFactory));
+
+            property[CoreAnnotationNames.ValueGeneratorFactoryAnnotation] = valueGeneratorFactory;
+        }
+
         /// <summary>
         ///     Sets the maximum length of data that is allowed in this property. For example, if the property is a <see cref="string" /> '
         ///     then this is the maximum number of characters.

--- a/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -16,6 +18,18 @@ namespace Microsoft.EntityFrameworkCore
     /// </summary>
     public static class PropertyExtensions
     {
+        /// <summary>
+        ///     Gets the factory that has been set to generate values for this property, if any.
+        /// </summary>
+        /// <param name="property"> The property to get the value generator factory for. </param>
+        /// <returns> The factory, or null if no factory has been set. </returns>
+        public static Func<IProperty, IEntityType, ValueGenerator> GetValueGeneratorFactory([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, nameof(property));
+
+            return (Func<IProperty, IEntityType, ValueGenerator>)property[CoreAnnotationNames.ValueGeneratorFactoryAnnotation];
+        }
+
         /// <summary>
         ///     Gets the maximum length of data that is allowed in this property. For example, if the property is a <see cref="string" /> '
         ///     then this is the maximum number of characters.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class PropertyBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalPropertyBuilder>
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public PropertyBuilder([NotNull] InternalPropertyBuilder builder)
@@ -98,6 +100,94 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual PropertyBuilder IsUnicode(bool unicode = true)
         {
             Builder.IsUnicode(unicode, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the <see cref="ValueGenerator" /> that will generate values for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         A single instance of this type will be created and used to generate values for this property in all
+        ///         instances of the entity type. The type must be instantiable and have a parameterless constructor.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        /// </summary>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder HasValueGenerator<TGenerator>()
+            where TGenerator : ValueGenerator
+        {
+            Builder.HasValueGenerator(typeof(TGenerator), ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the <see cref="ValueGenerator" /> that will generate values for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         A single instance of this type will be created and used to generate values for this property in all
+        ///         instances of the entity type. The type must be instantiable and have a parameterless constructor.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        ///     <para>
+        ///         Setting null does not disable value generation for this property, it just clears any generator explicitly
+        ///         configured for this property. The database provider may still have a value generator for the property type.
+        ///     </para>
+        /// </summary>
+        /// <param name="valueGeneratorType"> A type that inherits from <see cref="ValueGenerator" /> </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder HasValueGenerator([CanBeNull] Type valueGeneratorType)
+        {
+            Builder.HasValueGenerator(valueGeneratorType, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a factory for creating a <see cref="ValueGenerator" /> to use to generate values
+        ///         for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         This factory will be invoked once to create a single instance of the value generator, and
+        ///         this will be used to generate values for this property in all instances of the entity type.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        /// </summary>
+        /// <param name="factory"> A delegate that will be used to create value generator instances. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual PropertyBuilder HasValueGenerator([NotNull] Func<IProperty, IEntityType, ValueGenerator> factory)
+        {
+            Check.NotNull(factory, nameof(factory));
+
+            Builder.HasValueGenerator(factory, ConfigurationSource.Explicit);
 
             return this;
         }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/PropertyBuilder`.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
@@ -63,6 +65,80 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual PropertyBuilder<TProperty> IsUnicode(bool unicode = true)
             => (PropertyBuilder<TProperty>)base.IsUnicode(unicode);
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the <see cref="ValueGenerator" /> that will generate values for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         A single instance of this type will be created and used to generate values for this property in all
+        ///         instances of the entity type. The type must be instantiable and have a parameterless constructor.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        /// </summary>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> HasValueGenerator<TGenerator>()
+            where TGenerator : ValueGenerator
+            => (PropertyBuilder<TProperty>)base.HasValueGenerator<TGenerator>();
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the <see cref="ValueGenerator" /> that will generate values for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         A single instance of this type will be created and used to generate values for this property in all
+        ///         instances of the entity type. The type must be instantiable and have a parameterless constructor.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        ///     <para>
+        ///         Setting null does not disable value generation for this property, it just clears any generator explicitly
+        ///         configured for this property. The database provider may still have a value generator for the property type.
+        ///     </para>
+        /// </summary>
+        /// <param name="valueGeneratorType"> A type that inherits from <see cref="ValueGenerator" /> </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> HasValueGenerator([CanBeNull] Type valueGeneratorType)
+            => (PropertyBuilder<TProperty>)base.HasValueGenerator(valueGeneratorType);
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a factory for creating a <see cref="ValueGenerator" /> to use to generate values
+        ///         for this property.
+        ///     </para>
+        ///     <para>
+        ///         Values are generated when the entity is added to the context using, for example,
+        ///         <see cref="DbContext.Add{TEntity}" />. Values are generated only when the property is assigned 
+        ///         the CLR default value (null for string, 0 for int, Guid.Empty for Guid, etc.).
+        ///     </para>
+        ///     <para>
+        ///         This factory will be invoked once to create a single instance of the value generator, and
+        ///         this will be used to generate values for this property in all instances of the entity type.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use with custom value generation. Value generation for common cases is
+        ///         usually handled automatically by the database provider.
+        ///     </para>
+        /// </summary>
+        /// <param name="factory"> A delegate that will be used to create value generator instances. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> HasValueGenerator([NotNull] Func<IProperty, IEntityType, ValueGenerator> factory)
+            => (PropertyBuilder<TProperty>)base.HasValueGenerator(factory);
 
         /// <summary>
         ///     Configures whether this property should be used as a concurrency token. When a property is configured

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -26,5 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string ProductVersionAnnotation = "ProductVersion";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string ValueGeneratorFactoryAnnotation = "ValueGeneratorFactory";
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -257,6 +257,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// The type '{givenType}' cannot be used a a value generator because it does not inherit from '{expectedType}'.
+        /// </summary>
+        public static string BadValueGeneratorType([CanBeNull] object givenType, [CanBeNull] object expectedType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("BadValueGeneratorType", "givenType", "expectedType"), givenType, expectedType);
+        }
+
+        /// <summary>
+        /// Cannot create instance of value generator type '{generatorType}'. Ensure that the type is instantiable and has a parameterless constructor, or use the overload of HasValueGenerator that accepts a delegate.
+        /// </summary>
+        public static string CannotCreateValueGenerator([CanBeNull] object generatorType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotCreateValueGenerator", "generatorType"), generatorType);
+        }
+
+        /// <summary>
         /// The property '{property}' on entity type '{entityType}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.
         /// </summary>
         public static string TempValuePersists([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object state)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -207,6 +207,12 @@
   <data name="NoValueGenerator" xml:space="preserve">
     <value>The '{property}' on entity type '{entityType}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.</value>
   </data>
+  <data name="BadValueGeneratorType" xml:space="preserve">
+    <value>The type '{givenType}' cannot be used a a value generator because it does not inherit from '{expectedType}'.</value>
+  </data>
+  <data name="CannotCreateValueGenerator" xml:space="preserve">
+    <value>Cannot create instance of value generator type '{generatorType}'. Ensure that the type is instantiable and has a parameterless constructor, or use the overload of HasValueGenerator that accepts a delegate.</value>
+  </data>
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             Check.NotNull(property, nameof(property));
             Check.NotNull(entityType, nameof(entityType));
 
-            return Cache.GetOrAdd(property, entityType, Create);
+            return Cache.GetOrAdd(property, entityType, (p, e) => property.GetValueGeneratorFactory()?.Invoke(p, e) ?? Create(p, e));
         }
 
         /// <summary>

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/CustomValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/CustomValueGeneratorTest.cs
@@ -16,36 +16,158 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public class CustomValueGeneratorTest
     {
-        private static readonly IServiceProvider _serviceProvider
-            = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .AddScoped<InMemoryValueGeneratorSelector, CustomInMemoryValueGeneratorSelector>()
-                .BuildServiceProvider();
-
         [Fact]
         public void Can_use_custom_value_generators()
         {
-            var names = new[]
-            {
-                "Jamie Vardy", "Danny Drinkwater", "Andy King", "Riyad Mahrez",
-                "Kasper Schmeichel", "Wes Morgan", "Robert Huth", "Leonardo Ulloa"
-            };
-
             using (var context = new CustomValueGeneratorContext())
             {
                 var entities = new List<SomeEntity>();
                 for (var i = 0; i < CustomGuidValueGenerator.SpecialGuids.Length; i++)
                 {
-                    entities.Add(context.Add(new SomeEntity { Name = names[i] }).Entity);
+                    entities.Add(context.Add(new SomeEntity { Name = _names[i] }).Entity);
                 }
 
                 Assert.Equal(entities.Select(e => e.Id), entities.OrderBy(e => ToCounter(e.Id)).Select(e => e.Id));
 
                 Assert.Equal(CustomGuidValueGenerator.SpecialGuids, entities.Select(e => e.SpecialId));
 
-                Assert.Equal(names.Select((n, i) => n + " - " + (i + 1)), entities.Select(e => e.SpecialString));
+                Assert.Equal(_names.Select((n, i) => n + " - " + (i + 1)), entities.Select(e => e.SpecialString));
             }
         }
+
+        private class CustomValueGeneratorContext : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddScoped<InMemoryValueGeneratorSelector, CustomInMemoryValueGeneratorSelector>()
+                    .BuildServiceProvider();
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder
+                    .Entity<SomeEntity>(
+                        b =>
+                            {
+                                b.Property(e => e.SpecialId)
+                                    .HasAnnotation("SpecialGuid", true)
+                                    .Metadata.RequiresValueGenerator = true;
+
+                                b.Property(e => e.SpecialString)
+                                    .Metadata.RequiresValueGenerator = true;
+                            });
+        }
+
+        [Fact]
+        public void Can_use_custom_value_generator_from_annotated_type()
+        {
+            using (var context = new CustomValueGeneratorContextAnnotateType())
+            {
+                var entities = new List<SomeEntity>();
+                for (var i = 0; i < CustomGuidValueGenerator.SpecialGuids.Length; i++)
+                {
+                    entities.Add(context.Add(new SomeEntity { Name = _names[i] }).Entity);
+                }
+
+                Assert.Equal(entities.Select(e => e.Id), entities.OrderBy(e => ToCounter(e.Id)).Select(e => e.Id));
+
+                Assert.Equal(CustomGuidValueGenerator.SpecialGuids, entities.Select(e => e.SpecialId));
+
+                Assert.Equal(_names.Select((n, i) => n + " - " + (i + 1)), entities.Select(e => e.SpecialString));
+            }
+        }
+
+        private class CustomValueGeneratorContextAnnotateType : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .BuildServiceProvider();
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder
+                    .Entity<SomeEntity>(
+                        b =>
+                            {
+                                b.Property(e => e.Id).HasValueGenerator<SequentialGuidValueGenerator>();
+                                b.Property(e => e.SpecialId).HasValueGenerator(typeof(CustomGuidValueGenerator));
+                                b.Property(e => e.SpecialString).HasValueGenerator<SomeEntityStringValueGenerator>();
+                            });
+        }
+
+        [Fact]
+        public void Can_use_custom_value_generator_from_annotated_factory()
+        {
+            using (var context = new CustomValueGeneratorContextAnnotateFactory())
+            {
+                var entities = new List<SomeEntity>();
+                for (var i = 0; i < CustomGuidValueGenerator.SpecialGuids.Length; i++)
+                {
+                    entities.Add(context.Add(new SomeEntity { Name = _names[i] }).Entity);
+                }
+
+                Assert.Equal(entities.Select(e => e.Id), entities.OrderBy(e => ToCounter(e.Id)).Select(e => e.Id));
+
+                Assert.Equal(CustomGuidValueGenerator.SpecialGuids, entities.Select(e => e.SpecialId));
+
+                Assert.Equal(_names.Select((n, i) => n + " - " + (i + 1)), entities.Select(e => e.SpecialString));
+            }
+        }
+
+        private class CustomValueGeneratorContextAnnotateFactory : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .BuildServiceProvider();
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder
+                    .Entity<SomeEntity>(
+                        b =>
+                            {
+                                var factory = new CustomValueGeneratorFactory();
+
+                                b.Property(e => e.Id).HasValueGenerator((p, e) => factory.Create(p));
+
+                                b.Property(e => e.SpecialId)
+                                    .Metadata.SetValueGeneratorFactory((p, e) => factory.Create(p));
+
+                                b.Property(e => e.SpecialId)
+                                    .HasAnnotation("SpecialGuid", true)
+                                    .Metadata.RequiresValueGenerator = true;
+
+                                b.Property(e => e.SpecialString).HasValueGenerator((p, e) => factory.Create(p));
+                            });
+        }
+
+        private class SomeEntity
+        {
+            public Guid Id { get; set; }
+            public Guid SpecialId { get; set; }
+            public string SpecialString { get; set; }
+            public string Name { get; set; }
+        }
+
+        private readonly string[] _names =
+        {
+            "Jamie Vardy", "Danny Drinkwater", "Andy King", "Riyad Mahrez",
+            "Kasper Schmeichel", "Wes Morgan", "Robert Huth", "Leonardo Ulloa"
+        };
 
         private static long ToCounter(Guid guid)
         {
@@ -69,59 +191,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             return BitConverter.ToInt64(counterBytes, 0);
         }
 
-        private class CustomValueGeneratorContext : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseInternalServiceProvider(_serviceProvider)
-                    .UseInMemoryDatabase();
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder
-                    .Entity<SomeEntity>(
-                        b =>
-                            {
-                                b.Property(e => e.SpecialId)
-                                    .HasAnnotation("SpecialGuid", true)
-                                    .Metadata.RequiresValueGenerator = true;
-
-                                b.Property(e => e.SpecialString)
-                                    .Metadata.RequiresValueGenerator = true;
-                            });
-        }
-
-        private class SomeEntity
-        {
-            public Guid Id { get; set; }
-            public Guid SpecialId { get; set; }
-            public string SpecialString { get; set; }
-            public string Name { get; set; }
-        }
-
         private class CustomInMemoryValueGeneratorSelector : InMemoryValueGeneratorSelector
         {
+            private readonly ValueGeneratorFactory _factory = new CustomValueGeneratorFactory();
+
             public CustomInMemoryValueGeneratorSelector(IValueGeneratorCache cache)
                 : base(cache)
             {
             }
 
             public override ValueGenerator Create(IProperty property, IEntityType entityType)
-            {
-                if (property.ClrType == typeof(Guid))
-                {
-                    return property["SpecialGuid"] != null ?
-                        (ValueGenerator)new CustomGuidValueGenerator()
-                        : new SequentialGuidValueGenerator();
-                }
-
-                if (property.ClrType == typeof(string)
-                    && entityType.ClrType == typeof(SomeEntity))
-                {
-                    return new SomeEntityStringValueGenerator();
-                }
-
-                return base.Create(property, entityType);
-            }
+                => _factory.Create(property);
         }
 
         private class CustomGuidValueGenerator : ValueGenerator<Guid>
@@ -144,10 +224,31 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _counter;
 
-            public override string Next(EntityEntry entry) 
+            public override string Next(EntityEntry entry)
                 => ((SomeEntity)entry.Entity).Name + " - " + Interlocked.Increment(ref _counter);
 
             public override bool GeneratesTemporaryValues => false;
+        }
+
+        private class CustomValueGeneratorFactory : ValueGeneratorFactory
+        {
+            public override ValueGenerator Create(IProperty property)
+            {
+                if (property.ClrType == typeof(Guid))
+                {
+                    return property["SpecialGuid"] != null ?
+                        (ValueGenerator)new CustomGuidValueGenerator()
+                        : new SequentialGuidValueGenerator();
+                }
+
+                if (property.ClrType == typeof(string)
+                    && property.DeclaringEntityType.ClrType == typeof(SomeEntity))
+                {
+                    return new SomeEntityStringValueGenerator();
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.InMemory.FunctionalTests;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -22,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
 
             var selector = InMemoryTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
+            Assert.IsType<CustomValueGenerator>(selector.Select(entityType.FindProperty("Custom"), entityType));
             Assert.IsType<InMemoryIntegerValueGenerator<int>>(selector.Select(entityType.FindProperty("Id"), entityType));
             Assert.IsType<InMemoryIntegerValueGenerator<long>>(selector.Select(entityType.FindProperty("Long"), entityType));
             Assert.IsType<InMemoryIntegerValueGenerator<short>>(selector.Select(entityType.FindProperty("Short"), entityType));
@@ -60,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
         {
             var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
             builder.Ignore<Random>();
-            builder.Entity<AnEntity>();
+            builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
             entityType.AddProperty("Random", typeof(Random), shadow: false);
@@ -76,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
         private class AnEntity
         {
             public int Id { get; set; }
+            public int Custom { get; set; }
             public long Long { get; set; }
             public short Short { get; set; }
             public byte Byte { get; set; }
@@ -96,6 +99,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
             public byte[] Binary { get; set; }
             public float Float { get; set; }
             public Random Random { get; set; }
+        }
+
+        private class CustomValueGenerator : ValueGenerator<int>
+        {
+            public override int Next(EntityEntry entry)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool GeneratesTemporaryValues => false;
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
@@ -478,6 +480,66 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
                             x.Property<string>("Name").HasColumnName("BuffaloName").HasColumnType("nvarchar(30)");
                         }),
                 Assert.Empty);
+        }
+
+        [Fact]
+        public void Add_custom_value_generator()
+        {
+            Execute(
+                source => source.Entity(
+                    "Toad",
+                    x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("Name");
+                        }),
+                target => target.Entity(
+                    "Toad",
+                    x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("Name")
+                                .HasValueGenerator<CustomValueGenerator>();
+                        }),
+                operations =>
+                    {
+                        Assert.Equal(0, operations.Count);
+                    });
+        }
+
+        [Fact]
+        public void Remove_custom_value_generator()
+        {
+            Execute(
+                source => source.Entity(
+                    "Toad",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Name")
+                            .HasValueGenerator<CustomValueGenerator>();
+                    }),
+                target => target.Entity(
+                    "Toad",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<string>("Name");
+                    }),
+                operations =>
+                {
+                    Assert.Equal(0, operations.Count);
+                });
+        }
+
+        private class CustomValueGenerator : ValueGenerator<string>
+        {
+            public override string Next(EntityEntry entry)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool GeneratesTemporaryValues => false;
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
@@ -213,6 +214,15 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestPropertyBuilder<TProperty> ValueGeneratedOnAddOrUpdate()
                 => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.ValueGeneratedOnAddOrUpdate());
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator<TGenerator>()
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator<TGenerator>());
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator(Type valueGeneratorType)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator(valueGeneratorType));
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator(Func<IProperty, IEntityType, ValueGenerator> factory)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator(factory));
         }
 
         protected class GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
@@ -170,6 +171,15 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestPropertyBuilder<TProperty> ValueGeneratedOnAddOrUpdate()
                 => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.ValueGeneratedOnAddOrUpdate());
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator<TGenerator>()
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator<TGenerator>());
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator(Type valueGeneratorType)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator(valueGeneratorType));
+
+            public override TestPropertyBuilder<TProperty> HasValueGenerator(Func<IProperty, IEntityType, ValueGenerator> factory)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasValueGenerator(factory));
         }
 
         protected class NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
@@ -212,6 +213,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedNever();
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedOnAdd();
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedOnAddOrUpdate();
+
+            public abstract TestPropertyBuilder<TProperty> HasValueGenerator<TGenerator>() where TGenerator : ValueGenerator;
+            public abstract TestPropertyBuilder<TProperty> HasValueGenerator(Type valueGeneratorType);
+            public abstract TestPropertyBuilder<TProperty> HasValueGenerator(Func<IProperty, IEntityType, ValueGenerator> factory);
         }
 
         public abstract class TestCollectionNavigationBuilder<TEntity, TRelatedEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -22,6 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var selector = contextServices.GetRequiredService<ValueGeneratorSelector>();
+
+            Assert.IsType<CustomValueGenerator>(selector.Select(entityType.FindProperty("Custom"), entityType));
 
             Assert.Throws<NotSupportedException>(() => selector.Select(entityType.FindProperty("Id"), entityType));
             Assert.Throws<NotSupportedException>(() => selector.Select(entityType.FindProperty("Long"), entityType));
@@ -85,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
             builder.Ignore<Random>();
-            builder.Entity<AnEntity>();
+            builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
             entityType.AddProperty("Random", typeof(Random), shadow: false);
@@ -101,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         private class AnEntity
         {
             public int Id { get; set; }
+            public int Custom { get; set; }
             public long Long { get; set; }
             public short Short { get; set; }
             public byte Byte { get; set; }
@@ -131,6 +135,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             public DateTimeOffset DateTimeOffset { get; set; }
             public DateTimeOffset? NullableDateTimeOffset { get; set; }
             public Random Random { get; set; }
+        }
+
+        private class CustomValueGenerator : ValueGenerator<int>
+        {
+            public override int Next(EntityEntry entry)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool GeneratesTemporaryValues => false;
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -12,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations
@@ -98,6 +100,16 @@ namespace Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations
         {
             public int Id { get; set; }
             public Days Day { get; set; }
+        }
+
+        private class CustomValueGenerator : ValueGenerator<int>
+        {
+            public override int Next(EntityEntry entry)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool GeneratesTemporaryValues => false;
         }
 
         #region Model
@@ -733,6 +745,30 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrat
     });
 ",
                 o => { Assert.Equal("AnnotationValue", o.GetEntityTypes().First().FindProperty("Id")["AnnotationName"]); }
+                );
+        }
+
+        [ConditionalFact]
+        public void Custom_value_generator_is_ignored_in_snapshot()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithOneProperty>().Property<int>("Id").HasValueGenerator<CustomValueGenerator>();
+                    builder.Ignore<EntityWithTwoProperties>();
+                },
+                @"
+builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
+    {
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.HasKey(""Id"");
+
+        b.ToTable(""EntityWithOneProperty"");
+    });
+",
+                o => { Assert.Null(o.GetEntityTypes().First().FindProperty("Id")[CoreAnnotationNames.ValueGeneratorFactoryAnnotation]); }
                 );
         }
 


### PR DESCRIPTION
Issue #5537. Also see #5303.

This change added fluent API set set a custom value generator for use on a property. The value generator will be used regardless of provider and does not do anything special to ensure Migrations or the update pipeline are in sync with what is happening, but is useful to make a change to a value generator when these things do not matter or are already setup correctly.