### PR TITLE
Fix to #4749 - Query :: error during groupjoin flattening for complex query with multiple joins subquery and LOJ

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -871,6 +871,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                       }).Take(3));
         }
 
+        [ConditionalFact]
+        public virtual void GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened()
+        {
+            AssertQuery<Customer, Order, OrderDetail, Customer>(
+                (cs, os, ods) => (from c in cs
+                                  join subquery in
+                                  (
+                                    from od in ods
+                                    join o in os on od.OrderID equals 10260
+                                    join c2 in cs on o.CustomerID equals c2.CustomerID
+                                    select c2
+                                  )
+                                    on c.CustomerID equals subquery.CustomerID
+                                    into result
+                                  from subquery in result.DefaultIfEmpty()
+                                  select c), 
+                entryCount: 91);
+        }
+
         protected QueryNavigationsTestBase(TFixture fixture)
         {
             Fixture = fixture;
@@ -899,6 +918,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Action<IList<TResult>, IList<TResult>> asserter = null)
             where TItem1 : class
             where TItem2 : class 
+            => AssertQuery(query, query, assertOrder, entryCount, asserter);
+
+        protected void AssertQuery<TItem1, TItem2, TItem3, TResult>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> query,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<TResult>, IList<TResult>> asserter = null)
+            where TItem1 : class
+            where TItem2 : class
+            where TItem3 : class
             => AssertQuery(query, query, assertOrder, entryCount, asserter);
 
         protected void AssertQuery<TItem, TResult>(
@@ -961,6 +990,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 TestHelpers.AssertResults(
                     l2oQuery(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()).ToArray(),
                     efQuery(context.Set<TItem1>(), context.Set<TItem2>()).ToArray(),
+                    assertOrder,
+                    asserter);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        protected void AssertQuery<TItem1, TItem2, TItem3, TResult>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> efQuery,
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> l2oQuery,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<TResult>, IList<TResult>> asserter = null)
+            where TItem1 : class
+            where TItem2 : class
+            where TItem3 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()).ToArray(),
+                    efQuery(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()).ToArray(),
                     assertOrder,
                     asserter);
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1145,6 +1145,26 @@ ORDER BY [od1].[OrderID], [od1].[ProductID]",
                 Sql);
         }
 
+        public override void GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened()
+        {
+            base.GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened();
+
+            Assert.Contains(
+                @"SELECT [t].[CustomerID]
+FROM (
+    SELECT [c20].*
+    FROM [Order Details] AS [od0]
+    INNER JOIN [Orders] AS [o0] ON [od0].[OrderID] = 10260
+    INNER JOIN [Customers] AS [c20] ON [o0].[CustomerID] = [c20].[CustomerID]
+) AS [t]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"


### PR DESCRIPTION
Problem was that we tried to lift queries that we shouldn't have - i.e. GroupJoin whose ShapedQuery elements were wrapped in Select. Fix is to check the shape of the expression before performing the lifting - we do similar thing for SelectMany already.