### PR TITLE
Query: Make GroupJoinInclude in compiled query thread safe

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
@@ -15,14 +15,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class AsyncGroupJoinInclude : IDisposable
+    public class AsyncGroupJoinInclude
     {
         private readonly IReadOnlyList<INavigation> _navigationPath;
         private readonly IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> _relatedEntitiesLoaderFactories;
         private readonly bool _querySourceRequiresTracking;
 
-        private RelationalQueryContext _queryContext;
-        private IAsyncRelatedEntitiesLoader[] _relatedEntitiesLoaders;
         private AsyncGroupJoinInclude _previous;
 
         /// <summary>
@@ -59,55 +57,111 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Initialize([NotNull] RelationalQueryContext queryContext)
+        public virtual AsyncGroupJoinIncludeContext Initialize([NotNull] RelationalQueryContext queryContext)
         {
-            _queryContext = queryContext;
-            _queryContext.BeginIncludeScope();
+            var asyncGroupJoinIncludeContext
+                = new AsyncGroupJoinIncludeContext(
+                    _navigationPath,
+                    _querySourceRequiresTracking,
+                    queryContext,
+                    _relatedEntitiesLoaderFactories);
 
-            _relatedEntitiesLoaders
-                = _relatedEntitiesLoaderFactories.Select(f => f(queryContext))
-                    .ToArray();
-
-            _previous?.Initialize(queryContext);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual async Task IncludeAsync([CanBeNull] object entity, CancellationToken cancellationToken)
-        {
             if (_previous != null)
             {
-                await _previous.IncludeAsync(entity, cancellationToken);
+                asyncGroupJoinIncludeContext.SetPrevious(_previous.Initialize(queryContext));
             }
 
-            await _queryContext.QueryBuffer
-                .IncludeAsync(
-                    _queryContext,
-                    entity,
-                    _navigationPath,
-                    _relatedEntitiesLoaders,
-                    _querySourceRequiresTracking,
-                    cancellationToken);
+            return asyncGroupJoinIncludeContext;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Dispose()
+        public class AsyncGroupJoinIncludeContext : IDisposable
         {
-            if (_queryContext != null)
-            {
-                _previous?.Dispose();
+            private readonly IReadOnlyList<INavigation> _navigationPath;
+            private readonly bool _querySourceRequiresTracking;
+            private readonly RelationalQueryContext _queryContext;
+            private readonly IAsyncRelatedEntitiesLoader[] _relatedEntitiesLoaders;
 
-                foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+            private AsyncGroupJoinIncludeContext _previous;
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public AsyncGroupJoinIncludeContext(
+                [NotNull] IReadOnlyList<INavigation> navigationPath,
+                bool querySourceRequiresTracking,
+                [NotNull] RelationalQueryContext queryContext,
+                [NotNull] IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> relatedEntitiesLoaderFactories)
+            {
+                _navigationPath = navigationPath;
+                _querySourceRequiresTracking = querySourceRequiresTracking;
+
+                _queryContext = queryContext;
+                _queryContext.BeginIncludeScope();
+
+                _relatedEntitiesLoaders
+                    = relatedEntitiesLoaderFactories.Select(f => f(queryContext))
+                        .ToArray();
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void SetPrevious([NotNull] AsyncGroupJoinIncludeContext previous)
+            {
+                if (_previous != null)
                 {
-                    relatedEntitiesLoader.Dispose();
+                    _previous.SetPrevious(previous);
+                }
+                else
+                {
+                    _previous = previous;
+                }
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual async Task IncludeAsync([CanBeNull] object entity, CancellationToken cancellationToken)
+            {
+                if (_previous != null)
+                {
+                    await _previous.IncludeAsync(entity, cancellationToken);
                 }
 
-                _queryContext.EndIncludeScope();
+                await _queryContext.QueryBuffer
+                    .IncludeAsync(
+                        _queryContext,
+                        entity,
+                        _navigationPath,
+                        _relatedEntitiesLoaders,
+                        _querySourceRequiresTracking,
+                        cancellationToken);
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void Dispose()
+            {
+                if (_queryContext != null)
+                {
+                    _previous?.Dispose();
+
+                    foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+                    {
+                        relatedEntitiesLoader.Dispose();
+                    }
+
+                    _queryContext.EndIncludeScope();
+                }
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinInclude.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinInclude.cs
@@ -13,14 +13,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class GroupJoinInclude : IDisposable
+    public class GroupJoinInclude
     {
         private readonly IReadOnlyList<INavigation> _navigationPath;
         private readonly IReadOnlyList<Func<QueryContext, IRelatedEntitiesLoader>> _relatedEntitiesLoaderFactories;
         private readonly bool _querySourceRequiresTracking;
 
-        private RelationalQueryContext _queryContext;
-        private IRelatedEntitiesLoader[] _relatedEntitiesLoaders;
         private GroupJoinInclude _previous;
 
         /// <summary>
@@ -57,51 +55,107 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Initialize([NotNull] RelationalQueryContext queryContext)
+        public virtual GroupJoinIncludeContext Initialize([NotNull] RelationalQueryContext queryContext)
         {
-            _queryContext = queryContext;
-            _queryContext.BeginIncludeScope();
-
-            _relatedEntitiesLoaders
-                = _relatedEntitiesLoaderFactories.Select(f => f(queryContext))
-                    .ToArray();
-
-            _previous?.Initialize(queryContext);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual void Include([CanBeNull] object entity)
-        {
-            _previous?.Include(entity);
-
-            _queryContext.QueryBuffer
-                .Include(
-                    _queryContext,
-                    entity,
+            var groupJoinIncludeContext
+                = new GroupJoinIncludeContext(
                     _navigationPath,
-                    _relatedEntitiesLoaders,
-                    _querySourceRequiresTracking);
+                    _querySourceRequiresTracking,
+                    queryContext,
+                    _relatedEntitiesLoaderFactories);
+
+            if (_previous != null)
+            {
+                groupJoinIncludeContext.SetPrevious(_previous.Initialize(queryContext));
+            }
+
+            return groupJoinIncludeContext;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Dispose()
+        public class GroupJoinIncludeContext : IDisposable
         {
-            if (_queryContext != null)
+            private readonly IReadOnlyList<INavigation> _navigationPath;
+            private readonly bool _querySourceRequiresTracking;
+            private readonly RelationalQueryContext _queryContext;
+            private readonly IRelatedEntitiesLoader[] _relatedEntitiesLoaders;
+
+            private GroupJoinIncludeContext _previous;
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public GroupJoinIncludeContext(
+                [NotNull] IReadOnlyList<INavigation> navigationPath,
+                bool querySourceRequiresTracking,
+                [NotNull] RelationalQueryContext queryContext,
+                [NotNull] IReadOnlyList<Func<QueryContext, IRelatedEntitiesLoader>> relatedEntitiesLoaderFactories)
             {
-                _previous?.Dispose();
+                _navigationPath = navigationPath;
+                _querySourceRequiresTracking = querySourceRequiresTracking;
 
-                foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+                _queryContext = queryContext;
+                _queryContext.BeginIncludeScope();
+
+                _relatedEntitiesLoaders
+                    = relatedEntitiesLoaderFactories.Select(f => f(queryContext))
+                        .ToArray();
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void SetPrevious([NotNull] GroupJoinIncludeContext previous)
+            {
+                if (_previous != null)
                 {
-                    relatedEntitiesLoader.Dispose();
+                    _previous.SetPrevious(previous);
                 }
+                else
+                {
+                    _previous = previous;
+                }
+            }
 
-                _queryContext.EndIncludeScope();
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void Include([CanBeNull] object entity)
+            {
+                _previous?.Include(entity);
+
+                _queryContext.QueryBuffer
+                    .Include(
+                        _queryContext,
+                        entity,
+                        _navigationPath,
+                        _relatedEntitiesLoaders,
+                        _querySourceRequiresTracking);
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void Dispose()
+            {
+                if (_queryContext != null)
+                {
+                    _previous?.Dispose();
+
+                    foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+                    {
+                        relatedEntitiesLoader.Dispose();
+                    }
+
+                    _queryContext.EndIncludeScope();
+                }
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
@@ -270,8 +270,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             GroupJoinInclude outerGroupJoinInclude,
             GroupJoinInclude innerGroupJoinInclude)
         {
-            outerGroupJoinInclude?.Initialize(queryContext);
-            innerGroupJoinInclude?.Initialize(queryContext);
+            var outerGroupJoinIncludeContext = outerGroupJoinInclude?.Initialize(queryContext);
+            var innerGroupJoinIncludeContext = innerGroupJoinInclude?.Initialize(queryContext);
 
             var hasOuters = (innerShaper as EntityShaper)?.ValueBufferOffset > 0;
 
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         nextOuter = default(TOuter);
 
-                        outerGroupJoinInclude?.Include(outer);
+                        outerGroupJoinIncludeContext?.Include(outer);
 
                         var inner = innerShaper.Shape(queryContext, sourceEnumerator.Current);
                         var inners = new List<TInner>();
@@ -307,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             var currentGroupKey = innerKeySelector(inner);
 
-                            innerGroupJoinInclude?.Include(inner);
+                            innerGroupJoinIncludeContext?.Include(inner);
 
                             inners.Add(inner);
 
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     break;
                                 }
 
-                                innerGroupJoinInclude?.Include(inner);
+                                innerGroupJoinIncludeContext?.Include(inner);
 
                                 inners.Add(inner);
                             }
@@ -358,8 +358,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             finally
             {
-                innerGroupJoinInclude?.Dispose();
-                outerGroupJoinInclude?.Dispose();
+                innerGroupJoinIncludeContext?.Dispose();
+                outerGroupJoinIncludeContext?.Dispose();
             }
         }
 


### PR DESCRIPTION
Resolves #5456 
Issue: `GroupJoinInclude` in compiled query has querycontext as field which is initialized while iterating query. If the same query is ran from different thread and uses the cached entry then the querycontext in `GroupJoinInclude` gets changed. Which means only 1 query will have correct context, rest of them will be using incorrect data hence causing exception.
Solution: Make `GroupJoinInclude` immutable and use different data structure which is context based for each query.
Same applies to async case.