### PR TITLE
Fix to #6040 - Queries projecting entities incorrectly try to inline parts of their projection even when client side projection of those elements is required

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -175,21 +175,21 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         if (!(sqlExpression is ConstantExpression))
                         {
-                            index = selectExpression.AddToProjection(sqlExpression);
-
-                            aliasExpression = selectExpression.Projection[index] as AliasExpression;
-
-                            if (aliasExpression != null)
-                            {
-                                aliasExpression.SourceExpression = node;
-                            }
-
                             var targetExpression
                                 = QueryModelVisitor.QueryCompilationContext.QuerySourceMapping
                                     .GetExpression(_querySource);
 
                             if (targetExpression.Type == typeof(ValueBuffer))
                             {
+                                index = selectExpression.AddToProjection(sqlExpression);
+
+                                aliasExpression = selectExpression.Projection[index] as AliasExpression;
+
+                                if (aliasExpression != null)
+                                {
+                                    aliasExpression.SourceExpression = node;
+                                }
+
                                 var readValueExpression
                                     = _entityMaterializerSource
                                         .CreateReadValueCallExpression(targetExpression, index);
@@ -209,6 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                                 return Expression.Convert(readValueExpression, node.Type);
                             }
+
                             return node;
                         }
                     }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/InheritanceTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/InheritanceTestBase.cs
@@ -99,6 +99,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var animals = context.Set<Animal>().Select(a => a is Kiwi).ToList();
 
                 Assert.Equal(2, animals.Count);
+                Assert.Equal(1, animals.Count(a => a));
+                Assert.Equal(1, animals.Count(a => !a));
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1588,7 +1588,7 @@ ORDER BY [t].[GearNickName], [t].[GearSquadId]",
             base.Optional_navigation_type_compensation_works_with_list_initializers();
 
             Assert.Equal(
-                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank], 1
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank]
 FROM [CogTag] AS [t]
 LEFT JOIN [Gear] AS [t.Gear] ON ([t].[GearNickName] = [t.Gear].[Nickname]) AND ([t].[GearSquadId] = [t.Gear].[SquadId])
 WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -105,10 +105,7 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND (([a].[Discriminator] = N'K
             base.Can_use_is_kiwi_in_projection();
 
             Assert.Equal(
-                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn], CASE
-    WHEN [a].[Discriminator] = N'Kiwi'
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
 WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')",
                 Sql);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1048,6 +1048,103 @@ ORDER BY [od.Order].[CustomerID]",
                 Sql);
         }
 
+        public override void Project_first_or_default_on_empty_collection_of_value_types_returns_proper_default()
+        {
+            base.Project_first_or_default_on_empty_collection_of_value_types_returns_proper_default();
+
+            Assert.Equal(
+                @"",
+                Sql);
+        }
+
+        public override void Project_single_scalar_value_subquery_is_properly_inlined()
+        {
+            base.Project_single_scalar_value_subquery_is_properly_inlined();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], (
+    SELECT TOP(1) [o0].[OrderID]
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    ORDER BY [o0].[OrderID]
+)
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Project_single_entity_value_subquery_works()
+        {
+            base.Project_single_entity_value_subquery_works();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%'
+ORDER BY [c].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                Sql);
+        }
+
+        public override void Project_single_scalar_value_subquery_in_query_with_optional_navigation_works()
+        {
+            base.Project_single_scalar_value_subquery_in_query_with_optional_navigation_works();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [o].[OrderID], [o].[CustomerID]
+
+@_outer_OrderID: 10248
+
+SELECT TOP(1) [od1].[OrderID]
+FROM [Order Details] AS [od1]
+WHERE @_outer_OrderID = [od1].[OrderID]
+ORDER BY [od1].[OrderID], [od1].[ProductID]
+
+@_outer_OrderID: 10249
+
+SELECT TOP(1) [od1].[OrderID]
+FROM [Order Details] AS [od1]
+WHERE @_outer_OrderID = [od1].[OrderID]
+ORDER BY [od1].[OrderID], [od1].[ProductID]
+
+@_outer_OrderID: 10250
+
+SELECT TOP(1) [od1].[OrderID]
+FROM [Order Details] AS [od1]
+WHERE @_outer_OrderID = [od1].[OrderID]
+ORDER BY [od1].[OrderID], [od1].[ProductID]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -532,15 +532,7 @@ ORDER BY [o].[OrderID]",
             base.Let_any_subquery_anonymous();
 
             Assert.StartsWith(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], (
-    SELECT CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM [Orders] AS [o0]
-            WHERE [o0].[CustomerID] = [c].[CustomerID])
-        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-    END
-)
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
@@ -5609,7 +5601,7 @@ WHERE [c].[CustomerID] LIKE (N'%' + @__NewLine_0) + N'%'",
             base.String_concat_with_navigation1();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region], [o].[CustomerID] + N' '
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 ORDER BY [o].[CustomerID]",


### PR DESCRIPTION
Problem was that during Projection translation we would try to inline single element subqueries into the parent query. However, in case the query source was mapped to Entity as opposed to ValueBuffer we were not modifying the selector expression afterwards.
This resulted in the same subquery being processed again, later in the pipeline, producing redundant and confusing query plans (also the inlined queries were never used in the final result)

Fix is to only inline queries for which we know how to modify the selector (i.e. single element that can be extracted from a ValueBuffer)