### PR TITLE
Add Reference/Collection access methods

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides access to change tracking and loading information for a collection
+    ///         navigation property that associates this entity to a collection of another entities.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
+    ///         not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class CollectionEntry : NavigationEntry
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
+            : base(internalEntry, name, collection: true)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
+            : base(internalEntry, navigation)
+        {
+        }
+
+        /// <summary>
+        ///     Gets or sets the value currently assigned to this property. If the current value is set using this property,
+        ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
+        ///     for the context to detect the change.
+        /// </summary>
+        public new virtual IEnumerable CurrentValue
+        {
+            get { return (IEnumerable)base.CurrentValue; }
+            [param: CanBeNull] set { base.CurrentValue = value; }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry`.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -10,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
     ///     <para>
-    ///         Provides access to change tracking information and operations for a given property.
+    ///         Provides access to change tracking and loading information for a collection
+    ///         navigation property that associates this entity to a collection of another entities.
     ///     </para>
     ///     <para>
     ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
@@ -19,14 +21,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
-    public class PropertyEntry<TEntity, TProperty> : PropertyEntry
+    public class CollectionEntry<TEntity, TProperty> : CollectionEntry
         where TEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
+        public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
             : base(internalEntry, name)
         {
         }
@@ -35,8 +37,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] IProperty property)
-            : base(internalEntry, property)
+        public CollectionEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
+            : base(internalEntry, navigation)
         {
         }
 
@@ -51,22 +53,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
         ///     for the context to detect the change.
         /// </summary>
-        public new virtual TProperty CurrentValue
+        public new virtual IEnumerable<TProperty> CurrentValue
         {
-            get { return this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata); }
+            get { return this.GetInfrastructure().GetCurrentValue<IEnumerable<TProperty>>(Metadata); }
             [param: CanBeNull] set { base.CurrentValue = value; }
-        }
-
-        /// <summary>
-        ///     Gets or sets the value that was assigned to this property when it was retrieved from the database.
-        ///     This property is populated when an entity is retrieved from the database, but setting it may be
-        ///     useful in disconnected scenarios where entities are retrieved with one context instance and
-        ///     saved with a different context instance.
-        /// </summary>
-        public new virtual TProperty OriginalValue
-        {
-            get { return this.GetInfrastructure().GetOriginalValue<TProperty>(Metadata); }
-            [param: CanBeNull] set { base.OriginalValue = value; }
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         where TEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public EntityEntry([NotNull] InternalEntityEntry internalEntry)
@@ -53,9 +54,67 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            var propertyInfo = propertyExpression.GetPropertyAccess();
+            return new PropertyEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().Name);
+        }
 
-            return new PropertyEntry<TEntity, TProperty>(this.GetInfrastructure(), propertyInfo.Name);
+        /// <summary>
+        ///     Provides access to change tracking and loading information for a reference (i.e. non-collection)
+        ///     navigation property that associates this entity to another entity.
+        /// </summary>
+        /// <param name="propertyExpression">
+        ///     A lambda expression representing the property to access information and operations for
+        ///     (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns> An object representing the navigation property. </returns>
+        public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>(
+            [NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
+        {
+            Check.NotNull(propertyExpression, nameof(propertyExpression));
+
+            return new ReferenceEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().Name);
+        }
+
+        /// <summary>
+        ///     Provides access to change tracking and loading information for a collection
+        ///     navigation property that associates this entity to a collection of another entities.
+        /// </summary>
+        /// <param name="propertyExpression">
+        ///     A lambda expression representing the property to access information and operations for
+        ///     (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns> An object representing the navigation property. </returns>
+        public virtual CollectionEntry<TEntity, TProperty> Collection<TProperty>(
+            [NotNull] Expression<Func<TEntity, IEnumerable<TProperty>>> propertyExpression)
+        {
+            Check.NotNull(propertyExpression, nameof(propertyExpression));
+
+            return new CollectionEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().Name);
+        }
+
+        /// <summary>
+        ///     Provides access to change tracking and loading information for a reference (i.e. non-collection)
+        ///     navigation property that associates this entity to another entity.
+        /// </summary>
+        /// <param name="navigationPropertyName"> The name of the navigation property. </param>
+        /// <returns> An object representing the navigation property. </returns>
+        public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>([NotNull] string navigationPropertyName)
+        {
+            Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));
+
+            return new ReferenceEntry<TEntity, TProperty>(InternalEntry, navigationPropertyName);
+        }
+
+        /// <summary>
+        ///     Provides access to change tracking and loading information for a collection
+        ///     navigation property that associates this entity to a collection of another entities.
+        /// </summary>
+        /// <param name="navigationPropertyName"> The name of the navigation property. </param>
+        /// <returns> An object representing the navigation property. </returns>
+        public virtual CollectionEntry<TEntity, TProperty> Collection<TProperty>([NotNull] string navigationPropertyName)
+        {
+            Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));
+
+            return new CollectionEntry<TEntity, TProperty>(InternalEntry, navigationPropertyName);
         }
 
         /// <summary>
@@ -68,22 +127,25 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public virtual PropertyEntry<TEntity, TProperty> Property<TProperty>(
             [NotNull] string propertyName)
         {
-            Check.NotNull(propertyName, nameof(propertyName));
+            Check.NotEmpty(propertyName, nameof(propertyName));
 
-            var property = this.GetInfrastructure().EntityType.FindProperty(propertyName);
+            ValidateType<TProperty>(InternalEntry.EntityType.FindProperty(propertyName));
 
-            if ((property != null)
-                && (property.ClrType != typeof(TProperty)))
+            return new PropertyEntry<TEntity, TProperty>(InternalEntry, propertyName);
+        }
+
+        private static void ValidateType<TProperty>(IProperty property)
+        {
+            if (property != null
+                && property.ClrType != typeof(TProperty))
             {
                 throw new ArgumentException(
                     CoreStrings.WrongGenericPropertyType(
-                        propertyName, 
-                        property.DeclaringEntityType.DisplayName(), 
-                        property.ClrType.ShortDisplayName(), 
+                        property.Name,
+                        property.DeclaringEntityType.DisplayName(),
+                        property.ClrType.ShortDisplayName(),
                         typeof(TProperty).ShortDisplayName()));
             }
-
-            return new PropertyEntry<TEntity, TProperty>(this.GetInfrastructure(), propertyName);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/MemberEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/MemberEntry.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides access to change tracking information and operations for a given property
+    ///         or navigation property.
+    ///     </para>
+    ///     <para>
+    ///         Scalar properties use the derived class <see cref="PropertyEntry" />, reference navigation
+    ///         properties use the derived class <see cref="ReferenceEntry" />, and collection navigation
+    ///         properties use the derived class <see cref="CollectionEntry" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
+    ///         not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public abstract class MemberEntry : IInfrastructure<InternalEntityEntry>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected MemberEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] IPropertyBase metadata)
+        {
+            Check.NotNull(internalEntry, nameof(internalEntry));
+            Check.NotNull(metadata, nameof(metadata));
+
+            InternalEntry = internalEntry;
+            Metadata = metadata;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual InternalEntityEntry InternalEntry { get; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether the value of this property has been modified
+        ///     and should be updated in the database when <see cref="DbContext.SaveChanges()" />
+        ///     is called.
+        /// </summary>
+        public abstract bool IsModified { get; set; }
+
+        /// <summary>
+        ///     Gets the metadata that describes the facets of this property and how it maps to the database.
+        /// </summary>
+        public virtual IPropertyBase Metadata { get; }
+
+        /// <summary>
+        ///     Gets or sets the value currently assigned to this property. If the current value is set using this property,
+        ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
+        ///     for the context to detect the change.
+        /// </summary>
+        public virtual object CurrentValue
+        {
+            get { return InternalEntry[Metadata]; }
+            [param: CanBeNull] set { InternalEntry[Metadata] = value; }
+        }
+
+        /// <summary>
+        ///     The <see cref="EntityEntry" /> to which this member belongs.
+        /// </summary>
+        /// <value> An entry for the entity that owns this member. </value>
+        public virtual EntityEntry EntityEntry => new EntityEntry(InternalEntry);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance => InternalEntry;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/NavigationEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/NavigationEntry.cs
@@ -1,0 +1,160 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides access to change tracking and loading information for a collection
+    ///         navigation property that associates this entity to a collection of another entities.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
+    ///         not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public abstract class NavigationEntry : MemberEntry
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected NavigationEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name, bool collection)
+            : this(internalEntry, GetNavigation(internalEntry, name, collection))
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected NavigationEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
+            : base(internalEntry, navigation)
+        {
+        }
+
+        private static INavigation GetNavigation(InternalEntityEntry internalEntry, string name, bool collection)
+        {
+            var navigation = internalEntry.EntityType.FindNavigation(name);
+            if (navigation == null)
+            {
+                if (internalEntry.EntityType.FindProperty(name) != null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationIsProperty(name, internalEntry.EntityType.DisplayName(),
+                        nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)));
+                }
+                throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, internalEntry.EntityType.DisplayName()));
+            }
+
+            if (collection
+                && !navigation.IsCollection())
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.CollectionIsReference(name, internalEntry.EntityType.DisplayName(),
+                    nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)));
+            }
+
+            if (!collection
+                && navigation.IsCollection())
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ReferenceIsCollection(name, internalEntry.EntityType.DisplayName(),
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)));
+            }
+
+            return navigation;
+        }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether any of foreign key property values associated
+        ///     with this navigation property have been modified and should be updated in the database 
+        ///     when <see cref="DbContext.SaveChanges()" /> is called.
+        /// </summary>
+        public override bool IsModified
+        {
+            get
+            {
+                if (Metadata.IsDependentToPrincipal())
+                {
+                    return AnyFkPropertiesModified(InternalEntry);
+                }
+
+                var navigationValue = CurrentValue;
+
+                return navigationValue != null
+                       && (Metadata.IsCollection()
+                           ? ((IEnumerable)navigationValue).OfType<object>().Any(AnyFkPropertiesModified)
+                           : AnyFkPropertiesModified(navigationValue));
+            }
+            set
+            {
+                if (Metadata.IsDependentToPrincipal())
+                {
+                    SetFkPropertiesModified(InternalEntry, value);
+                }
+                else
+                {
+                    var navigationValue = CurrentValue;
+                    if (navigationValue != null)
+                    {
+                        if (Metadata.IsCollection())
+                        {
+                            foreach (var relatedEntity in (IEnumerable)navigationValue)
+                            {
+                                SetFkPropertiesModified(relatedEntity, value);
+                            }
+                        }
+                        else
+                        {
+                            SetFkPropertiesModified(navigationValue, value);
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool AnyFkPropertiesModified(object relatedEntity)
+        {
+            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity);
+
+            return relatedEntry != null
+                   && Metadata.ForeignKey.Properties.Any(relatedEntry.IsModified);
+        }
+
+        private void SetFkPropertiesModified(object relatedEntity, bool modified)
+        {
+            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity);
+            if (relatedEntry != null)
+            {
+                SetFkPropertiesModified(relatedEntry, modified);
+            }
+        }
+
+        private void SetFkPropertiesModified(InternalEntityEntry internalEntityEntry, bool modified)
+        {
+            foreach (var property in Metadata.ForeignKey.Properties)
+            {
+                internalEntityEntry.SetPropertyModified(property, isModified: modified);
+            }
+        }
+
+        private bool AnyFkPropertiesModified(InternalEntityEntry internalEntityEntry)
+            => Metadata.ForeignKey.Properties.Any(internalEntityEntry.IsModified);
+
+        /// <summary>
+        ///     Gets the metadata that describes the facets of this property and how it maps to the database.
+        /// </summary>
+        public new virtual INavigation Metadata
+            => (INavigation)base.Metadata;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides access to change tracking and loading information for a reference (i.e. non-collection)
+    ///         navigation property that associates this entity to another entity.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
+    ///         not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class ReferenceEntry : NavigationEntry
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
+            : base(internalEntry, name, collection: false)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
+            : base(internalEntry, navigation)
+        {
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry`.cs
@@ -10,7 +10,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
     ///     <para>
-    ///         Provides access to change tracking information and operations for a given property.
+    ///         Provides access to change tracking and loading information for a reference (i.e. non-collection)
+    ///         navigation property that associates this entity to another entity.
     ///     </para>
     ///     <para>
     ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
@@ -19,14 +20,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
-    public class PropertyEntry<TEntity, TProperty> : PropertyEntry
+    public class ReferenceEntry<TEntity, TProperty> : ReferenceEntry
         where TEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
+        public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
             : base(internalEntry, name)
         {
         }
@@ -35,8 +36,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] IProperty property)
-            : base(internalEntry, property)
+        public ReferenceEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] INavigation navigation)
+            : base(internalEntry, navigation)
         {
         }
 
@@ -55,18 +56,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             get { return this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata); }
             [param: CanBeNull] set { base.CurrentValue = value; }
-        }
-
-        /// <summary>
-        ///     Gets or sets the value that was assigned to this property when it was retrieved from the database.
-        ///     This property is populated when an entity is retrieved from the database, but setting it may be
-        ///     useful in disconnected scenarios where entities are retrieved with one context instance and
-        ///     saved with a different context instance.
-        /// </summary>
-        public new virtual TProperty OriginalValue
-        {
-            get { return this.GetInfrastructure().GetOriginalValue<TProperty>(Metadata); }
-            [param: CanBeNull] set { base.OriginalValue = value; }
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -49,6 +49,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public override Type ClrType => PropertyInfo?.PropertyType ?? typeof(object);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual ForeignKey ForeignKey { get; }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Type ClrType { get; }
+        public override Type ClrType { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -24,10 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual PropertyAccessors Create([NotNull] IPropertyBase propertyBase)
             => (PropertyAccessors)_genericCreate
-                .MakeGenericMethod((propertyBase as IProperty)?.ClrType
-                                   ?? (((INavigation)propertyBase).IsCollection()
-                                       ? typeof(HashSet<object>)
-                                       : typeof(object)))
+                .MakeGenericMethod(propertyBase.GetClrType())
                 .Invoke(null, new object[] { propertyBase });
 
         private static readonly MethodInfo _genericCreate

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -51,6 +52,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual PropertyInfo PropertyInfo { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract Type ClrType { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
@@ -139,6 +140,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static PropertyInfo GetPropertyInfo([NotNull] this IPropertyBase propertyBase)
             => propertyBase.AsPropertyBase().PropertyInfo;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static Type GetClrType([NotNull] this IPropertyBase propertyBase)
+            => propertyBase.AsPropertyBase().ClrType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -60,6 +60,8 @@
       <Link>StringBuilderExtensions.cs</Link>
     </Compile>
     <Compile Include="ChangeTracking\ChangeTracker.cs" />
+    <Compile Include="ChangeTracking\CollectionEntry.cs" />
+    <Compile Include="ChangeTracking\CollectionEntry`.cs" />
     <Compile Include="ChangeTracking\EntityEntry.cs" />
     <Compile Include="ChangeTracking\EntityEntryGraphNode.cs" />
     <Compile Include="ChangeTracking\EntityEntry`.cs" />
@@ -127,9 +129,13 @@
     <Compile Include="ChangeTracking\Internal\StoreGeneratedValues.cs" />
     <Compile Include="ChangeTracking\Internal\TrackingQueryMode.cs" />
     <Compile Include="ChangeTracking\Internal\ValueGenerationManager.cs" />
+    <Compile Include="ChangeTracking\MemberEntry.cs" />
+    <Compile Include="ChangeTracking\NavigationEntry.cs" />
     <Compile Include="ChangeTracking\ObservableHashSet.cs" />
     <Compile Include="ChangeTracking\PropertyEntry.cs" />
     <Compile Include="ChangeTracking\PropertyEntry`.cs" />
+    <Compile Include="ChangeTracking\ReferenceEntry.cs" />
+    <Compile Include="ChangeTracking\ReferenceEntry`.cs" />
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptions.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -89,6 +89,38 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is being accessed using the '{PropertyMethod}' method, but is defined in the model as a navigation property. Use either the '{ReferenceMethod}' or '{CollectionMethod}' method to access navigation properties.
+        /// </summary>
+        public static string PropertyIsNavigation([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object PropertyMethod, [CanBeNull] object ReferenceMethod, [CanBeNull] object CollectionMethod)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyIsNavigation", "property", "entityType", "PropertyMethod", "ReferenceMethod", "CollectionMethod"), property, entityType, PropertyMethod, ReferenceMethod, CollectionMethod);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is being accessed using the '{ReferenceMethod}' or '{CollectionMethod}' method, but is defined in the model as a non-navigation property. Use the '{PropertyMethod}' method to access non-navigation properties.
+        /// </summary>
+        public static string NavigationIsProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object ReferenceMethod, [CanBeNull] object CollectionMethod, [CanBeNull] object PropertyMethod)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationIsProperty", "property", "entityType", "ReferenceMethod", "CollectionMethod", "PropertyMethod"), property, entityType, ReferenceMethod, CollectionMethod, PropertyMethod);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is being accessed using the '{ReferenceMethod}' method, but is defined in the model as a collection navigation property. Use the '{CollectionMethod}' method to access collection navigation properties.
+        /// </summary>
+        public static string ReferenceIsCollection([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object ReferenceMethod, [CanBeNull] object CollectionMethod)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ReferenceIsCollection", "property", "entityType", "ReferenceMethod", "CollectionMethod"), property, entityType, ReferenceMethod, CollectionMethod);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation property. Use the '{ReferenceMethod}' method to access reference navigation properties.
+        /// </summary>
+        public static string CollectionIsReference([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object CollectionMethod, [CanBeNull] object ReferenceMethod)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CollectionIsReference", "property", "entityType", "CollectionMethod", "ReferenceMethod"), property, entityType, CollectionMethod, ReferenceMethod);
+        }
+
+        /// <summary>
         /// The collection argument '{argumentName}' must contain at least one element.
         /// </summary>
         public static string CollectionArgumentIsEmpty([CanBeNull] object argumentName)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -144,6 +144,18 @@
   <data name="PropertyNotFound" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' could not be found. Ensure that the property exists and has been included in the model.</value>
   </data>
+  <data name="PropertyIsNavigation" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is being accessed using the '{PropertyMethod}' method, but is defined in the model as a navigation property. Use either the '{ReferenceMethod}' or '{CollectionMethod}' method to access navigation properties.</value>
+  </data>
+  <data name="NavigationIsProperty" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is being accessed using the '{ReferenceMethod}' or '{CollectionMethod}' method, but is defined in the model as a non-navigation property. Use the '{PropertyMethod}' method to access non-navigation properties.</value>
+  </data>
+  <data name="ReferenceIsCollection" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is being accessed using the '{ReferenceMethod}' method, but is defined in the model as a collection navigation property. Use the '{CollectionMethod}' method to access collection navigation properties.</value>
+  </data>
+  <data name="CollectionIsReference" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation property. Use the '{ReferenceMethod}' method to access reference navigation properties.</value>
+  </data>
   <data name="CollectionArgumentIsEmpty" xml:space="preserve">
     <value>The collection argument '{argumentName}' must contain at least one element.</value>
   </data>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
@@ -1,0 +1,402 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
+{
+    public class CollectionEntryTest
+    {
+        [Fact]
+        public void Can_get_back_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Collection("Monkeys").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_back_reference_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Collection(e => e.Monkeys).EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                Assert.Equal("Monkeys", context.Entry(entity).Collection("Monkeys").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                Assert.Equal("Monkeys", context.Entry(entity).Collection(e => e.Monkeys).Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Collection("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_not_tracked()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+
+                var collection = context.Entry(cherry).Collection("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Null(chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Null(chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_generic_not_tracked()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Null(chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Null(chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+
+        [Fact]
+        public void Can_get_and_set_current_value_start_tracking()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.Add(cherry);
+
+                var collection = context.Entry(cherry).Collection("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_start_tracking_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.Add(cherry);
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Single());
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_attched()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AttachRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Collection("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_generic_attched()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AttachRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, collection.CurrentValue.Single());
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_tracks_state_of_FK_property_principal()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Garcia = cherry };
+                var chunky2 = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+                context.AttachRange(cherry, chunky1, chunky2);
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.False(collection.IsModified);
+
+                context.Entry(chunky1).State = EntityState.Modified;
+
+                Assert.True(collection.IsModified);
+
+                context.Entry(chunky1).State = EntityState.Unchanged;
+
+                Assert.False(collection.IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_can_set_fk_to_modified_principal()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Garcia = cherry };
+                var chunky2 = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+                context.AttachRange(cherry, chunky1, chunky2);
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.False(collection.IsModified);
+
+                collection.IsModified = true;
+
+                Assert.True(collection.IsModified);
+                Assert.True(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.True(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+
+                collection.IsModified = false;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky1).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky2).State);
+            }
+        }
+
+        private class Chunky
+        {
+            public int Monkey { get; set; }
+            public int Id { get; set; }
+
+            public int? GarciaId { get; set; }
+            public Cherry Garcia { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Garcia { get; set; }
+            public int Id { get; set; }
+
+            public ICollection<Chunky> Monkeys { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore.Specification.Tests;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
@@ -205,18 +206,360 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             }
         }
 
+        [Fact]
+        public void Throws_when_accessing_navigation_as_property()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.PropertyIsNavigation("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Property), nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Property("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyIsNavigation("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Property), nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Property("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyIsNavigation("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Property), nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Property<Cherry>("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyIsNavigation("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Property), nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Property(e => e.Garcia).Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Can_get_reference_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal("Garcia", context.Entry(entity).Reference("Garcia").Metadata.Name);
+                Assert.Equal("Garcia", context.Entry((object)entity).Reference("Garcia").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_generic_reference_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal("Garcia", context.Entry(entity).Reference<Cherry>("Garcia").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_generic_reference_entry_by_lambda()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal("Garcia", context.Entry(entity).Reference(e => e.Garcia).Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_wrong_reference_name_is_used_while_getting_property_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Reference("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference<Cherry>("Chimp").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_accessing_property_as_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference("Monkey").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Reference("Monkey").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference<int>("Monkey").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference(e => e.Monkey).Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_accessing_collection_as_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal(CoreStrings.ReferenceIsCollection("Monkeys", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference("Monkeys").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.ReferenceIsCollection("Monkeys", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Reference("Monkeys").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.ReferenceIsCollection("Monkeys", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference<int>("Monkeys").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.ReferenceIsCollection("Monkeys", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Reference(e => e.Monkeys).Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Can_get_collection_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal("Monkeys", context.Entry(entity).Collection("Monkeys").Metadata.Name);
+                Assert.Equal("Monkeys", context.Entry((object)entity).Collection("Monkeys").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_generic_collection_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal("Monkeys", context.Entry(entity).Collection<Chunky>("Monkeys").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_generic_collection_entry_by_lambda()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal("Monkeys", context.Entry(entity).Collection(e => e.Monkeys).Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_wrong_collection_name_is_used_while_getting_property_entry_by_name()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Collection("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection<Cherry>("Chimp").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_accessing_property_as_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                Assert.Equal(CoreStrings.NavigationIsProperty("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Collection("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection<int>("Garcia").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_accessing_refernce_as_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.CollectionIsReference("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.CollectionIsReference("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Collection("Garcia").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.CollectionIsReference("Garcia", entity.GetType().Name,
+                    nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Collection<Cherry>("Garcia").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Can_get_property_entry_by_name_using_Member()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                var entry = context.Entry(entity).Member("Monkey");
+                Assert.Equal("Monkey", entry.Metadata.Name);
+                Assert.IsType<PropertyEntry>(entry);
+
+                entry = context.Entry((object)entity).Member("Monkey");
+                Assert.Equal("Monkey", entry.Metadata.Name);
+                Assert.IsType<PropertyEntry>(entry);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_wrong_property_name_is_used_while_getting_property_entry_by_name_using_Member()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Member("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Member("Chimp").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Can_get_reference_entry_by_name_using_Member()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                var entry = context.Entry(entity).Member("Garcia");
+                Assert.Equal("Garcia", entry.Metadata.Name);
+                Assert.IsType<ReferenceEntry>(entry);
+
+                entry = context.Entry((object)entity).Member("Garcia");
+                Assert.Equal("Garcia", entry.Metadata.Name);
+                Assert.IsType<ReferenceEntry>(entry);
+            }
+        }
+
+        [Fact]
+        public void Can_get_collection_entry_by_name_using_Member()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                var entry = context.Entry(entity).Member("Monkeys");
+                Assert.Equal("Monkeys", entry.Metadata.Name);
+                Assert.IsType<CollectionEntry>(entry);
+
+                entry = context.Entry((object)entity).Member("Monkeys");
+                Assert.Equal("Monkeys", entry.Metadata.Name);
+                Assert.IsType<CollectionEntry>(entry);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_wrong_property_name_is_used_while_getting_property_entry_by_name_using_Navigation()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Navigation("Chimp").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.PropertyNotFound("Chimp", entity.GetType().Name),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Navigation("Chimp").Metadata.Name).Message);
+            }
+        }
+
+        [Fact]
+        public void Can_get_reference_entry_by_name_using_Navigation()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                var entry = context.Entry(entity).Navigation("Garcia");
+                Assert.Equal("Garcia", entry.Metadata.Name);
+                Assert.IsType<ReferenceEntry>(entry);
+
+                entry = context.Entry((object)entity).Navigation("Garcia");
+                Assert.Equal("Garcia", entry.Metadata.Name);
+                Assert.IsType<ReferenceEntry>(entry);
+            }
+        }
+
+        [Fact]
+        public void Can_get_collection_entry_by_name_using_Navigation()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Cherry()).Entity;
+
+                var entry = context.Entry(entity).Navigation("Monkeys");
+                Assert.Equal("Monkeys", entry.Metadata.Name);
+                Assert.IsType<CollectionEntry>(entry);
+
+                entry = context.Entry((object)entity).Navigation("Monkeys");
+                Assert.Equal("Monkeys", entry.Metadata.Name);
+                Assert.IsType<CollectionEntry>(entry);
+            }
+        }
+
+        [Fact]
+        public void Throws_when_accessing_property_as_navigation()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = context.Add(new Chunky()).Entity;
+
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(entity).Navigation("Monkey").Metadata.Name).Message);
+                Assert.Equal(CoreStrings.NavigationIsProperty("Monkey", entity.GetType().Name,
+                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry((object)entity).Navigation("Monkey").Metadata.Name).Message);
+            }
+        }
+
         private class Chunky
         {
             public int Monkey { get; set; }
             public int Id { get; set; }
+
+            public int GarciaId { get; set; }
+            public Cherry Garcia { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Garcia { get; set; }
+            public int Id { get; set; }
+
+            public ICollection<Chunky> Monkeys { get; set; }
         }
 
         private class FreezerContext : DbContext
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseInMemoryDatabase()
-                    .UseInternalServiceProvider(TestHelpers.Instance.CreateServiceProvider());
+                => optionsBuilder.UseInMemoryDatabase();
 
             public DbSet<Chunky> Icecream { get; set; }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/MemberEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/MemberEntryTest.cs
@@ -1,0 +1,245 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
+{
+    public class MemberEntryTest
+    {
+        [Fact]
+        public void Can_get_back_reference_property()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Member("Monkey").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_back_reference_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Member("Garcia").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_back_reference_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Member("Monkeys").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_property()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                Assert.Equal("Monkey", context.Entry(entity).Member("Monkey").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                Assert.Equal("Garcia", context.Entry(entity).Member("Garcia").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                Assert.Equal("Monkeys", context.Entry(entity).Member("Monkeys").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_property()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var property = context.Entry(entity).Member("GarciaId");
+
+                Assert.Null(property.CurrentValue);
+
+                property.CurrentValue = 77;
+                Assert.Equal(77, property.CurrentValue);
+
+                property.CurrentValue = null;
+                Assert.Null(property.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Member("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Member("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void IsModified_tracks_state_of_FK_property_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky };
+                context.AttachRange(cherry, chunky);
+
+                var reference = context.Entry(chunky).Member("Garcia");
+
+                Assert.False(reference.IsModified);
+
+                chunky.GarciaId = null;
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(reference.IsModified);
+
+                context.Entry(chunky).State = EntityState.Unchanged;
+
+                Assert.False(reference.IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_can_set_fk_to_modified_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Garcia = cherry };
+                var chunky2 = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+                context.AttachRange(cherry, chunky1, chunky2);
+
+                var collection = context.Entry(cherry).Member("Monkeys");
+
+                Assert.False(collection.IsModified);
+
+                collection.IsModified = true;
+
+                Assert.True(collection.IsModified);
+                Assert.True(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.True(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+
+                collection.IsModified = false;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky1).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky2).State);
+            }
+        }
+        private class Chunky
+        {
+            public int Monkey { get; set; }
+            public int Id { get; set; }
+
+            public int? GarciaId { get; set; }
+            public Cherry Garcia { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Garcia { get; set; }
+            public int Id { get; set; }
+
+            public ICollection<Chunky> Monkeys { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/NavigationEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/NavigationEntryTest.cs
@@ -1,0 +1,201 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
+{
+    public class NavigationEntryTest
+    {
+        [Fact]
+        public void Can_get_back_reference_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Navigation("Garcia").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_back_reference_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Navigation("Monkeys").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                Assert.Equal("Garcia", context.Entry(entity).Navigation("Garcia").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Cherry();
+                context.Add(entity);
+
+                Assert.Equal("Monkeys", context.Entry(entity).Navigation("Monkeys").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Navigation("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var collection = context.Entry(cherry).Navigation("Monkeys");
+
+                Assert.Null(collection.CurrentValue);
+
+                collection.CurrentValue = new List<Chunky> { chunky };
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
+
+                collection.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(collection.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void IsModified_tracks_state_of_FK_property_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky };
+                context.AttachRange(cherry, chunky);
+
+                var reference = context.Entry(chunky).Navigation("Garcia");
+
+                Assert.False(reference.IsModified);
+
+                chunky.GarciaId = null;
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(reference.IsModified);
+
+                context.Entry(chunky).State = EntityState.Unchanged;
+
+                Assert.False(reference.IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_can_set_fk_to_modified_collection()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Garcia = cherry };
+                var chunky2 = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+                context.AttachRange(cherry, chunky1, chunky2);
+
+                var collection = context.Entry(cherry).Navigation("Monkeys");
+
+                Assert.False(collection.IsModified);
+
+                collection.IsModified = true;
+
+                Assert.True(collection.IsModified);
+                Assert.True(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.True(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+
+                collection.IsModified = false;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky1).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(chunky2).State);
+            }
+        }
+
+        private class Chunky
+        {
+            public int Monkey { get; set; }
+            public int Id { get; set; }
+
+            public int? GarciaId { get; set; }
+            public Cherry Garcia { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Garcia { get; set; }
+            public int Id { get; set; }
+
+            public ICollection<Chunky> Monkeys { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -1,0 +1,460 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
+{
+    public class ReferenceEntryTest
+    {
+        [Fact]
+        public void Can_get_back_reference()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Reference("Garcia").EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_back_reference_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                var entityEntry = context.Entry(entity);
+                Assert.Same(entityEntry.Entity, entityEntry.Reference(e => e.Garcia).EntityEntry.Entity);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                Assert.Equal("Garcia", context.Entry(entity).Reference("Garcia").Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_metadata_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var entity = new Chunky();
+                context.Add(entity);
+
+                Assert.Equal("Garcia", context.Entry(entity).Reference(e => e.Garcia).Metadata.Name);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Reference("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AddRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Reference(e => e.Garcia);
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_not_tracked()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+
+                var reference = context.Entry(chunky).Reference("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_not_tracked_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+
+                var reference = context.Entry(chunky).Reference(e => e.Garcia);
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Null(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_start_tracking()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.Add(chunky);
+
+                var reference = context.Entry(chunky).Reference("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_start_tracking_generic()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.Add(chunky);
+
+                var reference = context.Entry(chunky).Reference(e => e.Garcia);
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+
+                Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_attached()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AttachRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Reference("Garcia");
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_current_value_generic_attached()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky();
+                context.AttachRange(chunky, cherry);
+
+                var reference = context.Entry(chunky).Reference(e => e.Garcia);
+
+                Assert.Null(reference.CurrentValue);
+
+                reference.CurrentValue = cherry;
+
+                Assert.Same(cherry, chunky.Garcia);
+                Assert.Same(chunky, cherry.Monkeys.Single());
+                Assert.Equal(cherry.Id, chunky.GarciaId);
+                Assert.Same(cherry, reference.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+
+                reference.CurrentValue = null;
+
+                Assert.Null(chunky.Garcia);
+                Assert.Empty(cherry.Monkeys);
+                Assert.Null(chunky.GarciaId);
+                Assert.Null(reference.CurrentValue);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(cherry).State);
+                Assert.Equal(EntityState.Modified, context.Entry(chunky).State);
+                Assert.True(context.Entry(chunky).Property(e => e.GarciaId).IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_tracks_state_of_FK_property()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky };
+                context.AttachRange(cherry, chunky);
+
+                var reference = context.Entry(chunky).Reference(e => e.Garcia);
+
+                Assert.False(reference.IsModified);
+
+                chunky.GarciaId = null;
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(reference.IsModified);
+
+                context.Entry(chunky).State = EntityState.Unchanged;
+
+                Assert.False(reference.IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_can_set_fk_to_modified()
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky = new Chunky { Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky };
+                context.AttachRange(cherry, chunky);
+
+                var entityEntry = context.Entry(chunky);
+                var reference = entityEntry.Reference(e => e.Garcia);
+
+                Assert.False(reference.IsModified);
+
+                reference.IsModified = true;
+
+                Assert.True(reference.IsModified);
+                Assert.True(entityEntry.Property(e => e.GarciaId).IsModified);
+
+                reference.IsModified = false;
+
+                Assert.False(reference.IsModified);
+                Assert.False(entityEntry.Property(e => e.GarciaId).IsModified);
+                Assert.Equal(EntityState.Unchanged, entityEntry.State);
+            }
+        }
+
+        [Fact]
+        public void IsModified_tracks_state_of_FK_property_principal()
+        {
+            using (var context = new FreezerContext())
+            {
+                var half = new Half();
+                var chunky = new Chunky { Baked = half };
+                half.Monkey =chunky;
+                context.AttachRange(chunky, half);
+
+                var reference = context.Entry(chunky).Reference(e => e.Baked);
+
+                Assert.False(reference.IsModified);
+
+                context.Entry(half).State = EntityState.Modified;
+
+                Assert.True(reference.IsModified);
+
+                context.Entry(half).State = EntityState.Unchanged;
+
+                Assert.False(reference.IsModified);
+            }
+        }
+
+        [Fact]
+        public void IsModified_can_set_fk_to_modified_principal()
+        {
+            using (var context = new FreezerContext())
+            {
+                var half = new Half();
+                var chunky = new Chunky { Baked = half };
+                half.Monkey = chunky;
+                context.AttachRange(chunky, half);
+
+                var reference = context.Entry(chunky).Reference(e => e.Baked);
+
+                Assert.False(reference.IsModified);
+
+                reference.IsModified = true;
+
+                Assert.True(reference.IsModified);
+                Assert.True(context.Entry(half).Property(e => e.MonkeyId).IsModified);
+
+                reference.IsModified = false;
+
+                Assert.False(reference.IsModified);
+                Assert.False(context.Entry(half).Property(e => e.MonkeyId).IsModified);
+                Assert.Equal(EntityState.Unchanged, context.Entry(half).State);
+            }
+        }
+
+        private class Chunky
+        {
+            public int Monkey { get; set; }
+            public int Id { get; set; }
+
+            public int? GarciaId { get; set; }
+            public Cherry Garcia { get; set; }
+
+            public Half Baked { get; set; }
+        }
+
+        private class Half
+        {
+            public int Baked { get; set; }
+            public int Id { get; set; }
+
+            public int? MonkeyId { get; set; }
+            public Chunky Monkey { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Garcia { get; set; }
+            public int Id { get; set; }
+
+            public ICollection<Chunky> Monkeys { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ApiConsistencyTestBase.cs" />
     <Compile Include="ChangeTracking\AggregatesTest.cs" />
     <Compile Include="ChangeTracking\ChangeTrackerTest.cs" />
+    <Compile Include="ChangeTracking\CollectionEntryTest.cs" />
     <Compile Include="ChangeTracking\EntityEntryTest.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeDetectorTest.cs" />
     <Compile Include="ChangeTracking\Internal\FixupTest.cs" />
@@ -73,8 +74,11 @@
     <Compile Include="ChangeTracking\Internal\ShadowFkFixupTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateDataTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateManagerTest.cs" />
+    <Compile Include="ChangeTracking\MemberEntryTest.cs" />
+    <Compile Include="ChangeTracking\NavigationEntryTest.cs" />
     <Compile Include="ChangeTracking\ObservableHashSetTest.cs" />
     <Compile Include="ChangeTracking\PropertyEntryTest.cs" />
+    <Compile Include="ChangeTracking\ReferenceEntryTest.cs" />
     <Compile Include="ContextConfigurationTest.cs" />
     <Compile Include="DatabaseFacadeTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />


### PR DESCRIPTION
Fills out the skeleton of the EntityEntry API adding methods for navigation properties. Patterned closely on the EF6 API.

Also implemented #5114.