### PR TITLE
Fix #5773 - FromSql in subqueries

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 // ReSharper disable ConvertToConstant.Local
 // ReSharper disable AccessToDisposedClosure
@@ -85,6 +86,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .ToArray();
 
                 Assert.Equal(14, actual.Length);
+            }
+        }
+
+        [Fact]
+        public virtual void From_sql_composed_contains()
+        {
+            using (var context = CreateContext())
+            {
+                var actual
+                    = (from c in context.Set<Customer>()
+                       where context.Orders.FromSql(@"SELECT * FROM ""Orders""")
+                           .Select(o => o.CustomerID)
+                           .Contains(c.CustomerID)
+                       select c)
+                        .ToArray();
+
+                Assert.Equal(89, actual.Length);
+            }
+        }
+
+        [Fact]
+        public virtual void From_sql_composed_contains2()
+        {
+            using (var context = CreateContext())
+            {
+                var actual
+                    = (from c in context.Set<Customer>()
+                       where
+                           c.CustomerID == "ALFKI"
+                           && context.Orders.FromSql(@"SELECT * FROM ""Orders""")
+                               .Select(o => o.CustomerID)
+                               .Contains(c.CustomerID)
+                       select c)
+                        .ToArray();
+
+                Assert.Equal(1, actual.Length);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -196,6 +196,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         .TrimStart()
                         .StartsWith("SELECT ", StringComparison.OrdinalIgnoreCase);
 
+                var requiresClientEval = !useQueryComposition;
+
                 if (!useQueryComposition)
                 {
                     if (relationalQueryCompilationContext.IsIncludeQuery)
@@ -215,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                 if (!useQueryComposition)
                 {
-                    QueryModelVisitor.RequiresClientEval = true;
+                    QueryModelVisitor.RequiresClientEval = requiresClientEval;
 
                     querySqlGeneratorFunc = ()
                         => selectExpression.CreateFromSqlQuerySqlGenerator(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -813,8 +813,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             Check.NotNull(expression, nameof(expression));
 
             var subQueryModel = expression.QueryModel;
-
             var subQueryOutputDataInfo = subQueryModel.GetOutputDataInfo();
+
             if (subQueryModel.IsIdentityQuery()
                 && subQueryModel.ResultOperators.Count == 1
                 && subQueryModel.ResultOperators.First() is ContainsResultOperator)
@@ -852,8 +852,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             else if (!(subQueryOutputDataInfo is StreamedSequenceInfo))
             {
                 var streamedSingleValueInfo = subQueryOutputDataInfo as StreamedSingleValueInfo;
-                var streamedSingleValueSupportedType = streamedSingleValueInfo != null
-                                                       && _relationalTypeMapper.FindMapping(streamedSingleValueInfo.DataType.UnwrapNullableType().UnwrapEnumType()) != null;
+
+                var streamedSingleValueSupportedType
+                    = streamedSingleValueInfo != null
+                      && _relationalTypeMapper.FindMapping(
+                          streamedSingleValueInfo.DataType
+                              .UnwrapNullableType()
+                              .UnwrapEnumType()) != null;
 
                 if (_inProjection
                     && !(subQueryOutputDataInfo is StreamedScalarValueInfo)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -133,6 +133,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public virtual bool IsProjectStar { get; set; }
 
         /// <summary>
+        ///     Determines whether this SelectExpression is an identity query. An identity query
+        ///     has a single table, and returns all of the rows from that table, unmodified.
+        /// </summary>
+        /// <returns>
+        ///     true if this SelectExpression is an identity query, false if not.
+        /// </returns>
+        public virtual bool IsIdentityQuery()
+            => !IsProjectStar
+               && !IsDistinct
+               && Predicate == null
+               && Limit == null
+               && Offset == null
+               && Projection.Count == 0
+               && OrderBy.Count == 0
+               && Tables.Count == 1;
+
+        /// <summary>
         ///     Adds a table to this SelectExpression.
         /// </summary>
         /// <param name="tableExpression"> The table expression. </param>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -359,7 +359,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
-            var typeIsExpressionTranslatingVisitor = new TypeIsExpressionTranslatingVisitor(QueryCompilationContext.Model, _relationalAnnotationProvider);
+            var typeIsExpressionTranslatingVisitor 
+                = new TypeIsExpressionTranslatingVisitor(QueryCompilationContext.Model, _relationalAnnotationProvider);
+
             queryModel.TransformExpressions(typeIsExpressionTranslatingVisitor.Visit);
 
             base.VisitQueryModel(queryModel);
@@ -519,7 +521,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             var outerShaper = outerShapedQuery.Arguments[2] as ConstantExpression;
-            if (outerShaper == null || !(outerShaper.Value is Shaper))
+            if (!(outerShaper?.Value is Shaper))
             {
                 return false;
             }
@@ -546,12 +548,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             var innerShaper = innerShapedQuery.Arguments[2] as ConstantExpression;
-            if (innerShaper == null || !(innerShaper.Value is Shaper))
-            {
-                return false;
-            }
 
-            return true;
+            return innerShaper?.Value is Shaper;
         }
 
         /// <summary>
@@ -834,7 +832,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         || !subSelectExpression.IsCorrelated()
                         || !(querySource is AdditionalFromClause)))
                 {
-                    subSelectExpression.PushDownSubquery().QuerySource = querySource;
+                    if (!subSelectExpression.IsIdentityQuery())
+                    {
+                        subSelectExpression.PushDownSubquery().QuerySource = querySource;
+                    }
 
                     AddQuery(querySource, subSelectExpression);
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
@@ -48,6 +49,38 @@ FROM (
     SELECT * FROM ""Customers""
 ) AS [c]
 WHERE [c].[ContactName] LIKE (N'%' + N'z') + N'%'",
+                Sql);
+        }
+
+        public override void From_sql_composed_contains()
+        {
+            base.From_sql_composed_contains();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (
+    SELECT [o0].[CustomerID]
+    FROM (
+        SELECT * FROM ""Orders""
+    ) AS [o0]
+)",
+                Sql);
+        }
+
+        public override void From_sql_composed_contains2()
+        {
+            base.From_sql_composed_contains2();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] = N'ALFKI') AND [c].[CustomerID] IN (
+    SELECT [o0].[CustomerID]
+    FROM (
+        SELECT * FROM ""Orders""
+    ) AS [o0]
+)",
                 Sql);
         }
 
@@ -334,9 +367,10 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p1",
                 Sql);
         }
 
-        public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
+        public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
         protected override DbParameter CreateDbParameter(string name, object value)


### PR DESCRIPTION
- Separated requires client eval from composability for FromSql queries in order that FromSql queries can be lifted.
- Fixed a broken assumption in QueryAnnotationExtractor: Extraction should do a deep search of query model expressions.