### PR TITLE
Sugar for HasForeignKey/HasPrincipalKey

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/InheritanceRelationshipsQueryFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/InheritanceRelationshipsQueryFixtureBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             modelBuilder.Entity<DerivedInheritanceRelationshipEntity>()
                 .HasOne(e => e.DerivedReferenceOnDerived)
                 .WithOne()
-                .HasForeignKey(typeof(DerivedReferenceOnDerived), "DerivedInheritanceRelationshipEntityId")
+                .HasForeignKey<DerivedReferenceOnDerived>("DerivedInheritanceRelationshipEntityId")
                 .IsRequired(false);
 
             modelBuilder.Entity<DerivedInheritanceRelationshipEntity>()

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/OneToOneQueryFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/OneToOneQueryFixtureBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             modelBuilder
                 .Entity<Person2>(
                     e => e.HasOne(p => p.Address).WithOne(a => a.Resident)
-                        .HasForeignKey(typeof(Address2), "PersonId"));
+                        .HasForeignKey<Address2>("PersonId"));
         }
 
         protected static void AddTestData(DbContext context)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -98,6 +98,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 foreignKeySet: true);
 
         /// <summary>
+        ///     <para>
+        ///         Configures the property(s) to use as the foreign key for this relationship.
+        ///     </para>
+        ///     <para>
+        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+        ///         that does not have a corresponding property in the entity class. The current value for the
+        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
+        ///         of the entity class.
+        ///     </para>
+        ///     <para>
+        ///         If <see cref="HasPrincipalKey(System.Type,string[])" /> is not specified, then an attempt will be made to
+        ///         match the data type and order of foreign key properties against the primary key of the principal
+        ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+        ///         added to the principal entity type to serve as the reference key.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TDependentEntity">
+        ///     The entity type that is the dependent in this relationship (the type that has the foreign key
+        ///     properties).
+        /// </typeparam>
+        /// <param name="foreignKeyPropertyNames">
+        ///     The name(s) of the foreign key property(s).
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
+            [NotNull] params string[] foreignKeyPropertyNames)
+            where TDependentEntity : class
+            => HasForeignKey(typeof(TDependentEntity), foreignKeyPropertyNames);
+
+        /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
         ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
         ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
@@ -118,6 +149,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != principalEntityType,
                 principalKeySet: true);
+
+        /// <summary>
+        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
+        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
+        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
+        ///     constraint will be introduced.
+        /// </summary>
+        /// <typeparam name="TPrincipalEntity">
+        ///     The entity type that is the principal in this relationship (the type
+        ///     that has the reference key properties).
+        /// </typeparam>
+        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
+            [NotNull] params string[] keyPropertyNames)
+            where TPrincipalEntity : class
+            => HasPrincipalKey(typeof(TPrincipalEntity), keyPropertyNames);
 
         /// <summary>
         ///     <para>
@@ -152,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 SetDependentEntityType(Check.NotEmpty(dependentEntityTypeName, nameof(dependentEntityTypeName)))
                     .HasForeignKey(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)), ConfigurationSource.Explicit),
                 this,
-                inverted: Builder.Metadata.DeclaringEntityType.Name != dependentEntityTypeName,
+                inverted: Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
                 foreignKeySet: true);
 
         /// <summary>
@@ -183,7 +231,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Configures the property(s) to use as the foreign key for this relationship.
         ///     </para>
         ///     <para>
-        ///         If <see cref="HasPrincipalKey{TPrincipalEntity}" />
+        ///         If <see cref="HasPrincipalKey(Type,string[])" />
         ///         is not specified, then an attempt will be made to match the data type and order of foreign key
         ///         properties against the primary key of the principal entity type. If they do not match, new shadow
         ///         state properties that form a unique index will be
@@ -204,12 +252,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
         ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
-        ///         corresponding keys in <see cref="HasPrincipalKey{TPrincipalEntity}" />.
+        ///         corresponding keys in <see cref="HasPrincipalKey(Type,string[])" />.
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
+            where TDependentEntity : class
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 SetDependentEntityType(typeof(TDependentEntity))
                     .HasForeignKey(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),
@@ -239,6 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
             [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
+            where TPrincipalEntity : class
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 SetPrincipalEntityType(typeof(TPrincipalEntity))
                     .HasPrincipalKey(Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -1743,22 +1743,22 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 modelBuilder.Entity<Parent>()
                     .HasOne(e => e.Child)
                     .WithOne(e => e.Parent)
-                    .HasForeignKey(typeof(Child), "ParentId");
+                    .HasForeignKey<Child>("ParentId");
 
                 modelBuilder.Entity<ParentPN>()
                     .HasOne(e => e.Child)
                     .WithOne()
-                    .HasForeignKey(typeof(ChildPN), "ParentId");
+                    .HasForeignKey<ChildPN>("ParentId");
 
                 modelBuilder.Entity<ChildDN>()
                     .HasOne(e => e.Parent)
                     .WithOne()
-                    .HasForeignKey(typeof(ChildDN), "ParentId");
+                    .HasForeignKey<ChildDN>("ParentId");
 
                 modelBuilder.Entity<ParentNN>()
                     .HasOne<ChildNN>()
                     .WithOne()
-                    .HasForeignKey(typeof(ChildNN), "ParentId");
+                    .HasForeignKey<ChildNN>("ParentId");
             }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
@@ -141,10 +141,12 @@
     <Compile Include="ModelBuilderTest\InheritanceTestBase.cs" />
     <Compile Include="ModelBuilderTest\ManyToOneTestBase.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderGenericRelationshipStringTest.cs" />
+    <Compile Include="ModelBuilderTest\ModelBuilderGenericRelationshipTypeStringTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderGenericRelationshipTypeTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderGenericTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderNonGenericStringTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderNonGenericTest.cs" />
+    <Compile Include="ModelBuilderTest\ModelBuilderNonGenericUnqualifiedStringTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderTestBase.cs" />
     <Compile Include="ModelBuilderTest\NonRelationshipTestBase.cs" />
     <Compile Include="ModelBuilderTest\OneToManyTestBase.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeStringTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.EntityFrameworkCore.Tests
+{
+    public class ModelBuilderGenericRelationshipTypeStringTest : ModelBuilderGenericRelationshipTypeTest
+    {
+        public class GenericOneToOneTypeString : GenericOneToOneType
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
+                => new GenericTypeTestModelBuilder(modelBuilder);
+        }
+
+        private class GenericTypeTestModelBuilder : TestModelBuilder
+        {
+            public GenericTypeTestModelBuilder(ModelBuilder modelBuilder)
+                : base(modelBuilder)
+            {
+            }
+
+            public override TestEntityTypeBuilder<TEntity> Entity<TEntity>()
+                => new GenericTypeTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity<TEntity>());
+
+            public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
+                => new GenericTypeTestModelBuilder(ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
+                    buildAction(new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+
+            public override TestModelBuilder Ignore<TEntity>()
+                => new GenericTypeTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+        }
+
+        private class GenericTypeTestEntityTypeBuilder<TEntity> : GenericTestEntityTypeBuilder<TEntity>
+            where TEntity : class
+        {
+            public GenericTypeTestEntityTypeBuilder(EntityTypeBuilder<TEntity> entityTypeBuilder)
+                : base(entityTypeBuilder)
+            {
+            }
+
+            protected override TestEntityTypeBuilder<TEntity> Wrap(EntityTypeBuilder<TEntity> entityTypeBuilder)
+                => new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder);
+
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(reference));
+        }
+
+        private class GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            public GenericTypeTestReferenceNavigationBuilder(ReferenceNavigationBuilder<TEntity, TRelatedEntity> referenceNavigationBuilder)
+                : base(referenceNavigationBuilder)
+            {
+            }
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
+        }
+
+        private class GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            public GenericTypeTestReferenceReferenceBuilder(ReferenceReferenceBuilder<TEntity, TRelatedEntity> referenceReferenceBuilder)
+                : base(referenceReferenceBuilder)
+            {
+            }
+
+            protected override GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> Wrap(ReferenceReferenceBuilder<TEntity, TRelatedEntity> referenceReferenceBuilder)
+                => new GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(referenceReferenceBuilder);
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(params string[] foreignKeyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasForeignKey(typeof(TDependentEntity), foreignKeyPropertyNames));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(params string[] keyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(typeof(TPrincipalEntity), keyPropertyNames));
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -321,11 +321,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(Expression<Func<TPrincipalEntity, object>> keyExpression)
                 => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(keyExpression));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(Type dependentEntityType, params string[] foreignKeyPropertyNames)
-                => Wrap(ReferenceReferenceBuilder.HasForeignKey(dependentEntityType, foreignKeyPropertyNames));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(params string[] foreignKeyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasForeignKey<TDependentEntity>(foreignKeyPropertyNames));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(Type principalEntityType, params string[] keyPropertyNames)
-                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(principalEntityType, keyPropertyNames));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(params string[] keyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey<TPrincipalEntity>(keyPropertyNames));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> IsRequired(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.IsRequired(isRequired));

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -275,11 +275,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(Expression<Func<TPrincipalEntity, object>> keyExpression)
                 => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(typeof(TPrincipalEntity), keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(Type dependentEntityType, params string[] foreignKeyPropertyNames)
-                => Wrap(ReferenceReferenceBuilder.HasForeignKey(dependentEntityType, foreignKeyPropertyNames));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(params string[] foreignKeyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasForeignKey<TDependentEntity>(foreignKeyPropertyNames));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(Type principalEntityType, params string[] keyPropertyNames)
-                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(principalEntityType, keyPropertyNames));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(params string[] keyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey<TPrincipalEntity>(keyPropertyNames));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> IsRequired(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.IsRequired(isRequired));

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.EntityFrameworkCore.Tests
+{
+    public class ModelBuilderNonGenericUnqualifiedStringTest : ModelBuilderNonGenericTest
+    {
+        public class NonGenericStringOneToManyType : OneToManyTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+        }
+
+        public class NonGenericStringManyToOneType : ManyToOneTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+        }
+
+        public class NonGenericStringOneToOneType : OneToOneTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+        }
+
+        private class NonGenericStringTestModelBuilder : TestModelBuilder
+        {
+            public NonGenericStringTestModelBuilder(ModelBuilder modelBuilder)
+                : base(modelBuilder)
+            {
+            }
+
+            public override TestEntityTypeBuilder<TEntity> Entity<TEntity>()
+                => new NonGenericStringTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity(typeof(TEntity)));
+
+            public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
+                => new NonGenericStringTestModelBuilder(ModelBuilder.Entity(typeof(TEntity), entityTypeBuilder =>
+                    buildAction(new NonGenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+
+            public override TestModelBuilder Ignore<TEntity>()
+                => new NonGenericStringTestModelBuilder(ModelBuilder.Ignore(typeof(TEntity)));
+        }
+
+        private class NonGenericStringTestEntityTypeBuilder<TEntity> : NonGenericTestEntityTypeBuilder<TEntity>
+            where TEntity : class
+        {
+            public NonGenericStringTestEntityTypeBuilder(EntityTypeBuilder entityTypeBuilder)
+                : base(entityTypeBuilder)
+            {
+            }
+
+            protected override NonGenericTestEntityTypeBuilder<TEntity> Wrap(EntityTypeBuilder entityTypeBuilder)
+                => new NonGenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder);
+
+            public override TestEntityTypeBuilder<TEntity> HasBaseType<TBaseEntity>()
+                => Wrap(EntityTypeBuilder.HasBaseType(typeof(TBaseEntity)));
+
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(typeof(TRelatedEntity).FullName, reference?.GetPropertyAccess().Name));
+
+            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(typeof(TRelatedEntity).FullName, collection?.GetPropertyAccess().Name));
+        }
+
+        private class NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            public NonGenericStringTestReferenceNavigationBuilder(ReferenceNavigationBuilder referenceNavigationBuilder)
+                : base(referenceNavigationBuilder)
+            {
+            }
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+            {
+                var referenceName = reference?.GetPropertyAccess().Name;
+                return new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(referenceName));
+            }
+        }
+
+        private class NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            public NonGenericStringTestReferenceReferenceBuilder(ReferenceReferenceBuilder referenceReferenceBuilder)
+                : base(referenceReferenceBuilder)
+            {
+            }
+
+            protected override NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> Wrap(ReferenceReferenceBuilder referenceReferenceBuilder)
+                => new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(referenceReferenceBuilder);
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(Expression<Func<TDependentEntity, object>> foreignKeyExpression)
+                => Wrap(ReferenceReferenceBuilder.HasForeignKey(typeof(TDependentEntity).Name, foreignKeyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(Expression<Func<TPrincipalEntity, object>> keyExpression)
+                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(typeof(TPrincipalEntity).Name, keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(params string[] foreignKeyPropertyNames)
+               => Wrap(ReferenceReferenceBuilder.HasForeignKey(typeof(TDependentEntity), foreignKeyPropertyNames));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(params string[] keyPropertyNames)
+                => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(typeof(TPrincipalEntity), keyPropertyNames));
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -274,16 +274,20 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 string annotation, object value);
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
-                Expression<Func<TDependentEntity, object>> foreignKeyExpression);
+                Expression<Func<TDependentEntity, object>> foreignKeyExpression)
+                where TDependentEntity : class;
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
-                Expression<Func<TPrincipalEntity, object>> keyExpression);
+                Expression<Func<TPrincipalEntity, object>> keyExpression)
+                where TPrincipalEntity : class;
 
-            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(
-                Type dependentEntityType, params string[] foreignKeyPropertyNames);
+            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
+                params string[] foreignKeyPropertyNames)
+                where TDependentEntity : class;
 
-            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
-                Type principalEntityType, params string[] keyPropertyNames);
+            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
+                params string[] keyPropertyNames)
+                where TPrincipalEntity : class;
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> IsRequired(bool isRequired = true);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2328,17 +2328,16 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public virtual void Throws_if_specified_FK_types_do_not_match()
             {
                 var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
                 modelBuilder.Ignore<Order>();
 
-                Assert.Equal(CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
-                    Assert.Throws<InvalidOperationException>(() =>
-                        modelBuilder
-                            .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                            .HasPrincipalKey(typeof(Customer), "Id")
-                            .HasForeignKey(typeof(CustomerDetails), "GuidProperty")).Message);
+                Assert.Equal(
+                    CoreStrings.ForeignKeyTypeMismatch("{'GuidProperty'}", nameof(CustomerDetails), "{'Id'}", nameof(Customer)),
+                    Assert.Throws<InvalidOperationException>(() => modelBuilder
+                        .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
+                        .HasPrincipalKey<Customer>("Id")
+                        .HasForeignKey<CustomerDetails>("GuidProperty")).Message);
             }
 
             [Fact]
@@ -2352,11 +2351,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasPrincipalKey(typeof(Customer), nameof(Customer.Id));
+                    .HasPrincipalKey<Customer>(nameof(Customer.Id));
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasForeignKey(typeof(CustomerDetails), "GuidProperty");
+                    .HasForeignKey<CustomerDetails>("GuidProperty");
 
                 var dependentType = model.FindEntityType(typeof(CustomerDetails));
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2377,8 +2376,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                            .HasForeignKey(typeof(CustomerDetails), "GuidProperty")
-                            .HasPrincipalKey(typeof(Customer), "Id")).Message);
+                            .HasForeignKey<CustomerDetails>("GuidProperty")
+                            .HasPrincipalKey<Customer>("Id")).Message);
             }
 
             [Fact]
@@ -2392,11 +2391,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasForeignKey(typeof(CustomerDetails), "GuidProperty");
+                    .HasForeignKey<CustomerDetails>("GuidProperty");
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasPrincipalKey(typeof(Customer), nameof(Customer.Id));
+                    .HasPrincipalKey<Customer>(nameof(Customer.Id));
 
                 var dependentType = model.FindEntityType(typeof(CustomerDetails));
                 var principalType = model.FindEntityType(typeof(Customer));
@@ -2418,8 +2417,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                            .HasPrincipalKey(typeof(Customer), "Id")
-                            .HasForeignKey(typeof(CustomerDetails), "Id", "GuidProperty")).Message);
+                            .HasPrincipalKey<Customer>("Id")
+                            .HasForeignKey<CustomerDetails>("Id", "GuidProperty")).Message);
             }
 
             [Fact]
@@ -2433,11 +2432,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasPrincipalKey(typeof(Customer), nameof(Customer.Id));
+                    .HasPrincipalKey<Customer>(nameof(Customer.Id));
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasForeignKey(typeof(CustomerDetails), nameof(CustomerDetails.Id), "GuidProperty");
+                    .HasForeignKey<CustomerDetails>(nameof(CustomerDetails.Id), "GuidProperty");
 
                 var dependentType = model.FindEntityType(typeof(CustomerDetails));
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2458,8 +2457,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
                             .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                            .HasForeignKey(typeof(CustomerDetails), "Id", "GuidProperty")
-                            .HasPrincipalKey(typeof(Customer), "Id")).Message);
+                            .HasForeignKey<CustomerDetails>("Id", "GuidProperty")
+                            .HasPrincipalKey<Customer>("Id")).Message);
             }
 
             [Fact]
@@ -2475,11 +2474,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasForeignKey(typeof(CustomerDetails), nameof(CustomerDetails.Id), "GuidProperty");
+                    .HasForeignKey<CustomerDetails>(nameof(CustomerDetails.Id), "GuidProperty");
 
                 var fk = modelBuilder
                     .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
-                    .HasPrincipalKey(typeof(Customer), nameof(Customer.Id)).Metadata;
+                    .HasPrincipalKey<Customer>(nameof(Customer.Id)).Metadata;
 
                 Assert.Same(principalType.FindProperty(nameof(Customer.Id)), fk.PrincipalKey.Properties.Single());
                 Assert.Equal(1, fk.Properties.Count());
@@ -2930,7 +2929,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     {
                         b.HasOne(e => e.FirstNav)
                             .WithOne()
-                            .HasForeignKey(typeof(Beta), "ShadowId");
+                            .HasForeignKey<Beta>("ShadowId");
                     });
 
                 Assert.Equal("ShadowId", modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
@@ -2948,7 +2947,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 var entityB = modelBuilder.Entity<Beta>();
 
-                entityB.HasOne(e => e.FirstNav).WithOne().HasForeignKey(typeof(Beta), "ShadowId");
+                entityB.HasOne(e => e.FirstNav).WithOne().HasForeignKey<Beta>("ShadowId");
                 
                 Assert.Equal("ShadowId", modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
             }


### PR DESCRIPTION
Issue #5377

Added back generic overloads so that in the common case of a shadow property in CLR entity types the generic method can be used instead of using typeof().

Also, only for these APIs, the short name of the type can be passed as a string since the resolution space is very small--it just checks the name at either end of the relationship.