### PR TITLE
Fix to #5738 - Query Perf: Selecting entire table for navigation properties in projections

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -617,6 +617,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         .BindMethodCallExpression(methodCallExpression, CreateAliasedColumnExpressionCore);
             }
 
+            if (expression == null)
+            {
+                return _queryModelVisitor.BindMethodToOuterQueryParameter(methodCallExpression);
+            }
+
             return expression;
         }
 
@@ -683,6 +688,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                                 .SingleOrDefault(ae => ae.SourceMember == expression.Member);
                     }
                 }
+            }
+
+            if (aliasExpression == null)
+            {
+                return _queryModelVisitor.BindMemberToOuterQueryParameter(expression);
             }
 
             return aliasExpression;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
@@ -95,6 +95,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         MethodInfo CreateCollectionRelatedEntitiesLoaderMethod { get; }
 
         /// <summary>
+        ///     Gets the pre execute method.
+        /// </summary>
+        /// <value>
+        ///     The pre execute method.
+        /// </value>
+        MethodInfo PreExecuteMethod { get; }
+
+        /// <summary>
         ///     Gets the type of the group join include.
         /// </summary>
         /// <value>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -387,6 +387,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         methodCallExpression.Arguments);
                 }
 
+                if (methodCallExpression.Method.MethodIsClosedFormOf(
+                    _relationalQueryCompilationContext.QueryMethodProvider.PreExecuteMethod))
+                {
+                    var newSource = VisitMethodCall((MethodCallExpression)methodCallExpression.Arguments[1]);
+
+                    return Expression.Call(
+                        methodCallExpression.Method,
+                        methodCallExpression.Arguments[0],
+                        newSource,
+                        methodCallExpression.Arguments[2]);
+                }
+
                 return base.VisitMethodCall(methodCallExpression);
             }
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/ShaperCommandContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/ShaperCommandContext.cs
@@ -62,6 +62,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public override int GetHashCode() => 0;
+
+            public CommandCacheKey Clone()
+            {
+                var clonedParameters = new Dictionary<string, object>();
+                foreach (var parameterValue in _parameterValues)
+                {
+                    clonedParameters.Add(parameterValue.Key, parameterValue.Value);
+                }
+
+                return new CommandCacheKey(clonedParameters);
+            }
         }
 
         private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
@@ -112,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (generator.IsCacheable)
             {
-                _commandCache.TryAdd(key, relationalCommand);
+                _commandCache.TryAdd(key.Clone(), relationalCommand);
             }
 
             return relationalCommand;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(queryMethodProvider, nameof(queryMethodProvider));
 
             QueryMethodProvider = queryMethodProvider;
+            ParentQueryNavigationParameters = new List<string>();
         }
 
         /// <summary>
@@ -61,6 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     The query method provider.
         /// </value>
         public virtual IQueryMethodProvider QueryMethodProvider { get; }
+
+        public virtual List<string> ParentQueryNavigationParameters { get; }
 
         /// <summary>
         ///     Creates a query model visitor.

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -1427,12 +1427,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Select_correlated_subquery_filtered()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                select os.Where(o => o.CustomerID == c.CustomerID),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => (IEnumerable<Order>)q1)
+                                .OrderBy(o => o.OrderID);
+
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => (IEnumerable<Order>)q1)
+                                .OrderBy(o => o.OrderID);
+
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [ConditionalFact]
         public virtual async Task Select_correlated_subquery_ordered()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
-                select os
-                    .OrderBy(o => c.CustomerID),
+                select os.OrderBy(o => c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
                         {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1616,6 +1616,64 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Where(g => g.CityOfBirth.Name == "Ephyra" || g.CityOfBirth.Name == "Hanover")
+                    .Select(g => g.Weapons.Where(w => w.Name != "Lancer"));
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+                var coleWeapons = resultList.Where(l => l.All(w => w.Name.Contains("Cole's"))).Single();
+                var domWeapons = resultList.Where(l => l.All(w => w.Name.Contains("Dom's"))).Single();
+
+                Assert.Equal(2, coleWeapons.Count);
+                Assert.True(coleWeapons.Select(w => w.Name).Contains("Cole's Gnasher"));
+
+                Assert.Equal(2, domWeapons.Count);
+                Assert.True(domWeapons.Select(w => w.Name).Contains("Dom's Hammerburst"));
+                Assert.True(domWeapons.Select(w => w.Name).Contains("Dom's Gnasher"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection_with_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.OfType<Officer>().Select(g => g.Reports.Where(r => r.Nickname != "Dom"));
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+                var bairdReports = resultList.Where(l => l.Count == 1).Single();
+                var marcusReports = resultList.Where(l => l.Count == 2).Single();
+
+                Assert.True(bairdReports.Select(g => g.FullName).Contains("Garron Paduk"));
+                Assert.True(marcusReports.Select(g => g.FullName).Contains("Augustus Cole"));
+                Assert.True(marcusReports.Select(g => g.FullName).Contains("Damon Baird"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection_works_with_caching()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Select(t => context.Gears.Where(g => g.Nickname == t.GearNickName));
+                var result = query.ToList();
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -116,14 +116,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .Select(c => c.Orders.FirstOrDefault()));
         }
 
-
         [ConditionalFact]
         public virtual void Select_collection_FirstOrDefault_project_single_column1()
         {
             AssertQuery<Customer>(
                 cs => cs.Take(2).Select(c => c.Orders.FirstOrDefault().CustomerID));
         }
-
+        
         [ConditionalFact]
         public virtual void Select_collection_FirstOrDefault_project_single_column2()
         {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -2022,11 +2022,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Select_correlated_subquery_ordered()
+        public virtual void Select_correlated_subquery_filtered()
         {
             AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
                 select os.Where(o => o.CustomerID == c.CustomerID),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
+
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
+
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_subquery_ordered()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                select os.OrderBy(o => c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
                         {

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ILinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ILinqOperatorProvider.cs
@@ -235,6 +235,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         MethodInfo Union { get; }
 
+        ///// <summary>
+        /////     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        /////     directly from your code. This API may change or be removed in future releases.
+        ///// </summary>
+        //MethodInfo PreExecute { get; }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -403,9 +403,12 @@ FROM [Level1] AS [e1]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"@_outer_Id: ?
+
+SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
 LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
+WHERE [subQuery].[Level1_Required_Id] = @_outer_Id
 ORDER BY [subQuery].[Id]",
                 Sql);
         }
@@ -425,10 +428,14 @@ FROM [Level4] AS [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"@_outer_Id: ?
+
+SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
 LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
-ORDER BY [subQuery].[Id]",
+WHERE [subQuery].[Level1_Required_Id] = @_outer_Id
+ORDER BY [subQuery].[Id]
+",
                 Sql);
         }
 
@@ -1310,29 +1317,15 @@ WHERE EXISTS (
         {
             base.Correlated_nested_subquery_doesnt_project_unnecessary_columns_in_top_level();
 
-            Assert.StartsWith(
-                @"SELECT [l1].[Name]
+            Assert.Equal(
+                @"SELECT DISTINCT [l1].[Name]
 FROM [Level1] AS [l1]
-
-SELECT [l20].[Id]
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level2] AS [l2]
+    WHERE EXISTS (
         SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [l20].[Id]
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
+        FROM [Level3] AS [l3]))",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1656,6 +1656,81 @@ ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
         }
 
+        public override void Select_correlated_filtered_collection()
+        {
+            base.Select_correlated_filtered_collection();
+
+            Assert.Equal(
+                @"SELECT [g].[FullName]
+FROM [Gear] AS [g]
+WHERE (([g].[Discriminator] = N'Officer') OR ([g].[Discriminator] = N'Gear')) AND [g].[CityOrBirthName] IN (N'Ephyra', N'Hanover')
+
+@_outer_FullName: Augustus Cole (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND ((@_outer_FullName = [w].[OwnerFullName]) AND [w].[OwnerFullName] IS NOT NULL)
+
+@_outer_FullName: Dominic Santiago (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND ((@_outer_FullName = [w].[OwnerFullName]) AND [w].[OwnerFullName] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Select_correlated_filtered_collection_with_composite_key()
+        {
+            base.Select_correlated_filtered_collection_with_composite_key();
+
+            Assert.Equal(
+                @"SELECT [t].[Nickname], [t].[SquadId]
+FROM (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] = N'Officer'
+) AS [t]
+
+@_outer_Nickname: Baird (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
+FROM [Gear] AS [r]
+WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom')) AND ((@_outer_Nickname = [r].[LeaderNickname]) AND (@_outer_SquadId = [r].[LeaderSquadId]))
+
+@_outer_Nickname: Marcus (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
+FROM [Gear] AS [r]
+WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom')) AND ((@_outer_Nickname = [r].[LeaderNickname]) AND (@_outer_SquadId = [r].[LeaderSquadId]))",
+                Sql);
+        }
+
+        public override void Select_correlated_filtered_collection_works_with_caching()
+        {
+            base.Select_correlated_filtered_collection_works_with_caching();
+
+            Assert.Contains(
+                @"SELECT [t].[GearNickName]
+FROM [CogTag] AS [t]",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_GearNickName: Cole Train (Size = 450)
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[Nickname] IS NULL",
+                Sql);
+        }
+
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -40,7 +40,7 @@ ORDER BY [od].[OrderID], [od].[ProductID], [od.Order].[CustomerID]",
         {
             base.Take_Select_Navigation();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
@@ -49,9 +49,17 @@ FROM (
     FROM [Customers] AS [c0]
 ) AS [t]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-",
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -97,7 +105,7 @@ FROM (
         {
             base.Select_collection_FirstOrDefault_project_anonymous_type();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
@@ -106,11 +114,17 @@ FROM (
     FROM [Customers] AS [c0]
 ) AS [t]
 
-SELECT [o].[CustomerID], [o].[OrderID]
-FROM [Orders] AS [o]
+@_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o].[CustomerID], [o].[OrderID]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -118,7 +132,7 @@ FROM [Orders] AS [o]",
         {
             base.Select_collection_FirstOrDefault_project_entity();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
@@ -127,11 +141,17 @@ FROM (
     FROM [Customers] AS [c0]
 ) AS [t]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
+@_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -367,17 +387,29 @@ WHERE [e].[ReportsTo] IS NULL",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%'
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANTON (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -501,8 +533,17 @@ FROM [Customers] AS [c]",
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 
+@_outer_CustomerID: ALFKI (Size = 450)
+
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]",
+FROM [Orders] AS [o1]
+WHERE @_outer_CustomerID = [o1].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Orders] AS [o1]
+WHERE @_outer_CustomerID = [o1].[CustomerID]",
                 Sql);
         }
 
@@ -528,8 +569,17 @@ WHERE NOT EXISTS (
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 
+@_outer_CustomerID: ALFKI (Size = 450)
+
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -682,8 +732,17 @@ WHERE (
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -692,21 +751,41 @@ FROM [Orders] AS [o]",
             base.Collection_select_nav_prop_first_or_default_then_nav_prop();
 
             // TODO: Projection sub-query lifting
-            Assert.StartsWith(
+            Assert.Equal(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
 WHERE [e].[CustomerID] LIKE N'A' + N'%'
 
-SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
-FROM [Orders] AS [e0]
-LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
-WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
-ORDER BY [e0].[CustomerID]
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
-WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
+ORDER BY [e0].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
+ORDER BY [e0].[CustomerID]
+
+@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
+ORDER BY [e0].[CustomerID]
+
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
 ORDER BY [e0].[CustomerID]",
                 Sql);
         }
@@ -898,14 +977,23 @@ WHERE EXISTS (
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 
-SELECT [o3].[OrderID]
-FROM [Orders] AS [o3]
+SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]
 
-SELECT [o2].[CustomerID], [o2].[OrderID]
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o2].[OrderID]
 FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID = [o2].[CustomerID]
 
-SELECT [o3].[OrderID]
-FROM [Orders] AS [o3]",
+SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o2].[OrderID]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID = [o2].[CustomerID]",
                 Sql);
 
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -163,25 +163,63 @@ WHERE [e1].[FirstName] = (
         {
             base.Where_query_composition_is_null();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
         }
 
         public override void Where_query_composition_is_not_null()
         {
-            base.Where_query_composition_is_null();
+            base.Where_query_composition_is_not_null();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
         }
 
@@ -189,12 +227,31 @@ FROM [Employees] AS [e2]",
         {
             base.Where_query_composition_entity_equality_one_element_SingleOrDefault();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e20].[EmployeeID]
-FROM [Employees] AS [e20]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] IS NULL",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
         }
 
@@ -295,11 +352,17 @@ WHERE [e].[Title] = (
 SELECT TOP(@__p_0) [od].[OrderID]
 FROM [Order Details] AS [od]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
+@_outer_OrderID: 10285
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]
+
+@_outer_OrderID: 10294
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
                 Sql);
         }
 
@@ -311,11 +374,17 @@ FROM [Orders] AS [o]",
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
 
-SELECT [o0].[OrderID], [o0].[CustomerID]
-FROM [Orders] AS [o0]
+@_outer_OrderID: 10248
 
-SELECT [c2].[CustomerID], [c2].[City]
-FROM [Customers] AS [c2]",
+SELECT TOP(2) [o0].[CustomerID]
+FROM [Orders] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]
+
+@_outer_CustomerID1: VINET (Size = 450)
+
+SELECT TOP(2) [c2].[City]
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID1 = [c2].[CustomerID]",
                 Sql);
         }
 
@@ -362,9 +431,16 @@ FROM (
 SELECT [c5].[CustomerID], [c5].[Country]
 FROM [Customers] AS [c5]
 
-SELECT [o23].[OrderID], [c6].[Country]
+@_outer_OrderID1: 10285
+
+SELECT TOP(1) [c6].[Country]
 FROM [Orders] AS [o23]
-INNER JOIN [Customers] AS [c6] ON [o23].[CustomerID] = [c6].[CustomerID]",
+INNER JOIN [Customers] AS [c6] ON [o23].[CustomerID] = [c6].[CustomerID]
+WHERE [o23].[OrderID] = @_outer_OrderID1
+
+SELECT [c5].[CustomerID], [c5].[Country]
+FROM [Customers] AS [c5]
+",
                 Sql);
         }
 
@@ -409,8 +485,17 @@ WHERE EXISTS (
                 @"SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
 
+@_outer_CustomerID: ALFKI (Size = 450)
+
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
-FROM [Customers] AS [c2]",
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID = [c2].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 Sql);
         }
 
@@ -445,8 +530,25 @@ ORDER BY [o].[OrderID]",
 )
 FROM [Customers] AS [c]
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o1]
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o1]
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
                 Sql);
         }
 
@@ -3095,19 +3197,19 @@ ORDER BY [c].[CustomerID]",
             base.SelectMany_Joined_DefaultIfEmpty();
 
             Assert.StartsWith(
-                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[ContactName]
+                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty0]
+    ) AS [empty10]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t1]",
+    ) AS [t1] ON 1 = 1
+) AS [t2]",
                 Sql);
         }
 
@@ -3115,20 +3217,20 @@ CROSS APPLY (
         {
             base.SelectMany_Joined_DefaultIfEmpty2();
 
-            Assert.StartsWith(
-                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+            Assert.Equal(
+                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty0]
+    ) AS [empty10]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t1]",
+    ) AS [t1] ON 1 = 1
+) AS [t2]",
                 Sql);
         }
 
@@ -4659,12 +4761,19 @@ FROM [Customers] AS [c]
 WHERE [c].[City] = N'London'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderID]
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID]
 FROM [Orders] AS [o]
-WHERE DATEPART(year, [o].[OrderDate]) = 1997
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]
 
-",
+@_outer_CustomerID: BSBEV (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 
@@ -4676,10 +4785,39 @@ ORDER BY [o].[OrderID]
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 
+@_outer_CustomerID: ALFKI (Size = 450)
+
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID
 
-",
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID",
+                Sql);
+        }
+
+        public override void Select_correlated_subquery_filtered()
+        {
+            base.Select_correlated_subquery_filtered();
+
+            Assert.StartsWith(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID",
                 Sql);
         }
 
@@ -4694,7 +4832,8 @@ FROM [Customers] AS [c]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
-",
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
                 Sql);
         }
 
@@ -5335,8 +5474,17 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
 FROM [Customers] AS [e]
 WHERE [e].[ContactTitle] = N'Owner'
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -5455,5 +5603,38 @@ ORDER BY [o].[CustomerID]",
 ";
 
         private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+
+
+
+        public override void Select_nested_collection_deep()
+        {
+            base.Select_nested_collection_deep();
+
+            Assert.StartsWith(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'London'
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o1].[CustomerID], [o1].[OrderID]
+FROM [Orders] AS [o1]
+WHERE ([o1].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o1].[OrderDate]) = 1997)
+ORDER BY [o1].[OrderID]
+
+@_outer_OrderID: 10453
+
+SELECT @_outer_OrderID
+FROM [Orders] AS [o2]
+ORDER BY [o2].[OrderID]
+
+@_outer_OrderID: 10558
+
+SELECT @_outer_OrderID
+FROM [Orders] AS [o2]
+ORDER BY [o2].[OrderID]",
+                Sql);
+        }
     }
 }


### PR DESCRIPTION
Fix is to allow more queries to be translated to SQL, specifically subqueries that are correlated with outer query, e.g.

customers.Select(c => c.Orders.FirstOrDefault())

would get translated to:

customers.Select(c => orders.Where(o => o.CustomerId == c.Id).FirstOrDefault())

This would produce outer query to fetch all the customers and for each customer another query, fetching ALL the orders each time filtering out the orders for each customer and returning only the first one on the client (because we didn't know how to handle o.CustomerId in this case)

With this change we will convert o.CustomerId into a SQL parameter, whose value is set for each iteration of the outer query - this can be easily translated to SQL and produce much more efficient queries:

SELECT [t].[CustomerID]
FROM [Customers] AS [c]

@_outer_CustomerID: ALFKI (Size = 450)

SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
FROM [Orders] AS [o]
WHERE @_outer_CustomerID = [o].[CustomerID]

We achieve this by introducing a new query method that executes a delegate before enumerating it's source, and then executing another delegate after all elements have been enumerated or the enumerator has been disposed.
Those functions set and remove the necessary parameters just before/after the inner query is accessed.