### PR TITLE
Fix #5640 - Only block composed async queries at the top level.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config.test.json
 .idea/
 *.sln.iml
 *.DotSettings
+.idea.*

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -58,6 +58,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual async Task Where_all_any_client()
+        {
+            var expectedOrders = new[] {1, 2, 3};
+
+            await AssertQuery<Customer>(
+                cs => cs
+                    .Where(c => expectedOrders
+                        .All(expected => c.Orders.Select(o => o.OrderID)
+                            .Any(orderId => orderId == expected))));
+        }
+
         public virtual async Task Single_Predicate_Cancellation(CancellationToken cancellationToken)
         {
             await AssertQuery<Customer>(

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
             }
 
-            return base.Visit(expression);
+            return expression;
         }
 
         private static readonly MethodInfo _resultMethodInfo


### PR DESCRIPTION
Fix #5640 - Only block composed async queries at the top level.