### PR TITLE
Pull down the relationship to the derived type for any order it can be configured.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -27,12 +28,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public CollectionNavigationBuilder(
+            [NotNull] EntityType declaringEntityType,
+            [NotNull] EntityType relatedEntityType,
+            [CanBeNull] PropertyInfo navigationProperty,
             [NotNull] InternalRelationshipBuilder builder)
-            : base(builder)
+            : base(declaringEntityType, relatedEntityType, navigationProperty, builder)
         {
         }
 
@@ -48,6 +52,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
+                DeclaringEntityType,
+                RelatedEntityType,
                 WithOneBuilder(navigationExpression?.GetPropertyAccess()));
 
         /// <summary>
@@ -60,6 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
+                DeclaringEntityType,
+                RelatedEntityType,
                 WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     public class EntityTypeBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalEntityTypeBuilder>
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public EntityTypeBuilder([NotNull] InternalEntityTypeBuilder builder)
@@ -34,11 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     Creates a new builder based on the provided internal builder. This can be overridden by derived builders
-        ///     so that logic inherited from this base class will create instances of the derived builder.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="builder"> The internal builder to create the new builder from. </param>
-        /// <returns> The newly created builder. </returns>
         protected virtual EntityTypeBuilder New([NotNull] InternalEntityTypeBuilder builder)
             => new EntityTypeBuilder(builder);
 
@@ -270,9 +268,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null)
-            => new CollectionNavigationBuilder(HasManyBuilder(
-                Builder.ModelBuilder.Entity(Check.NotNull(relatedType, nameof(relatedType)), ConfigurationSource.Explicit).Metadata,
-                Check.NullButNotEmpty(navigationName, nameof(navigationName))));
+        {
+            Check.NotNull(relatedType, nameof(relatedType));
+            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+
+            var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+
+            return new CollectionNavigationBuilder(
+                Builder.Metadata,
+                relatedEntityType,
+                navigationName,
+                HasManyBuilder(relatedEntityType, navigationName));
+        }
 
         /// <summary>
         ///     <para>
@@ -296,32 +303,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName = null)
-            => new CollectionNavigationBuilder(HasManyBuilder(
-                Builder.ModelBuilder.Entity(Check.NotEmpty(relatedTypeName, nameof(relatedTypeName)), ConfigurationSource.Explicit).Metadata,
-                Check.NullButNotEmpty(navigationName, nameof(navigationName))));
+        {
+            Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
+            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+
+            var relatedEntityType = Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
+
+            return new CollectionNavigationBuilder(
+                Builder.Metadata,
+                relatedEntityType,
+                navigationName,
+                HasManyBuilder(relatedEntityType, navigationName));
+        }
 
         /// <summary>
-        ///     Creates a relationship builder for a relationship that has a reference navigation property on this entity.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="relatedEntityType"> The entity type that the relationship targets. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on this entity. If null is passed, then a relationship with no navigation
-        ///     property is created.
-        /// </param>
-        /// <returns> The newly created builder. </returns>
         protected virtual InternalRelationshipBuilder HasOneBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
             => HasOneBuilder(relatedEntityType, PropertyIdentity.Create(navigationName));
 
         /// <summary>
-        ///     Creates a relationship builder for a relationship that has a reference navigation property on this entity.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="relatedEntityType"> The entity type that the relationship targets. </param>
-        /// <param name="navigationProperty">
-        ///     The reference navigation property on this entity. If null is passed, then a relationship with no navigation
-        ///     property is created.
-        /// </param>
-        /// <returns> The newly created builder. </returns>
         protected virtual InternalRelationshipBuilder HasOneBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] PropertyInfo navigationProperty)
             => HasOneBuilder(relatedEntityType, PropertyIdentity.Create(navigationProperty));
@@ -337,23 +343,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     ? relationship.DependentToPrincipal(navigationProperty, ConfigurationSource.Explicit)
                     : relationship.DependentToPrincipal(navigation.Name, ConfigurationSource.Explicit);
             }
-            else
-            {
-                return navigationProperty != null
-                    ? Builder.Navigation(relatedEntityType.Builder, navigationProperty, ConfigurationSource.Explicit)
-                    : Builder.Navigation(relatedEntityType.Builder, navigation.Name, ConfigurationSource.Explicit);
-            }
+
+            return navigationProperty != null
+                ? Builder.Navigation(relatedEntityType.Builder, navigationProperty, ConfigurationSource.Explicit)
+                : Builder.Navigation(relatedEntityType.Builder, navigation.Name, ConfigurationSource.Explicit);
         }
 
         /// <summary>
-        ///     Creates a relationship builder for a relationship that has a collection navigation property on this entity.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="relatedEntityType"> The entity type that the relationship targets. </param>
-        /// <param name="navigationName">
-        ///     The name of the collection navigation property on this entity. If null is passed, then a relationship with no navigation
-        ///     property is created.
-        /// </param>
-        /// <returns> The newly created builder. </returns>
         protected virtual InternalRelationshipBuilder HasManyBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
             => relatedEntityType.Builder
@@ -363,23 +362,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 .PrincipalToDependent(navigationName, ConfigurationSource.Explicit);
 
         /// <summary>
-        ///     Creates a relationship builder for a relationship that has a collection navigation property on this entity.
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        /// <param name="relatedEntityType"> The entity type that the relationship targets. </param>
-        /// <param name="navigationProperty">
-        ///     The collection navigation property on this entity. If null is passed, then a relationship with no navigation
-        ///     property is created.
-        /// </param>
-        /// <returns> The newly created builder. </returns>
         protected virtual InternalRelationshipBuilder HasManyBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] PropertyInfo navigationProperty)
             => relatedEntityType.Builder
                 .Relationship(Builder, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Explicit)
+                .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
                 .PrincipalToDependent(navigationProperty, ConfigurationSource.Explicit);
 
         /// <summary>
-        ///     Configures the <see cref="ChangeTrackingStrategy"/> to be used for this entity type.
+        ///     Configures the <see cref="ChangeTrackingStrategy" /> to be used for this entity type.
         ///     This strategy indicates how the context detects changes to properties for an instance of the entity type.
         /// </summary>
         /// <param name="changeTrackingStrategy"> The change tracking strategy to be used. </param>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public EntityTypeBuilder([NotNull] InternalEntityTypeBuilder builder)
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                 Builder.Metadata,
                 relatedEntityType,
-                navigation?.Name,
+                navigation,
                 HasOneBuilder(relatedEntityType, navigation));
         }
 
@@ -237,12 +237,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
             [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
             where TRelatedEntity : class
-            => new CollectionNavigationBuilder<TEntity, TRelatedEntity>(HasManyBuilder(
-                Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata,
-                navigationExpression?.GetPropertyAccess()));
+        {
+            var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
+            var navigation = navigationExpression?.GetPropertyAccess();
+
+            return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(
+                Builder.Metadata,
+                relatedEntityType,
+                navigation,
+                HasManyBuilder(relatedEntityType, navigation));
+        }
 
         /// <summary>
-        ///     Configures the <see cref="ChangeTrackingStrategy"/> to be used for this entity type.
+        ///     Configures the <see cref="ChangeTrackingStrategy" /> to be used for this entity type.
         ///     This strategy indicates how the context detects changes to properties for an instance of the entity type.
         /// </summary>
         /// <param name="changeTrackingStrategy"> The change tracking strategy to be used. </param>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -27,19 +27,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TDependentEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ReferenceCollectionBuilder([NotNull] InternalRelationshipBuilder builder)
-            : base(builder)
+        public ReferenceCollectionBuilder(
+            [NotNull] EntityType principalEntityType,
+            [NotNull] EntityType dependentEntityType,
+            [NotNull] InternalRelationshipBuilder builder)
+            : base(principalEntityType, dependentEntityType, builder)
         {
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected ReferenceCollectionBuilder(InternalRelationshipBuilder builder,
+        protected ReferenceCollectionBuilder(
+            InternalRelationshipBuilder builder,
             ReferenceCollectionBuilder oldBuilder,
             bool foreignKeySet = false,
             bool principalKeySet = false,
@@ -75,14 +79,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasForeignKey(
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
-        {
-            Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression));
-
-            return new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                Builder.HasForeignKey(foreignKeyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit),
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasForeignKeyBuilder(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
                 this,
                 foreignKeySet: true);
-        }
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -102,14 +102,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasPrincipalKey(
             [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
-        {
-            Check.NotNull(keyExpression, nameof(keyExpression));
-
-            return new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                Builder.HasPrincipalKey(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit),
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasPrincipalKeyBuilder(Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList()),
                 this,
                 principalKeySet: true);
-        }
 
         /// <summary>
         ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
@@ -119,12 +115,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasAnnotation([NotNull] string annotation, [NotNull] object value)
-        {
-            Check.NotEmpty(annotation, nameof(annotation));
-            Check.NotNull(value, nameof(value));
-
-            return (ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>)base.HasAnnotation(annotation, value);
-        }
+            => (ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>)base.HasAnnotation(
+                Check.NotEmpty(annotation, nameof(annotation)),
+                Check.NotNull(value, nameof(value)));
 
         /// <summary>
         ///     <para>
@@ -150,14 +143,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasForeignKey([NotNull] params string[] foreignKeyPropertyNames)
-        {
-            Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames));
-
-            return new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                Builder.HasForeignKey(foreignKeyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasForeignKeyBuilder(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
                 this,
                 foreignKeySet: true);
-        }
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -168,14 +157,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasPrincipalKey([NotNull] params string[] keyPropertyNames)
-        {
-            Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames));
-
-            return new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                Builder.HasPrincipalKey(keyPropertyNames, ConfigurationSource.Explicit),
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasPrincipalKeyBuilder(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames))),
                 this,
                 principalKeySet: true);
-        }
 
         /// <summary>
         ///     Configures whether this is a required relationship (i.e. whether the foreign key property(s) can

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -28,15 +29,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ReferenceNavigationBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] string navigationName,
+            [CanBeNull] PropertyInfo navigationProperty,
             [NotNull] InternalRelationshipBuilder builder)
-            : base(declaringEntityType, relatedEntityType, navigationName, builder)
+            : base(declaringEntityType, relatedEntityType, navigationProperty, builder)
         {
         }
 
@@ -52,6 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
             [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
             => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
+                RelatedEntityType,
+                DeclaringEntityType,
                 WithManyBuilder(navigationExpression?.GetPropertyAccess()));
 
         /// <summary>
@@ -66,9 +69,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(navigationExpression?.GetPropertyAccess()),
                 DeclaringEntityType,
-                RelatedEntityType);
+                RelatedEntityType,
+                WithOneBuilder(navigationExpression?.GetPropertyAccess()));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
@@ -80,6 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string navigationName = null)
             => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
+                RelatedEntityType,
+                DeclaringEntityType,
                 WithManyBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
 
         /// <summary>
@@ -92,8 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))),
                 DeclaringEntityType,
-                RelatedEntityType);
+                RelatedEntityType,
+                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -26,19 +26,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelatedEntity : class
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ReferenceReferenceBuilder(
-            [NotNull] InternalRelationshipBuilder builder,
             [NotNull] EntityType declaringEntityType,
-            [NotNull] EntityType relatedEntityType)
+            [NotNull] EntityType relatedEntityType,
+            [NotNull] InternalRelationshipBuilder builder)
             : base(builder, declaringEntityType, relatedEntityType)
         {
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected ReferenceReferenceBuilder(InternalRelationshipBuilder builder,
@@ -91,8 +91,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Type dependentEntityType,
             [NotNull] params string[] foreignKeyPropertyNames)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetDependentEntityType(Check.NotNull(dependentEntityType, nameof(dependentEntityType)))
-                    .HasForeignKey(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)), ConfigurationSource.Explicit),
+                HasForeignKeyBuilder(ResolveEntityType(Check.NotNull(dependentEntityType, nameof(dependentEntityType))),
+                    dependentEntityType.ShortDisplayName(),
+                    Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.ClrType != dependentEntityType,
                 foreignKeySet: true);
@@ -109,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         of the entity class.
         ///     </para>
         ///     <para>
-        ///         If <see cref="HasPrincipalKey(System.Type,string[])" /> is not specified, then an attempt will be made to
+        ///         If <see cref="HasPrincipalKey(Type, string[])" /> is not specified, then an attempt will be made to
         ///         match the data type and order of foreign key properties against the primary key of the principal
         ///         entity type. If they do not match, new shadow state properties that form a unique index will be
         ///         added to the principal entity type to serve as the reference key.
@@ -144,8 +145,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Type principalEntityType,
             [NotNull] params string[] keyPropertyNames)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetPrincipalEntityType(Check.NotNull(principalEntityType, nameof(principalEntityType)))
-                    .HasPrincipalKey(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames)), ConfigurationSource.Explicit),
+                HasPrincipalKeyBuilder(
+                    ResolveEntityType(Check.NotNull(principalEntityType, nameof(principalEntityType))),
+                    principalEntityType.ShortDisplayName(),
+                    Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames))),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != principalEntityType,
                 principalKeySet: true);
@@ -197,8 +200,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] string dependentEntityTypeName,
             [NotNull] params string[] foreignKeyPropertyNames)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetDependentEntityType(Check.NotEmpty(dependentEntityTypeName, nameof(dependentEntityTypeName)))
-                    .HasForeignKey(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)), ConfigurationSource.Explicit),
+                HasForeignKeyBuilder(ResolveEntityType(Check.NotNull(dependentEntityTypeName, nameof(dependentEntityTypeName))),
+                    dependentEntityTypeName,
+                    Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
                 foreignKeySet: true);
@@ -220,8 +224,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] string principalEntityTypeName,
             [NotNull] params string[] keyPropertyNames)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetPrincipalEntityType(Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName)))
-                    .HasPrincipalKey(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames)), ConfigurationSource.Explicit),
+                HasPrincipalKeyBuilder(
+                    ResolveEntityType(Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName))),
+                    principalEntityTypeName,
+                    Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames))),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.Name != principalEntityTypeName,
                 principalKeySet: true);
@@ -260,8 +266,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
             where TDependentEntity : class
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetDependentEntityType(typeof(TDependentEntity))
-                    .HasForeignKey(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),
+                HasForeignKeyBuilder(ResolveEntityType(typeof(TDependentEntity)),
+                    typeof(TDependentEntity).ShortDisplayName(),
+                Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.ClrType != typeof(TDependentEntity),
                 foreignKeySet: true);
@@ -290,8 +297,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
             where TPrincipalEntity : class
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                SetPrincipalEntityType(typeof(TPrincipalEntity))
-                    .HasPrincipalKey(Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit),
+                HasPrincipalKeyBuilder(
+                    ResolveEntityType(typeof(TPrincipalEntity)),
+                    typeof(TPrincipalEntity).ShortDisplayName(),
+                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList()),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != typeof(TPrincipalEntity),
                 principalKeySet: true);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -246,12 +246,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
                 foreach (var foreignKey in entityType.GetDeclaredForeignKeys().Concat(entityType.GetDerivedForeignKeys()).ToList())
                 {
-                    Apply(foreignKey.Builder);
+                    if (foreignKey.Builder != null)
+                    {
+                        Apply(foreignKey.Builder);
+                    }
                 }
 
                 foreach (var foreignKey in entityType.GetReferencingForeignKeys().ToList())
                 {
-                    Apply(foreignKey.Builder);
+                    if (foreignKey.Builder != null)
+                    {
+                        Apply(foreignKey.Builder);
+                    }
                 }
             }
             return propertyBuilder;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -312,8 +312,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
             else if (existingProperty.DeclaringEntityType != Metadata)
             {
-                return existingProperty.DeclaringEntityType.Builder
-                    .Property(existingProperty, propertyName, propertyType, clrProperty, configurationSource);
+                if (clrProperty != null
+                    && existingProperty.DeclaringEntityType.ClrType.GetRuntimeProperties().FirstOrDefault(p => p.Name == propertyName) == null)
+                {
+                    detachedProperties = DetachProperties(new[] { existingProperty });
+                }
+                else
+                {
+                    return existingProperty.DeclaringEntityType.Builder
+                        .Property(existingProperty, propertyName, propertyType, clrProperty, configurationSource);
+                }
             }
 
             var builder = Property(existingProperty, propertyName, propertyType, clrProperty, configurationSource);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -13,14 +13,14 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     [DebuggerDisplay("{Metadata,nq}")]
     public class InternalRelationshipBuilder : InternalMetadataItemBuilder<ForeignKey>
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InternalRelationshipBuilder(
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentToPrincipal(
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentToPrincipal(
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalToDependent(
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalToDependent(
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder Navigations(
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder Navigations(
@@ -108,9 +108,54 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             PropertyIdentity? navigationToPrincipal,
             PropertyIdentity? navigationToDependent,
             ConfigurationSource? configurationSource)
+            => Navigations(
+                navigationToPrincipal,
+                navigationToDependent,
+                Metadata.PrincipalEntityType,
+                Metadata.DeclaringEntityType,
+                configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Navigations(
+            [CanBeNull] string navigationToPrincipalName,
+            [CanBeNull] string navigationToDependentName,
+            [NotNull] EntityType principalEntityType,
+            [NotNull] EntityType dependentEntityType,
+            ConfigurationSource configurationSource)
+            => Navigations(
+                PropertyIdentity.Create(navigationToPrincipalName),
+                PropertyIdentity.Create(navigationToDependentName),
+                principalEntityType,
+                dependentEntityType,
+                configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Navigations(
+            [CanBeNull] PropertyInfo navigationToPrincipalProperty,
+            [CanBeNull] PropertyInfo navigationToDependentProperty,
+            [NotNull] EntityType principalEntityType,
+            [NotNull] EntityType dependentEntityType,
+            ConfigurationSource configurationSource)
+            => Navigations(
+                PropertyIdentity.Create(navigationToPrincipalProperty),
+                PropertyIdentity.Create(navigationToDependentProperty),
+                principalEntityType,
+                dependentEntityType,
+                configurationSource);
+
+        private InternalRelationshipBuilder Navigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
+            EntityType principalEntityType,
+            EntityType dependentEntityType,
+            ConfigurationSource? configurationSource)
         {
-            var principalEntityType = Metadata.PrincipalEntityType;
-            var dependentEntityType = Metadata.DeclaringEntityType;
             var shouldThrow = configurationSource == ConfigurationSource.Explicit;
 
             var navigationToPrincipalName = navigationToPrincipal?.Name;
@@ -139,12 +184,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 navigationToDependent = PropertyIdentity.Create(navigationProperty);
             }
 
-            return Navigations(navigationToPrincipal, navigationToDependent, configurationSource.Value, runConventions: true);
+            return Navigations(
+                navigationToPrincipal,
+                navigationToDependent,
+                principalEntityType,
+                dependentEntityType,
+                configurationSource,
+                runConventions: true);
         }
 
         private InternalRelationshipBuilder Navigations(
             PropertyIdentity? navigationToPrincipal,
             PropertyIdentity? navigationToDependent,
+            ConfigurationSource? configurationSource,
+            bool runConventions)
+            => Navigations(
+                navigationToPrincipal,
+                navigationToDependent,
+                Metadata.PrincipalEntityType,
+                Metadata.DeclaringEntityType,
+                configurationSource,
+                runConventions);
+
+        private InternalRelationshipBuilder Navigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
+            EntityType principalEntityType,
+            EntityType dependentEntityType,
             ConfigurationSource? configurationSource,
             bool runConventions)
         {
@@ -176,6 +242,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!CanSetNavigations(
                 navigationToPrincipal,
                 navigationToDependent,
+                principalEntityType,
+                dependentEntityType,
                 configurationSource,
                 shouldThrow,
                 true,
@@ -201,8 +269,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Debug.Assert(configurationSource.HasValue);
 
-            var principalEntityType = Metadata.PrincipalEntityType;
-            var dependentEntityType = Metadata.DeclaringEntityType;
             IReadOnlyList<Property> dependentProperties = null;
             IReadOnlyList<Property> principalProperties = null;
             if (shouldInvert == true)
@@ -316,7 +382,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool CanSetNavigation(
@@ -359,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool CanSetNavigation(
@@ -420,6 +486,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             out bool? shouldInvert,
             out bool? shouldBeUnique,
             out bool removeOppositeNavigation)
+            => CanSetNavigations(
+                navigationToPrincipal,
+                navigationToDependent,
+                Metadata.PrincipalEntityType,
+                Metadata.DeclaringEntityType,
+                configurationSource,
+                shouldThrow,
+                overrideSameSource,
+                out shouldInvert,
+                out shouldBeUnique,
+                out removeOppositeNavigation);
+
+        private bool CanSetNavigations(
+            PropertyIdentity? navigationToPrincipal,
+            PropertyIdentity? navigationToDependent,
+            EntityType principalEntityType,
+            EntityType dependentEntityType,
+            ConfigurationSource? configurationSource,
+            bool shouldThrow,
+            bool overrideSameSource,
+            out bool? shouldInvert,
+            out bool? shouldBeUnique,
+            out bool removeOppositeNavigation)
         {
             shouldInvert = null;
             shouldBeUnique = null;
@@ -450,7 +539,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (navigationToPrincipalName != null)
                 {
-                    if (Metadata.DeclaringEntityType.Builder.IsIgnored(navigationToPrincipalName, configurationSource))
+                    if (dependentEntityType.Builder.IsIgnored(navigationToPrincipalName, configurationSource))
                     {
                         return false;
                     }
@@ -482,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (navigationToDependentName != null)
                 {
-                    if (Metadata.PrincipalEntityType.Builder.IsIgnored(navigationToDependentName, configurationSource))
+                    if (principalEntityType.Builder.IsIgnored(navigationToDependentName, configurationSource))
                     {
                         return false;
                     }
@@ -510,8 +599,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && !IsCompatible(
                     navigationToPrincipalProperty,
                     false,
-                    Metadata.PrincipalEntityType.ClrType,
-                    Metadata.DeclaringEntityType.ClrType,
+                    principalEntityType.ClrType,
+                    dependentEntityType.ClrType,
                     false,
                     out invertedShouldBeUnique))
             {
@@ -523,8 +612,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && !IsCompatible(
                     navigationToDependentProperty,
                     true,
-                    Metadata.PrincipalEntityType.ClrType,
-                    Metadata.DeclaringEntityType.ClrType,
+                    principalEntityType.ClrType,
+                    dependentEntityType.ClrType,
                     false,
                     out _))
             {
@@ -535,8 +624,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && !IsCompatible(
                     navigationToPrincipalProperty,
                     true,
-                    Metadata.DeclaringEntityType.ClrType,
-                    Metadata.PrincipalEntityType.ClrType,
+                    dependentEntityType.ClrType,
+                    principalEntityType.ClrType,
                     shouldThrow && shouldInvert != null,
                     out _))
             {
@@ -551,8 +640,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && !IsCompatible(
                     navigationToDependentProperty,
                     false,
-                    Metadata.DeclaringEntityType.ClrType,
-                    Metadata.PrincipalEntityType.ClrType,
+                    dependentEntityType.ClrType,
+                    principalEntityType.ClrType,
                     shouldThrow && shouldInvert != null,
                     out shouldBeUnique))
             {
@@ -643,7 +732,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder IsRequired(bool isRequired, ConfigurationSource configurationSource)
@@ -693,7 +782,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool CanSetRequired(bool isRequired, ConfigurationSource? configurationSource)
@@ -748,7 +837,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DeleteBehavior(DeleteBehavior deleteBehavior, ConfigurationSource configurationSource)
@@ -769,7 +858,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool CanSetDeleteBehavior(DeleteBehavior deleteBehavior, ConfigurationSource? configurationSource)
@@ -789,7 +878,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder IsUnique(bool unique, ConfigurationSource configurationSource)
@@ -866,7 +955,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         // Note: These will not invert relationships, use RelatedEntityTypes for that
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentEntityType(
@@ -874,7 +963,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => DependentEntityType(dependentEntityTypeBuilder.Metadata, configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentEntityType(
@@ -883,7 +972,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentEntityType(
@@ -891,7 +980,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => DependentEntityType(ModelBuilder.Entity(dependentTypeName, configurationSource).Metadata, configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder DependentEntityType(
@@ -929,7 +1018,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         // Note: These will not invert relationships, use RelatedEntityTypes for that
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalEntityType(
@@ -937,7 +1026,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => PrincipalEntityType(principalEntityTypeBuilder.Metadata, configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalEntityType(
@@ -946,7 +1035,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalEntityType(
@@ -955,7 +1044,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 configurationSource, runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder PrincipalEntityType(
@@ -992,7 +1081,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder RelatedEntityTypes(
@@ -1033,7 +1122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 return null;
             }
-            
+
             var dependentProperties = (IReadOnlyList<Property>)new Property[0];
             var principalProperties = (IReadOnlyList<Property>)new Property[0];
             var builder = this;
@@ -1101,7 +1190,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool CanInvert(
@@ -1122,42 +1211,82 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
             [NotNull] IReadOnlyList<PropertyInfo> properties, ConfigurationSource configurationSource)
-            => HasForeignKey(
-                Metadata.DeclaringEntityType.Builder.GetOrCreateProperties(properties, configurationSource),
-                configurationSource,
-                runConventions: true);
+            => HasForeignKey(properties, Metadata.DeclaringEntityType, configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
             [NotNull] IReadOnlyList<string> propertyNames, ConfigurationSource configurationSource)
-            => HasForeignKey(
-                Metadata.DeclaringEntityType.Builder.GetOrCreateProperties(propertyNames, configurationSource, Metadata.PrincipalKey.Properties),
-                configurationSource,
-                runConventions: true);
+            => HasForeignKey(propertyNames, Metadata.DeclaringEntityType, configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
             [CanBeNull] IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
-            => HasForeignKey(
-                GetExistingProperties(properties, Metadata.DeclaringEntityType), configurationSource, runConventions: true);
+            => HasForeignKey(properties, Metadata.DeclaringEntityType, configurationSource);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder HasForeignKey(
+            [NotNull] IReadOnlyList<PropertyInfo> properties, [NotNull] EntityType dependentEntityType, ConfigurationSource configurationSource)
+            => HasForeignKey(
+                dependentEntityType.Builder.GetOrCreateProperties(properties, configurationSource),
+                dependentEntityType,
+                configurationSource,
+                runConventions: true);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder HasForeignKey(
+            [NotNull] IReadOnlyList<string> propertyNames, [NotNull] EntityType dependentEntityType, ConfigurationSource configurationSource)
+            => HasForeignKey(
+                dependentEntityType.Builder.GetOrCreateProperties(propertyNames, configurationSource, Metadata.PrincipalKey.Properties),
+                dependentEntityType,
+                configurationSource,
+                runConventions: true);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder HasForeignKey(
+            [CanBeNull] IReadOnlyList<Property> properties, [NotNull] EntityType dependentEntityType, ConfigurationSource configurationSource)
+            => HasForeignKey(
+                GetExistingProperties(properties, dependentEntityType),
+                dependentEntityType,
+                configurationSource,
+                runConventions: true);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
             [CanBeNull] IReadOnlyList<Property> properties, ConfigurationSource? configurationSource, bool runConventions)
+            => HasForeignKey(properties, Metadata.DeclaringEntityType, configurationSource, runConventions);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder HasForeignKey(
+            [CanBeNull] IReadOnlyList<Property> properties,
+            [NotNull] EntityType dependentEntityType,
+            ConfigurationSource? configurationSource,
+            bool runConventions)
         {
             if (properties == null)
             {
@@ -1200,7 +1329,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             bool resetIsRequired;
             bool resetPrincipalKey;
-            if (!CanSetForeignKey(properties, Metadata.DeclaringEntityType, configurationSource, out resetIsRequired, out resetPrincipalKey))
+            if (!CanSetForeignKey(properties, dependentEntityType, configurationSource, out resetIsRequired, out resetPrincipalKey))
             {
                 return null;
             }
@@ -1208,9 +1337,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             // FKs are not allowed to use properties from inherited keys since this could result in an ambiguous value space
             Debug.Assert(configurationSource.HasValue);
 
-            if ((Metadata.DeclaringEntityType.BaseType != null)
-                && (configurationSource != ConfigurationSource.Explicit) // let it throw for explicit
-                && properties.Any(p => p.GetContainingKeys().Any(k => k.DeclaringEntityType != Metadata.DeclaringEntityType)))
+            if (dependentEntityType.BaseType != null
+                && configurationSource != ConfigurationSource.Explicit // let it throw for explicit
+                && properties.Any(p => p.GetContainingKeys().Any(k => k.DeclaringEntityType != dependentEntityType)))
             {
                 return null;
             }
@@ -1222,6 +1351,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             return builder.ReplaceForeignKey(
                 configurationSource,
+                dependentEntityTypeBuilder: dependentEntityType.Builder,
                 dependentProperties: properties,
                 principalProperties: resetPrincipalKey ? new Property[0] : null,
                 runConventions: runConventions);
@@ -1311,7 +1441,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasPrincipalKey([NotNull] IReadOnlyList<PropertyInfo> properties,
@@ -1322,7 +1452,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasPrincipalKey([NotNull] IReadOnlyList<string> propertyNames,
@@ -1333,7 +1463,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 runConventions: true);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasPrincipalKey(
@@ -2218,7 +2348,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 bool _;
                 bool? __;
-                if (candidateRelationship.CanSetRelatedTypes(
+                if (!candidateRelationship.CanSetRelatedTypes(
                     principalEntityType,
                     dependentEntityType,
                     principalEndConfigurationSource,
@@ -2233,9 +2363,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     out _,
                     out __))
                 {
-                    newRelationshipBuilder = candidateRelationship;
-                    break;
+                    continue;
                 }
+                if (dependentProperties != null
+                    && !Property.AreCompatible(dependentProperties, candidateRelationship.Metadata.DeclaringEntityType))
+                {
+                    continue;
+                }
+                if (principalProperties != null
+                    && !Property.AreCompatible(principalProperties, candidateRelationship.Metadata.PrincipalEntityType))
+                {
+                    continue;
+                }
+
+                newRelationshipBuilder = candidateRelationship;
+                break;
             }
 
             if (unresolvableRelationships.Any(r => r != newRelationshipBuilder))
@@ -2494,7 +2636,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static InternalRelationshipBuilder FindCurrentRelationshipBuilder(
@@ -2573,7 +2715,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder Attach(ConfigurationSource configurationSource)
@@ -2628,7 +2770,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static bool AreCompatible(

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
@@ -45,6 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestModelBuilder Ignore<TEntity>()
                 => new GenericStringTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+
+            public override string GetDisplayName(Type entityType) => entityType.FullName;
         }
 
         private class GenericStringTestEntityTypeBuilder<TEntity> : GenericTestEntityTypeBuilder<TEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -175,6 +175,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public override TestModelBuilder Ignore<TEntity>()
                 => new NonGenericStringTestModelBuilder(ModelBuilder.Ignore(typeof(TEntity)));
+
+            public override string GetDisplayName(Type entityType) => entityType.FullName;
         }
 
         private class NonGenericStringTestEntityTypeBuilder<TEntity> : NonGenericTestEntityTypeBuilder<TEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -35,6 +35,12 @@ namespace Microsoft.EntityFrameworkCore.Tests
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
+        public class NonGenericInheritance : InheritanceTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
+                => new NonGenericTestModelBuilder(modelBuilder);
+        }
+
         public class NonGenericOneToMany : OneToManyTestBase
         {
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -129,6 +129,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
             public virtual TestModelBuilder Validate()
                 => ((IInfrastructure<InternalModelBuilder>)ModelBuilder).Instance.Validate() == null ? null : this;
+
+            public virtual string GetDisplayName(Type entityType) => entityType.Name;
         }
 
         public abstract class TestEntityTypeBuilder<TEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -96,9 +96,14 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public CustomerDetails Details { get; set; }
         }
 
+        [NotMapped]
         protected class SpecialCustomer : Customer
         {
             public ICollection<SpecialOrder> SpecialOrders { get; set; }
+        }
+
+        protected class OtherCustomer : Customer
+        {
         }
 
         protected class CustomerDetails
@@ -124,8 +129,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public OrderDetails Details { get; set; }
         }
 
+        [NotMapped]
         protected class SpecialOrder : Order
         {
+            public int? SpecialCustomerId { get; set; }
+            public SpecialCustomer SpecialCustomer { get; set; }
             public BackOrder BackOrder { get; set; }
             public OrderCombination SpecialOrderCombination { get; set; }
         }


### PR DESCRIPTION
This bug would prevent the user from configuring a relationship on the derived type if a convention created a relationship on the base that used any of the same members.