### PR TITLE
Add non-generic Find to DbContext

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FindTestBase.cs
@@ -18,6 +18,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             fixture.Initialize();
         }
 
+        protected abstract TEntity Find<TEntity>(DbContext context, params object[] keyValues) where TEntity : class;
+
+        protected abstract Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues) where TEntity : class;
+
         [Fact]
         public virtual void Find_int_key_tracked()
         {
@@ -25,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new IntKey { Id = 88 }).Entity;
 
-                Assert.Same(entity, context.IntKeys.Find(88));
+                Assert.Same(entity, Find<IntKey>(context, 88));
             }
         }
 
@@ -34,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Smokey", context.IntKeys.Find(77).Foo);
+                Assert.Equal("Smokey", Find<IntKey>(context, 77).Foo);
             }
         }
 
@@ -43,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.IntKeys.Find(99));
+                Assert.Null(Find<IntKey>(context, 99));
             }
         }
 
@@ -54,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new StringKey { Id = "Rabbit" }).Entity;
 
-                Assert.Same(entity, context.StringKeys.Find("Rabbit"));
+                Assert.Same(entity, Find<StringKey>(context, "Rabbit"));
             }
         }
 
@@ -63,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Alice", context.StringKeys.Find("Cat").Foo);
+                Assert.Equal("Alice", Find<StringKey>(context, "Cat").Foo);
             }
         }
 
@@ -72,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.StringKeys.Find("Fox"));
+                Assert.Null(Find<StringKey>(context, "Fox"));
             }
         }
 
@@ -83,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new CompositeKey { Id1 = 88, Id2 = "Rabbit" }).Entity;
 
-                Assert.Same(entity, context.CompositeKeys.Find(88, "Rabbit"));
+                Assert.Same(entity, Find<CompositeKey>(context, 88, "Rabbit"));
             }
         }
 
@@ -92,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Olive", context.CompositeKeys.Find(77, "Dog").Foo);
+                Assert.Equal("Olive", Find<CompositeKey>(context, 77, "Dog").Foo);
             }
         }
 
@@ -101,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.CompositeKeys.Find(77, "Fox"));
+                Assert.Null(Find<CompositeKey>(context, 77, "Fox"));
             }
         }
 
@@ -112,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new BaseType { Id = 88 }).Entity;
 
-                Assert.Same(entity, context.BaseTypes.Find(88));
+                Assert.Same(entity, Find<BaseType>(context, 88));
             }
         }
 
@@ -121,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Baxter", context.BaseTypes.Find(77).Foo);
+                Assert.Equal("Baxter", Find<BaseType>(context, 77).Foo);
             }
         }
 
@@ -130,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.BaseTypes.Find(99));
+                Assert.Null(Find<BaseType>(context, 99));
             }
         }
 
@@ -141,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
 
-                Assert.Same(entity, context.DerivedTypes.Find(88));
+                Assert.Same(entity, Find<DerivedType>(context, 88));
             }
         }
 
@@ -150,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var derivedType = context.DerivedTypes.Find(78);
+                var derivedType = Find<DerivedType>(context, 78);
                 Assert.Equal("Strawberry", derivedType.Foo);
                 Assert.Equal("Cheesecake", derivedType.Boo);
             }
@@ -161,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.DerivedTypes.Find(99));
+                Assert.Null(Find<DerivedType>(context, 99));
             }
         }
 
@@ -172,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 context.Attach(new BaseType { Id = 88 });
 
-                Assert.Null(context.DerivedTypes.Find(88));
+                Assert.Null(Find<DerivedType>(context, 88));
             }
         }
 
@@ -181,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.DerivedTypes.Find(77));
+                Assert.Null(Find<DerivedType>(context, 77));
             }
         }
 
@@ -192,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
 
-                Assert.Same(entity, context.BaseTypes.Find(88));
+                Assert.Same(entity, Find<BaseType>(context, 88));
             }
         }
 
@@ -201,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var derivedType = context.BaseTypes.Find(78);
+                var derivedType = Find<BaseType>(context, 78);
                 Assert.Equal("Strawberry", derivedType.Foo);
                 Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
             }
@@ -216,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entry.Property("Id").CurrentValue = 88;
                 entry.State = EntityState.Unchanged;
 
-                Assert.Same(entry.Entity, context.ShadowKeys.Find(88));
+                Assert.Same(entry.Entity, Find<ShadowKey>(context, 88));
             }
         }
 
@@ -225,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Clippy", context.ShadowKeys.Find(77).Foo);
+                Assert.Equal("Clippy", Find<ShadowKey>(context, 77).Foo);
             }
         }
 
@@ -234,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(context.ShadowKeys.Find(99));
+                Assert.Null(Find<ShadowKey>(context, 99));
             }
         }
 
@@ -244,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    Assert.Throws<ArgumentNullException>(() => context.CompositeKeys.Find(null)).ParamName);
+                    Assert.Throws<ArgumentNullException>(() => Find<CompositeKey>(context, null)).ParamName);
             }
         }
 
@@ -254,7 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    Assert.Throws<ArgumentNullException>(() => context.IntKeys.Find(new object[] { null })).ParamName);
+                    Assert.Throws<ArgumentNullException>(() => Find<IntKey>(context, new object[] { null })).ParamName);
             }
         }
 
@@ -264,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    Assert.Throws<ArgumentNullException>(() => context.CompositeKeys.Find(77, null)).ParamName);
+                    Assert.Throws<ArgumentNullException>(() => Find<CompositeKey>(context, 77, null)).ParamName);
             }
         }
 
@@ -274,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindNotCompositeKey("IntKey", 2),
-                    Assert.Throws<ArgumentException>(() => context.IntKeys.Find(77, 88)).Message);
+                    Assert.Throws<ArgumentException>(() => Find<IntKey>(context, 77, 88)).Message);
             }
         }
 
@@ -284,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueCountMismatch("CompositeKey", 2, 1),
-                    Assert.Throws<ArgumentException>(() => context.CompositeKeys.Find(77)).Message);
+                    Assert.Throws<ArgumentException>(() => Find<CompositeKey>(context, 77)).Message);
             }
         }
 
@@ -294,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
-                    Assert.Throws<ArgumentException>(() => context.IntKeys.Find("77")).Message);
+                    Assert.Throws<ArgumentException>(() => Find<IntKey>(context, "77")).Message);
             }
         }
 
@@ -304,7 +308,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "int", "string"),
-                    Assert.Throws<ArgumentException>(() => context.CompositeKeys.Find(77, 88)).Message);
+                    Assert.Throws<ArgumentException>(() => Find<CompositeKey>(context, 77, 88)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_for_bad_entity_type()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.InvalidSetType(nameof(Random)),
+                    Assert.Throws<InvalidOperationException>(() => Find<Random>(context, 77)).Message);
             }
         }
 
@@ -315,7 +329,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new IntKey { Id = 88 }).Entity;
 
-                Assert.Same(entity, await context.IntKeys.FindAsync(88));
+                Assert.Same(entity, await FindAsync<IntKey>(context, 88));
             }
         }
 
@@ -324,7 +338,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Smokey", (await context.IntKeys.FindAsync(77)).Foo);
+                Assert.Equal("Smokey", (await FindAsync<IntKey>(context, 77)).Foo);
             }
         }
 
@@ -333,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.IntKeys.FindAsync(99));
+                Assert.Null(await FindAsync<IntKey>(context, 99));
             }
         }
 
@@ -344,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new StringKey { Id = "Rabbit" }).Entity;
 
-                Assert.Same(entity, await context.StringKeys.FindAsync("Rabbit"));
+                Assert.Same(entity, await FindAsync<StringKey>(context, "Rabbit"));
             }
         }
 
@@ -353,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Alice", (await context.StringKeys.FindAsync("Cat")).Foo);
+                Assert.Equal("Alice", (await FindAsync<StringKey>(context, "Cat")).Foo);
             }
         }
 
@@ -362,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.StringKeys.FindAsync("Fox"));
+                Assert.Null(await FindAsync<StringKey>(context, "Fox"));
             }
         }
 
@@ -373,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new CompositeKey { Id1 = 88, Id2 = "Rabbit" }).Entity;
 
-                Assert.Same(entity, await context.CompositeKeys.FindAsync(88, "Rabbit"));
+                Assert.Same(entity, await FindAsync<CompositeKey>(context, 88, "Rabbit"));
             }
         }
 
@@ -382,7 +396,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Olive", (await context.CompositeKeys.FindAsync(77, "Dog")).Foo);
+                Assert.Equal("Olive", (await FindAsync<CompositeKey>(context, 77, "Dog")).Foo);
             }
         }
 
@@ -391,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.CompositeKeys.FindAsync(77, "Fox"));
+                Assert.Null(await FindAsync<CompositeKey>(context, 77, "Fox"));
             }
         }
 
@@ -402,7 +416,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new BaseType { Id = 88 }).Entity;
 
-                Assert.Same(entity, await context.BaseTypes.FindAsync(88));
+                Assert.Same(entity, await FindAsync<BaseType>(context, 88));
             }
         }
 
@@ -411,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Baxter", (await context.BaseTypes.FindAsync(77)).Foo);
+                Assert.Equal("Baxter", (await FindAsync<BaseType>(context, 77)).Foo);
             }
         }
 
@@ -420,7 +434,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.BaseTypes.FindAsync(99));
+                Assert.Null(await FindAsync<BaseType>(context, 99));
             }
         }
 
@@ -431,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
 
-                Assert.Same(entity, await context.DerivedTypes.FindAsync(88));
+                Assert.Same(entity, await FindAsync<DerivedType>(context, 88));
             }
         }
 
@@ -440,7 +454,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var derivedType = await context.DerivedTypes.FindAsync(78);
+                var derivedType = await FindAsync<DerivedType>(context, 78);
                 Assert.Equal("Strawberry", derivedType.Foo);
                 Assert.Equal("Cheesecake", derivedType.Boo);
             }
@@ -451,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.DerivedTypes.FindAsync(99));
+                Assert.Null(await FindAsync<DerivedType>(context, 99));
             }
         }
 
@@ -462,7 +476,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 context.Attach(new BaseType { Id = 88 });
 
-                Assert.Null(await context.DerivedTypes.FindAsync(88));
+                Assert.Null(await FindAsync<DerivedType>(context, 88));
             }
         }
 
@@ -471,7 +485,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.DerivedTypes.FindAsync(77));
+                Assert.Null(await FindAsync<DerivedType>(context, 77));
             }
         }
 
@@ -482,7 +496,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var entity = context.Attach(new DerivedType { Id = 88 }).Entity;
 
-                Assert.Same(entity, await context.BaseTypes.FindAsync(88));
+                Assert.Same(entity, await FindAsync<BaseType>(context, 88));
             }
         }
 
@@ -491,7 +505,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var derivedType = await context.BaseTypes.FindAsync(78);
+                var derivedType = await FindAsync<BaseType>(context, 78);
                 Assert.Equal("Strawberry", derivedType.Foo);
                 Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
             }
@@ -506,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entry.Property("Id").CurrentValue = 88;
                 entry.State = EntityState.Unchanged;
 
-                Assert.Same(entry.Entity, await context.ShadowKeys.FindAsync(88));
+                Assert.Same(entry.Entity, await FindAsync<ShadowKey>(context, 88));
             }
         }
 
@@ -515,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal("Clippy", (await context.ShadowKeys.FindAsync(77)).Foo);
+                Assert.Equal("Clippy", (await FindAsync<ShadowKey>(context, 77)).Foo);
             }
         }
 
@@ -524,7 +538,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Null(await context.ShadowKeys.FindAsync(99));
+                Assert.Null(await FindAsync<ShadowKey>(context, 99));
             }
         }
 
@@ -534,7 +548,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.CompositeKeys.FindAsync(null))).ParamName);
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => FindAsync<CompositeKey>(context, null))).ParamName);
             }
         }
 
@@ -544,7 +558,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.IntKeys.FindAsync(new object[] { null }))).ParamName);
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => FindAsync<IntKey>(context, new object[] { null }))).ParamName);
             }
         }
 
@@ -554,7 +568,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal("keyValues",
-                    (await Assert.ThrowsAsync<ArgumentNullException>(() => context.CompositeKeys.FindAsync(77, null))).ParamName);
+                    (await Assert.ThrowsAsync<ArgumentNullException>(() => FindAsync<CompositeKey>(context, 77, null))).ParamName);
             }
         }
 
@@ -564,7 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindNotCompositeKey("IntKey", 2),
-                    (await Assert.ThrowsAsync<ArgumentException>(() => context.IntKeys.FindAsync(77, 88))).Message);
+                    (await Assert.ThrowsAsync<ArgumentException>(() => FindAsync<IntKey>(context, 77, 88))).Message);
             }
         }
 
@@ -574,7 +588,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueCountMismatch("CompositeKey", 2, 1),
-                    (await Assert.ThrowsAsync<ArgumentException>(() => context.CompositeKeys.FindAsync(77))).Message);
+                    (await Assert.ThrowsAsync<ArgumentException>(() => FindAsync<CompositeKey>(context, 77))).Message);
             }
         }
 
@@ -584,7 +598,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueTypeMismatch(0, "IntKey", "string", "int"),
-                    (await Assert.ThrowsAsync<ArgumentException>(() => context.IntKeys.FindAsync("77"))).Message);
+                    (await Assert.ThrowsAsync<ArgumentException>(() => FindAsync<IntKey>(context, "77"))).Message);
             }
         }
 
@@ -594,7 +608,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(CoreStrings.FindValueTypeMismatch(1, "CompositeKey", "int", "string"),
-                    (await Assert.ThrowsAsync<ArgumentException>(() => context.CompositeKeys.FindAsync(77, 88))).Message);
+                    (await Assert.ThrowsAsync<ArgumentException>(() => FindAsync<CompositeKey>(context, 77, 88))).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Throws_for_bad_entity_type_async()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.InvalidSetType(nameof(Random)),
+                    (await Assert.ThrowsAsync<InvalidOperationException>(() => FindAsync<Random>(context, 77))).Message);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -50,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore
 
         private IDbContextServices _contextServices;
         private IDbSetInitializer _setInitializer;
+        private IEntityFinderSource _entityFinderSource;
         private ChangeTracker _changeTracker;
         private IStateManager _stateManager;
         private IChangeDetector _changeDetector;
@@ -919,5 +920,89 @@ namespace Microsoft.EntityFrameworkCore
             return (_setInitializer
                     ?? (_setInitializer = InternalServiceProvider.GetRequiredService<IDbSetInitializer>())).CreateSet<TEntity>(this);
         }
+
+        private IEntityFinder Finder(Type entityType)
+            => (_entityFinderSource
+                ?? (_entityFinderSource = InternalServiceProvider.GetRequiredService<IEntityFinderSource>())).Create(this, entityType);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="entityType"> The type of entity to find. </param>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual object Find([NotNull] Type entityType, [NotNull] params object[] keyValues)
+            => Finder(entityType).Find(keyValues);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="entityType"> The type of entity to find. </param>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<object> FindAsync([NotNull] Type entityType, [NotNull] params object[] keyValues)
+            => Finder(entityType).FindAsync(keyValues);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <param name="entityType"> The type of entity to find. </param>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<object> FindAsync([NotNull] Type entityType, [NotNull] object[] keyValues, CancellationToken cancellationToken)
+            => Finder(entityType).FindAsync(keyValues, cancellationToken);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual TEntity Find<TEntity>([NotNull] params object[] keyValues) where TEntity : class
+            => ((IEntityFinder<TEntity>)Finder(typeof(TEntity))).Find(keyValues);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<TEntity> FindAsync<TEntity>([NotNull] params object[] keyValues) where TEntity : class
+            => ((IEntityFinder<TEntity>)Finder(typeof(TEntity))).FindAsync(keyValues);
+
+        /// <summary>
+        ///     Finds an entity with the given primary key values. If an entity with the given primary key values
+        ///     is being tracked by the context, then it is returned immediately without making a request to the
+        ///     database. Otherwise, a query is made to the dataabse for an entity with the given primary key values
+        ///     and this entity, if found, is attached to the context and returned. If no entity is found, then
+        ///     null is returned.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity to find. </typeparam>
+        /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The entity found, or null.</returns>
+        public virtual Task<TEntity> FindAsync<TEntity>([NotNull] object[] keyValues, CancellationToken cancellationToken) where TEntity : class
+            => ((IEntityFinder<TEntity>)Finder(typeof(TEntity))).FindAsync(keyValues, cancellationToken);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddSingleton<IDbSetFinder, DbSetFinder>()
                 .AddSingleton<IDbSetInitializer, DbSetInitializer>()
                 .AddSingleton<IDbSetSource, DbSetSource>()
+                .AddSingleton<IEntityFinderSource, EntityFinderSource>()
                 .AddSingleton<ICollectionTypeFactory, CollectionTypeFactory>()
                 .AddSingleton<IEntityMaterializerSource, EntityMaterializerSource>()
                 .AddSingleton<IMemberMapper, MemberMapper>()

--- a/src/Microsoft.EntityFrameworkCore/Internal/EntityFinder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/EntityFinder.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EntityFinder<TEntity> : IEntityFinder<TEntity>
+        where TEntity : class
+    {
+        private readonly IModel _model;
+        private readonly IStateManager _stateManager;
+        private readonly DbSet<TEntity> _set;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public EntityFinder([NotNull] DbContext context)
+        {
+            _model = context.Model;
+            _stateManager = context.GetService<IStateManager>();
+            _set = context.Set<TEntity>();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual TEntity Find(object[] keyValues)
+        {
+            Check.NotNull(keyValues, nameof(keyValues));
+
+            IReadOnlyList<IProperty> keyProperties;
+            return FindTracked(keyValues, out keyProperties)
+                   ?? _set.FirstOrDefault(BuildLambda(keyProperties, keyValues));
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        object IEntityFinder.Find(object[] keyValues)
+            => Find(keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Check.NotNull(keyValues, nameof(keyValues));
+
+            IReadOnlyList<IProperty> keyProperties;
+            var tracked = FindTracked(keyValues, out keyProperties);
+            return tracked != null
+                ? Task.FromResult(tracked)
+                : _set.FirstOrDefaultAsync(BuildLambda(keyProperties, keyValues), cancellationToken);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Task<object> IEntityFinder.FindAsync(object[] keyValues, CancellationToken cancellationToken)
+        {
+            Check.NotNull(keyValues, nameof(keyValues));
+
+            IReadOnlyList<IProperty> keyProperties;
+            var tracked = FindTracked(keyValues, out keyProperties);
+            return tracked != null
+                ? Task.FromResult((object)tracked)
+                : _set.FirstOrDefaultAsync(
+                    BuildObjectLambda(keyProperties, keyValues), cancellationToken);
+        }
+
+        private TEntity FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
+        {
+            var key = _model.FindEntityType(typeof(TEntity)).FindPrimaryKey();
+            keyProperties = key.Properties;
+
+            if (keyProperties.Count != keyValues.Length)
+            {
+                if (keyProperties.Count == 1)
+                {
+                    throw new ArgumentException(
+                        CoreStrings.FindNotCompositeKey(typeof(TEntity).ShortDisplayName(), keyValues.Length));
+                }
+                throw new ArgumentException(
+                    CoreStrings.FindValueCountMismatch(typeof(TEntity).ShortDisplayName(), keyProperties.Count, keyValues.Length));
+            }
+
+            for (var i = 0; i < keyValues.Length; i++)
+            {
+                if (keyValues[i] == null)
+                {
+                    throw new ArgumentNullException(nameof(keyValues));
+                }
+
+                var valueType = keyValues[i].GetType();
+                var propertyType = keyProperties[i].ClrType;
+                if (valueType != propertyType)
+                {
+                    throw new ArgumentException(
+                        CoreStrings.FindValueTypeMismatch(
+                            i, typeof(TEntity).ShortDisplayName(), valueType.ShortDisplayName(), propertyType.ShortDisplayName()));
+                }
+            }
+
+            return _stateManager.TryGetEntry(key, keyValues)?.Entity as TEntity;
+        }
+
+        private static Expression<Func<TEntity, bool>> BuildLambda(IReadOnlyList<IProperty> keyProperties, object[] keyValues)
+        {
+            var entityParameter = Expression.Parameter(typeof(TEntity), "e");
+
+            return Expression.Lambda<Func<TEntity, bool>>(
+                BuildPredicate(keyProperties, keyValues, entityParameter), entityParameter);
+        }
+
+        private static Expression<Func<object, bool>> BuildObjectLambda(IReadOnlyList<IProperty> keyProperties, object[] keyValues)
+        {
+            var entityParameter = Expression.Parameter(typeof(object), "e");
+
+            return Expression.Lambda<Func<object, bool>>(
+                BuildPredicate(keyProperties, keyValues, entityParameter), entityParameter);
+        }
+
+        private static BinaryExpression BuildPredicate(
+            IReadOnlyList<IProperty> keyProperties,
+            object[] keyValues,
+            ParameterExpression entityParameter)
+        {
+            BinaryExpression predicate = null;
+            for (var i = 0; i < keyProperties.Count; i++)
+            {
+                var property = keyProperties[i];
+                var equalsExpression =
+                    Expression.Equal(
+                        Expression.Call(
+                            EF.PropertyMethod.MakeGenericMethod(property.ClrType),
+                            entityParameter,
+                            Expression.Constant(property.Name, typeof(string))),
+                        Expression.Constant(
+                            keyValues[i], property.ClrType));
+
+                predicate = predicate == null ? equalsExpression : Expression.AndAlso(predicate, equalsExpression);
+            }
+            return predicate;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/EntityFinderSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/EntityFinderSource.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EntityFinderSource : IEntityFinderSource
+    {
+        private static readonly MethodInfo _genericCreate
+            = typeof(EntityFinderSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateConstructor));
+
+        private readonly ConcurrentDictionary<Type, Func<DbContext, IEntityFinder>> _cache
+            = new ConcurrentDictionary<Type, Func<DbContext, IEntityFinder>>();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEntityFinder Create(DbContext context, Type type)
+            => _cache.GetOrAdd(
+                type,
+                t
+                    =>
+                    {
+                        if (context.Model.FindEntityType(t) == null)
+                        {
+                            throw new InvalidOperationException(CoreStrings.InvalidSetType(t.ShortDisplayName()));
+                        }
+
+                        return (Func<DbContext, IEntityFinder>)_genericCreate.MakeGenericMethod(t).Invoke(null, null);
+                    })(context);
+
+        [UsedImplicitly]
+        private static Func<DbContext, IEntityFinder> CreateConstructor<TEntity>() where TEntity : class
+            => c => new EntityFinder<TEntity>(c);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IEntityFinder
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        object Find([NotNull] object[] keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Task<object> FindAsync([NotNull] object[] keyValues, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinderSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinderSource.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IEntityFinderSource
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IEntityFinder Create([NotNull] DbContext context, [NotNull] Type type);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder`.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IEntityFinder<TEntity> : IEntityFinder
+        where TEntity : class
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        new TEntity Find([NotNull] object[] keyValues);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        new Task<TEntity> FindAsync([NotNull] object[] keyValues, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -10,9 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -27,7 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         where TEntity : class
     {
         private readonly DbContext _context;
-        private IStateManager _stateManager;
         private readonly LazyRef<EntityQueryable<TEntity>> _entityQueryable;
 
         /// <summary>
@@ -52,97 +49,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override TEntity Find(params object[] keyValues)
-        {
-            Check.NotNull(keyValues, nameof(keyValues));
-
-            IReadOnlyList<IProperty> keyProperties;
-            return FindTracked(keyValues, out keyProperties)
-                   ?? this.FirstOrDefault(BuildPredicate(keyProperties, keyValues));
-        }
+            => _context.Find<TEntity>(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override Task<TEntity> FindAsync(params object[] keyValues)
-            => FindAsync(keyValues, default(CancellationToken));
+            => _context.FindAsync<TEntity>(keyValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken)
-        {
-            Check.NotNull(keyValues, nameof(keyValues));
-
-            IReadOnlyList<IProperty> keyProperties;
-            var tracked = FindTracked(keyValues, out keyProperties);
-            return tracked != null
-                ? Task.FromResult(tracked)
-                : this.FirstOrDefaultAsync(BuildPredicate(keyProperties, keyValues), cancellationToken);
-        }
-
-        private TEntity FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
-        {
-            var key = _context.Model.FindEntityType(typeof(TEntity)).FindPrimaryKey();
-            keyProperties = key.Properties;
-
-            if (keyProperties.Count != keyValues.Length)
-            {
-                if (keyProperties.Count == 1)
-                {
-                    throw new ArgumentException(
-                        CoreStrings.FindNotCompositeKey(typeof(TEntity).ShortDisplayName(), keyValues.Length));
-                }
-                throw new ArgumentException(
-                    CoreStrings.FindValueCountMismatch(typeof(TEntity).ShortDisplayName(), keyProperties.Count, keyValues.Length));
-            }
-
-            for (var i = 0; i < keyValues.Length; i++)
-            {
-                if (keyValues[i] == null)
-                {
-                    throw new ArgumentNullException(nameof(keyValues));
-                }
-
-                var valueType = keyValues[i].GetType();
-                var propertyType = keyProperties[i].ClrType;
-                if (valueType != propertyType)
-                {
-                    throw new ArgumentException(
-                        CoreStrings.FindValueTypeMismatch(
-                            i, typeof(TEntity).ShortDisplayName(), valueType.ShortDisplayName(), propertyType.ShortDisplayName()));
-                }
-            }
-
-            return StateManager.TryGetEntry(key, keyValues)?.Entity as TEntity;
-        }
-
-        private IStateManager StateManager => _stateManager ?? (_stateManager = _context.GetService<IStateManager>());
-
-
-        private static Expression<Func<TEntity, bool>> BuildPredicate(IReadOnlyList<IProperty> keyProperties, object[] keyValues)
-        {
-            var entityParameter = Expression.Parameter(typeof(TEntity), "e");
-
-            BinaryExpression predicate = null;
-            for (var i = 0; i < keyValues.Length; i++)
-            {
-                var property = keyProperties[i];
-                var equals =
-                    Expression.Equal(
-                        Expression.Call(
-                            EF.PropertyMethod.MakeGenericMethod(property.ClrType),
-                            entityParameter,
-                            Expression.Constant(property.Name, typeof(string))),
-                        Expression.Constant(
-                            keyValues[i], property.ClrType));
-
-                predicate = predicate == null ? equals : Expression.AndAlso(predicate, equals);
-            }
-
-            return Expression.Lambda<Func<TEntity, bool>>(predicate, entityParameter);
-        }
+            => _context.FindAsync<TEntity>(keyValues, cancellationToken);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -150,7 +71,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public override EntityEntry<TEntity> Add(TEntity entity)
             => _context.Add(entity);
-
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -189,7 +189,12 @@
     <Compile Include="Internal\AsyncLock.cs" />
     <Compile Include="Internal\ConcurrencyDetector.cs" />
     <Compile Include="Internal\CurrentDbContext.cs" />
+    <Compile Include="Internal\EntityFinder.cs" />
+    <Compile Include="Internal\EntityFinderSource.cs" />
     <Compile Include="Internal\ICurrentDbContext.cs" />
+    <Compile Include="Internal\IEntityFinder.cs" />
+    <Compile Include="Internal\IEntityFinderSource.cs" />
+    <Compile Include="Internal\IEntityFinder`.cs" />
     <Compile Include="Internal\InterceptingLogger.cs" />
     <Compile Include="Internal\CoreOptionsExtension.cs" />
     <Compile Include="Internal\DatabaseProviderSelector.cs" />

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FindInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FindInMemoryTest.cs
@@ -2,17 +2,60 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
-    public class FindInMemoryTest
+    public abstract class FindInMemoryTest
         : FindTestBase<FindInMemoryTest.FindInMemoryFixture>
     {
-        public FindInMemoryTest(FindInMemoryFixture fixture)
+        protected FindInMemoryTest(FindInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        public class FindInMemoryTestSet : FindInMemoryTest
+        {
+            public FindInMemoryTestSet(FindInMemoryFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().Find(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().FindAsync(keyValues);
+        }
+
+        public class FindInMemoryTestContext : FindInMemoryTest
+        {
+            public FindInMemoryTestContext(FindInMemoryFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Find<TEntity>(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.FindAsync<TEntity>(keyValues);
+        }
+
+        public class FindInMemoryTestNonGeneric : FindInMemoryTest
+        {
+            public FindInMemoryTestNonGeneric(FindInMemoryFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)context.Find(typeof(TEntity), keyValues);
+
+            protected override async Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)await context.FindAsync(typeof(TEntity), keyValues);
         }
 
         public class FindInMemoryFixture : FindFixtureBase
@@ -25,14 +68,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
                     .BuildServiceProvider();
-            }
 
-            public override void CreateTestStore()
-            {
                 using (var context = CreateContext())
                 {
                     Seed(context);
                 }
+            }
+
+            public override void CreateTestStore()
+            {
             }
 
             public override DbContext CreateContext()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,12 +11,54 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
-    public class FindSqlServerTest
+    public abstract class FindSqlServerTest
         : FindTestBase<FindSqlServerTest.FindSqlServerFixture>
     {
-        public FindSqlServerTest(FindSqlServerFixture fixture)
+        protected FindSqlServerTest(FindSqlServerFixture fixture)
             : base(fixture)
         {
+        }
+
+        public class FindSqlServerTestSet : FindSqlServerTest
+        {
+            public FindSqlServerTestSet(FindSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().Find(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().FindAsync(keyValues);
+        }
+
+        public class FindSqlServerTestContext : FindSqlServerTest
+        {
+            public FindSqlServerTestContext(FindSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Find<TEntity>(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.FindAsync<TEntity>(keyValues);
+        }
+
+        public class FindSqlServerTestNonGeneric : FindSqlServerTest
+        {
+            public FindSqlServerTestNonGeneric(FindSqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)context.Find(typeof(TEntity), keyValues);
+
+            protected override async Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)await context.FindAsync(typeof(TEntity), keyValues);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
@@ -2,17 +2,60 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
-    public class FindSqliteTest
+    public abstract class FindSqliteTest
         : FindTestBase<FindSqliteTest.FindSqliteFixture>
     {
-        public FindSqliteTest(FindSqliteFixture fixture)
+        protected FindSqliteTest(FindSqliteFixture fixture)
             : base(fixture)
         {
+        }
+
+        public class FindSqliteTestSet : FindSqliteTest
+        {
+            public FindSqliteTestSet(FindSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().Find(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.Set<TEntity>().FindAsync(keyValues);
+        }
+
+        public class FindSqliteTestContext : FindSqliteTest
+        {
+            public FindSqliteTestContext(FindSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => context.Find<TEntity>(keyValues);
+
+            protected override Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => context.FindAsync<TEntity>(keyValues);
+        }
+
+        public class FindSqliteTestNonGeneric : FindSqliteTest
+        {
+            public FindSqliteTestNonGeneric(FindSqliteFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            protected override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)context.Find(typeof(TEntity), keyValues);
+
+            protected override async Task<TEntity> FindAsync<TEntity>(DbContext context, params object[] keyValues)
+                => (TEntity)await context.FindAsync(typeof(TEntity), keyValues);
         }
 
         public class FindSqliteFixture : FindFixtureBase

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -5099,15 +5099,17 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             // methods (tests all paths)
             Assert.Throws<ObjectDisposedException>(() => context.Add(new object()));
+            Assert.Throws<ObjectDisposedException>(() => context.Find(typeof(Random), 77));
             Assert.Throws<ObjectDisposedException>(() => context.Attach(new object()));
             Assert.Throws<ObjectDisposedException>(() => context.Update(new object()));
             Assert.Throws<ObjectDisposedException>(() => context.Remove(new object()));
             Assert.Throws<ObjectDisposedException>(() => context.SaveChanges());
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.SaveChangesAsync());
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.AddAsync(new object()));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77));
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 31;
+            var expectedMethodCount = 37;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +


### PR DESCRIPTION
Issue #5998

Moved Find code into its own service and re-factored so it could also be used in a non-generic way.