### PR TITLE
Query: Add test for string.Compare where argument is not constant

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4223,6 +4223,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void String_compare_with_parameter()
+        {
+            Customer customer = null;
+            using (var context = CreateContext())
+            {
+                customer = context.Customers.OrderBy(c => c.CustomerID).First();
+            }
+
+            ClearLog();
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Compare(c.CustomerID, customer.CustomerID) == 1),
+                entryCount: 90);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => -1 == string.Compare(c.CustomerID, customer.CustomerID)),
+                entryCount: 0);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Compare(c.CustomerID, customer.CustomerID) < 1),
+                entryCount: 1);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => 1 > string.Compare(c.CustomerID, customer.CustomerID)),
+                entryCount: 1);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Compare(c.CustomerID, customer.CustomerID) > -1),
+                entryCount: 91);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => -1 < string.Compare(c.CustomerID, customer.CustomerID)),
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
         public virtual void String_Compare_simple_client()
         {
             AssertQuery<Customer>(
@@ -5803,7 +5839,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             int? entryCount = null,
             Action<IList<object>, IList<object>> asserter = null)
             where TItem1 : class
-            where TItem2 : class 
+            where TItem2 : class
             => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         private void AssertQuery<TItem1, TItem2>(
@@ -5910,6 +5946,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     query(context.Set<TItem>()).ToArray(),
                     assertOrder);
             }
+        }
+
+        protected virtual void ClearLog()
+        {
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4245,6 +4245,49 @@ WHERE [c].[CustomerID] >= N'ALFKI'",
                 Sql);
         }
 
+        public override void String_compare_with_parameter()
+        {
+            base.String_compare_with_parameter();
+
+            Assert.Equal(
+                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] > @__customer_CustomerID_0
+
+@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] < @__customer_CustomerID_0
+
+@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+
+@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] <= @__customer_CustomerID_0
+
+@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] >= @__customer_CustomerID_0
+
+@__customer_CustomerID_0: ALFKI (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] >= @__customer_CustomerID_0",
+                Sql);
+        }
+
         public override void String_Compare_simple_client()
         {
             base.String_Compare_simple_client();
@@ -5622,6 +5665,8 @@ ORDER BY [o].[CustomerID]",
 
         private const string FileLineEnding = @"
 ";
+
+        protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }


### PR DESCRIPTION
Test for #5369 
we already have support for string.Compare. For the particular query it failed because the argument was property of other object. In current code, that is converted to parameter hence correctly translating to SQL.