### PR TITLE
Fix to #5522 - Model with nullable FK fails parent child query with "Argument Types do not match"

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1534,6 +1534,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Optional_navigation_type_compensation_works_with_DTOs()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Where(t => t.Note != "K.I.A.").Select(t => new Squad { Id = t.Gear.SquadId });
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_navigation_type_compensation_works_with_list_initializers()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Where(t => t.Note != "K.I.A.").Select(t => new List<int> { t.Gear.SquadId, t.Gear.SquadId + 1, 42 });
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_navigation_type_compensation_works_with_array_initializers()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Where(t => t.Note != "K.I.A.").Select(t => new int[] { t.Gear.SquadId });
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Optional_navigation_type_compensation_works_with_orderby()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1570,6 +1570,45 @@ ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
         }
 
+        public override void Optional_navigation_type_compensation_works_with_DTOs()
+        {
+            base.Optional_navigation_type_compensation_works_with_DTOs();
+
+            Assert.Equal(
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [t.Gear] ON ([t].[GearNickName] = [t.Gear].[Nickname]) AND ([t].[GearSquadId] = [t.Gear].[SquadId])
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+ORDER BY [t].[GearNickName], [t].[GearSquadId]",
+                Sql);
+        }
+
+        public override void Optional_navigation_type_compensation_works_with_list_initializers()
+        {
+            base.Optional_navigation_type_compensation_works_with_list_initializers();
+
+            Assert.Equal(
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank], 1
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [t.Gear] ON ([t].[GearNickName] = [t.Gear].[Nickname]) AND ([t].[GearSquadId] = [t.Gear].[SquadId])
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+ORDER BY [t].[GearNickName], [t].[GearSquadId]",
+                Sql);
+        }
+
+        public override void Optional_navigation_type_compensation_works_with_array_initializers()
+        {
+            base.Optional_navigation_type_compensation_works_with_array_initializers();
+
+            Assert.Equal(
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [t.Gear] ON ([t].[GearNickName] = [t.Gear].[Nickname]) AND ([t].[GearSquadId] = [t.Gear].[SquadId])
+WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL
+ORDER BY [t].[GearNickName], [t].[GearSquadId]",
+                Sql);
+        }
+
         public override void Optional_navigation_type_compensation_works_with_orderby()
         {
             base.Optional_navigation_type_compensation_works_with_orderby();


### PR DESCRIPTION
Problem was that during navigation rewrite we sometimes change types of expressions, e.g.

o.Customer.Id (originally int)

would get converted to:

(o != null) ? (int?)o.CustomerId : null (change type to int?)

We try to compensate for this later, by casting back to the original type, but we missed some cases: MemberAssignment, ElementInit, NewArray.

Fix is to add the compensation for those nodes.