### PR TITLE
Store original values for principal keys

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -871,6 +871,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                       }).Take(3));
         }
 
+        [ConditionalFact]
+        public virtual void GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened()
+        {
+            AssertQuery<Customer, Order, OrderDetail, Customer>(
+                (cs, os, ods) => (from c in cs
+                                  join subquery in
+                                  (
+                                    from od in ods
+                                    join o in os on od.OrderID equals 10260
+                                    join c2 in cs on o.CustomerID equals c2.CustomerID
+                                    select c2
+                                  )
+                                    on c.CustomerID equals subquery.CustomerID
+                                    into result
+                                  from subquery in result.DefaultIfEmpty()
+                                  select c), 
+                entryCount: 91);
+        }
+
         protected QueryNavigationsTestBase(TFixture fixture)
         {
             Fixture = fixture;
@@ -899,6 +918,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Action<IList<TResult>, IList<TResult>> asserter = null)
             where TItem1 : class
             where TItem2 : class 
+            => AssertQuery(query, query, assertOrder, entryCount, asserter);
+
+        protected void AssertQuery<TItem1, TItem2, TItem3, TResult>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> query,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<TResult>, IList<TResult>> asserter = null)
+            where TItem1 : class
+            where TItem2 : class
+            where TItem3 : class
             => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem, TResult>(
@@ -961,6 +990,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 TestHelpers.AssertResults(
                     l2oQuery(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()).ToArray(),
                     efQuery(context.Set<TItem1>(), context.Set<TItem2>()).ToArray(),
+                    assertOrder,
+                    asserter);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        protected void AssertQuery<TItem1, TItem2, TItem3, TResult>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> efQuery,
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> l2oQuery,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<TResult>, IList<TResult>> asserter = null)
+            where TItem1 : class
+            where TItem2 : class
+            where TItem3 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()).ToArray(),
+                    efQuery(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()).ToArray(),
                     assertOrder,
                     asserter);
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry.cs
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     Provides access to change tracking information and operations for a given
-        ///     property or navigation property of this entity.
+        ///     navigation property of this entity.
         /// </summary>
         /// <param name="propertyName"> The property to access information and operations for. </param>
         /// <returns> An object that exposes change tracking information and operations for the given property. </returns>
@@ -141,8 +141,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             if (InternalEntry.EntityType.FindProperty(propertyName) != null)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.NavigationIsProperty(propertyName, InternalEntry.EntityType.DisplayName(), 
-                    nameof(Reference), nameof(Collection), nameof(Property)));
+                    CoreStrings.NavigationIsProperty(propertyName, InternalEntry.EntityType.DisplayName(),
+                        nameof(Reference), nameof(Collection), nameof(Property)));
             }
 
             throw new InvalidOperationException(
@@ -167,7 +167,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     navigation property that associates this entity to another entity.
         /// </summary>
         /// <param name="navigationPropertyName"> The name of the navigation property. </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual ReferenceEntry Reference([NotNull] string navigationPropertyName)
         {
             Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));
@@ -180,7 +183,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     navigation property that associates this entity to a collection of another entities.
         /// </summary>
         /// <param name="navigationPropertyName"> The name of the navigation property. </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual CollectionEntry Collection([NotNull] string navigationPropertyName)
         {
             Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/EntityEntry`.cs
@@ -65,7 +65,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     A lambda expression representing the property to access information and operations for
         ///     (<c>t => t.Property1</c>).
         /// </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>(
             [NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
         {
@@ -82,7 +85,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     A lambda expression representing the property to access information and operations for
         ///     (<c>t => t.Property1</c>).
         /// </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual CollectionEntry<TEntity, TProperty> Collection<TProperty>(
             [NotNull] Expression<Func<TEntity, IEnumerable<TProperty>>> propertyExpression)
         {
@@ -96,7 +102,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     navigation property that associates this entity to another entity.
         /// </summary>
         /// <param name="navigationPropertyName"> The name of the navigation property. </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>([NotNull] string navigationPropertyName)
         {
             Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));
@@ -109,7 +118,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     navigation property that associates this entity to a collection of another entities.
         /// </summary>
         /// <param name="navigationPropertyName"> The name of the navigation property. </param>
-        /// <returns> An object representing the navigation property. </returns>
+        /// <returns>
+        ///     An object that exposes change tracking information and operations for the
+        ///     given navigation property.
+        /// </returns>
         public virtual CollectionEntry<TEntity, TProperty> Collection<TProperty>([NotNull] string navigationPropertyName)
         {
             Check.NotEmpty(navigationPropertyName, nameof(navigationPropertyName));

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/MemberEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/MemberEntry.cs
@@ -46,9 +46,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         protected virtual InternalEntityEntry InternalEntry { get; }
 
         /// <summary>
-        ///     Gets or sets a value indicating whether the value of this property has been modified
-        ///     and should be updated in the database when <see cref="DbContext.SaveChanges()" />
-        ///     is called.
+        ///     <para>
+        ///         For non-navigation properties, gets or sets a value indicating whether the value of this
+        ///         property has been modified and should be updated in the database when
+        ///         <see cref="DbContext.SaveChanges()" />
+        ///         is called.
+        ///     </para>
+        ///     <para>
+        ///         For navigation properties, gets or sets a value indicating whether any of foreign key
+        ///         property values associated with this navigation property have been modified and should
+        ///         be updated in the database  when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
         /// </summary>
         public abstract bool IsModified { get; set; }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/NavigationEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/NavigationEntry.cs
@@ -14,8 +14,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
     ///     <para>
-    ///         Provides access to change tracking and loading information for a collection
-    ///         navigation property that associates this entity to a collection of another entities.
+    ///         Provides access to change tracking and loading information for a navigation property
+    ///         that associates this entity to one or more other entities.
     ///     </para>
     ///     <para>
     ///         Instances of this class are returned from methods when using the <see cref="ChangeTracker" /> API and it is
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     throw new InvalidOperationException(
                         CoreStrings.NavigationIsProperty(name, internalEntry.EntityType.DisplayName(),
-                        nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)));
+                            nameof(EntityEntry.Reference), nameof(EntityEntry.Collection), nameof(EntityEntry.Property)));
                 }
                 throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, internalEntry.EntityType.DisplayName()));
             }
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             {
                 throw new InvalidOperationException(
                     CoreStrings.CollectionIsReference(name, internalEntry.EntityType.DisplayName(),
-                    nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)));
+                        nameof(EntityEntry.Collection), nameof(EntityEntry.Reference)));
             }
 
             if (!collection
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             {
                 throw new InvalidOperationException(
                     CoreStrings.ReferenceIsCollection(name, internalEntry.EntityType.DisplayName(),
-                    nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)));
+                        nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)));
             }
 
             return navigation;
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     Gets or sets a value indicating whether any of foreign key property values associated
-        ///     with this navigation property have been modified and should be updated in the database 
+        ///     with this navigation property have been modified and should be updated in the database
         ///     when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         public override bool IsModified

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
@@ -107,6 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static bool RequiresOriginalValue([NotNull] this IProperty property)
             => property.DeclaringEntityType.GetChangeTrackingStrategy() != ChangeTrackingStrategy.ChangingAndChangedNotifications
                || property.IsConcurrencyToken
+               || property.IsKey()
                || property.IsForeignKey();
 
         /// <summary>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1145,6 +1145,26 @@ ORDER BY [od1].[OrderID], [od1].[ProductID]",
                 Sql);
         }
 
+        public override void GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened()
+        {
+            base.GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened();
+
+            Assert.Contains(
+                @"SELECT [t].[CustomerID]
+FROM (
+    SELECT [c20].*
+    FROM [Order Details] AS [od0]
+    INNER JOIN [Orders] AS [o0] ON [od0].[OrderID] = 10260
+    INNER JOIN [Customers] AS [c20] ON [o0].[CustomerID] = [c20].[CustomerID]
+) AS [t]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2647,10 +2647,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
 
-            Assert.Equal(-1, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(0, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
+            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
+            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Token").GetOriginalValueIndex());
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2667,7 +2667,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
 
             Assert.Equal(0, entityType.ShadowPropertyCount());
-            Assert.Equal(2, entityType.OriginalValueCount());
+            Assert.Equal(3, entityType.OriginalValueCount());
             Assert.Equal(3, entityType.RelationshipPropertyCount());
             Assert.Equal(2, entityType.StoreGeneratedCount());
 
@@ -2693,12 +2693,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
 
-            Assert.Equal(-1, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(0, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("Game").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Mane").GetOriginalValueIndex());
+            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
+            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Game").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("Mane").GetOriginalValueIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2719,7 +2719,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
 
             Assert.Equal(2, entityType.ShadowPropertyCount());
-            Assert.Equal(4, entityType.OriginalValueCount());
+            Assert.Equal(5, entityType.OriginalValueCount());
             Assert.Equal(3, entityType.RelationshipPropertyCount());
             Assert.Equal(2, entityType.StoreGeneratedCount());
 
@@ -2742,12 +2742,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("Token").GetShadowIndex());
 
-            Assert.Equal(-1, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(0, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
+            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
+            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
             Assert.Equal(-1, entityType.FindProperty("Game").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("Mane").GetOriginalValueIndex());
-            Assert.Equal(2, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(3, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Mane").GetOriginalValueIndex());
+            Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
+            Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
 
             Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
@@ -2768,7 +2768,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(-1, entityType.FindNavigation("ReferenceNav").GetStoreGeneratedIndex());
 
             Assert.Equal(2, entityType.ShadowPropertyCount());
-            Assert.Equal(4, entityType.OriginalValueCount());
+            Assert.Equal(5, entityType.OriginalValueCount());
             Assert.Equal(3, entityType.RelationshipPropertyCount());
             Assert.Equal(2, entityType.StoreGeneratedCount());
         }
@@ -2952,17 +2952,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
-        public void Only_concurrency_and_FK_properties_have_original_value_indexes_when_using_full_notifications()
+        public void Only_concurrency_and_key_properties_have_original_value_indexes_when_using_full_notifications()
         {
             var entityType = BuildFullNotificationEntityModel().FindEntityType(typeof(FullNotificationEntity));
             entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
-            Assert.Equal(-1, entityType.FindProperty("Id").GetOriginalValueIndex());
-            Assert.Equal(0, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
+            Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
+            Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-            Assert.Equal(1, entityType.FindProperty("Token").GetOriginalValueIndex());
+            Assert.Equal(2, entityType.FindProperty("Token").GetOriginalValueIndex());
 
-            Assert.Equal(2, entityType.OriginalValueCount());
+            Assert.Equal(3, entityType.OriginalValueCount());
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -526,12 +526,12 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.True(entityType.FindProperty("Top").IsConcurrencyToken);
                 Assert.False(entityType.FindProperty("Bottom").IsConcurrencyToken);
 
-                Assert.Equal(-1, entityType.FindProperty(Customer.IdProperty.Name).GetOriginalValueIndex());
-                Assert.Equal(2, entityType.FindProperty("Up").GetOriginalValueIndex());
+                Assert.Equal(0, entityType.FindProperty(Customer.IdProperty.Name).GetOriginalValueIndex());
+                Assert.Equal(3, entityType.FindProperty("Up").GetOriginalValueIndex());
                 Assert.Equal(-1, entityType.FindProperty("Down").GetOriginalValueIndex());
-                Assert.Equal(0, entityType.FindProperty("Charm").GetOriginalValueIndex());
+                Assert.Equal(1, entityType.FindProperty("Charm").GetOriginalValueIndex());
                 Assert.Equal(-1, entityType.FindProperty("Strange").GetOriginalValueIndex());
-                Assert.Equal(1, entityType.FindProperty("Top").GetOriginalValueIndex());
+                Assert.Equal(2, entityType.FindProperty("Top").GetOriginalValueIndex());
                 Assert.Equal(-1, entityType.FindProperty("Bottom").GetOriginalValueIndex());
             }
 


### PR DESCRIPTION
Update pipeline requires them for certain delete scenarios. Issue #6106

Also add test coverage for changes/fixup using different change notification strategies.