### PR TITLE
Query: Better error messages when encountering invalid data.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
@@ -5,19 +5,128 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Xunit;
+
 // ReSharper disable InconsistentNaming
 
 // ReSharper disable ConvertToConstant.Local
 // ReSharper disable AccessToDisposedClosure
-
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public abstract class FromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryRelationalFixture, new()
     {
+        [Fact]
+        public virtual void Bad_data_error_handling_invalid_cast_key()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingValueInvalidCast(typeof(int), typeof(string)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .FromSql(@"SELECT ""ProductID"" AS ProductName, ""ProductName"" AS ProductID, ""SupplierID"", ""UnitsInStock"", ""Discontinued""
+                               FROM ""Products""")
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_invalid_cast()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "ProductName", typeof(string), typeof(int)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .FromSql(@"SELECT ""ProductID"", ""ProductName"" AS SupplierID, ""SupplierID"" AS ProductName, ""UnitsInStock"", ""Discontinued""
+                               FROM ""Products""")
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_invalid_cast_projection()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingValueInvalidCast(typeof(string), typeof(int)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .FromSql(@"SELECT ""ProductID"", ""ProductName"" AS SupplierID, ""SupplierID"" AS ProductName, ""UnitsInStock"", ""Discontinued""
+                               FROM ""Products""")
+                            .Select(p => p.ProductName)
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_invalid_cast_no_tracking()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "ProductID", typeof(int), typeof(string)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .AsNoTracking()
+                            .FromSql(@"SELECT ""ProductID"" AS ProductName, ""ProductName"" AS ProductID, ""SupplierID"", ""UnitsInStock"", ""Discontinued""
+                               FROM ""Products""")
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_null()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .FromSql(@"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitsInStock"", NULL AS ""Discontinued""
+                               FROM ""Products""")
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_null_projection()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingValueNullReference(typeof(bool)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .FromSql(@"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitsInStock"", NULL AS ""Discontinued""
+                               FROM ""Products""")
+                            .Select(p => p.Discontinued)
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Bad_data_error_handling_null_no_tracking()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        context.Set<Product>()
+                            .AsNoTracking()
+                            .FromSql(@"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitsInStock"", NULL AS ""Discontinued""
+                               FROM ""Products""")
+                            .ToList()).Message);
+            }
+        }
+
         [Fact]
         public virtual void From_sql_queryable_simple()
         {
@@ -495,9 +604,9 @@ AND ((UnitsInStock + UnitsOnOrder) < ReorderLevel)")
                 ctx.Database.OpenConnection();
 
                 var query = ctx.Customers
-                        .Include(v => v.Orders)
-                        .Where(v => v.CustomerID == "MAMRFC")
-                        .ToList();
+                    .Include(v => v.Orders)
+                    .Where(v => v.CustomerID == "MAMRFC")
+                    .ToList();
 
                 Assert.Empty(query);
                 Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -8,25 +8,29 @@ using JetBrains.Annotations;
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public interface IEntityMaterializerSource
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateReadValueExpression([NotNull] Expression valueBuffer, [NotNull] Type type, int index);
+        Expression CreateReadValueExpression(
+            [NotNull] Expression valueBuffer,
+            [NotNull] Type type,
+            int index,
+            [CanBeNull] IProperty property = null);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         Expression CreateReadValueCallExpression([NotNull] Expression valueBuffer, int index);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         Expression CreateMaterializeExpression(

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1336,6 +1336,54 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("NoProviderConfiguredFailedToResolveService", "service"), service);
         }
 
+        /// <summary>
+        /// An exception occured while reading a database value for property '{entityType}.{property}'. See the inner exception for more information.
+        /// </summary>
+        public static string ErrorMaterializingProperty([CanBeNull] object entityType, [CanBeNull] object property)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ErrorMaterializingProperty", "entityType", "property"), entityType, property);
+        }
+
+        /// <summary>
+        /// An exception occured while reading a database value for property '{entityType}.{property}'. The expected type was '{expectedType}' but the actual value was of type '{actualType}'.
+        /// </summary>
+        public static string ErrorMaterializingPropertyInvalidCast([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object expectedType, [CanBeNull] object actualType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ErrorMaterializingPropertyInvalidCast", "entityType", "property", "expectedType", "actualType"), entityType, property, expectedType, actualType);
+        }
+
+        /// <summary>
+        /// An exception occured while reading a database value for property '{entityType}.{property}'. The expected type was '{expectedType}' but the actual value was null.
+        /// </summary>
+        public static string ErrorMaterializingPropertyNullReference([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object expectedType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ErrorMaterializingPropertyNullReference", "entityType", "property", "expectedType"), entityType, property, expectedType);
+        }
+
+        /// <summary>
+        /// An exception occured while reading a database value. See the inner exception for more information.
+        /// </summary>
+        public static string ErrorMaterializingValue
+        {
+            get { return GetString("ErrorMaterializingValue"); }
+        }
+
+        /// <summary>
+        /// An exception occured while reading a database value. The expected type was '{expectedType}' but the actual value was of type '{actualType}'.
+        /// </summary>
+        public static string ErrorMaterializingValueInvalidCast([CanBeNull] object expectedType, [CanBeNull] object actualType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ErrorMaterializingValueInvalidCast", "expectedType", "actualType"), expectedType, actualType);
+        }
+
+        /// <summary>
+        /// An exception occured while reading a database value. The expected type was '{expectedType}' but the actual value was null.
+        /// </summary>
+        public static string ErrorMaterializingValueNullReference([CanBeNull] object expectedType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ErrorMaterializingValueNullReference", "expectedType"), expectedType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -612,4 +612,22 @@
   <data name="NoProviderConfiguredFailedToResolveService" xml:space="preserve">
     <value>Unable to resolve service for type '{service}'. This is often because no database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions&lt;TContext&gt; object in its constructor and passes it to the base constructor for DbContext.</value>
   </data>
+  <data name="ErrorMaterializingProperty" xml:space="preserve">
+    <value>An exception occured while reading a database value for property '{entityType}.{property}'. See the inner exception for more information.</value>
+  </data>
+  <data name="ErrorMaterializingPropertyInvalidCast" xml:space="preserve">
+    <value>An exception occured while reading a database value for property '{entityType}.{property}'. The expected type was '{expectedType}' but the actual value was of type '{actualType}'.</value>
+  </data>
+  <data name="ErrorMaterializingPropertyNullReference" xml:space="preserve">
+    <value>An exception occured while reading a database value for property '{entityType}.{property}'. The expected type was '{expectedType}' but the actual value was null.</value>
+  </data>
+  <data name="ErrorMaterializingValue" xml:space="preserve">
+    <value>An exception occured while reading a database value. See the inner exception for more information.</value>
+  </data>
+  <data name="ErrorMaterializingValueInvalidCast" xml:space="preserve">
+    <value>An exception occured while reading a database value. The expected type was '{expectedType}' but the actual value was of type '{actualType}'.</value>
+  </data>
+  <data name="ErrorMaterializingValueNullReference" xml:space="preserve">
+    <value>An exception occured while reading a database value. The expected type was '{expectedType}' but the actual value was null.</value>
+  </data>
 </root>

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FromSqlQuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FromSqlQuerySqliteTest.cs
@@ -14,6 +14,26 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
         }
 
+        public override void Bad_data_error_handling_invalid_cast_key()
+        {
+            // Not supported on SQLite
+        }
+
+        public override void Bad_data_error_handling_invalid_cast()
+        {
+            // Not supported on SQLite
+        }
+
+        public override void Bad_data_error_handling_invalid_cast_projection()
+        {
+            // Not supported on SQLite
+        }
+
+        public override void Bad_data_error_handling_invalid_cast_no_tracking()
+        {
+            // Not supported on SQLite
+        }
+
         protected override DbParameter CreateDbParameter(string name, object value)
             => new SqliteParameter
             {


### PR DESCRIPTION
Surround generated ValueBuffer reads with a Try/Catch so we can throw a better exception. Explicit detection of common cases: Null ref and invalid cast.

Fix: #6039, #4289

No perf degradation observed when running tests locally. I will monitor perf runs after this goes in.