### PR TITLE
Query: Make GroupJoinInclude in compiled query thread safe

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
@@ -21,8 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> _relatedEntitiesLoaderFactories;
         private readonly bool _querySourceRequiresTracking;
 
-        private RelationalQueryContext _queryContext;
-        private IAsyncRelatedEntitiesLoader[] _relatedEntitiesLoaders;
         private AsyncGroupJoinInclude _previous;
 
         /// <summary>
@@ -40,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetPrevious([NotNull] AsyncGroupJoinInclude previous)
@@ -56,58 +54,123 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Initialize([NotNull] RelationalQueryContext queryContext)
+        public virtual AsyncGroupJoinIncludeContext Initialize([NotNull] RelationalQueryContext queryContext)
         {
-            _queryContext = queryContext;
-            _queryContext.BeginIncludeScope();
+            var asyncGroupJoinIncludeContext
+                = new AsyncGroupJoinIncludeContext(
+                    _navigationPath,
+                    _querySourceRequiresTracking,
+                    queryContext,
+                    _relatedEntitiesLoaderFactories);
 
-            _relatedEntitiesLoaders
-                = _relatedEntitiesLoaderFactories.Select(f => f(queryContext))
-                    .ToArray();
-
-            _previous?.Initialize(queryContext);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual async Task IncludeAsync([CanBeNull] object entity, CancellationToken cancellationToken)
-        {
             if (_previous != null)
             {
-                await _previous.IncludeAsync(entity, cancellationToken);
+                asyncGroupJoinIncludeContext.SetPrevious(_previous.Initialize(queryContext));
             }
 
-            await _queryContext.QueryBuffer
-                .IncludeAsync(
-                    _queryContext,
-                    entity,
-                    _navigationPath,
-                    _relatedEntitiesLoaders,
-                    _querySourceRequiresTracking,
-                    cancellationToken);
+            return asyncGroupJoinIncludeContext;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Dispose()
         {
-            if (_queryContext != null)
-            {
-                _previous?.Dispose();
+            // no-op
+        }
 
-                foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public class AsyncGroupJoinIncludeContext : IDisposable
+        {
+            private readonly IReadOnlyList<INavigation> _navigationPath;
+            private readonly bool _querySourceRequiresTracking;
+            private readonly RelationalQueryContext _queryContext;
+            private readonly IAsyncRelatedEntitiesLoader[] _relatedEntitiesLoaders;
+
+            private AsyncGroupJoinIncludeContext _previous;
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public AsyncGroupJoinIncludeContext(
+                [NotNull] IReadOnlyList<INavigation> navigationPath,
+                bool querySourceRequiresTracking,
+                [NotNull] RelationalQueryContext queryContext,
+                [NotNull] IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> relatedEntitiesLoaderFactories)
+            {
+                _navigationPath = navigationPath;
+                _querySourceRequiresTracking = querySourceRequiresTracking;
+
+                _queryContext = queryContext;
+                _queryContext.BeginIncludeScope();
+
+                _relatedEntitiesLoaders
+                    = relatedEntitiesLoaderFactories.Select(f => f(queryContext))
+                        .ToArray();
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void SetPrevious([NotNull] AsyncGroupJoinIncludeContext previous)
+            {
+                if (_previous != null)
                 {
-                    relatedEntitiesLoader.Dispose();
+                    _previous.SetPrevious(previous);
+                }
+                else
+                {
+                    _previous = previous;
+                }
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual async Task IncludeAsync([CanBeNull] object entity, CancellationToken cancellationToken)
+            {
+                if (_previous != null)
+                {
+                    await _previous.IncludeAsync(entity, cancellationToken);
                 }
 
-                _queryContext.EndIncludeScope();
+                await _queryContext.QueryBuffer
+                    .IncludeAsync(
+                        _queryContext,
+                        entity,
+                        _navigationPath,
+                        _relatedEntitiesLoaders,
+                        _querySourceRequiresTracking,
+                        cancellationToken);
+            }
+
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            public virtual void Dispose()
+            {
+                if (_queryContext != null)
+                {
+                    _previous?.Dispose();
+
+                    foreach (var relatedEntitiesLoader in _relatedEntitiesLoaders)
+                    {
+                        relatedEntitiesLoader.Dispose();
+                    }
+
+                    _queryContext.EndIncludeScope();
+                }
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
@@ -269,8 +269,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             GroupJoinInclude outerGroupJoinInclude,
             GroupJoinInclude innerGroupJoinInclude)
         {
-            outerGroupJoinInclude?.Initialize(queryContext);
-            innerGroupJoinInclude?.Initialize(queryContext);
+            var outerGroupJoinIncludeContext = outerGroupJoinInclude?.Initialize(queryContext);
+            var innerGroupJoinIncludeContext = innerGroupJoinInclude?.Initialize(queryContext);
 
             var hasOuters = (innerShaper as EntityShaper)?.ValueBufferOffset > 0;
 
@@ -291,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         nextOuter = default(TOuter);
 
-                        outerGroupJoinInclude?.Include(outer);
+                        outerGroupJoinIncludeContext?.Include(outer);
 
                         var inner = innerShaper.Shape(queryContext, sourceEnumerator.Current);
                         var inners = new List<TInner>();
@@ -306,7 +306,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             var currentGroupKey = innerKeySelector(inner);
 
-                            innerGroupJoinInclude?.Include(inner);
+                            innerGroupJoinIncludeContext?.Include(inner);
 
                             inners.Add(inner);
 
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     break;
                                 }
 
-                                innerGroupJoinInclude?.Include(inner);
+                                innerGroupJoinIncludeContext?.Include(inner);
 
                                 inners.Add(inner);
                             }
@@ -357,8 +357,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             finally
             {
-                innerGroupJoinInclude?.Dispose();
-                outerGroupJoinInclude?.Dispose();
+                innerGroupJoinIncludeContext?.Dispose();
+                outerGroupJoinIncludeContext?.Dispose();
             }
         }
 


### PR DESCRIPTION
Resolves #5456 
 Issue:  `GroupJoinInclude`  in compiled query has querycontext as field which is initialized while iterating query. If the same query is ran from different thread and uses the cached entry then the querycontext in  `GroupJoinInclude`  gets changed. Which means only 1 query will have correct context, rest of them will be using incorrect data hence causing exception.
 Solution: Make  `GroupJoinInclude`  immutable and use different data structure which is context based for each query.
 Same applies to async case.