### PR TITLE
[1.0.1] Fix to #5738 - Query Perf: Selecting entire table for navigation properties in projections

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
@@ -713,5 +713,87 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public void Dispose() => _includeCollectionIterator?.Dispose();
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual MethodInfo InjectParametersMethod => _injectParametersMethodInfo;
+
+        private static readonly MethodInfo _injectParametersMethodInfo
+            = typeof(AsyncQueryMethodProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParameters));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static IAsyncEnumerable<TElement> _InjectParameters<TElement>(
+            QueryContext queryContext,
+            IAsyncEnumerable<TElement> source,
+            string[] parameterNames,
+            object[] parameterValues)
+            => new ParameterInjector<TElement>(queryContext, source, parameterNames, parameterValues);
+
+        private sealed class ParameterInjector<TElement> : IAsyncEnumerable<TElement>
+        {
+            private readonly QueryContext _queryContext;
+            private readonly IAsyncEnumerable<TElement> _innerEnumerable;
+            private readonly string[] _parameterNames;
+            private readonly object[] _parameterValues;
+
+            public ParameterInjector(
+                QueryContext queryContext,
+                IAsyncEnumerable<TElement> innerEnumerable,
+                string[] parameterNames,
+                object[] parameterValues)
+            {
+                _queryContext = queryContext;
+                _innerEnumerable = innerEnumerable;
+                _parameterNames = parameterNames;
+                _parameterValues = parameterValues;
+            }
+
+            IAsyncEnumerator<TElement> IAsyncEnumerable<TElement>.GetEnumerator() => new InjectParametersEnumerator(this);
+
+            private sealed class InjectParametersEnumerator : IAsyncEnumerator<TElement>
+            {
+                private readonly ParameterInjector<TElement> _parameterInjector;
+                private readonly IAsyncEnumerator<TElement> _innerEnumerator;
+                private bool _disposed;
+
+                public InjectParametersEnumerator(ParameterInjector<TElement> parameterInjector)
+                {
+                    _parameterInjector = parameterInjector;
+
+                    for (var i = 0; i < _parameterInjector._parameterNames.Length; i++)
+                    {
+                        _parameterInjector._queryContext.AddParameter(
+                            _parameterInjector._parameterNames[i],
+                            _parameterInjector._parameterValues[i]);
+                    }
+
+                    _innerEnumerator = _parameterInjector._innerEnumerable.GetEnumerator();
+                }
+
+                public TElement Current => _innerEnumerator.Current;
+
+                public async Task<bool> MoveNext(CancellationToken cancellationToken)
+                    => await _innerEnumerator.MoveNext(cancellationToken);
+
+                public void Dispose()
+                {
+                    if (!_disposed)
+                    {
+                        _innerEnumerator.Dispose();
+
+                        foreach (var parameterName in _parameterInjector._parameterNames)
+                        {
+                            _parameterInjector._queryContext.RemoveParameter(parameterName);
+                        }
+
+                        _disposed = true;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
 
@@ -55,6 +56,24 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         Expression.Call(
                             _relationalQueryCompilationContext.QueryMethodProvider.QueryMethod,
                             queryArguments));
+            }
+
+            if (node.Method.MethodIsClosedFormOf(
+                _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
+            {
+                var sourceArgument = (MethodCallExpression)Visit(node.Arguments[1]);
+                if (sourceArgument.Method.MethodIsClosedFormOf(
+                    _relationalQueryCompilationContext.QueryMethodProvider.GetResultMethod))
+                {
+                    var getResultArgument = sourceArgument.Arguments[0];
+                    var newGetResultArgument = Expression.Call(
+                        _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod.MakeGenericMethod(typeof(ValueBuffer)),
+                        node.Arguments[0], getResultArgument, node.Arguments[2], node.Arguments[3]);
+
+                    return Expression.Call(sourceArgument.Method, newGetResultArgument);
+                }
+
+                return sourceArgument;
             }
 
             // ReSharper disable once LoopCanBePartlyConvertedToQuery

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -617,7 +617,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         .BindMethodCallExpression(methodCallExpression, CreateAliasedColumnExpressionCore);
             }
 
-            return expression;
+            return expression == null
+                ? _queryModelVisitor.BindMethodToOuterQueryParameter(methodCallExpression)
+                : expression;
         }
 
         /// <summary>
@@ -685,7 +687,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 }
             }
 
-            return aliasExpression;
+            return aliasExpression == null
+                ? _queryModelVisitor.BindMemberToOuterQueryParameter(expression)
+                : aliasExpression;
         }
 
         private AliasExpression CreateAliasedColumnExpression(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
@@ -95,6 +95,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         MethodInfo CreateCollectionRelatedEntitiesLoaderMethod { get; }
 
         /// <summary>
+        ///     Gets the inject parameters method.
+        /// </summary>
+        /// <value>
+        ///     The pre execute method.
+        /// </value>
+        MethodInfo InjectParametersMethod { get; }
+
+        /// <summary>
         ///     Gets the type of the group join include.
         /// </summary>
         /// <value>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -387,6 +387,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         methodCallExpression.Arguments);
                 }
 
+                if (methodCallExpression.Method.MethodIsClosedFormOf(
+                    _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
+                {
+                    var newSource = VisitMethodCall((MethodCallExpression)methodCallExpression.Arguments[1]);
+
+                    return Expression.Call(
+                        methodCallExpression.Method,
+                        methodCallExpression.Arguments[0],
+                        newSource,
+                        methodCallExpression.Arguments[2],
+                        methodCallExpression.Arguments[3]);
+                }
+
                 return base.VisitMethodCall(methodCallExpression);
             }
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/ShaperCommandContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/ShaperCommandContext.cs
@@ -62,6 +62,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public override int GetHashCode() => 0;
+
+            public CommandCacheKey Clone() => new CommandCacheKey(
+                new Dictionary<string, object>((Dictionary<string, object>)_parameterValues));
         }
 
         private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
@@ -112,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (generator.IsCacheable)
             {
-                _commandCache.TryAdd(key, relationalCommand);
+                _commandCache.TryAdd(key.Clone(), relationalCommand);
             }
 
             return relationalCommand;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -528,6 +529,93 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             public void Dispose() => _includeCollectionIterator?.Dispose();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual MethodInfo InjectParametersMethod => _injectParametersMethodInfo;
+
+        private static readonly MethodInfo _injectParametersMethodInfo
+            = typeof(QueryMethodProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParameters));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static IEnumerable<TElement> _InjectParameters<TElement>(
+            QueryContext queryContext,
+            IEnumerable<TElement> source,
+            string[] parameterNames,
+            object[] parameterValues)
+            => new ParameterInjector<TElement>(queryContext, source, parameterNames, parameterValues);
+
+        private sealed class ParameterInjector<TElement> : IEnumerable<TElement>
+        {
+            private readonly QueryContext _queryContext;
+            private readonly IEnumerable<TElement> _innerEnumerable;
+            private readonly string[] _parameterNames;
+            private readonly object[] _parameterValues;
+
+            public ParameterInjector(
+                QueryContext queryContext,
+                IEnumerable<TElement> innerEnumerable,
+                string[] parameterNames,
+                object[] parameterValues)
+            {
+                _queryContext = queryContext;
+                _innerEnumerable = innerEnumerable;
+                _parameterNames = parameterNames;
+                _parameterValues = parameterValues;
+            }
+
+            public IEnumerator<TElement> GetEnumerator() => new InjectParametersEnumerator(this);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private sealed class InjectParametersEnumerator : IEnumerator<TElement>
+            {
+                private readonly ParameterInjector<TElement> _parameterInjector;
+                private readonly IEnumerator<TElement> _innerEnumerator;
+                private bool _disposed;
+
+                public InjectParametersEnumerator(ParameterInjector<TElement> parameterInjector)
+                {
+                    _parameterInjector = parameterInjector;
+
+                    for (var i = 0; i < _parameterInjector._parameterNames.Length; i++)
+                    {
+                        _parameterInjector._queryContext.AddParameter(
+                            _parameterInjector._parameterNames[i],
+                            _parameterInjector._parameterValues[i]);
+                    }
+
+                    _innerEnumerator = _parameterInjector._innerEnumerable.GetEnumerator();
+                }
+
+                public TElement Current => _innerEnumerator.Current;
+
+                object IEnumerator.Current => _innerEnumerator.Current;
+
+                public bool MoveNext() => _innerEnumerator.MoveNext();
+
+                public void Reset() => _innerEnumerator.Reset();
+
+                public void Dispose()
+                {
+                    if (!_disposed)
+                    {
+                        _innerEnumerator.Dispose();
+
+                        foreach (var parameterName in _parameterInjector._parameterNames)
+                        {
+                            _parameterInjector._queryContext.RemoveParameter(parameterName);
+                        }
+
+                        _disposed = true;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(queryMethodProvider, nameof(queryMethodProvider));
 
             QueryMethodProvider = queryMethodProvider;
+            ParentQueryReferenceParameters = new List<string>();
         }
 
         /// <summary>
@@ -61,6 +62,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     The query method provider.
         /// </value>
         public virtual IQueryMethodProvider QueryMethodProvider { get; }
+
+        /// <summary>
+        ///     Gets the list of parameter names that represent reference to a parent query.
+        /// </summary>
+        /// <value>
+        ///     The list of parameter names that represent reference to a parent query.
+        /// </value>
+        public virtual IList<string> ParentQueryReferenceParameters { get; }
 
         /// <summary>
         ///     Creates a query model visitor.

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -451,7 +451,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     var previousSelectExpression = TryGetQuery(previousQuerySource);
 
-                    if (previousSelectExpression != null)
+                    if (previousSelectExpression != null
+                        && CanFlattenSelectMany())
                     {
                         if (!QueryCompilationContext.QuerySourceRequiresMaterialization(previousQuerySource))
                         {
@@ -499,6 +500,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 WarnClientEval(fromClause);
             }
+        }
+
+        private bool CanFlattenSelectMany()
+        {
+            var selectManyExpression = Expression as MethodCallExpression;
+            if (selectManyExpression == null
+                || !selectManyExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.SelectMany))
+            {
+                return false;
+            }
+
+            var outerShapedQuery = selectManyExpression.Arguments[0] as MethodCallExpression;
+            if (outerShapedQuery == null || outerShapedQuery.Arguments.Count != 3)
+            {
+                return false;
+            }
+
+            var outerShaper = outerShapedQuery.Arguments[2] as ConstantExpression;
+            if (outerShaper == null || !(outerShaper.Value is Shaper))
+            {
+                return false;
+            }
+
+            var innerShapedQuery = (selectManyExpression.Arguments[1] as LambdaExpression)?.Body as MethodCallExpression;
+            if (innerShapedQuery == null)
+            {
+                return false;
+            }
+
+            if (innerShapedQuery.Method.MethodIsClosedFormOf(LinqOperatorProvider.DefaultIfEmpty)
+                || innerShapedQuery.Method.MethodIsClosedFormOf(LinqOperatorProvider.DefaultIfEmptyArg))
+            {
+                innerShapedQuery = innerShapedQuery.Arguments.Single() as MethodCallExpression;
+                if (innerShapedQuery == null)
+                {
+                    return false;
+                }
+            }
+
+            if (innerShapedQuery.Arguments.Count != 3)
+            {
+                return false;
+            }
+
+            var innerShaper = innerShapedQuery.Arguments[2] as ConstantExpression;
+            if (innerShaper == null || !(innerShaper.Value is Shaper))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -965,9 +1017,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 foreach (var ordering in orderByClause.Orderings)
                 {
+                    // we disable this for order by, because you can't have a parameter (that is integer) in the order by
+                    var canBindPropertyToOuterParameter = _canBindPropertyToOuterParameter;
+                    _canBindPropertyToOuterParameter = false;
+
                     var sqlOrderingExpression
                         = sqlTranslatingExpressionVisitor
                             .Visit(ordering.Expression);
+
+                    _canBindPropertyToOuterParameter = canBindPropertyToOuterParameter;
 
                     if (sqlOrderingExpression == null)
                     {
@@ -1180,6 +1238,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (property, qs) => BindMemberOrMethod(memberBinder, qs, property, bindSubQueries));
         }
 
+        public virtual Expression BindMemberToOuterQueryParameter(
+            [NotNull] MemberExpression memberExpression)
+        {
+            return base.BindMemberExpression(
+                memberExpression,
+                null,
+                (property, qs) => BindPropertyToOuterParameter(qs, property, true));
+        }
+
         /// <summary>
         ///     Bind a method call expression.
         /// </summary>
@@ -1246,6 +1313,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                     });
         }
 
+        public virtual Expression BindMethodToOuterQueryParameter(
+            [NotNull] MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            return base.BindMethodCallExpression<Expression>(
+                methodCallExpression,
+                null,
+                (property, qs) => BindPropertyToOuterParameter(qs, property, false));
+        }
+
         private TResult BindMemberOrMethod<TResult>(
             Func<IProperty, IQuerySource, SelectExpression, TResult> memberBinder,
             IQuerySource querySource,
@@ -1290,5 +1368,84 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        private bool _canBindPropertyToOuterParameter = true;
+
+        private const string OuterQueryParameterNamePrefix = @"_outer_";
+
+        private ParameterExpression BindPropertyToOuterParameter(IQuerySource querySource, IProperty property, bool isMemberExpression)
+        {
+            if (querySource != null && _canBindPropertyToOuterParameter)
+            {
+                SelectExpression parentSelectExpression = null;
+                ParentQueryModelVisitor?.QueriesBySource.TryGetValue(querySource, out parentSelectExpression);
+                if (parentSelectExpression != null)
+                {
+                    var parameterName = OuterQueryParameterNamePrefix + property.Name;
+                    var parameterWithSamePrefixCount
+                        = QueryCompilationContext.ParentQueryReferenceParameters.Count(p => p.StartsWith(parameterName, StringComparison.Ordinal));
+
+                    if (parameterWithSamePrefixCount > 0)
+                    {
+                        parameterName += parameterWithSamePrefixCount;
+                    }
+
+                    QueryCompilationContext.ParentQueryReferenceParameters.Add(parameterName);
+                    Expression = CreateInjectParametersExpression(Expression, querySource, property, parameterName, isMemberExpression);
+
+                    return Expression.Parameter(
+                        property.ClrType,
+                        parameterName);
+                }
+            }
+
+            return null;
+        }
+
+        private Expression CreateInjectParametersExpression(
+            Expression expression,
+            IQuerySource querySource,
+            IProperty property,
+            string parameterName,
+            bool isMemberExpression)
+        {
+            var querySourceReference = new QuerySourceReferenceExpression(querySource);
+            var propertyExpression = isMemberExpression
+                ? Expression.Property(querySourceReference, property.GetPropertyInfo())
+                : CreatePropertyExpression(querySourceReference, property);
+
+            if (propertyExpression.Type.GetTypeInfo().IsValueType)
+            {
+                propertyExpression = Expression.Convert(propertyExpression, typeof(object));
+            }
+
+            var parameterNameExpressions = new List<ConstantExpression>();
+            var parameterValueExpressions = new List<Expression>();
+
+            var methodCallExpression = expression as MethodCallExpression;
+            if (methodCallExpression != null
+                && methodCallExpression.Method.MethodIsClosedFormOf(QueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
+            {
+                var existingParamterNamesExpression = (NewArrayExpression)methodCallExpression.Arguments[2];
+                parameterNameExpressions.AddRange(existingParamterNamesExpression.Expressions.Cast<ConstantExpression>());
+
+                var existingParameterValuesExpression = (NewArrayExpression)methodCallExpression.Arguments[3];
+                parameterValueExpressions.AddRange(existingParameterValuesExpression.Expressions);
+
+                expression = methodCallExpression.Arguments[1];
+            }
+
+            parameterNameExpressions.Add(Expression.Constant(parameterName));
+            parameterValueExpressions.Add(propertyExpression);
+
+            var elementType = expression.Type.GetGenericArguments().Single();
+
+            return Expression.Call(
+                QueryCompilationContext.QueryMethodProvider.InjectParametersMethod.MakeGenericMethod(elementType),
+                QueryContextParameter,
+                expression,
+                Expression.NewArrayInit(typeof(string), parameterNameExpressions),
+                Expression.NewArrayInit(typeof(object), parameterValueExpressions));
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -1427,12 +1427,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Select_correlated_subquery_filtered()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                select os.Where(o => o.CustomerID == c.CustomerID),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => (IEnumerable<Order>)q1)
+                                .OrderBy(o => o.OrderID);
+
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => (IEnumerable<Order>)q1)
+                                .OrderBy(o => o.OrderID);
+
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [ConditionalFact]
         public virtual async Task Select_correlated_subquery_ordered()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
-                select os
-                    .OrderBy(o => c.CustomerID),
+                select os.OrderBy(o => c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
                         {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1616,6 +1616,63 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Where(g => g.CityOfBirth.Name == "Ephyra" || g.CityOfBirth.Name == "Hanover")
+                    .Select(g => g.Weapons.Where(w => w.Name != "Lancer"));
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+                var coleWeapons = resultList.Where(l => l.All(w => w.Name.Contains("Cole's"))).Single();
+                var domWeapons = resultList.Where(l => l.All(w => w.Name.Contains("Dom's"))).Single();
+
+                Assert.Equal(2, coleWeapons.Count);
+                Assert.True(coleWeapons.Select(w => w.Name).Contains("Cole's Gnasher"));
+
+                Assert.Equal(2, domWeapons.Count);
+                Assert.True(domWeapons.Select(w => w.Name).Contains("Dom's Hammerburst"));
+                Assert.True(domWeapons.Select(w => w.Name).Contains("Dom's Gnasher"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection_with_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.OfType<Officer>().Select(g => g.Reports.Where(r => r.Nickname != "Dom"));
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+                var bairdReports = resultList.Where(l => l.Count == 1).Single();
+                var marcusReports = resultList.Where(l => l.Count == 2).Single();
+
+                Assert.True(bairdReports.Select(g => g.FullName).Contains("Garron Paduk"));
+                Assert.True(marcusReports.Select(g => g.FullName).Contains("Augustus Cole"));
+                Assert.True(marcusReports.Select(g => g.FullName).Contains("Damon Baird"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_filtered_collection_works_with_caching()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Select(t => context.Gears.Where(g => g.Nickname == t.GearNickName));
+                var result = query.ToList();
+
+                var resultList = result.Select(r => r.ToList()).ToList();
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Take_Select_Navigation()
         {
             AssertQuery<Customer>(
-                cs => cs.Take(2)
+                cs => cs.OrderBy(c => c.CustomerID).Take(2)
                     .Select(c => c.Orders.FirstOrDefault()));
         }
 
@@ -121,28 +121,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Select_collection_FirstOrDefault_project_single_column1()
         {
             AssertQuery<Customer>(
-                cs => cs.Take(2).Select(c => c.Orders.FirstOrDefault().CustomerID));
+                cs => cs.OrderBy(c => c.CustomerID).Take(2).Select(c => c.Orders.FirstOrDefault().CustomerID));
         }
 
         [ConditionalFact]
         public virtual void Select_collection_FirstOrDefault_project_single_column2()
         {
             AssertQuery<Customer>(
-                cs => cs.Take(2).Select(c => c.Orders.Select(o => o.CustomerID).FirstOrDefault()));
+                cs => cs.OrderBy(c => c.CustomerID).Take(2).Select(c => c.Orders.Select(o => o.CustomerID).FirstOrDefault()));
         }
 
         [ConditionalFact]
         public virtual void Select_collection_FirstOrDefault_project_anonymous_type()
         {
             AssertQuery<Customer>(
-                cs => cs.Take(2).Select(c => c.Orders.Select(o => new { o.CustomerID, o.OrderID }).FirstOrDefault()));
+                cs => cs.OrderBy(c => c.CustomerID).Take(2).Select(c => c.Orders.Select(o => new { o.CustomerID, o.OrderID }).FirstOrDefault()));
         }
 
         [ConditionalFact]
         public virtual void Select_collection_FirstOrDefault_project_entity()
         {
             AssertQuery<Customer>(
-                cs => cs.Take(2).Select(c => c.Orders.FirstOrDefault()));
+                cs => cs.OrderBy(c => c.CustomerID).Take(2).Select(c => c.Orders.FirstOrDefault()));
         }
 
         [ConditionalFact]
@@ -322,6 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertQuery<Customer>(
                 cs => from c in cs
                       where c.CustomerID.StartsWith("A")
+                      orderby c.CustomerID
                       select new { c.CustomerID, c.Orders },
                 asserter: (l2oItems, efItems) =>
                 {
@@ -415,8 +416,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Customer>(
                 cs => from c in cs
+                      orderby c.CustomerID
                       select new { All = c.Orders.All(o => o.ShipCity == "London") },
                 cs => from c in cs
+                      orderby c.CustomerID
                       select new { All = (c.Orders ?? new List<Order>()).All(o => o.ShipCity == "London") });
         }
 
@@ -440,6 +443,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var customers
                     = (from c in context.Set<Customer>()
+                       orderby c.CustomerID
                        where c.Orders.All(o => o.ShipCity == "London")
                        select c).ToList();
 
@@ -566,8 +570,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Customer>(
                 cs => from c in cs
+                      orderby c.CustomerID
                       select new { First = c.Orders.FirstOrDefault() },
                 cs => from c in cs
+                      orderby c.CustomerID
                       select new { First = (c.Orders ?? new List<Order>()).FirstOrDefault() });
         }
 
@@ -578,8 +584,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             AssertQuery<Customer>(
                 cs => from c in cs.Where(e => e.CustomerID.StartsWith("A"))
+                      orderby c.CustomerID
                       select new { c.Orders.Where(e => orderIds.Contains(e.OrderID)).FirstOrDefault().Customer },
                 cs => from c in cs.Where(e => e.CustomerID.StartsWith("A"))
+                      orderby c.CustomerID
                       select new { Customer = c.Orders != null && c.Orders.Where(e => orderIds.Contains(e.OrderID)).Any() 
                         ? c.Orders.Where(e => orderIds.Contains(e.OrderID)).First().Customer 
                         : null });
@@ -723,6 +731,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Customer, Order, Customer>(
                 (cs, os) => from c in cs
+                            orderby c.CustomerID
                             where c.Orders.Select(o => o.OrderID)
                                 .Contains(
                                     os.OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -926,7 +926,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Where_subquery_correlated_client_eval()
         {
             AssertQuery<Customer>(
-                cs => cs.Where(c1 => cs.Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
+                cs => cs.OrderBy(c1 => c1.CustomerID).Where(c1 => cs.Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
                 entryCount: 6);
         }
 
@@ -2005,6 +2005,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
+                orderby c.CustomerID
                 select os
                     .Where(o => o.CustomerID == c.CustomerID),
                 asserter:
@@ -2025,26 +2026,49 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Select_correlated_subquery_ordered()
+        public virtual void Select_correlated_subquery_filtered()
         {
             AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
                 select os.Where(o => o.CustomerID == c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Select_correlated_subquery_ordered()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                select os.OrderBy(o => c.CustomerID),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
+
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
+
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         // TODO: Re-linq parser
@@ -3152,6 +3176,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Customer, Order>((cs, os) =>
                 from c in cs
+                orderby c.CustomerID
                 let hasOrders = os.Any(o => o.CustomerID == c.CustomerID)
                 select new { c, hasOrders });
         }
@@ -5348,7 +5373,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var q = from c in context.Customers.Include(e => e.Orders).Where(c => c.ContactTitle == "Owner")
+                var q = from c in context.Customers.Include(e => e.Orders).Where(c => c.ContactTitle == "Owner").OrderBy(c => c.CustomerID)
                         select new
                         {
                             Id = c.CustomerID,

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -79,6 +79,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
+        public override Task Select_nested_collection_deep()
+        {
+            return base.Select_nested_collection_deep();
+        }
+
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -404,9 +404,12 @@ FROM [Level1] AS [e1]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"@_outer_Id: ?
+
+SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
 LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
+WHERE [subQuery].[Level1_Required_Id] = @_outer_Id
 ORDER BY [subQuery].[Id]",
                 Sql);
         }
@@ -426,9 +429,12 @@ FROM [Level4] AS [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"@_outer_Id: ?
+
+SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
 LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
+WHERE [subQuery].[Level1_Required_Id] = @_outer_Id
 ORDER BY [subQuery].[Id]",
                 Sql);
         }
@@ -1348,29 +1354,15 @@ WHERE EXISTS (
         {
             base.Correlated_nested_subquery_doesnt_project_unnecessary_columns_in_top_level();
 
-            Assert.StartsWith(
-                @"SELECT [l1].[Name]
+            Assert.Equal(
+                @"SELECT DISTINCT [l1].[Name]
 FROM [Level1] AS [l1]
-
-SELECT [l20].[Id]
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level2] AS [l2]
+    WHERE EXISTS (
         SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [l20].[Id]
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
+        FROM [Level3] AS [l3]))",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1656,6 +1656,81 @@ ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
         }
 
+        public override void Select_correlated_filtered_collection()
+        {
+            base.Select_correlated_filtered_collection();
+
+            Assert.Equal(
+                @"SELECT [g].[FullName]
+FROM [Gear] AS [g]
+WHERE (([g].[Discriminator] = N'Officer') OR ([g].[Discriminator] = N'Gear')) AND [g].[CityOrBirthName] IN (N'Ephyra', N'Hanover')
+
+@_outer_FullName: Augustus Cole (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND ((@_outer_FullName = [w].[OwnerFullName]) AND [w].[OwnerFullName] IS NOT NULL)
+
+@_outer_FullName: Dominic Santiago (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND ((@_outer_FullName = [w].[OwnerFullName]) AND [w].[OwnerFullName] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Select_correlated_filtered_collection_with_composite_key()
+        {
+            base.Select_correlated_filtered_collection_with_composite_key();
+
+            Assert.Equal(
+                @"SELECT [t].[Nickname], [t].[SquadId]
+FROM (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] = N'Officer'
+) AS [t]
+
+@_outer_Nickname: Baird (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
+FROM [Gear] AS [r]
+WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom')) AND ((@_outer_Nickname = [r].[LeaderNickname]) AND (@_outer_SquadId = [r].[LeaderSquadId]))
+
+@_outer_Nickname: Marcus (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
+FROM [Gear] AS [r]
+WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom')) AND ((@_outer_Nickname = [r].[LeaderNickname]) AND (@_outer_SquadId = [r].[LeaderSquadId]))",
+                Sql);
+        }
+
+        public override void Select_correlated_filtered_collection_works_with_caching()
+        {
+            base.Select_correlated_filtered_collection_works_with_caching();
+
+            Assert.Contains(
+                @"SELECT [t].[GearNickName]
+FROM [CogTag] AS [t]",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_GearNickName: Cole Train (Size = 450)
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[Nickname] IS NULL",
+                Sql);
+        }
+
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -41,18 +41,27 @@ ORDER BY [od].[OrderID], [od].[ProductID], [od.Order].[CustomerID]",
         {
             base.Take_Select_Navigation();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
 FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
 ) AS [t]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-",
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -71,6 +80,7 @@ SELECT (
 FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
 ) AS [t]",
                 Sql);
         }
@@ -90,6 +100,7 @@ SELECT (
 FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
 ) AS [t]",
                 Sql);
         }
@@ -98,20 +109,27 @@ FROM (
         {
             base.Select_collection_FirstOrDefault_project_anonymous_type();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
 FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
 ) AS [t]
 
-SELECT [o].[CustomerID], [o].[OrderID]
-FROM [Orders] AS [o]
+@_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o].[CustomerID], [o].[OrderID]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -119,20 +137,27 @@ FROM [Orders] AS [o]",
         {
             base.Select_collection_FirstOrDefault_project_entity();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"@__p_0: 2
 
 SELECT [t].[CustomerID]
 FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
 ) AS [t]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
+@_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -367,18 +392,31 @@ WHERE [e].[ReportsTo] IS NULL",
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%'
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANTON (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: AROUT (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -501,9 +539,19 @@ FROM [Customers] AS [c]",
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]",
+FROM [Orders] AS [o1]
+WHERE @_outer_CustomerID = [o1].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM [Orders] AS [o1]
+WHERE @_outer_CustomerID = [o1].[CustomerID]",
                 Sql);
         }
 
@@ -528,9 +576,19 @@ WHERE NOT EXISTS (
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -678,13 +736,22 @@ WHERE (
         {
             base.Collection_select_nav_prop_first_or_default();
 
-            // TODO: Projection sub-query lifting
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -692,22 +759,26 @@ FROM [Orders] AS [o]",
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop();
 
-            // TODO: Projection sub-query lifting
             Assert.StartsWith(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
 WHERE [e].[CustomerID] LIKE N'A' + N'%'
+ORDER BY [e].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
-WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
 ORDER BY [e0].[CustomerID]
 
+@_outer_CustomerID: ANATR (Size = 450)
+
 SELECT [e0].[OrderID], [e0].[CustomerID], [e0].[EmployeeID], [e0].[OrderDate], [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
-WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011)
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
 ORDER BY [e0].[CustomerID]",
                 Sql);
         }
@@ -898,17 +969,29 @@ WHERE EXISTS (
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
-SELECT [o3].[OrderID]
-FROM [Orders] AS [o3]
+SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]
 
-SELECT [o2].[CustomerID], [o2].[OrderID]
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o2].[OrderID]
 FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID = [o2].[CustomerID]
 
-SELECT [o3].[OrderID]
-FROM [Orders] AS [o3]",
+SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o2].[OrderID]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID = [o2].[CustomerID]
+
+SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]",
                 Sql);
-
         }
 
         public override void Navigation_in_subquery_referencing_outer_query()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -164,12 +164,31 @@ WHERE [e1].[FirstName] = (
         {
             base.Where_query_composition_is_null();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
                 Sql);
         }
 
@@ -177,12 +196,31 @@ FROM [Employees] AS [e2]",
         {
             base.Where_query_composition_is_null();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
                 Sql);
         }
 
@@ -190,12 +228,31 @@ FROM [Employees] AS [e2]",
         {
             base.Where_query_composition_entity_equality_one_element_SingleOrDefault();
 
-            Assert.StartsWith(
+            Assert.Contains(
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+FROM [Employees] AS [e1]",
+                Sql);
 
-SELECT [e20].[EmployeeID]
-FROM [Employees] AS [e20]",
+            Assert.Contains(
+                @"@_outer_ReportsTo: 2 (Nullable = true)
+
+SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"@_outer_ReportsTo: 5 (Nullable = true)
+
+SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT TOP(2) [e20].[EmployeeID]
+FROM [Employees] AS [e20]
+WHERE [e20].[EmployeeID] IS NULL",
                 Sql);
         }
 
@@ -296,11 +353,17 @@ WHERE [e].[Title] = (
 SELECT TOP(@__p_0) [od].[OrderID]
 FROM [Order Details] AS [od]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
+@_outer_OrderID: 10285
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]
+
+@_outer_OrderID: 10294
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
                 Sql);
         }
 
@@ -312,11 +375,17 @@ FROM [Orders] AS [o]",
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
 
-SELECT [o0].[OrderID], [o0].[CustomerID]
-FROM [Orders] AS [o0]
+@_outer_OrderID: 10248
 
-SELECT [c2].[CustomerID], [c2].[City]
-FROM [Customers] AS [c2]",
+SELECT TOP(2) [o0].[CustomerID]
+FROM [Orders] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]
+
+@_outer_CustomerID1: VINET (Size = 450)
+
+SELECT TOP(2) [c2].[City]
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID1 = [c2].[CustomerID]",
                 Sql);
         }
 
@@ -363,9 +432,28 @@ FROM (
 SELECT [c5].[CustomerID], [c5].[Country]
 FROM [Customers] AS [c5]
 
-SELECT [o23].[OrderID], [c6].[Country]
+@_outer_OrderID1: 10285
+
+SELECT TOP(1) [c6].[Country]
 FROM [Orders] AS [o23]
-INNER JOIN [Customers] AS [c6] ON [o23].[CustomerID] = [c6].[CustomerID]",
+INNER JOIN [Customers] AS [c6] ON [o23].[CustomerID] = [c6].[CustomerID]
+WHERE [o23].[OrderID] = @_outer_OrderID1
+
+SELECT [c5].[CustomerID], [c5].[Country]
+FROM [Customers] AS [c5]
+
+@_outer_OrderID1: 10294
+
+SELECT TOP(1) [c6].[Country]
+FROM [Orders] AS [o23]
+INNER JOIN [Customers] AS [c6] ON [o23].[CustomerID] = [c6].[CustomerID]
+WHERE [o23].[OrderID] = @_outer_OrderID1
+
+SELECT [t1].[OrderID]
+FROM (
+    SELECT TOP(2) [o4].[OrderID], [o4].[ProductID], [o4].[Discount], [o4].[Quantity], [o4].[UnitPrice]
+    FROM [Order Details] AS [o4]
+) AS [t1]",
                 Sql);
         }
 
@@ -409,9 +497,19 @@ WHERE EXISTS (
             Assert.StartsWith(
                 @"SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
+ORDER BY [c1].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
-FROM [Customers] AS [c2]",
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID = [c2].[CustomerID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+FROM [Customers] AS [c2]
+WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 Sql);
         }
 
@@ -445,9 +543,27 @@ ORDER BY [o].[OrderID]",
     END
 )
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o1]
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o1]
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
                 Sql);
         }
 
@@ -3095,20 +3211,20 @@ ORDER BY [c].[CustomerID]",
         {
             base.SelectMany_Joined_DefaultIfEmpty();
 
-            Assert.StartsWith(
-                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[ContactName]
+            Assert.Equal(
+                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty0]
+    ) AS [empty10]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t1]",
+    ) AS [t1] ON 1 = 1
+) AS [t2]",
                 Sql);
         }
 
@@ -3116,20 +3232,20 @@ CROSS APPLY (
         {
             base.SelectMany_Joined_DefaultIfEmpty2();
 
-            Assert.StartsWith(
-                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+            Assert.Equal(
+                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty0]
+    ) AS [empty10]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t1]",
+    ) AS [t1] ON 1 = 1
+) AS [t2]",
                 Sql);
         }
 
@@ -4300,6 +4416,11 @@ FROM [Customers] AS [c0]",
                 Sql);
         }
 
+        public override void Select_nested_collection_deep()
+        {
+            base.Select_nested_collection_deep();
+        }
+
         public override void Where_math_power()
         {
             base.Where_math_power();
@@ -4654,18 +4775,53 @@ WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar, CONVERT(nvarchar, [o]
         {
             base.Select_nested_collection();
 
-            Assert.StartsWith(
+            Assert.Equal(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[City] = N'London'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderID]
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID]
 FROM [Orders] AS [o]
-WHERE DATEPART(year, [o].[OrderDate]) = 1997
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]
 
-",
+@_outer_CustomerID: BSBEV (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: CONSH (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: EASTC (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: NORTS (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: SEVES (Size = 450)
+
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 
@@ -4676,11 +4832,19 @@ ORDER BY [o].[OrderID]
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID
 
-",
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID",
                 Sql);
         }
 
@@ -5335,9 +5499,19 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
 )
 FROM [Customers] AS [e]
 WHERE [e].[ContactTitle] = N'Owner'
+ORDER BY [e].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]",
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 


### PR DESCRIPTION
Fix is to allow more queries to be translated to SQL, specifically subqueries that are correlated with outer query, e.g.

customers.Select(c => c.Orders.FirstOrDefault())

would be translated to:

customers.Select(c => orders.Where(o => o.CustomerId == c.Id).FirstOrDefault())

This would previously produce outer query to fetch all the customers and for each customer another query, fetching ALL the orders each time filtering out the orders for each customer and returning only the first one on the client (because we didn't know how to handle o.CustomerId in this case)

With this change we will convert o.CustomerId into a SQL parameter, whose value is set for each iteration of the outer query - this can be easily translated to SQL and produce much more efficient queries:

SELECT [t].[CustomerID]
FROM [Customers] AS [c]

@_outer_CustomerID: ALFKI (Size = 450)

SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
FROM [Orders] AS [o]
WHERE @_outer_CustomerID = [o].[CustomerID]

We achieve this by introducing a new query method that creates additional parameters before enumerating it's source, and then removing those parameters after all elements have been enumerated or the enumerator has been disposed.
This way we make sure that the additional parameters only exist in the scope that the inner query is executed.

This also forces some changes in the CommandCache - we used QueryContext.ParameterValues as cache key, but since now the parameter values are modified during query execution we need to rely on cloning them at and used the cloned values as the cache key.