### PR TITLE
Bring back AddAsync

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerSequenceHiLoValueGenerator.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -53,6 +55,18 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
                 _rawSqlCommandBuilder
                     .Build(_sqlGenerator.GenerateNextSequenceValueOperation(_sequence.Name, _sequence.Schema))
                     .ExecuteScalar(_connection),
+                typeof(long),
+                CultureInfo.InvariantCulture);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override async Task<long> GetNewLowValueAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => (long)Convert.ChangeType(
+                await _rawSqlCommandBuilder
+                    .Build(_sqlGenerator.GenerateNextSequenceValueOperation(_sequence.Name, _sequence.Schema))
+                    .ExecuteScalarAsync(_connection, cancellationToken: cancellationToken),
                 typeof(long),
                 CultureInfo.InvariantCulture);
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IKeyPropagator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IKeyPropagator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -17,5 +19,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         void PropagateValue([NotNull] InternalEntityEntry entry, [NotNull] IProperty property);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Task PropagateValueAsync(
+            [NotNull] InternalEntityEntry entry, 
+            [NotNull] IProperty property,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IValueGenerationManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IValueGenerationManager.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -17,6 +19,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         void Generate([NotNull] InternalEntityEntry entry);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Task GenerateAsync(
+            [NotNull] InternalEntityEntry entry, 
+            CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -8,6 +8,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -69,6 +71,25 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             if (PrepareForAdd(entityState))
             {
                 StateManager.ValueGeneration.Generate(this);
+            }
+
+            SetEntityState(oldState, entityState, acceptChanges);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual async Task SetEntityStateAsync(
+            EntityState entityState, 
+            bool acceptChanges,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var oldState = _stateData.EntityState;
+
+            if (PrepareForAdd(entityState))
+            {
+                await StateManager.ValueGeneration.GenerateAsync(this, cancellationToken);
             }
 
             SetEntityState(oldState, entityState, acceptChanges);

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -10,7 +13,7 @@ using Microsoft.EntityFrameworkCore.ValueGeneration;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ValueGenerationManager : IValueGenerationManager
@@ -19,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly IKeyPropagator _keyPropagator;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ValueGenerationManager(
@@ -31,13 +34,67 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Generate(InternalEntityEntry entry)
         {
             var entityEntry = new EntityEntry(entry);
 
+            foreach (var propertyTuple in FindProperties(entry))
+            {
+                var property = propertyTuple.Item1;
+
+                if (propertyTuple.Item2)
+                {
+                    _keyPropagator.PropagateValue(entry, property);
+                }
+                else
+                {
+                    var valueGenerator = GetValueGenerator(entry, property);
+
+                    SetGeneratedValue(
+                        entry, 
+                        property, 
+                        valueGenerator.Next(entityEntry), 
+                        valueGenerator.GeneratesTemporaryValues);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual async Task GenerateAsync(
+            InternalEntityEntry entry, 
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var entityEntry = new EntityEntry(entry);
+
+            foreach (var propertyTuple in FindProperties(entry))
+            {
+                var property = propertyTuple.Item1;
+
+                if (propertyTuple.Item2)
+                {
+                    _keyPropagator.PropagateValue(entry, property);
+                }
+                else
+                {
+                    var valueGenerator = GetValueGenerator(entry, property);
+
+                    SetGeneratedValue(
+                        entry, 
+                        property, 
+                        await valueGenerator.NextAsync(entityEntry, cancellationToken), 
+                        valueGenerator.GeneratesTemporaryValues);
+                }
+            }
+        }
+
+        private IEnumerable<Tuple<IProperty, bool>> FindProperties(InternalEntityEntry entry)
+        {
             foreach (var property in entry.EntityType.GetProperties())
             {
                 var isForeignKey = property.IsForeignKey();
@@ -45,26 +102,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 if ((property.RequiresValueGenerator || isForeignKey)
                     && property.ClrType.IsDefaultValue(entry[property]))
                 {
-                    if (isForeignKey)
-                    {
-                        _keyPropagator.PropagateValue(entry, property);
-                    }
-                    else
-                    {
-                        var valueGenerator = _valueGeneratorSelector.Select(property, property.IsKey()
-                            ? property.DeclaringEntityType
-                            : entry.EntityType);
-
-                        Debug.Assert(valueGenerator != null);
-
-                        SetGeneratedValue(entry, property, valueGenerator.Next(entityEntry), valueGenerator.GeneratesTemporaryValues);
-                    }
+                    yield return Tuple.Create(property, isForeignKey);
                 }
             }
         }
 
+        private ValueGenerator GetValueGenerator(InternalEntityEntry entry, IProperty property)
+            => _valueGeneratorSelector.Select(property, property.IsKey()
+                ? property.DeclaringEntityType
+                : entry.EntityType);
+
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool MayGetTemporaryValue(IProperty property, IEntityType entityType)

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore
             => _stateManager
                ?? (_stateManager = InternalServiceProvider.GetRequiredService<IStateManager>());
 
-        internal IAsyncQueryProvider QueryProvider 
+        internal IAsyncQueryProvider QueryProvider
             => _queryProvider ?? (_queryProvider = this.GetService<IAsyncQueryProvider>());
 
         private IServiceProvider InternalServiceProvider
@@ -441,6 +441,41 @@ namespace Microsoft.EntityFrameworkCore
             => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Added);
 
         /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entity, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the entity. </typeparam>
+        /// <param name="entity"> The entity to add. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous Add operation. The task result contains the
+        ///     <see cref="EntityEntry{TEntity}" /> for the entity. The entry provides access to change tracking
+        ///     information and operations for the entity.
+        /// </returns>
+        public virtual async Task<EntityEntry<TEntity>> AddAsync<TEntity>(
+            [NotNull] TEntity entity,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where TEntity : class
+        {
+            var entry = EntryWithoutDetectChanges(entity);
+
+            await entry.GetInfrastructure().SetEntityStateAsync(
+                EntityState.Added,
+                acceptChanges: true,
+                cancellationToken: cancellationToken);
+
+            return entry;
+        }
+
+        /// <summary>
         ///     Begins tracking the given entity, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="SaveChanges()" /> is called.
@@ -545,6 +580,39 @@ namespace Microsoft.EntityFrameworkCore
             => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Added);
 
         /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entity, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entity"> The entity to add. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous Add operation. The task result contains the
+        ///     <see cref="EntityEntry" /> for the entity. The entry provides access to change tracking
+        ///     information and operations for the entity.
+        /// </returns>
+        public virtual async Task<EntityEntry> AddAsync(
+            [NotNull] object entity,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var entry = EntryWithoutDetectChanges(entity);
+
+            await entry.GetInfrastructure().SetEntityStateAsync(
+                EntityState.Added,
+                acceptChanges: true,
+                cancellationToken: cancellationToken);
+
+            return entry;
+        }
+
+        /// <summary>
         ///     Begins tracking the given entity, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="SaveChanges()" /> is called.
@@ -639,6 +707,23 @@ namespace Microsoft.EntityFrameworkCore
             => AddRange((IEnumerable<object>)entities);
 
         /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entity, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entities"> The entities to add. </param>
+        /// <returns> A task that represents the asynchronous operation. </returns>
+        public virtual Task AddRangeAsync([NotNull] params object[] entities)
+            => AddRangeAsync((IEnumerable<object>)entities);
+
+        /// <summary>
         ///     Begins tracking the given entities, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="SaveChanges()" /> is called.
@@ -701,6 +786,38 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entities"> The entities to add. </param>
         public virtual void AddRange([NotNull] IEnumerable<object> entities)
             => SetEntityStates(Check.NotNull(entities, nameof(entities)), EntityState.Added);
+
+        /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entity, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entities"> The entities to add. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        /// </returns>
+        public virtual async Task AddRangeAsync(
+            [NotNull] IEnumerable<object> entities,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var stateManager = StateManager;
+
+            foreach (var entity in entities)
+            {
+                await stateManager.GetOrCreateEntry(entity).SetEntityStateAsync(
+                    EntityState.Added,
+                    acceptChanges: true,
+                    cancellationToken: cancellationToken);
+            }
+        }
 
         /// <summary>
         ///     Begins tracking the given entities, and any other reachable entities that are

--- a/src/Microsoft.EntityFrameworkCore/DbSet`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbSet`.cs
@@ -104,6 +104,32 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entity, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entity"> The entity to add. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous Add operation. The task result contains the
+        ///     <see cref="EntityEntry{TEntity}" /> for the entity. The entry provides access to change tracking
+        ///     information and operations for the entity.
+        /// </returns>
+        public virtual Task<EntityEntry<TEntity>> AddAsync(
+            [NotNull] TEntity entity,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         ///     Begins tracking the given entity, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="DbContext.SaveChanges()" /> is called.
@@ -178,6 +204,25 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entities, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entities"> The entities to add. </param>
+        /// <returns> A task that represents the asynchronous operation. </returns>
+        public virtual Task AddRangeAsync([NotNull] params TEntity[] entities)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         ///     Begins tracking the given entities, and any other reachable entities that are
         ///     not already being tracked, in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="DbContext.SaveChanges()" /> is called.
@@ -235,6 +280,28 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
         public virtual void AddRange([NotNull] IEnumerable<TEntity> entities)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Begins tracking the given entities, and any other reachable entities that are
+        ///         not already being tracked, in the <see cref="EntityState.Added" /> state such that they will
+        ///         be inserted into the database when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         This method is async only to allow special value generators, such as the one used by
+        ///         'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo',
+        ///         to access the database asynchronously. For all other cases the non async method should be used.
+        ///     </para>
+        /// </summary>
+        /// <param name="entities"> The entities to add. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns> A task that represents the asynchronous operation. </returns>
+        public virtual Task AddRangeAsync(
+            [NotNull] IEnumerable<TEntity> entities,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.EntityFrameworkCore/Internal/AsyncLock.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/AsyncLock.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public sealed class AsyncLock
+    {
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        private readonly Releaser _releaser;
+        private readonly Task<Releaser> _releaserTask;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public AsyncLock()
+        {
+            _releaser = new Releaser(this);
+            _releaserTask = Task.FromResult(_releaser);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public Task<Releaser> LockAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var wait = _semaphore.WaitAsync(cancellationToken);
+
+            return wait.IsCompleted ?
+                _releaserTask :
+                wait.ContinueWith((_, state) => ((AsyncLock)state)._releaser,
+                    this, CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public Releaser Lock()
+        {
+            _semaphore.Wait();
+
+            return _releaser;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public struct Releaser : IDisposable
+        {
+            private readonly AsyncLock _toRelease;
+
+            internal Releaser([NotNull] AsyncLock toRelease)
+            {
+                _toRelease = toRelease;
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public void Dispose() 
+                => _toRelease._semaphore.Release();
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -48,14 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
-        ///     is being tracked by the context, then it is returned immediately without making a request to the
-        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
-        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
-        ///     null is returned.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
-        /// <returns>The entity found, or null.</returns>
         public override TEntity Find(params object[] keyValues)
         {
             Check.NotNull(keyValues, nameof(keyValues));
@@ -66,27 +61,16 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
-        ///     is being tracked by the context, then it is returned immediately without making a request to the
-        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
-        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
-        ///     null is returned.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
-        /// <returns>The entity found, or null.</returns>
         public override Task<TEntity> FindAsync(params object[] keyValues)
             => FindAsync(keyValues, default(CancellationToken));
 
         /// <summary>
-        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
-        ///     is being tracked by the context, then it is returned immediately without making a request to the
-        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
-        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
-        ///     null is returned.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-        /// <returns>The entity found, or null.</returns>
         public override Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken)
         {
             Check.NotNull(keyValues, nameof(keyValues));
@@ -165,28 +149,38 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override EntityEntry<TEntity> Add(TEntity entity)
-            => _context.Add(Check.NotNull(entity, nameof(entity)));
+            => _context.Add(entity);
+
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Task<EntityEntry<TEntity>> AddAsync(
+            TEntity entity,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => _context.AddAsync(entity, cancellationToken);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override EntityEntry<TEntity> Attach(TEntity entity)
-            => _context.Attach(Check.NotNull(entity, nameof(entity)));
+            => _context.Attach(entity);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override EntityEntry<TEntity> Remove(TEntity entity)
-            => _context.Remove(Check.NotNull(entity, nameof(entity)));
+            => _context.Remove(entity);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override EntityEntry<TEntity> Update(TEntity entity)
-            => _context.Update(Check.NotNull(entity, nameof(entity)));
+            => _context.Update(entity);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -194,7 +188,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public override void AddRange(params TEntity[] entities)
             // ReSharper disable once CoVariantArrayConversion
-            => _context.AddRange(Check.NotNull(entities, nameof(entities)));
+            => _context.AddRange(entities);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Task AddRangeAsync(params TEntity[] entities)
+            // ReSharper disable once CoVariantArrayConversion
+            => _context.AddRangeAsync(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -202,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public override void AttachRange(params TEntity[] entities)
             // ReSharper disable once CoVariantArrayConversion
-            => _context.AttachRange(Check.NotNull(entities, nameof(entities)));
+            => _context.AttachRange(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -210,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public override void RemoveRange(params TEntity[] entities)
             // ReSharper disable once CoVariantArrayConversion
-            => _context.RemoveRange(Check.NotNull(entities, nameof(entities)));
+            => _context.RemoveRange(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -218,35 +220,44 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public override void UpdateRange(params TEntity[] entities)
             // ReSharper disable once CoVariantArrayConversion
-            => _context.UpdateRange(Check.NotNull(entities, nameof(entities)));
+            => _context.UpdateRange(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override void AddRange(IEnumerable<TEntity> entities)
-            => _context.AddRange(Check.NotNull(entities, nameof(entities)));
+            => _context.AddRange(entities);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Task AddRangeAsync(
+            IEnumerable<TEntity> entities,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => _context.AddRangeAsync(entities, cancellationToken);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override void AttachRange(IEnumerable<TEntity> entities)
-            => _context.AttachRange(Check.NotNull(entities, nameof(entities)));
+            => _context.AttachRange(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override void RemoveRange(IEnumerable<TEntity> entities)
-            => _context.RemoveRange(Check.NotNull(entities, nameof(entities)));
+            => _context.RemoveRange(entities);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override void UpdateRange(IEnumerable<TEntity> entities)
-            => _context.UpdateRange(Check.NotNull(entities, nameof(entities)));
+            => _context.UpdateRange(entities);
 
         IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => _entityQueryable.Value.GetEnumerator();
 

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Infrastructure\ModelSource.cs" />
     <Compile Include="Infrastructure\SensitiveDataLogger.cs" />
     <Compile Include="Infrastructure\WarningsConfigurationBuilder.cs" />
+    <Compile Include="Internal\AsyncLock.cs" />
     <Compile Include="Internal\ConcurrencyDetector.cs" />
     <Compile Include="Internal\CurrentDbContext.cs" />
     <Compile Include="Internal\ICurrentDbContext.cs" />

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/HiLoValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/HiLoValueGenerator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -43,9 +45,25 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         public override TValue Next(EntityEntry entry) => _generatorState.Next<TValue>(GetNewLowValue);
 
         /// <summary>
+        ///     Gets a value to be assigned to a property.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The value to be assigned to a property. </returns>
+        public override Task<TValue> NextAsync(
+            EntityEntry entry, CancellationToken cancellationToken = default(CancellationToken)) 
+            => _generatorState.NextAsync<TValue>(GetNewLowValueAsync);
+
+        /// <summary>
         ///     Gets the low value for the next block of values to be used.
         /// </summary>
         /// <returns> The low value for the next block of values to be used. </returns>
         protected abstract long GetNewLowValue();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual Task<long> GetNewLowValueAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(GetNewLowValue());
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
@@ -17,7 +19,8 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// </summary>
         /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        public virtual object Next([NotNull] EntityEntry entry) => NextValue(entry);
+        public virtual object Next([NotNull] EntityEntry entry) 
+            => NextValue(entry);
 
         /// <summary>
         ///     Template method to be overridden by implementations to perform value generation.
@@ -25,6 +28,26 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The generated value. </returns>
         protected abstract object NextValue([NotNull] EntityEntry entry);
+
+        /// <summary>
+        ///     Gets a value to be assigned to a property.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The value to be assigned to a property. </returns>
+        public virtual Task<object> NextAsync(
+            [NotNull] EntityEntry entry, 
+            CancellationToken cancellationToken = default(CancellationToken)) 
+            => NextValueAsync(entry, cancellationToken);
+
+        /// <summary>
+        ///     Template method to be overridden by implementations to perform value generation.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The generated value. </returns>
+        protected virtual Task<object> NextValueAsync(
+            [NotNull] EntityEntry entry, 
+            CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(NextValue(entry));
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGenerator`.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
@@ -19,10 +21,31 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         public new abstract TValue Next([NotNull] EntityEntry entry);
 
         /// <summary>
+        ///     Template method to be overridden by implementations to perform value generation.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The generated value. </returns>
+        public new virtual Task<TValue> NextAsync(
+            [NotNull] EntityEntry entry,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(Next(entry));
+
+        /// <summary>
         ///     Gets a value to be assigned to a property.
         /// </summary>
         /// <para>The change tracking entry of the entity for which the value is being generated.</para>
         /// <returns> The value to be assigned to a property. </returns>
-        protected override object NextValue(EntityEntry entry) => Next(entry);
+        protected override object NextValue(EntityEntry entry)
+            => Next(entry);
+
+        /// <summary>
+        ///     Gets a value to be assigned to a property.
+        /// </summary>
+        /// <para>The change tracking entry of the entity for which the value is being generated.</para>
+        /// <returns> The value to be assigned to a property. </returns>
+        protected override Task<object> NextValueAsync(
+            EntityEntry entry,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult((object)Next(entry));
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -73,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "BroniesAsync"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                await context.Database.EnsureDeletedAsync();
+                await context.Database.EnsureCreatedAsync();
             }
 
             await AddEntitiesAsync(serviceProvider, "BroniesAsync");
@@ -106,8 +106,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 for (var i = 0; i < 10; i++)
                 {
-                    context.Add(new Pegasus { Name = "Rainbow Dash " + i });
-                    context.Add(new Pegasus { Name = "Fluttershy " + i });
+                    await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i });
+                    await context.AddAsync(new Pegasus { Name = "Fluttershy " + i });
                 }
 
                 await context.SaveChangesAsync();
@@ -115,7 +115,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         }
 
         [ConditionalFact]
-        [PlatformSkipCondition(TestPlatform.Mac | TestPlatform.Linux, SkipReason = "Test is flaky on OSX/Linux. See https://github.com/dotnet/corefx/issues/8701")]
         public async Task Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -124,8 +123,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "ManyBronies"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                await context.Database.EnsureDeletedAsync();
+                await context.Database.EnsureCreatedAsync();
             }
 
             const int threadCount = 50;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -20,31 +20,47 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 {
     public class SqlServerSequenceValueGeneratorTest
     {
-        [Fact]
-        public void Generates_sequential_int_values() => Generates_sequential_values<int>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_int_values(bool async) => await Generates_sequential_values<int>(async);
 
-        [Fact]
-        public void Generates_sequential_long_values() => Generates_sequential_values<long>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_long_values(bool async) => await Generates_sequential_values<long>(async);
 
-        [Fact]
-        public void Generates_sequential_short_values() => Generates_sequential_values<short>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_short_values(bool async) => await Generates_sequential_values<short>(async);
 
-        [Fact]
-        public void Generates_sequential_byte_values() => Generates_sequential_values<byte>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_byte_values(bool async) => await Generates_sequential_values<byte>(async);
 
-        [Fact]
-        public void Generates_sequential_uint_values() => Generates_sequential_values<uint>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_uint_values(bool async) => await Generates_sequential_values<uint>(async);
 
-        [Fact]
-        public void Generates_sequential_ulong_values() => Generates_sequential_values<ulong>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_ulong_values(bool async) => await Generates_sequential_values<ulong>(async);
 
-        [Fact]
-        public void Generates_sequential_ushort_values() => Generates_sequential_values<ushort>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_ushort_values(bool async) => await Generates_sequential_values<ushort>(async);
 
-        [Fact]
-        public void Generates_sequential_sbyte_values() => Generates_sequential_values<sbyte>();
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Generates_sequential_sbyte_values(bool async) => await Generates_sequential_values<sbyte>(async);
 
-        public void Generates_sequential_values<TValue>()
+        public async Task Generates_sequential_values<TValue>(bool async)
         {
             const int blockSize = 4;
 
@@ -60,17 +76,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             for (var i = 1; i <= 27; i++)
             {
-                Assert.Equal(i, (int)Convert.ChangeType(generator.Next(null), typeof(int), CultureInfo.InvariantCulture));
+                var value = async
+                    ? await generator.NextAsync(null)
+                    : generator.Next(null);
+
+                Assert.Equal(i, (int)Convert.ChangeType(value, typeof(int), CultureInfo.InvariantCulture));
             }
         }
 
         [Fact]
-        public void Multiple_threads_can_use_the_same_generator_state()
+        public async Task Multiple_threads_can_use_the_same_generator_state()
         {
             const int threadCount = 50;
             const int valueCount = 35;
 
-            var generatedValues = GenerateValuesInMultipleThreads(threadCount, valueCount);
+            var generatedValues = await GenerateValuesInMultipleThreads(threadCount, valueCount);
 
             // Check that each value was generated once and only once
             var checks = new bool[threadCount * valueCount];
@@ -86,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.True(checks.All(c => c));
         }
 
-        private IEnumerable<List<long>> GenerateValuesInMultipleThreads(int threadCount, int valueCount)
+        private async Task<IEnumerable<List<long>>> GenerateValuesInMultipleThreads(int threadCount, int valueCount)
         {
             const int blockSize = 10;
 
@@ -99,25 +119,34 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             var executor = new FakeRawSqlCommandBuilder(blockSize);
             var sqlGenerator = new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerationHelper(), new SqlServerTypeMapper());
 
-            var tests = new Action[threadCount];
+            var tests = new Func<Task>[threadCount];
             var generatedValues = new List<long>[threadCount];
             for (var i = 0; i < tests.Length; i++)
             {
                 var testNumber = i;
                 generatedValues[testNumber] = new List<long>();
-                tests[testNumber] = () =>
+                tests[testNumber] = async () =>
                     {
                         for (var j = 0; j < valueCount; j++)
                         {
                             var connection = CreateConnection(serviceProvider);
                             var generator = new SqlServerSequenceHiLoValueGenerator<long>(executor, sqlGenerator, state, connection);
 
-                            generatedValues[testNumber].Add(generator.Next(null));
+                            var value = j % 2 == 0
+                                ? await generator.NextAsync(null)
+                                : generator.Next(null);
+
+                            generatedValues[testNumber].Add(value);
                         }
                     };
             }
 
-            Parallel.Invoke(tests);
+            var tasks = tests.Select(Task.Run).ToArray();
+
+            foreach (var t in tasks)
+            {
+                await t;
+            }
 
             return generatedValues;
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -383,32 +383,46 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_deleted()
+        public async Task Can_add_existing_entities_to_context_to_be_deleted()
         {
-            TrackEntitiesTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+            await TrackEntitiesTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_new_entities_to_context_with_graph_method()
+        public async Task Can_add_new_entities_to_context_with_graph_method()
         {
-            TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            await TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_attached_with_graph_method()
+        public async Task Can_add_new_entities_to_context_with_graph_method_async()
         {
-            TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesTest((c, e) => c.AddAsync(e), (c, e) => c.AddAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_updated_with_graph_method()
+        public async Task Can_add_existing_entities_to_context_to_be_attached_with_graph_method()
         {
-            TrackEntitiesTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
         }
 
-        private static void TrackEntitiesTest(
+        [Fact]
+        public async Task Can_add_existing_entities_to_context_to_be_updated_with_graph_method()
+        {
+            await TrackEntitiesTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+        }
+
+        private static Task TrackEntitiesTest(
             Func<DbContext, Category, EntityEntry<Category>> categoryAdder,
             Func<DbContext, Product, EntityEntry<Product>> productAdder, EntityState expectedState)
+            => TrackEntitiesTest(
+                (c, e) => Task.FromResult(categoryAdder(c, e)),
+                (c, e) => Task.FromResult(productAdder(c, e)),
+                expectedState);
+
+        private static async Task TrackEntitiesTest(
+            Func<DbContext, Category, Task<EntityEntry<Category>>> categoryAdder,
+            Func<DbContext, Product, Task<EntityEntry<Product>>> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
@@ -417,10 +431,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var product1 = new Product { Id = 1, Name = "Marmite", Price = 7.99m };
                 var product2 = new Product { Id = 2, Name = "Bovril", Price = 4.99m };
 
-                var categoryEntry1 = categoryAdder(context, category1);
-                var categoryEntry2 = categoryAdder(context, category2);
-                var productEntry1 = productAdder(context, product1);
-                var productEntry2 = productAdder(context, product2);
+                var categoryEntry1 = await categoryAdder(context, category1);
+                var categoryEntry2 = await categoryAdder(context, category2);
+                var productEntry1 = await productAdder(context, product1);
+                var productEntry2 = await productAdder(context, product2);
 
                 Assert.Same(category1, categoryEntry1.Entity);
                 Assert.Same(category2, categoryEntry2.Entity);
@@ -445,32 +459,54 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_multiple_new_entities_to_context()
+        public async Task Can_add_multiple_new_entities_to_context()
         {
-            TrackMultipleEntitiesTest((c, e) => c.AddRange(e[0], e[1]), (c, e) => c.AddRange(e[0], e[1]), EntityState.Added);
+            await TrackMultipleEntitiesTest((c, e) => c.AddRange(e[0], e[1]), (c, e) => c.AddRange(e[0], e[1]), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_attached()
+        public async Task Can_add_multiple_new_entities_to_context_async()
         {
-            TrackMultipleEntitiesTest((c, e) => c.AttachRange(e[0], e[1]), (c, e) => c.AttachRange(e[0], e[1]), EntityState.Unchanged);
+            await TrackMultipleEntitiesTest((c, e) => c.AddRangeAsync(e[0], e[1]), (c, e) => c.AddRangeAsync(e[0], e[1]), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_updated()
+        public async Task Can_add_multiple_existing_entities_to_context_to_be_attached()
         {
-            TrackMultipleEntitiesTest((c, e) => c.UpdateRange(e[0], e[1]), (c, e) => c.UpdateRange(e[0], e[1]), EntityState.Modified);
+            await TrackMultipleEntitiesTest((c, e) => c.AttachRange(e[0], e[1]), (c, e) => c.AttachRange(e[0], e[1]), EntityState.Unchanged);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_deleted()
+        public async Task Can_add_multiple_existing_entities_to_context_to_be_updated()
         {
-            TrackMultipleEntitiesTest((c, e) => c.RemoveRange(e[0], e[1]), (c, e) => c.RemoveRange(e[0], e[1]), EntityState.Deleted);
+            await TrackMultipleEntitiesTest((c, e) => c.UpdateRange(e[0], e[1]), (c, e) => c.UpdateRange(e[0], e[1]), EntityState.Modified);
         }
 
-        private static void TrackMultipleEntitiesTest(
+        [Fact]
+        public async Task Can_add_multiple_existing_entities_to_context_to_be_deleted()
+        {
+            await TrackMultipleEntitiesTest((c, e) => c.RemoveRange(e[0], e[1]), (c, e) => c.RemoveRange(e[0], e[1]), EntityState.Deleted);
+        }
+
+        private static Task TrackMultipleEntitiesTest(
             Action<DbContext, object[]> categoryAdder,
             Action<DbContext, object[]> productAdder, EntityState expectedState)
+            => TrackMultipleEntitiesTest(
+                (c, e) =>
+                    {
+                        categoryAdder(c, e);
+                        return Task.FromResult(0);
+                    },
+                (c, e) =>
+                    {
+                        productAdder(c, e);
+                        return Task.FromResult(0);
+                    },
+                expectedState);
+
+        private static async Task TrackMultipleEntitiesTest(
+            Func<DbContext, object[], Task> categoryAdder,
+            Func<DbContext, object[], Task> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
@@ -479,8 +515,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var product1 = new Product { Id = 1, Name = "Marmite", Price = 7.99m };
                 var product2 = new Product { Id = 2, Name = "Bovril", Price = 4.99m };
 
-                categoryAdder(context, new[] { category1, category2 });
-                productAdder(context, new[] { product1, product2 });
+                await categoryAdder(context, new[] { category1, category2 });
+                await productAdder(context, new[] { product1, product2 });
 
                 Assert.Same(category1, context.Entry(category1).Entity);
                 Assert.Same(category2, context.Entry(category2).Entity);
@@ -500,41 +536,55 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_deleted()
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_deleted()
         {
-            TrackEntitiesDefaultValueTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+            await TrackEntitiesDefaultValueTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_new_entities_with_default_value_to_context_with_graph_method()
+        public async Task Can_add_new_entities_with_default_value_to_context_with_graph_method()
         {
-            TrackEntitiesDefaultValueTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            await TrackEntitiesDefaultValueTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_attached_with_graph_method()
+        public async Task Can_add_new_entities_with_default_value_to_context_with_graph_method_async()
         {
-            TrackEntitiesDefaultValueTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesDefaultValueTest((c, e) => c.AddAsync(e), (c, e) => c.AddAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_updated_with_graph_method()
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_attached_with_graph_method()
         {
-            TrackEntitiesDefaultValueTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesDefaultValueTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
         }
 
-        // Issue #3890
-        private static void TrackEntitiesDefaultValueTest(
+        [Fact]
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_updated_with_graph_method()
+        {
+            await TrackEntitiesDefaultValueTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+        }
+
+        private static Task TrackEntitiesDefaultValueTest(
             Func<DbContext, Category, EntityEntry<Category>> categoryAdder,
             Func<DbContext, Product, EntityEntry<Product>> productAdder, EntityState expectedState)
+            => TrackEntitiesDefaultValueTest(
+                (c, e) => Task.FromResult(categoryAdder(c, e)),
+                (c, e) => Task.FromResult(productAdder(c, e)),
+                expectedState);
+
+        // Issue #3890
+        private static async Task TrackEntitiesDefaultValueTest(
+            Func<DbContext, Category, Task<EntityEntry<Category>>> categoryAdder,
+            Func<DbContext, Product, Task<EntityEntry<Product>>> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
                 var category1 = new Category { Id = 0, Name = "Beverages" };
                 var product1 = new Product { Id = 0, Name = "Marmite", Price = 7.99m };
 
-                var categoryEntry1 = categoryAdder(context, category1);
-                var productEntry1 = productAdder(context, product1);
+                var categoryEntry1 = await categoryAdder(context, category1);
+                var productEntry1 = await productAdder(context, product1);
 
                 Assert.Same(category1, categoryEntry1.Entity);
                 Assert.Same(product1, productEntry1.Entity);
@@ -551,41 +601,63 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_multiple_new_entities_with_default_values_to_context()
+        public async Task Can_add_multiple_new_entities_with_default_values_to_context()
         {
-            TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AddRange(e[0]), (c, e) => c.AddRange(e[0]), EntityState.Added);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AddRange(e[0]), (c, e) => c.AddRange(e[0]), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached()
+        public async Task Can_add_multiple_new_entities_with_default_values_to_context_async()
         {
-            TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AttachRange(e[0]), (c, e) => c.AttachRange(e[0]), EntityState.Unchanged);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AddRangeAsync(e[0]), (c, e) => c.AddRangeAsync(e[0]), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated()
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached()
         {
-            TrackMultipleEntitiesDefaultValuesTest((c, e) => c.UpdateRange(e[0]), (c, e) => c.UpdateRange(e[0]), EntityState.Modified);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AttachRange(e[0]), (c, e) => c.AttachRange(e[0]), EntityState.Unchanged);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_deleted()
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated()
         {
-            TrackMultipleEntitiesDefaultValuesTest((c, e) => c.RemoveRange(e[0]), (c, e) => c.RemoveRange(e[0]), EntityState.Deleted);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.UpdateRange(e[0]), (c, e) => c.UpdateRange(e[0]), EntityState.Modified);
         }
 
-        // Issue #3890
-        private static void TrackMultipleEntitiesDefaultValuesTest(
+        [Fact]
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_deleted()
+        {
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.RemoveRange(e[0]), (c, e) => c.RemoveRange(e[0]), EntityState.Deleted);
+        }
+
+        private static Task TrackMultipleEntitiesDefaultValuesTest(
             Action<DbContext, object[]> categoryAdder,
             Action<DbContext, object[]> productAdder, EntityState expectedState)
+            => TrackMultipleEntitiesDefaultValuesTest(
+                (c, e) =>
+                {
+                    categoryAdder(c, e);
+                    return Task.FromResult(0);
+                },
+                (c, e) =>
+                {
+                    productAdder(c, e);
+                    return Task.FromResult(0);
+                },
+                expectedState);
+
+        // Issue #3890
+        private static async Task TrackMultipleEntitiesDefaultValuesTest(
+            Func<DbContext, object[], Task> categoryAdder,
+            Func<DbContext, object[], Task> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
                 var category1 = new Category { Id = 0, Name = "Beverages" };
                 var product1 = new Product { Id = 0, Name = "Marmite", Price = 7.99m };
 
-                categoryAdder(context, new[] { category1 });
-                productAdder(context, new[] { product1 });
+                await categoryAdder(context, new[] { category1 });
+                await productAdder(context, new[] { product1 });
 
                 Assert.Same(category1, context.Entry(category1).Entity);
                 Assert.Same(product1, context.Entry(product1).Entity);
@@ -602,6 +674,17 @@ namespace Microsoft.EntityFrameworkCore.Tests
         public void Can_add_no_new_entities_to_context()
         {
             TrackNoEntitiesTest(c => c.AddRange(), c => c.AddRange());
+        }
+
+        [Fact]
+        public async Task Can_add_no_new_entities_to_context_async()
+        {
+            using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
+            {
+                await context.AddRangeAsync();
+                await context.AddRangeAsync();
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
         }
 
         [Fact]
@@ -633,32 +716,46 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_deleted_non_generic()
+        public async Task Can_add_existing_entities_to_context_to_be_deleted_non_generic()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+            await TrackEntitiesTestNonGeneric((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_new_entities_to_context_non_generic_graph()
+        public async Task Can_add_new_entities_to_context_non_generic_graph()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            await TrackEntitiesTestNonGeneric((c, e) => c.AddAsync(e), (c, e) => c.AddAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_attached_non_generic_graph()
+        public async Task Can_add_new_entities_to_context_non_generic_graph_async()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_to_context_to_be_updated_non_generic_graph()
+        public async Task Can_add_existing_entities_to_context_to_be_attached_non_generic_graph()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
         }
 
-        private static void TrackEntitiesTestNonGeneric(
+        [Fact]
+        public async Task Can_add_existing_entities_to_context_to_be_updated_non_generic_graph()
+        {
+            await TrackEntitiesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+        }
+
+        private static Task TrackEntitiesTestNonGeneric(
             Func<DbContext, object, EntityEntry> categoryAdder,
             Func<DbContext, object, EntityEntry> productAdder, EntityState expectedState)
+            => TrackEntitiesTestNonGeneric(
+                (c, e) => Task.FromResult(categoryAdder(c, e)),
+                (c, e) => Task.FromResult(productAdder(c, e)),
+                expectedState);
+
+        private static async Task TrackEntitiesTestNonGeneric(
+            Func<DbContext, object, Task<EntityEntry>> categoryAdder,
+            Func<DbContext, object, Task<EntityEntry>> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
@@ -667,10 +764,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var product1 = new Product { Id = 1, Name = "Marmite", Price = 7.99m };
                 var product2 = new Product { Id = 2, Name = "Bovril", Price = 4.99m };
 
-                var categoryEntry1 = categoryAdder(context, category1);
-                var categoryEntry2 = categoryAdder(context, category2);
-                var productEntry1 = productAdder(context, product1);
-                var productEntry2 = productAdder(context, product2);
+                var categoryEntry1 = await categoryAdder(context, category1);
+                var categoryEntry2 = await categoryAdder(context, category2);
+                var productEntry1 = await productAdder(context, product1);
+                var productEntry2 = await productAdder(context, product2);
 
                 Assert.Same(category1, categoryEntry1.Entity);
                 Assert.Same(category2, categoryEntry2.Entity);
@@ -695,32 +792,54 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_deleted_Enumerable()
+        public async Task Can_add_multiple_existing_entities_to_context_to_be_deleted_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e), EntityState.Deleted);
+            await TrackMultipleEntitiesTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_multiple_new_entities_to_context_Enumerable_graph()
+        public async Task Can_add_multiple_new_entities_to_context_Enumerable_graph()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e), EntityState.Added);
+            await TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_attached_Enumerable_graph()
+        public async Task Can_add_multiple_new_entities_to_context_Enumerable_graph_async()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
+            await TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRangeAsync(e), (c, e) => c.AddRangeAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_to_context_to_be_updated_Enumerable_graph()
+        public async Task  Can_add_multiple_existing_entities_to_context_to_be_attached_Enumerable_graph()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+            await TrackMultipleEntitiesTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
         }
 
-        private static void TrackMultipleEntitiesTestEnumerable(
+        [Fact]
+        public async Task Can_add_multiple_existing_entities_to_context_to_be_updated_Enumerable_graph()
+        {
+            await TrackMultipleEntitiesTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+        }
+
+        private static Task TrackMultipleEntitiesTestEnumerable(
             Action<DbContext, IEnumerable<object>> categoryAdder,
             Action<DbContext, IEnumerable<object>> productAdder, EntityState expectedState)
+            => TrackMultipleEntitiesTestEnumerable(
+                (c, e) =>
+                    {
+                        categoryAdder(c, e);
+                        return Task.FromResult(0);
+                    },
+                (c, e) =>
+                    {
+                        productAdder(c, e);
+                        return Task.FromResult(0);
+                    },
+                expectedState);
+        
+        private static async Task TrackMultipleEntitiesTestEnumerable(
+            Func<DbContext, IEnumerable<object>, Task> categoryAdder,
+            Func<DbContext, IEnumerable<object>, Task> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
@@ -729,8 +848,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var product1 = new Product { Id = 1, Name = "Marmite", Price = 7.99m };
                 var product2 = new Product { Id = 2, Name = "Bovril", Price = 4.99m };
 
-                categoryAdder(context, new List<Category> { category1, category2 });
-                productAdder(context, new List<Product> { product1, product2 });
+                await categoryAdder(context, new List<Category> { category1, category2 });
+                await productAdder(context, new List<Product> { product1, product2 });
 
                 Assert.Same(category1, context.Entry(category1).Entity);
                 Assert.Same(category2, context.Entry(category2).Entity);
@@ -750,41 +869,55 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_deleted_non_generic()
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_deleted_non_generic()
         {
-            TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_new_entities_with_default_value_to_context_non_generic_graph()
+        public async Task Can_add_new_entities_with_default_value_to_context_non_generic_graph()
         {
-            TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_attached_non_generic_graph()
+        public async Task Can_add_new_entities_with_default_value_to_context_non_generic_graph_async()
         {
-            TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.AddAsync(e), (c, e) => c.AddAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_existing_entities_with_default_value_to_context_to_be_updated_non_generic_graph()
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_attached_non_generic_graph()
         {
-            TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
         }
 
-        // Issue #3890
-        private static void TrackEntitiesDefaultValuesTestNonGeneric(
+        [Fact]
+        public async Task Can_add_existing_entities_with_default_value_to_context_to_be_updated_non_generic_graph()
+        {
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+        }
+
+        private static Task TrackEntitiesDefaultValuesTestNonGeneric(
             Func<DbContext, object, EntityEntry> categoryAdder,
             Func<DbContext, object, EntityEntry> productAdder, EntityState expectedState)
+            => TrackEntitiesDefaultValuesTestNonGeneric(
+                (c, e) => Task.FromResult(categoryAdder(c, e)),
+                (c, e) => Task.FromResult(productAdder(c, e)),
+                expectedState);
+
+        // Issue #3890
+        private static async Task TrackEntitiesDefaultValuesTestNonGeneric(
+            Func<DbContext, object, Task<EntityEntry>> categoryAdder,
+            Func<DbContext, object, Task<EntityEntry>> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
                 var category1 = new Category { Id = 0, Name = "Beverages" };
                 var product1 = new Product { Id = 0, Name = "Marmite", Price = 7.99m };
 
-                var categoryEntry1 = categoryAdder(context, category1);
-                var productEntry1 = productAdder(context, product1);
+                var categoryEntry1 = await categoryAdder(context, category1);
+                var productEntry1 = await productAdder(context, product1);
 
                 Assert.Same(category1, categoryEntry1.Entity);
                 Assert.Same(product1, productEntry1.Entity);
@@ -801,41 +934,63 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_deleted_Enumerable()
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_deleted_Enumerable()
         {
-            TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e), EntityState.Deleted);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e), EntityState.Deleted);
         }
 
         [Fact]
-        public void Can_add_multiple_new_entities_with_default_values_to_context_Enumerable_graph()
+        public async Task Can_add_multiple_new_entities_with_default_values_to_context_Enumerable_graph()
         {
-            TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e), EntityState.Added);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached_Enumerable_graph()
+        public async Task Can_add_multiple_new_entities_with_default_values_to_context_Enumerable_graph_async()
         {
-            TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AddRangeAsync(e), (c, e) => c.AddRangeAsync(e), EntityState.Added);
         }
 
         [Fact]
-        public void Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated_Enumerable_graph()
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached_Enumerable_graph()
         {
-            TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
         }
 
-        // Issue #3890
-        private static void TrackMultipleEntitiesDefaultValueTestEnumerable(
+        [Fact]
+        public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated_Enumerable_graph()
+        {
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+        }
+
+        private static Task TrackMultipleEntitiesDefaultValueTestEnumerable(
             Action<DbContext, IEnumerable<object>> categoryAdder,
             Action<DbContext, IEnumerable<object>> productAdder, EntityState expectedState)
+            => TrackMultipleEntitiesDefaultValueTestEnumerable(
+                (c, e) =>
+                {
+                    categoryAdder(c, e);
+                    return Task.FromResult(0);
+                },
+                (c, e) =>
+                {
+                    productAdder(c, e);
+                    return Task.FromResult(0);
+                },
+                expectedState);
+
+        // Issue #3890
+        private static async Task TrackMultipleEntitiesDefaultValueTestEnumerable(
+            Func<DbContext, IEnumerable<object>, Task> categoryAdder,
+            Func<DbContext, IEnumerable<object>, Task> productAdder, EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
                 var category1 = new Category { Id = 0, Name = "Beverages" };
                 var product1 = new Product { Id = 0, Name = "Marmite", Price = 7.99m };
 
-                categoryAdder(context, new List<Category> { category1 });
-                productAdder(context, new List<Product> { product1 });
+                await categoryAdder(context, new List<Category> { category1 });
+                await productAdder(context, new List<Product> { product1 });
 
                 Assert.Same(category1, context.Entry(category1).Entity);
                 Assert.Same(product1, context.Entry(product1).Entity);
@@ -858,6 +1013,17 @@ namespace Microsoft.EntityFrameworkCore.Tests
         public void Can_add_no_new_entities_to_context_Enumerable_graph()
         {
             TrackNoEntitiesTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e));
+        }
+
+        [Fact]
+        public async Task Can_add_no_new_entities_to_context_Enumerable_graph_async()
+        {
+            using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
+            {
+                await context.AddRangeAsync(new HashSet<Category>());
+                await context.AddRangeAsync(new HashSet<Product>());
+                Assert.Empty(context.ChangeTracker.Entries());
+            }
         }
 
         [Fact]
@@ -884,21 +1050,27 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
         }
 
-        [Fact]
-        public void Can_add_new_entities_to_context_with_key_generation_graph()
-        {
-            TrackEntitiesWithKeyGenerationTest((c, e) => c.Add(e).Entity);
-        }
-
-        private static void TrackEntitiesWithKeyGenerationTest(Func<DbContext, TheGu, TheGu> adder)
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Can_add_new_entities_to_context_with_key_generation_graph(bool async)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
                 var gu1 = new TheGu { ShirtColor = "Red" };
                 var gu2 = new TheGu { ShirtColor = "Still Red" };
 
-                Assert.Same(gu1, adder(context, gu1));
-                Assert.Same(gu2, adder(context, gu2));
+                if (async)
+                {
+                    Assert.Same(gu1, (await context.AddAsync(gu1)).Entity);
+                    Assert.Same(gu2, (await context.AddAsync(gu2)).Entity);
+                }
+                else
+                {
+                    Assert.Same(gu1, context.Add(gu1).Entity);
+                    Assert.Same(gu2, context.Add(gu2).Entity);
+                }
+
                 Assert.NotEqual(default(Guid), gu1.Id);
                 Assert.NotEqual(default(Guid), gu2.Id);
                 Assert.NotEqual(gu1.Id, gu2.Id);
@@ -914,46 +1086,71 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Can_use_Remove_to_change_entity_state()
+        public async Task Can_use_Remove_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Detached, EntityState.Deleted);
-            ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Unchanged, EntityState.Deleted);
-            ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Deleted, EntityState.Deleted);
-            ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Modified, EntityState.Deleted);
-            ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Added, EntityState.Detached);
+            await ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Detached, EntityState.Deleted);
+            await ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Unchanged, EntityState.Deleted);
+            await ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Deleted, EntityState.Deleted);
+            await ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Modified, EntityState.Deleted);
+            await ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Added, EntityState.Detached);
         }
 
         [Fact]
-        public void Can_use_graph_Add_to_change_entity_state()
+        public async Task Can_use_graph_Add_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Detached, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Unchanged, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Deleted, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Modified, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Added, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Detached, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Unchanged, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Deleted, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Modified, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Added, EntityState.Added);
         }
 
         [Fact]
-        public void Can_use_graph_Attach_to_change_entity_state()
+        public async Task Can_use_graph_Add_to_change_entity_state_async()
         {
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Detached, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Unchanged, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Deleted, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Modified, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Added, EntityState.Unchanged);
+            await ChangeStateWithMethod((c, e) => c.AddAsync(e), EntityState.Detached, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.AddAsync(e), EntityState.Unchanged, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.AddAsync(e), EntityState.Deleted, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.AddAsync(e), EntityState.Modified, EntityState.Added);
+            await ChangeStateWithMethod((c, e) => c.AddAsync(e), EntityState.Added, EntityState.Added);
         }
 
         [Fact]
-        public void Can_use_graph_Update_to_change_entity_state()
+        public async Task Can_use_graph_Attach_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Detached, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Unchanged, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Deleted, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Modified, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Added, EntityState.Modified);
+            await ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Detached, EntityState.Unchanged);
+            await ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Unchanged, EntityState.Unchanged);
+            await ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Deleted, EntityState.Unchanged);
+            await ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Modified, EntityState.Unchanged);
+            await ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Added, EntityState.Unchanged);
         }
 
-        private void ChangeStateWithMethod(Action<DbContext, object> action, EntityState initialState, EntityState expectedState)
+        [Fact]
+        public async Task Can_use_graph_Update_to_change_entity_state()
+        {
+            await ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Detached, EntityState.Modified);
+            await ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Unchanged, EntityState.Modified);
+            await ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Deleted, EntityState.Modified);
+            await ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Modified, EntityState.Modified);
+            await ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Added, EntityState.Modified);
+        }
+
+        private Task ChangeStateWithMethod(
+            Action<DbContext, object> action,
+            EntityState initialState,
+            EntityState expectedState)
+            => ChangeStateWithMethod((c, e) =>
+                {
+                    action(c, e);
+                    return Task.FromResult(0);
+                },
+                initialState,
+                expectedState);
+
+        private async Task ChangeStateWithMethod(
+            Func<DbContext, object, Task> action,
+            EntityState initialState,
+            EntityState expectedState)
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
@@ -962,7 +1159,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 entry.State = initialState;
 
-                action(context, entity);
+                await action(context, entity);
 
                 Assert.Equal(expectedState, entry.State);
             }
@@ -4813,7 +5010,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Add_Attach_Remove_Update_do_not_call_DetectChanges()
+        public async Task Add_Attach_Remove_Update_do_not_call_DetectChanges()
         {
             var provider = TestHelpers.Instance.CreateServiceProvider(new ServiceCollection().AddScoped<IChangeDetector, ChangeDetectorProxy>());
             using (var context = new ButTheHedgehogContext(provider))
@@ -4830,6 +5027,12 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 context.AddRange(new Product { Id = id++, Name = "Little Hedgehogs" });
                 context.AddRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
                 context.AddRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                await context.AddAsync(new Product { Id = id++, Name = "Little Hedgehogs" });
+                await context.AddAsync((object)new Product { Id = id++, Name = "Little Hedgehogs" });
+                await context.AddRangeAsync(new Product { Id = id++, Name = "Little Hedgehogs" });
+                await context.AddRangeAsync(new Product { Id = id++, Name = "Little Hedgehogs" });
+                await context.AddRangeAsync(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                await context.AddRangeAsync(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
                 context.Attach(new Product { Id = id++, Name = "Little Hedgehogs" });
                 context.Attach((object)new Product { Id = id++, Name = "Little Hedgehogs" });
                 context.AttachRange(new Product { Id = id++, Name = "Little Hedgehogs" });
@@ -4901,9 +5104,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
             Assert.Throws<ObjectDisposedException>(() => context.Remove(new object()));
             Assert.Throws<ObjectDisposedException>(() => context.SaveChanges());
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.SaveChangesAsync());
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => context.AddAsync(new object()));
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 27;
+            var expectedMethodCount = 31;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +


### PR DESCRIPTION
But only AddAsync and not everything else that was virally async by association. This allows a path by which an application can ensure that database calls are all async even when using value generators that make calls to the database.

Issue #2291, #5254