### PR TITLE
Separate SqlServer code in optimistic concurrency tests

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/F1FixtureBase.cs
@@ -20,16 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             modelBuilder.Entity<Chassis>(b =>
                 {
                     b.HasKey(c => c.TeamId);
-                    b.Property<byte[]>("Version")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-                });
-
-            modelBuilder.Entity<Driver>(b =>
-                {
-                    b.Property<byte[]>("Version")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
                 });
 
             modelBuilder.Entity<Engine>(b =>
@@ -76,10 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             modelBuilder.Entity<Team>(b =>
                 {
-                    b.Property<byte[]>("Version")
-                        .ValueGeneratedOnAddOrUpdate()
-                        .IsConcurrencyToken();
-
                     b.HasOne(e => e.Gearbox).WithOne().HasForeignKey<Team>(e => e.GearboxId);
                     b.HasOne(e => e.Chassis).WithOne(e => e.Team).HasForeignKey<Chassis>(e => e.TeamId);
                 });

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -151,39 +151,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         where TFixture : F1FixtureBase<TTestStore>, new()
     {
         [Fact]
-        public virtual async Task Modifying_concurrency_token_only_is_noop()
-        {
-            byte[] firstVersion;
-            using (var context = CreateF1Context())
-            {
-                var driver = context.Drivers.Single(d => d.CarNumber == 1);
-                Assert.NotEqual(1, context.Entry(driver).Property<byte[]>("Version").CurrentValue[0]);
-                driver.Podiums = StorePodiums;
-                firstVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
-                await context.SaveChangesAsync();
-            }
-
-            byte[] secondVersion;
-            using (var context = CreateF1Context())
-            {
-                var driver = context.Drivers.Single(d => d.CarNumber == 1);
-                Assert.NotEqual(firstVersion, context.Entry(driver).Property<byte[]>("Version").CurrentValue);
-                Assert.Equal(StorePodiums, driver.Podiums);
-
-                secondVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
-                context.Entry(driver).Property<byte[]>("Version").CurrentValue = firstVersion;
-                await context.SaveChangesAsync();
-            }
-
-            using (var validationContext = CreateF1Context())
-            {
-                var driver = validationContext.Drivers.Single(d => d.CarNumber == 1);
-                Assert.Equal(secondVersion, validationContext.Entry(driver).Property<byte[]>("Version").CurrentValue);
-                Assert.Equal(StorePodiums, driver.Podiums);
-            }
-        }
-
-        [Fact]
         public virtual void Nullable_client_side_concurrency_token_can_be_used()
         {
             string originalName;
@@ -658,8 +625,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         #region Helpers
 
-        private const int StorePodiums = 20;
-        private const int ClientPodiums = 30;
+        protected const int StorePodiums = 20;
+        protected const int ClientPodiums = 30;
 
         protected virtual void ResolveConcurrencyTokens(EntityEntry entry)
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -59,5 +59,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             context.Database.UseTransaction(testStore.Transaction);
             return context;
         }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Chassis>(b =>
+                {
+                    b.Property<byte[]>("Version")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .IsConcurrencyToken();
+                });
+
+            modelBuilder.Entity<Driver>(b =>
+                {
+                    b.Property<byte[]>("Version")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .IsConcurrencyToken();
+                });
+
+            modelBuilder.Entity<Team>(b =>
+                {
+                    b.Property<byte[]>("Version")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .IsConcurrencyToken();
+                });
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/OptimisticConcurrencySqlServerTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
@@ -11,6 +14,39 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public OptimisticConcurrencySqlServerTest(F1SqlServerFixture fixture)
             : base(fixture)
         {
+        }
+
+        [Fact]
+        public async Task Modifying_concurrency_token_only_is_noop()
+        {
+            byte[] firstVersion;
+            using (var context = CreateF1Context())
+            {
+                var driver = context.Drivers.Single(d => d.CarNumber == 1);
+                Assert.NotEqual(1, context.Entry(driver).Property<byte[]>("Version").CurrentValue[0]);
+                driver.Podiums = StorePodiums;
+                firstVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
+                await context.SaveChangesAsync();
+            }
+
+            byte[] secondVersion;
+            using (var context = CreateF1Context())
+            {
+                var driver = context.Drivers.Single(d => d.CarNumber == 1);
+                Assert.NotEqual(firstVersion, context.Entry(driver).Property<byte[]>("Version").CurrentValue);
+                Assert.Equal(StorePodiums, driver.Podiums);
+
+                secondVersion = context.Entry(driver).Property<byte[]>("Version").CurrentValue;
+                context.Entry(driver).Property<byte[]>("Version").CurrentValue = firstVersion;
+                await context.SaveChangesAsync();
+            }
+
+            using (var validationContext = CreateF1Context())
+            {
+                var driver = validationContext.Drivers.Single(d => d.CarNumber == 1);
+                Assert.Equal(secondVersion, validationContext.Entry(driver).Property<byte[]>("Version").CurrentValue);
+                Assert.Equal(StorePodiums, driver.Podiums);
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
@@ -16,7 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         // Override failing tests because SQLite does not allow store-generated row versions.
         // Row version behavior could be imitated on SQLite. See Issue #2195
         // TODO move these tests into the testing just for SqlServer since they don't apply to SQLite
-        public override Task Modifying_concurrency_token_only_is_noop() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_client_values() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_new_values() => Task.FromResult(true);


### PR DESCRIPTION
The optimistic concurrency test base classes contained some SqlServer-specific code, i.e. the setup of a byte[] rowversion as the concurrency column. Moved that out to the SqlServer tests.

@AndriySvyryd, this is a continuation of the discussion in #5367 (thanks for fixing those the tests in #5608.

Also just to let you guys know (@rowanmiller, @divega, @ajcvickers), I've added first-class optimistic concurrency support to the Npgsql provider, using PostgreSQL's xmin column. This is a special system column that all tables have, and which contains the id of the last transaction that touched the row ([see the docs](https://www.postgresql.org/docs/current/static/ddl-system-columns.html)). Challenges included uint support, and also making Npgsql's ModelDiffer totally ignore system columns and never produce migrations for them (as they're always there and unchangeable).