### PR TITLE
Fix code scaffolding in hotfix-branch

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/DesignTimeProviderServicesTest.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/DesignTimeProviderServicesTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests
+{
+    public abstract class DesignTimeProviderServicesTest
+    {
+        protected abstract Assembly GetRuntimeAssembly();
+        protected abstract Type GetDesignTimeServicesType();
+
+        [Fact]
+        public void EnsureAssemblyIdentityMatches()
+        {
+            var runtimeAssembly = GetRuntimeAssembly();
+            var dtAttribute = runtimeAssembly.GetCustomAttribute<DesignTimeProviderServicesAttribute>();
+            var dtType = GetDesignTimeServicesType();
+            Assert.NotNull(dtType);
+
+            Assert.NotNull(dtAttribute);
+            Assert.Equal(dtType.GetTypeInfo().Assembly.GetName().FullName, dtAttribute.AssemblyName);
+            Assert.Equal(dtType.FullName, dtAttribute.TypeName);
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="DesignTimeProviderServicesTest.cs" />
     <Compile Include="ReverseEngineering\E2ETestBase.cs" />
     <Compile Include="ReverseEngineering\FileSet.cs" />
     <Compile Include="ReverseEngineering\InMemoryCommandLogger.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
     typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqlServerDesignTimeServices",
-    assemblyName: "Microsoft.EntityFrameworkCore.SqlServer.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+    assemblyName: "Microsoft.EntityFrameworkCore.SqlServer.Design, Version=1.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.SqlServer.Design")]
 [assembly: AssemblyCompany("Microsoft Corporation.")]
 [assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
     typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqliteDesignTimeServices",
-    assemblyName: "Microsoft.EntityFrameworkCore.Sqlite.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+    assemblyName: "Microsoft.EntityFrameworkCore.Sqlite.Design, Version=1.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.Sqlite.Design")]
 [assembly: AssemblyCompany("Microsoft Corporation.")]
 [assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="ScaffoldingTypeMapperSqlServerTest.cs" />
+    <Compile Include="SqlServerDesignTimeProviderServicesTest.cs" />
     <Compile Include="SqlServerTableSelectionSetExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/SqlServerDesignTimeProviderServicesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/SqlServerDesignTimeProviderServicesTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Design
+{
+    public class SqlServerDesignTimeProviderServicesTest : DesignTimeProviderServicesTest
+    {
+        protected override Assembly GetRuntimeAssembly()
+            => typeof(SqlServerConnection).GetTypeInfo().Assembly;
+
+        protected override Type GetDesignTimeServicesType()
+            => typeof(SqlServerDesignTimeServices);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="ScaffoldingTypeMapperSqliteTest.cs" />
+    <Compile Include="SqliteDesignTimeProviderServicesTest.cs" />
     <Compile Include="SqliteTableSelectionSetExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/SqliteDesignTimeProviderServicesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/SqliteDesignTimeProviderServicesTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Design
+{
+    public class SqliteDesignTimeProviderServicesTest : DesignTimeProviderServicesTest
+    {
+        protected override Assembly GetRuntimeAssembly()
+            => typeof(SqliteRelationalConnection).GetTypeInfo().Assembly;
+
+        protected override Type GetDesignTimeServicesType()
+            => typeof(SqliteDesignTimeServices);
+    }
+}


### PR DESCRIPTION
Code scaffolding is broken in the hotfix branch because the assembly version has changed to "1.0.1.0".

I will also apply this same fix to the dev branch.

cc @Eilon @lajones  