### PR TITLE
[1.0.1] Fix KeyAttribute on derived types

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
@@ -13,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public abstract TTestStore CreateTestStore();
 
         public abstract DataAnnotationContext CreateContext(TTestStore testStore);
+
+        public abstract ModelValidator ThrowingValidator { get; }
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -25,10 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
-            var clrType = propertyBuilder.Metadata.DeclaringEntityType.ClrType;
-            var propertyName = propertyBuilder.Metadata.Name;
-
-            var propertyInfo = clrType?.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == propertyName);
+            var propertyInfo = propertyBuilder.Metadata.PropertyInfo;
             var attributes = propertyInfo?.GetCustomAttributes<TAttribute>(true);
             if (attributes != null)
             {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DataAnnotationInMemoryFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DataAnnotationInMemoryFixture.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,7 +19,20 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             _serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ThrowingModelValidator>()
                 .BuildServiceProvider();
+        }
+
+        public override ModelValidator ThrowingValidator
+            => _serviceProvider.GetService<ThrowingModelValidator>();
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class ThrowingModelValidator : ModelValidator
+        {
+            protected override void ShowWarning(string message)
+            {
+                throw new InvalidOperationException(message);
+            }
         }
 
         public override InMemoryTestStore CreateTestStore()

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             Assert.Equal(
                 CoreStrings.KeyAttributeOnDerivedEntity(derivedEntityTypeBuilder.Metadata.DisplayName(), propertyBuilder.Metadata.Name),
-                Assert.Throws<InvalidOperationException>(() => new KeyAttributeConvention().Apply(propertyBuilder)).Message);
+                Assert.Throws<InvalidOperationException>(() => new KeyAttributeConvention().Apply(derivedEntityTypeBuilder.ModelBuilder)).Message);
         }
 
         [Fact]


### PR DESCRIPTION
When entities are discovered through relationships the conventions run in a different order. This can cause the KeyAttributeConvention to run on derived types before the base. Move the check to validation to avoid the false positive.

Fixes #5898