### PR TITLE
New method of cleaning databases to improve test perf

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="AsyncFromSqlQueryTestBase.cs" />
     <Compile Include="AsyncFromSqlSprocQueryTestBase.cs" />
     <Compile Include="ComplexNavigationsQueryRelationalFixture.cs" />
+    <Compile Include="RelationalDatabaseCleaner.cs" />
     <Compile Include="F1RelationalFixture.cs" />
     <Compile Include="FromSqlQueryTestBase.cs" />
     <Compile Include="FromSqlSprocQueryTestBase.cs" />
@@ -75,6 +76,10 @@
     <ProjectReference Include="..\Microsoft.EntityFrameworkCore.InMemory\Microsoft.EntityFrameworkCore.InMemory.csproj">
       <Project>{6b102cc4-4396-4a7b-9f72-2c6b5c4d8310}</Project>
       <Name>Microsoft.EntityFrameworkCore.InMemory</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.EntityFrameworkCore.Relational.Design\Microsoft.EntityFrameworkCore.Relational.Design.csproj">
+      <Project>{1942c281-c12b-4818-8cc8-c42842871ff5}</Project>
+      <Name>Microsoft.EntityFrameworkCore.Relational.Design</Name>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.EntityFrameworkCore.Relational\Microsoft.EntityFrameworkCore.Relational.csproj">
       <Project>{6a25df99-2615-46d8-9532-821764647ee1}</Project>

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/RelationalDatabaseCleaner.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/RelationalDatabaseCleaner.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Tests
+{
+    public abstract class RelationalDatabaseCleaner
+    {
+        protected abstract IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory);
+
+        protected virtual bool AcceptTable(TableModel table) => true;
+
+        protected virtual bool AcceptForeignKey(ForeignKeyModel foreignKey) => true;
+
+        protected virtual bool AcceptIndex(IndexModel index) => true;
+
+        protected virtual bool AcceptSequence(SequenceModel sequence) => true;
+
+        protected virtual string BuildCustomSql(DatabaseModel databaseModel) => null;
+
+        public virtual void Clean(DatabaseFacade facade)
+        {
+            var creator = facade.GetService<IRelationalDatabaseCreator>();
+            var sqlGenerator = facade.GetService<IMigrationsSqlGenerator>();
+            var executor = facade.GetService<IMigrationCommandExecutor>();
+            var connection = facade.GetService<IRelationalConnection>();
+            var sqlBuilder = facade.GetService<IRawSqlCommandBuilder>();
+            var loggerFactory = facade.GetService<ILoggerFactory>();
+
+            if (!creator.Exists())
+            {
+                creator.Create();
+            }
+            else
+            {
+                var databaseModelFactory = CreateDatabaseModelFactory(loggerFactory);
+                var databaseModel = databaseModelFactory.Create(connection.ConnectionString, TableSelectionSet.All);
+
+                var operations = new List<MigrationOperation>();
+
+                foreach (var index in databaseModel.Tables
+                    .SelectMany(t => t.Indexes.Where(AcceptIndex)))
+                {
+                    operations.Add(new DropIndexOperation
+                    {
+                        Name = index.Name,
+                        Table = index.Table.Name,
+                        Schema = index.Table.SchemaName
+                    });
+                }
+
+                foreach (var foreignKey in databaseModel.Tables
+                    .SelectMany(t => t.ForeignKeys.Where(AcceptForeignKey)))
+                {
+                    operations.Add(new DropForeignKeyOperation
+                    {
+                        Name = foreignKey.Name,
+                        Table = foreignKey.Table.Name,
+                        Schema = foreignKey.Table.SchemaName
+                    });
+                }
+
+                foreach (var table in databaseModel.Tables.Where(AcceptTable))
+                {
+                    operations.Add(new DropTableOperation
+                    {
+                        Name = table.Name,
+                        Schema = table.SchemaName
+                    });
+                }
+
+                foreach (var sequence in databaseModel.Sequences.Where(AcceptSequence))
+                {
+                    operations.Add(new DropSequenceOperation
+                    {
+                        Name = sequence.Name,
+                        Schema = sequence.SchemaName
+                    });
+                }
+
+                var commands = sqlGenerator.Generate(operations);
+
+                connection.Open();
+
+                try
+                {
+                    var customSql = BuildCustomSql(databaseModel);
+                    if (!string.IsNullOrWhiteSpace(customSql))
+                    {
+                        sqlBuilder.Build(customSql).ExecuteNonQuery(connection);
+                    }
+                    executor.ExecuteNonQuery(commands, connection);
+                }
+                finally
+                {
+                    connection.Close();
+                }
+            }
+
+            creator.CreateTables();
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.0-*",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.0-*",
     "Microsoft.EntityFrameworkCore.Relational": "1.1.0-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -64,8 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = createContext(serviceProvider))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingNavigations(principalNavs: true, dependentNavs: true);
             }
 
@@ -95,8 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = createContext(serviceProvider))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingNavigations(principalNavs: false, dependentNavs: true);
             }
 
@@ -126,8 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = createContext(serviceProvider))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingNavigations(principalNavs: true, dependentNavs: false);
             }
 
@@ -157,8 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = createContext(serviceProvider))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingNavigationsWithDeferredAdd();
             }
 
@@ -185,8 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = createContext(serviceProvider))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingFKs(saveChanges: false);
 
                 var stateManager = context.ChangeTracker.GetInfrastructure();
@@ -1599,6 +1594,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         protected abstract DbContextOptions CreateOptions(string databaseName);
 
         protected abstract void CreateAndSeedDatabase(string databaseName, Func<MonsterContext> createContext);
+
+        protected abstract void EnsureClean(DbContext context);
 
         private SnapshotMonsterContext CreateSnapshotMonsterContext(IServiceProvider serviceProvider, string databaseName = SnapshotDatabaseName)
             => new SnapshotMonsterContext(new DbContextOptionsBuilder(CreateOptions(databaseName)).UseInternalServiceProvider(serviceProvider).Options,

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/NotificationEntitiesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/NotificationEntitiesTestBase.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        public abstract class NotificationEntitiesFixtureBase : IDisposable
+        public abstract class NotificationEntitiesFixtureBase
         {
             public abstract DbContext CreateContext();
 
@@ -128,26 +128,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 using (var context = CreateContext())
                 {
-                    if (context.Database.EnsureCreated())
+                    EnsureClean(context);
+
+                    context.Add(new Blog
                     {
-                        context.Add(new Blog
-                        {
-                            Id = 1,
-                            Posts = new List<Post> { new Post { Id = 1 }, new Post { Id = 2 } }
-                        });
+                        Id = 1,
+                        Posts = new List<Post> { new Post { Id = 1 }, new Post { Id = 2 } }
+                    });
 
-                        context.SaveChanges();
-                    }
+                    context.SaveChanges();
                 }
             }
 
-            public void Dispose()
-            {
-                using (var context = CreateContext())
-                {
-                    context.Database.EnsureDeleted();
-                }
-            }
+            protected abstract void EnsureClean(DbContext context);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/NullKeysTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/NullKeysTestBase.cs
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public WithAllNullableIntKey Principal { get; set; }
         }
 
-        public abstract class NullKeysFixtureBase : IDisposable
+        public abstract class NullKeysFixtureBase
         {
             public abstract DbContext CreateContext();
 
@@ -269,61 +269,54 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 using (var context = CreateContext())
                 {
-                    if (context.Database.EnsureCreated())
-                    {
-                        context.Add(new WithStringKey { Id = "Stereo" });
-                        context.Add(new WithStringKey { Id = "Fire" });
-                        context.Add(new WithStringKey { Id = "Empire" });
+                    EnsureClean(context);
 
-                        context.Add(new WithStringFk { Id = "Wendy", Fk = "Stereo", SelfFk = "Rodrigue" });
-                        context.Add(new WithStringFk { Id = "And", SelfFk = "By" });
-                        context.Add(new WithStringFk { Id = "Me", Fk = "Fire" });
-                        context.Add(new WithStringFk { Id = "By" });
-                        context.Add(new WithStringFk { Id = "George", Fk = "Empire" });
-                        context.Add(new WithStringFk { Id = "Rodrigue", Fk = "Stereo" });
+                    context.Add(new WithStringKey { Id = "Stereo" });
+                    context.Add(new WithStringKey { Id = "Fire" });
+                    context.Add(new WithStringKey { Id = "Empire" });
 
-                        context.Add(new WithIntKey { Id = 1 });
-                        context.Add(new WithIntKey { Id = 2 });
-                        context.Add(new WithIntKey { Id = 3 });
+                    context.Add(new WithStringFk { Id = "Wendy", Fk = "Stereo", SelfFk = "Rodrigue" });
+                    context.Add(new WithStringFk { Id = "And", SelfFk = "By" });
+                    context.Add(new WithStringFk { Id = "Me", Fk = "Fire" });
+                    context.Add(new WithStringFk { Id = "By" });
+                    context.Add(new WithStringFk { Id = "George", Fk = "Empire" });
+                    context.Add(new WithStringFk { Id = "Rodrigue", Fk = "Stereo" });
 
-                        context.Add(new WithNullableIntFk { Id = 1 });
-                        context.Add(new WithNullableIntFk { Id = 2, Fk = 1 });
-                        context.Add(new WithNullableIntFk { Id = 3 });
-                        context.Add(new WithNullableIntFk { Id = 4, Fk = 2 });
-                        context.Add(new WithNullableIntFk { Id = 5 });
-                        context.Add(new WithNullableIntFk { Id = 6 });
+                    context.Add(new WithIntKey { Id = 1 });
+                    context.Add(new WithIntKey { Id = 2 });
+                    context.Add(new WithIntKey { Id = 3 });
 
-                        context.Add(new WithNullableIntKey { Id = 1 });
-                        context.Add(new WithNullableIntKey { Id = 2 });
-                        context.Add(new WithNullableIntKey { Id = 3 });
+                    context.Add(new WithNullableIntFk { Id = 1 });
+                    context.Add(new WithNullableIntFk { Id = 2, Fk = 1 });
+                    context.Add(new WithNullableIntFk { Id = 3 });
+                    context.Add(new WithNullableIntFk { Id = 4, Fk = 2 });
+                    context.Add(new WithNullableIntFk { Id = 5 });
+                    context.Add(new WithNullableIntFk { Id = 6 });
 
-                        context.Add(new WithIntFk { Id = 1, Fk = 1 });
-                        context.Add(new WithIntFk { Id = 2, Fk = 1 });
-                        context.Add(new WithIntFk { Id = 3, Fk = 3 });
+                    context.Add(new WithNullableIntKey { Id = 1 });
+                    context.Add(new WithNullableIntKey { Id = 2 });
+                    context.Add(new WithNullableIntKey { Id = 3 });
 
-                        context.Add(new WithAllNullableIntKey { Id = 1 });
-                        context.Add(new WithAllNullableIntKey { Id = 2 });
-                        context.Add(new WithAllNullableIntKey { Id = 3 });
+                    context.Add(new WithIntFk { Id = 1, Fk = 1 });
+                    context.Add(new WithIntFk { Id = 2, Fk = 1 });
+                    context.Add(new WithIntFk { Id = 3, Fk = 3 });
 
-                        context.Add(new WithAllNullableIntFk { Id = 1 });
-                        context.Add(new WithAllNullableIntFk { Id = 2, Fk = 1 });
-                        context.Add(new WithAllNullableIntFk { Id = 3 });
-                        context.Add(new WithAllNullableIntFk { Id = 4, Fk = 2 });
-                        context.Add(new WithAllNullableIntFk { Id = 5 });
-                        context.Add(new WithAllNullableIntFk { Id = 6 });
+                    context.Add(new WithAllNullableIntKey { Id = 1 });
+                    context.Add(new WithAllNullableIntKey { Id = 2 });
+                    context.Add(new WithAllNullableIntKey { Id = 3 });
 
-                        context.SaveChanges();
-                    }
+                    context.Add(new WithAllNullableIntFk { Id = 1 });
+                    context.Add(new WithAllNullableIntFk { Id = 2, Fk = 1 });
+                    context.Add(new WithAllNullableIntFk { Id = 3 });
+                    context.Add(new WithAllNullableIntFk { Id = 4, Fk = 2 });
+                    context.Add(new WithAllNullableIntFk { Id = 5 });
+                    context.Add(new WithAllNullableIntFk { Id = 6 });
+
+                    context.SaveChanges();
                 }
             }
 
-            public void Dispose()
-            {
-                using (var context = CreateContext())
-                {
-                    context.Database.EnsureDeleted();
-                }
-            }
+            protected abstract void EnsureClean(DbContext context);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/MonsterFixupInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/MonsterFixupInMemoryTest.cs
@@ -35,8 +35,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         {
             using (var context = createContext())
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                EnsureClean(context);
                 context.SeedUsingFKs();
             }
         }
@@ -48,6 +47,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             builder.Entity<TMessage>().Property(e => e.MessageId).ValueGeneratedOnAdd();
             builder.Entity<TProductPhoto>().Property(e => e.PhotoId).ValueGeneratedOnAdd();
             builder.Entity<TProductReview>().Property(e => e.ReviewId).ValueGeneratedOnAdd();
+        }
+
+        protected override void EnsureClean(DbContext context)
+        {
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
@@ -34,6 +34,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NullKeysInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NullKeysInMemoryTest.cs
@@ -33,6 +33,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -29,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             var expectedBlogs = new List<Blog>();
             using (var context = new BloggingContext(_serviceProvider, optionsBuilder.Options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
+
                 var owner1 = new Owner();
                 var owner2 = new Owner();
                 context.Owners.Add(owner1);
@@ -72,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             var expectedBlogs = new List<Blog>();
             using (var context = new BloggingContext(_serviceProvider, optionsBuilder.Options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
+
                 var owner1 = new Owner {Name = "0"};
                 var owner2 = new Owner {Name = "1" };
                 context.Owners.Add(owner1);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new DbContext(_options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             _fixture.CreateDatabase();
         }
 
-        public class CommandConfigurationTestFixture : IDisposable
+        public class CommandConfigurationTestFixture
         {
             public IServiceProvider ServiceProvider { get; } = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
@@ -36,18 +36,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     {
                         using (var context = new ChipsContext(ServiceProvider))
                         {
-                            context.Database.EnsureDeleted();
-                            context.Database.EnsureCreated();
+                            context.Database.EnsureClean();
                         }
                     });
-            }
-
-            public void Dispose()
-            {
-                using (var context = new ChipsContext(ServiceProvider))
-                {
-                    context.Database.EnsureDeleted();
-                }
             }
         }
 
@@ -76,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new ConfiguredChipsContext(serviceProvider))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 for (var i = 0; i < count; i++)
                 {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
@@ -39,13 +39,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new ComplexNavigationsContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-
-                        if (context.Database.EnsureCreated())
-                        {
-                            ComplexNavigationsModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        ComplexNavigationsModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 context.Add(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
                 await context.SaveChangesAsync();
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var added = context.Add(new Unicorn { Id2 = id2, Name = "Rarity" }).Entity;
 
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var pony1 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 1" }).Entity;
                 var pony2 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 2" }).Entity;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComputedColumnTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComputedColumnTest.cs
@@ -19,8 +19,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new Context(serviceProvider, "ComputedColumns"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var entity = context.Add(new Entity { P1 = 20, P2 = 30, P3 = 80 }).Entity;
 
@@ -40,8 +39,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new Context(serviceProvider, "ComputedColumns"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var entity = context.Add(new Entity { P1 = 20, P2 = 30 }).Entity;
 
@@ -141,8 +139,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new NullableContext(serviceProvider, "NullableEnumComputedColumns"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var entity = context.EnumItems.Add(new EnumItem { FlagEnum = FlagEnum.AValue, OptionalFlagEnum = FlagEnum.BValue }).Entity;
                 context.SaveChanges();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
@@ -62,12 +62,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new DataAnnotationContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            DataAnnotationModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        DataAnnotationModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -232,38 +232,8 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();",
         {
             base.TimestampAttribute_throws_if_value_in_database_changed();
 
-            Assert.Equal(@"SELECT TOP(1) [r].[Id], [r].[Data], [r].[Timestamp]
-FROM [Two] AS [r]
-WHERE [r].[Id] = 1
-
-SELECT TOP(1) [r].[Id], [r].[Data], [r].[Timestamp]
-FROM [Two] AS [r]
-WHERE [r].[Id] = 1
-
-@p1: 1
-@p0: ModifiedData (Size = 16)
-@p2: 0x00000000000007D1 (Size = 8)
-
-SET NOCOUNT ON;
-DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));
-UPDATE [Two] SET [Data] = @p0
-OUTPUT INSERTED.[Timestamp]
-INTO @inserted0
-WHERE [Id] = @p1 AND [Timestamp] = @p2;
-SELECT [Timestamp] FROM @inserted0;
-
-@p1: 1
-@p0: ChangedData (Size = 16)
-@p2: 0x00000000000007D1 (Size = 8)
-
-SET NOCOUNT ON;
-DECLARE @inserted0 TABLE ([Timestamp] varbinary(8));
-UPDATE [Two] SET [Data] = @p0
-OUTPUT INSERTED.[Timestamp]
-INTO @inserted0
-WHERE [Id] = @p1 AND [Timestamp] = @p2;
-SELECT [Timestamp] FROM @inserted0;",
-                Sql);
+            // Not vallidating SQL because not significantly different from other tests and
+            // row version value is not stable.
         }
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
-    public class DefaultValuesTest : IDisposable
+    public class DefaultValuesTest
     {
         private readonly IServiceProvider _serviceProvider = new ServiceCollection()
             .AddEntityFrameworkSqlServer()
@@ -20,8 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon" }).Entity;
                 var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", BestBuyDate = new DateTime(2111, 1, 11) }).Entity;
@@ -36,14 +35,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single(c => c.Name == "Honey Dijon").BestBuyDate);
                 Assert.Equal(new DateTime(2111, 1, 11), context.Chips.Single(c => c.Name == "Buffalo Bleu").BestBuyDate);
-            }
-        }
-
-        public void Dispose()
-        {
-            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
-            {
-                context.Database.EnsureDeleted();
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -37,12 +37,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new F1Context(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            ConcurrencyModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        ConcurrencyModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -257,8 +257,7 @@ WHERE [e].[Id] = 99", Sql);
             {
                 using (var context = CreateContext())
                 {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
                     Seed(context);
                     TestSqlLoggerFactory.Reset();
                 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
@@ -37,12 +37,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new GearsOfWarContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            GearsOfWarModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        GearsOfWarModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestBase.cs
@@ -40,11 +40,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                         using (var context = new GraphUpdatesContext(optionsBuilder.Options))
                         {
-                            context.Database.EnsureDeleted();
-                            if (context.Database.EnsureCreated())
-                            {
-                                Seed(context);
-                            }
+                            context.Database.EnsureClean();
+                            Seed(context);
                         }
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerFixture.cs
@@ -37,12 +37,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new InheritanceRelationshipsContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            InheritanceRelationshipsModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        InheritanceRelationshipsModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
                 SeedData(context);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -118,8 +118,10 @@
     <Compile Include="SqlAzure\SqlAzureFundamentalsTest.cs" />
     <Compile Include="SqlExecutorSqlServerTest.cs" />
     <Compile Include="SqlServerConfigPatternsTest.cs" />
+    <Compile Include="SqlServerDatabaseCleaner.cs" />
     <Compile Include="SqlServerDatabaseCreationTest.cs" />
     <Compile Include="SqlServerDatabaseCreatorTest.cs" />
+    <Compile Include="SqlServerDatabaseFacadeExtensions.cs" />
     <Compile Include="SqlServerEndToEndTest.cs" />
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="SqlServerMigrationsTest.cs" />
@@ -153,6 +155,10 @@
       <Project>{6b102cc4-4396-4a7b-9f72-2c6b5c4d8310}</Project>
       <Name>Microsoft.EntityFrameworkCore.InMemory</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Relational.Design\Microsoft.EntityFrameworkCore.Relational.Design.csproj">
+      <Project>{1942c281-c12b-4818-8cc8-c42842871ff5}</Project>
+      <Name>Microsoft.EntityFrameworkCore.Relational.Design</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Relational.Specification.Tests\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj">
       <Project>{07fa2b15-a6a5-4292-a096-7771fb32eeda}</Project>
       <Name>Microsoft.EntityFrameworkCore.Relational.Specification.Tests</Name>
@@ -164,6 +170,10 @@
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Specification.Tests\Microsoft.EntityFrameworkCore.Specification.Tests.csproj">
       <Project>{1a73d95e-e8b5-4f96-908c-7b040e4f7afe}</Project>
       <Name>Microsoft.EntityFrameworkCore.Specification.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.SqlServer.Design\Microsoft.EntityFrameworkCore.SqlServer.Design.csproj">
+      <Project>{da30fc85-8d88-4bb2-98ce-b8a5845bb3ea}</Project>
+      <Name>Microsoft.EntityFrameworkCore.SqlServer.Design</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.SqlServer\Microsoft.EntityFrameworkCore.SqlServer.csproj">
       <Project>{99595b81-d47c-40ba-8c61-5328a5a0e4ab}</Project>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
@@ -57,8 +57,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 {
                     using (var context = createContext())
                     {
-                        context.Database.EnsureDeleted();
-                        context.Database.EnsureCreated();
+                        EnsureClean(context);
                         context.SeedUsingFKs();
                     }
 
@@ -75,5 +74,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             builder.Entity<TProductPhoto>().Property(e => e.PhotoId).UseSqlServerIdentityColumn();
             builder.Entity<TProductReview>().Property(e => e.ReviewId).UseSqlServerIdentityColumn();
         }
+
+        protected override void EnsureClean(DbContext context)
+            => context.Database.EnsureClean();
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
@@ -34,6 +34,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+                => context.Database.EnsureClean();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullKeysSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullKeysSqlServerTest.cs
@@ -33,6 +33,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+                => context.Database.EnsureClean();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
@@ -35,12 +35,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                         .UseSqlServer(_connectionString)
                         .UseInternalServiceProvider(_serviceProvider).Options))
                     {
-                        // TODO: Delete DB if model changed
-
-                        if (context.Database.EnsureCreated())
-                        {
-                            NullSemanticsModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        NullSemanticsModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/OneToOneQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/OneToOneQuerySqlServerFixture.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new DbContext(_options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 AddTestData(context);
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 using (var context = new DeadlockContext(testStore.ConnectionString))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
                     context.EnsureSeeded();
 
                     var count
@@ -169,8 +169,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             using (var context = new MyContext603(_fixture.ServiceProvider))
             {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
+                context.Database.EnsureClean();
 
                 context.Products.Add(new Product { Name = "Product 1" });
                 context.SaveChanges();
@@ -187,8 +186,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new MyContext603(_fixture.ServiceProvider))
             {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
+                context.Database.EnsureClean();
 
                 context.Products.Add(new Product { Name = "Product 1" });
                 context.SaveChanges();
@@ -1173,10 +1171,8 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
 
                     using (var context = contextCreator(serviceProvider, optionsBuilder.Options))
                     {
-                        if (context.Database.EnsureCreated())
-                        {
-                            contextInitializer(context);
-                        }
+                        context.Database.EnsureClean();
+                        contextInitializer(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -23,8 +23,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "Bronies"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
 
             AddEntities(serviceProvider);
@@ -73,8 +72,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "BroniesAsync"))
             {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
+                context.Database.EnsureClean();
             }
 
             await AddEntitiesAsync(serviceProvider, "BroniesAsync");
@@ -164,8 +162,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "ExplicitBronies"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
 
             AddEntitiesWithIds(serviceProvider, 0);
@@ -253,8 +250,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new NullableBronieContext(serviceProvider, "NullableBronies", useSequence: true))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
 
             AddEntitiesNullable(serviceProvider, "NullableBronies", useSequence: true);
@@ -282,8 +278,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new NullableBronieContext(serviceProvider, "IdentityBronies", useSequence: false))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
 
             AddEntitiesNullable(serviceProvider, "IdentityBronies", false);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -22,8 +22,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "GooieBronies"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 for (var i = 0; i < 50; i++)
                 {
@@ -55,8 +54,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "GooieExplicitBronies"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 for (var i = 0; i < 50; i++)
                 {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCleaner.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCleaner.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.Tests;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class SqlServerDatabaseCleaner : RelationalDatabaseCleaner
+    {
+        protected override IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
+            => new SqlServerDatabaseModelFactory(loggerFactory);
+
+        protected override bool AcceptIndex(IndexModel index)
+            => !index.Name.StartsWith("PK_", StringComparison.Ordinal)
+               && !index.Name.StartsWith("AK_", StringComparison.Ordinal);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseFacadeExtensions.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseFacadeExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public static class SqlServerDatabaseFacadeExtensions
+    {
+        public static void EnsureClean(this DatabaseFacade databaseFacade)
+            => new SqlServerDatabaseCleaner().Clean(databaseFacade);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -38,8 +38,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             using (var context = new NumNumContext())
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 context.AddRange(numNum1, numNum2, adNum1, adNum2, anNum1, anNum2);
 
@@ -525,7 +524,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         private static async Task<TBlog[]> CreateBlogDatabaseAsync<TBlog>(DbContext context) where TBlog : class, IBlog, new()
         {
-            await context.Database.EnsureCreatedAsync();
+            context.Database.EnsureClean();
+
             var blog1 = context.Add(new TBlog
             {
                 Name = "Blog1",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -17,14 +17,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
     {
         // Positive cases
 
-        public class IdentityColumn : TestBase<IdentityColumn.BlogContext>
+        public class IdentityColumn
         {
             [Fact]
             public void Insert_with_Identity_column()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Name = "One Unicorn" }, new Blog { Name = "Two Unicorns" });
 
@@ -46,14 +46,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsSequences)]
-        public class SequenceHiLo : TestBase<SequenceHiLo.BlogContext>
+        public class SequenceHiLo
         {
             [ConditionalFact]
             public void Insert_with_sequence_HiLo()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Name = "One Unicorn" }, new Blog { Name = "Two Unicorns" });
 
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class SequenceKeyColumnWithDefaultValue : TestBase<SequenceKeyColumnWithDefaultValue.BlogContext>
+        public class SequenceKeyColumnWithDefaultValue
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Name = "One Unicorn" }, new Blog { Name = "Two Unicorns" });
 
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class ReadOnlySequenceKeyColumnWithDefaultValue : TestBase<ReadOnlySequenceKeyColumnWithDefaultValue.BlogContext>
+        public class ReadOnlySequenceKeyColumnWithDefaultValue
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Name = "One Unicorn" }, new Blog { Name = "Two Unicorns" });
 
@@ -158,14 +158,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class NoKeyGeneration : TestBase<NoKeyGeneration.BlogContext>
+        public class NoKeyGeneration
         {
             [Fact]
             public void Insert_with_explicit_non_default_keys()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Id = 66, Name = "One Unicorn" }, new Blog { Id = 67, Name = "Two Unicorns" });
 
@@ -193,14 +193,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class NoKeyGenerationNullableKey : TestBase<NoKeyGenerationNullableKey.BlogContext>
+        public class NoKeyGenerationNullableKey
         {
             [Fact]
             public void Insert_with_explicit_with_default_keys()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(
                         new NullableKeyBlog { Id = 0, Name = "One Unicorn" },
@@ -230,14 +230,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class NonKeyDefaultValue : TestBase<NonKeyDefaultValue.BlogContext>
+        public class NonKeyDefaultValue
         {
             [Fact]
             public void Insert_with_non_key_default_value()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     var blogs = new List<Blog>
                     {
@@ -287,14 +287,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class NonKeyReadOnlyDefaultValue : TestBase<NonKeyReadOnlyDefaultValue.BlogContext>
+        public class NonKeyReadOnlyDefaultValue
         {
             [Fact]
             public void Insert_with_non_key_default_value()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(
                         new Blog { Name = "One Unicorn" },
@@ -343,14 +343,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class ComputedColumn : TestBase<ComputedColumn.BlogContext>
+        public class ComputedColumn
         {
             [Fact]
             public void Insert_and_update_with_computed_column()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     var blog = context.Add(new FullNameBlog { FirstName = "One", LastName = "Unicorn" }).Entity;
 
@@ -384,7 +384,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public class ComputedColumnWithFunction : TestBase<ComputedColumnWithFunction.BlogContext>
+        public class ComputedColumnWithFunction
         {
             //[Fact] Disabled due to issue #6044
             public void Insert_and_update_with_computed_column()
@@ -393,14 +393,26 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 {
                     var creator = context.GetService<IRelationalDatabaseCreator>();
 
-                    creator.Create();
+                    if (!creator.Exists())
+                    {
+                        creator.Create();
 
-                    context.Database.ExecuteSqlCommand
-                        (@"CREATE FUNCTION 
+                        context.Database.ExecuteSqlCommand
+                            (@"CREATE FUNCTION 
 [dbo].[GetFullName](@First NVARCHAR(MAX), @Second NVARCHAR(MAX))
 RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
-                    creator.CreateTables();
+                        creator.CreateTables();
+                    }
+                    else
+                    {
+                        foreach (var blog in context.FullNameBlogs.ToList())
+                        {
+                            context.Remove(blog);
+                        }
+
+                        context.SaveChanges();
+                    }
                 }
 
                 using (var context = new BlogContext())
@@ -442,7 +454,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class ClientGuidKey : TestBase<ClientGuidKey.BlogContext>
+        public class ClientGuidKey
         {
             [Fact]
             public void Insert_with_client_generated_GUID_key()
@@ -451,7 +463,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     var blog = context.Add(new GuidBlog { Name = "One Unicorn" }).Entity;
 
@@ -475,7 +487,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class ServerGuidKey : TestBase<ServerGuidKey.BlogContext>
+        public class ServerGuidKey
         {
             [Fact]
             public void Insert_with_server_generated_GUID_key()
@@ -484,7 +496,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     var blog = context.Add(new GuidBlog { Name = "One Unicorn" }).Entity;
 
@@ -517,14 +529,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
         // Negative cases
 
-        public class DoNothingButSpecifyKeys : TestBase<DoNothingButSpecifyKeys.BlogContext>
+        public class DoNothingButSpecifyKeys
         {
             [Fact]
             public void Insert_with_explicit_non_default_keys()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Id = 1, Name = "One Unicorn" }, new Blog { Id = 2, Name = "Two Unicorns" });
 
@@ -541,14 +553,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class DoNothingButSpecifyKeysUsingDefault : TestBase<DoNothingButSpecifyKeysUsingDefault.BlogContext>
+        public class DoNothingButSpecifyKeysUsingDefault
         {
             [Fact]
             public void Insert_with_explicit_default_keys()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Id = 0, Name = "One Unicorn" }, new Blog { Id = 1, Name = "Two Unicorns" });
 
@@ -565,14 +577,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class SpecifyKeysUsingDefault : TestBase<SpecifyKeysUsingDefault.BlogContext>
+        public class SpecifyKeysUsingDefault
         {
             [Fact]
             public void Insert_with_explicit_default_keys()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Id = 0, Name = "One Unicorn" }, new Blog { Id = 1, Name = "Two Unicorns" });
 
@@ -600,7 +612,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class ReadOnlySequenceKeyColumnWithDefaultValueThrows : TestBase<ReadOnlySequenceKeyColumnWithDefaultValueThrows.BlogContext>
+        public class ReadOnlySequenceKeyColumnWithDefaultValueThrows
         {
             [ConditionalFact]
             [SqlServerCondition(SqlServerCondition.SupportsSequences)]
@@ -608,7 +620,7 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(new Blog { Id = 1, Name = "One Unicorn" }, new Blog { Name = "Two Unicorns" });
 
@@ -635,14 +647,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class NonKeyReadOnlyDefaultValueThrows : TestBase<NonKeyReadOnlyDefaultValueThrows.BlogContext>
+        public class NonKeyReadOnlyDefaultValueThrows
         {
             [Fact]
             public void Insert_explicit_value_throws_when_readonly_before_save()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.AddRange(
                         new Blog { Name = "One Unicorn" },
@@ -668,14 +680,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class ComputedColumnInsertValue : TestBase<ComputedColumnInsertValue.BlogContext>
+        public class ComputedColumnInsertValue
         {
             [Fact]
             public void Insert_explicit_value_into_computed_column()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.Add(new FullNameBlog { FirstName = "One", LastName = "Unicorn", FullName = "Gerald" });
 
@@ -698,14 +710,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             }
         }
 
-        public class ComputedColumnUpdateValue : TestBase<ComputedColumnUpdateValue.BlogContext>
+        public class ComputedColumnUpdateValue
         {
             [Fact]
             public void Update_explicit_value_in_computed_column()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     context.Add(new FullNameBlog { FirstName = "One", LastName = "Unicorn" });
 
@@ -739,14 +751,14 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
         // Concurrency
 
-        public class ConcurrencyWithRowversion : TestBase<ConcurrencyWithRowversion.BlogContext>
+        public class ConcurrencyWithRowversion
         {
             [Fact]
             public void Resolve_concurreny()
             {
                 using (var context = new BlogContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
 
                     var blog = context.Add(new ConcurrentBlog { Name = "One Unicorn" }).Entity;
 
@@ -839,18 +851,6 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
             {
                 var name = GetType().FullName.Substring((GetType().Namespace + nameof(SqlServerValueGenerationScenariosTest)).Length + 2);
                 optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(name));
-            }
-        }
-
-        public class TestBase<TContext>
-            where TContext : ContextBase, new()
-        {
-            public TestBase()
-            {
-                using (var context = new TContext())
-                {
-                    context.Database.EnsureDeleted();
-                }
             }
         }
     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -87,8 +87,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                         using (var context = new StoreGeneratedContext(optionsBuilder.Options))
                         {
-                            context.Database.EnsureDeleted();
-                            context.Database.EnsureCreated();
+                            context.Database.EnsureClean();
                         }
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
@@ -32,11 +32,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     using (var context = new UpdatesContext(optionsBuilder.Options))
                     {
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            UpdatesModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        UpdatesModelInitializer.Seed(context);
                     }
                 });
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
@@ -13,6 +13,7 @@
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.0-*",
     "Microsoft.EntityFrameworkCore.SqlServer": "1.1.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.1.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.1.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0-*"
   },

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AutoincrementTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AutoincrementTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
                 context.People.Add(new Person { Name = "Bruce" });
                 context.SaveChanges();
 
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
             using (var context = new JokerContext(_options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = new DbContext(_options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CommandConfigurationTest.cs
@@ -34,8 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                     {
                         using (var context = new ChipsContext(ServiceProvider))
                         {
-                            context.Database.EnsureDeleted();
-                            context.Database.EnsureCreated();
+                            context.Database.EnsureClean();
                         }
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
@@ -37,12 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                         using (var context = new ComplexNavigationsContext(optionsBuilder.Options))
                         {
-                            // TODO: Delete DB if model changed
-                            context.Database.EnsureDeleted();
-                            if (context.Database.EnsureCreated())
-                            {
-                                ComplexNavigationsModelInitializer.Seed(context);
-                            }
+                            context.Database.EnsureClean();
+                            ComplexNavigationsModelInitializer.Seed(context);
 
                             TestSqlLoggerFactory.Reset();
                         }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 context.Add(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
                 await context.SaveChangesAsync();
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var pony1 = context.Add(new EarthPony { Id1 = 1, Id2 = 7, Name = "Apple Jack 1" }).Entity;
                 var pony2 = context.Add(new EarthPony { Id1 = 2, Id2 = 7, Name = "Apple Jack 2" }).Entity;

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
@@ -61,12 +61,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                     using (var context = new DataAnnotationContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            DataAnnotationModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        DataAnnotationModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DefaultValuesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DefaultValuesTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
-    public class DefaultValuesTest : IDisposable
+    public class DefaultValuesTest
     {
         private readonly IServiceProvider _serviceProvider = new ServiceCollection()
             .AddEntityFrameworkSqlite()
@@ -19,8 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
             using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon" }).Entity;
                 var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", BestBuyDate = new DateTime(2111, 1, 11) }).Entity;
@@ -35,14 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             {
                 Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single(c => c.Name == "Honey Dijon").BestBuyDate);
                 Assert.Equal(new DateTime(2111, 1, 11), context.Chips.Single(c => c.Name == "Buffalo Bleu").BestBuyDate);
-            }
-        }
-
-        public void Dispose()
-        {
-            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
-            {
-                context.Database.EnsureDeleted();
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
@@ -36,12 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                     using (var context = new F1Context(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            ConcurrencyModelInitializer.Seed(context);
-                        }
+                        context.Database.EnsureClean();
+                        ConcurrencyModelInitializer.Seed(context);
 
                         TestSqlLoggerFactory.Reset();
                     }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FindSqliteTest.cs
@@ -31,8 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             {
                 using (var context = CreateContext())
                 {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureClean();
                     Seed(context);
                 }
             }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GearsOfWarQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GearsOfWarQuerySqliteFixture.cs
@@ -36,13 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                     using (var context = new GearsOfWarContext(optionsBuilder.Options))
                     {
-                        // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            GearsOfWarModelInitializer.Seed(context);
-                        }
-
+                        context.Database.EnsureClean();
+                        GearsOfWarModelInitializer.Seed(context);
+                        
                         TestSqlLoggerFactory.Reset();
                     }
                 });

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
@@ -39,11 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                         using (var context = new GraphUpdatesContext(optionsBuilder.Options))
                         {
-                            context.Database.EnsureDeleted();
-                            if (context.Database.EnsureCreated())
-                            {
-                                Seed(context);
-                            }
+                            context.Database.EnsureClean();
+                            Seed(context);
                         }
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceRelationshipsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceRelationshipsQuerySqliteFixture.cs
@@ -48,13 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                         using (var context = new InheritanceRelationshipsContext(optionsBuilder.Options))
                         {
-                            // TODO: Delete DB if model changed
-                            context.Database.EnsureDeleted();
-                            if (context.Database.EnsureCreated())
-                            {
-                                InheritanceRelationshipsModelInitializer.Seed(context);
-                            }
-
+                            context.Database.EnsureClean();
+                            InheritanceRelationshipsModelInitializer.Seed(context);
+                            
                             TestSqlLoggerFactory.Reset();
                         }
                     });

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
@@ -25,8 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = CreateContext())
             {
-                context.Database.EnsureDeleted();
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
                 SeedData(context);
             }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -79,7 +79,9 @@
     <Compile Include="QueryNoClientEvalSqliteFixture.cs" />
     <Compile Include="QueryNoClientEvalSqliteTest.cs" />
     <Compile Include="QuerySqliteTest.cs" />
+    <Compile Include="SqliteDatabaseCleaner.cs" />
     <Compile Include="SqliteDatabaseCreatorTest.cs" />
+    <Compile Include="SqliteDatabaseFacadeExtensions.cs" />
     <Compile Include="SqliteForeignKeyTest.cs" />
     <Compile Include="SqliteTestHelpers.cs" />
     <Compile Include="SqliteTestStore.cs" />
@@ -101,6 +103,10 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Relational.Design\Microsoft.EntityFrameworkCore.Relational.Design.csproj">
+      <Project>{1942c281-c12b-4818-8cc8-c42842871ff5}</Project>
+      <Name>Microsoft.EntityFrameworkCore.Relational.Design</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Relational.Specification.Tests\Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj">
       <Project>{07fa2b15-a6a5-4292-a096-7771fb32eeda}</Project>
       <Name>Microsoft.EntityFrameworkCore.Relational.Specification.Tests</Name>
@@ -112,6 +118,10 @@
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Specification.Tests\Microsoft.EntityFrameworkCore.Specification.Tests.csproj">
       <Project>{1a73d95e-e8b5-4f96-908c-7b040e4f7afe}</Project>
       <Name>Microsoft.EntityFrameworkCore.Specification.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Sqlite.Design\Microsoft.EntityFrameworkCore.Sqlite.Design.csproj">
+      <Project>{d94396a3-391f-4015-9b61-89a9e08d6618}</Project>
+      <Name>Microsoft.EntityFrameworkCore.Sqlite.Design</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.EntityFrameworkCore.Sqlite\Microsoft.EntityFrameworkCore.Sqlite.csproj">
       <Project>{a257c01b-bb91-44ba-831c-1e04f7800ac8}</Project>

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
@@ -55,8 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                 {
                     using (var context = createContext())
                     {
-                        context.Database.EnsureDeleted();
-                        context.Database.EnsureCreated();
+                        EnsureClean(context);
                         context.SeedUsingFKs();
                     }
 
@@ -72,5 +71,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             builder.Entity<TProductPhoto>().HasKey(e => e.PhotoId);
             builder.Entity<TProductReview>().HasKey(e => e.ReviewId);
         }
+
+        protected override void EnsureClean(DbContext context)
+            => context.Database.EnsureClean();
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
@@ -35,6 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+                => context.Database.EnsureClean();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullKeysSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullKeysSqliteTest.cs
@@ -34,6 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             public override DbContext CreateContext()
                 => new DbContext(_options);
+
+            protected override void EnsureClean(DbContext context)
+                => context.Database.EnsureClean();
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullSemanticsQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NullSemanticsQuerySqliteFixture.cs
@@ -37,12 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                     using (var context = new NullSemanticsContext(optionsBuilder.Options))
                     {
                         // TODO: Delete DB if model changed
-                        context.Database.EnsureDeleted();
-                        if (context.Database.EnsureCreated())
-                        {
-                            NullSemanticsModelInitializer.Seed(context);
-                        }
-
+                        context.Database.EnsureClean();
+                        NullSemanticsModelInitializer.Seed(context);
+                        
                         TestSqlLoggerFactory.Reset();
                     }
                 });

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OneToOneQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OneToOneQuerySqliteFixture.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = new DbContext(_options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
 
                 AddTestData(context);
             }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.Tests;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class SqliteDatabaseCleaner : RelationalDatabaseCleaner
+    {
+        protected override IDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
+            => new SqliteDatabaseModelFactory(loggerFactory);
+
+        protected override bool AcceptForeignKey(ForeignKeyModel foreignKey) => false;
+
+        protected override bool AcceptIndex(IndexModel index) => false;
+
+        protected override string BuildCustomSql(DatabaseModel databaseModel) => "PRAGMA foreign_keys=OFF;";
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteDatabaseFacadeExtensions.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteDatabaseFacadeExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public static class SqliteDatabaseFacadeExtensions
+    {
+        public static void EnsureClean(this DatabaseFacade databaseFacade)
+            => new SqliteDatabaseCleaner().Clean(databaseFacade);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteForeignKeyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteForeignKeyTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = new MyContext(options))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
                 context.Add(new Child { ParentId = 4 });
                 if (suppress)
                 {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -39,8 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
                         using (var context = new StoreGeneratedContext(optionsBuilder.Options))
                         {
-                            context.Database.EnsureDeleted();
-                            context.Database.EnsureCreated();
+                            context.Database.EnsureClean();
                         }
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
@@ -32,13 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                             .UseSqlite(_connectionString)
                             .UseInternalServiceProvider(_serviceProvider).Options))
                         {
-                            // TODO: Delete DB if model changed
-                            context.Database.EnsureDeleted();
-                            if (context.Database.EnsureCreated())
-                            {
-                                UpdatesModelInitializer.Seed(context);
-                            }
-
+                            context.Database.EnsureClean();
+                            UpdatesModelInitializer.Seed(context);
+                            
                             TestSqlLoggerFactory.Reset();
                         }
                     });

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.0-*",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.0-*"
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.0-*",
+    "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.1.0-*"
   },
   "publishOptions": {
     "includeFiles": "northwind.db"


### PR DESCRIPTION
context.Database.EnsureClean method for SQLite and SQL Server.

Makes use of the reverse engineering code to query for database structure and then uses Migrations to generate SQL  to drop all the structure. Doesn't handle everything, but handles what we need for 99% of our tests.

Results from my machine (VS/TestDriven.NET)
- Before change:
 - Sqlite.FunctionalTests: 72.02 seconds
 - SqlServer.FunctionalTests: 272.74 seconds

- After change:
 - Sqlite.FunctionalTests: 71.21 seconds
 - SqlServer.FunctionalTests: 165.66 seconds

So no significant change for SQLite, but big improvement for SQL Server

Overall:
========== Total Tests: 11925 passed, 0 failed, 10 skipped, took 448.80 seconds ==========