### PR TITLE
[1.0.1] Fix: #5717 - Incorrect type mapping chosen for parameter

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1304,6 +1304,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             _relationalCommandBuilder.Append("CAST(");
 
+            var parentTypeMapping = _typeMapping;
+
+            _typeMapping = InferTypeMappingFromColumn(explicitCastExpression.Operand);
+
             Visit(explicitCastExpression.Operand);
 
             _relationalCommandBuilder.Append(" AS ");
@@ -1318,6 +1322,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _relationalCommandBuilder.Append(typeMapping.StoreType);
 
             _relationalCommandBuilder.Append(")");
+
+            _typeMapping = parentTypeMapping;
 
             return explicitCastExpression;
         }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -2090,7 +2090,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Join_flattening_bug_4539()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
+// ReSharper disable StringStartsWithIsCultureSpecific
 
 #if NETSTANDARD1_3
 using System.Reflection;
@@ -67,8 +68,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         {
                             using (var context = CreateContext())
                             {
-                                var query = context.Set<Order>()
+                                context.Set<Order>()
                                     .Include(o => new { o.Customer, o.OrderDetails })
+                                    // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
                                     .ToList();
                             }
                         }).Message);
@@ -122,9 +124,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         {
                             using (var context = CreateContext())
                             {
-                                var query = context.Set<Customer>()
+                                context.Set<Customer>()
                                     .Include(o => o.Orders)
                                     .ThenInclude(o => new { o.Customer, o.OrderDetails })
+                                    // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
                                     .ToList();
                             }
                         }).Message);
@@ -171,6 +174,39 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(91 + 830, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Include_collection_skip_no_order_by()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = context.Set<Customer>()
+                        .Skip(10)
+                        .Include(c => c.Orders)
+                        .ToList();
+
+                Assert.Equal(81, customers.Count);
+                Assert.True(customers.All(c => c.Orders != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_collection_skip_take_no_order_by()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = context.Set<Customer>()
+                        .Skip(10)
+                        .Take(5)
+                        .Include(c => c.Orders)
+                        .ToList();
+
+                Assert.Equal(5, customers.Count);
+                Assert.True(customers.All(c => c.Orders != null));
             }
         }
 
@@ -396,7 +432,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             })
                             .ToList();
 
-                Assert.Equal(2, orders.Count());
+                Assert.Equal(2, orders.Count);
             }
         }
 
@@ -605,8 +641,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .FirstOrDefault();
 
                 Assert.NotNull(customer);
-                Assert.Equal(7, customer?.Orders.Count);
-                Assert.True(customer?.Orders.All(o => o.Customer != null));
+                Assert.Equal(7, customer.Orders.Count);
+                Assert.True(customer.Orders.All(o => o.Customer != null));
                 Assert.Equal(1 + 7, context.ChangeTracker.Entries().Count());
             }
         }
@@ -1083,6 +1119,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [Fact]
         public virtual void Include_collection_force_alias_uniquefication()
         {
             using (var context = CreateContext())
@@ -1093,7 +1130,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                        select o)
                         .ToList();
 
-                Assert.Equal(6, result.Count());
+                Assert.Equal(6, result.Count);
                 Assert.True(result.SelectMany(r => r.OrderDetails).All(od => od.Order != null));
             }
         }
@@ -1459,7 +1496,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                                 }
                             };
 
-                var result = query.ToList();
+                var results = query.ToList();
+
+                Assert.Equal(830, results.Count);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+// ReSharper disable InconsistentNaming
+// ReSharper disable AccessToDisposedClosure
 
 // ReSharper disable ReplaceWithSingleCallToCount
 // ReSharper disable StringStartsWithIsCultureSpecific
@@ -1712,6 +1714,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var flag = new Random().Next(0, 2) == 1;
 
             AssertQuery<Product>(ps => ps
+                // ReSharper disable once SimplifyConditionalTernaryExpression
                 .Where(p => flag ? p.UnitsInStock >= 20 : false),
                     entryCount: flag ? 51 : 0);
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -57,6 +57,66 @@ ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_collection_skip_no_order_by()
+        {
+            base.Include_collection_skip_no_order_by();
+
+            Assert.Equal(
+                @"@__p_0: 10
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS
+
+@__p_0: 10
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS
+    ) AS [t]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
+                Sql);
+        }
+
+        public override void Include_collection_skip_take_no_order_by()
+        {
+            base.Include_collection_skip_take_no_order_by();
+
+            Assert.Equal(
+                @"@__p_0: 10
+@__p_1: 5
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+
+@__p_0: 10
+@__p_1: 5
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
+                Sql);
+        }
+
         public override void Include_reference_and_collection()
         {
             base.Include_reference_and_collection();
@@ -375,7 +435,7 @@ INNER JOIN (
     WHERE [c].[CustomerID] = N'ALFKI'
     ORDER BY [c0_0], [c].[CustomerID]
 ) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[c0_0], [c0].[CustomerID]", 
+ORDER BY [c0].[c0_0], [c0].[CustomerID]",
                 Sql);
         }
 
@@ -1151,6 +1211,7 @@ ORDER BY [c0].[City] DESC, [c0].[CustomerID]",
         public override void Include_with_skip()
         {
             base.Include_with_skip();
+
             if (SupportsOffset)
             {
                 Assert.Equal(
@@ -1182,6 +1243,7 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]",
         public override void Then_include_collection_order_by_collection_column()
         {
             base.Then_include_collection_order_by_collection_column();
+
             Assert.Equal(
     @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3510,7 +3510,7 @@ WHERE (@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)",
             base.Where_concat_string_int_comparison1();
 
             Assert.Equal(
-                @"@__i_0: 10 (Size = -1)
+                @"@__i_0: 10
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -3523,7 +3523,7 @@ WHERE ([c].[CustomerID] + CAST(@__i_0 AS nvarchar(max))) = [c].[CompanyName]",
             base.Where_concat_string_int_comparison2();
 
             Assert.Equal(
-                @"@__i_0: 10 (Size = -1)
+                @"@__i_0: 10
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -3536,8 +3536,8 @@ WHERE (CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID]) = [c].[CompanyName]",
             base.Where_concat_string_int_comparison3();
 
             Assert.Equal(
-                @"@__i_0: 10 (Size = -1)
-@__j_1: 21 (Size = -1)
+                @"@__i_0: 10
+@__j_1: 21
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]


### PR DESCRIPTION
Ensure we update type mapping stack when visiting ExplicitCastExpression.