### PR TITLE
[1.0.1] Fix GetReferencingForeignKeys for derived types

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var root = context.Roots.Single();
+                var root = context.Roots.Single(IsTheRoot);
 
                 root.OptionalSingle = new OptionalSingle1();
 
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var root = context.Roots.Single();
+                var root = context.Roots.Single(IsTheRoot);
 
                 root.RequiredSingle = new RequiredSingle1();
 
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var root = context.Roots.Single();
+                var root = context.Roots.Single(IsTheRoot);
 
                 root.OptionalSingleAk = new OptionalSingleAk1();
 
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var root = context.Roots.Single();
+                var root = context.Roots.Single(IsTheRoot);
 
                 root.RequiredSingleAk = new RequiredSingleAk1();
 
@@ -95,21 +95,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
         public virtual void Save_optional_many_to_one_dependents(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
+            var new1 = new Optional1();
+            var new1d = new Optional1Derived();
+            var new1dd = new Optional1MoreDerived();
             var new2a = new Optional2();
             var new2b = new Optional2();
-            var new1 = new Optional1();
+            var new2d = new Optional2Derived();
+            var new2dd = new Optional2MoreDerived();
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.SaveChanges();
                 }
             }
 
             Root root;
-            int entityCount;
+            IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
                 root = LoadFullGraph(context);
@@ -118,57 +122,85 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 if (useExistingEntities)
                 {
                     new1 = context.Optional1s.Single(e => e.Id == new1.Id);
+                    new1d = (Optional1Derived)context.Optional1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (Optional1MoreDerived)context.Optional1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.Optional2s.Single(e => e.Id == new2a.Id);
                     new2b = context.Optional2s.Single(e => e.Id == new2b.Id);
+                    new2d = (Optional2Derived)context.Optional2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (Optional2MoreDerived)context.Optional2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(new1d.Children, new2d);
+                    Add(new1dd.Children, new2dd);
                     Add(root.OptionalChildren, new1);
+                    Add(root.OptionalChildren, new1d);
+                    Add(root.OptionalChildren, new1dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2d.Parent = new1d;
+                    new2dd.Parent = new1dd;
                     new1.Parent = root;
+                    new1d.Parent = root;
+                    new1dd.Parent = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new2a.ParentId = existing.Id;
                     new2b.ParentId = existing.Id;
+                    new2d.ParentId = new1d.Id;
+                    new2dd.ParentId = new1dd.Id;
                     new1.ParentId = root.Id;
+                    new1d.ParentId = root.Id;
+                    new1dd.ParentId = root.Id;
                 }
 
                 context.SaveChanges();
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2d, new1d.Children);
+                Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.OptionalChildren);
+                Assert.Contains(new1d, root.OptionalChildren);
+                Assert.Contains(new1dd, root.OptionalChildren);
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(new1d, new2d.Parent);
+                Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
+                Assert.Same(root, new1d.Parent);
+                Assert.Same(root, new1dd.Parent);
 
                 Assert.Equal(existing.Id, new2a.ParentId);
                 Assert.Equal(existing.Id, new2b.ParentId);
+                Assert.Equal(new1d.Id, new2d.ParentId);
+                Assert.Equal(new1dd.Id, new2dd.ParentId);
                 Assert.Equal(root.Id, existing.ParentId);
+                Assert.Equal(root.Id, new1d.ParentId);
+                Assert.Equal(root.Id, new1dd.ParentId);
 
-                entityCount = context.ChangeTracker.Entries().Count();
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
                 var loadedRoot = LoadFullGraph(context);
 
-                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
             }
@@ -193,34 +225,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             var newRoot = new Root();
             var new1 = new Required1 { Parent = newRoot };
+            var new1d = new Required1Derived { Parent = newRoot };
+            var new1dd = new Required1MoreDerived { Parent = newRoot };
             var new2a = new Required2 { Parent = new1 };
             var new2b = new Required2 { Parent = new1 };
+            var new2d = new Required2Derived { Parent = new1 };
+            var new2dd = new Required2MoreDerived { Parent = new1 };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new2a, new2b);
+                    context.AddRange(newRoot, new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.SaveChanges();
                 }
             }
 
             Root root;
-            int entityCount;
+            IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
                 var existing = root.RequiredChildren.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
                 {
                     new1 = context.Required1s.Single(e => e.Id == new1.Id);
+                    new1d = (Required1Derived)context.Required1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (Required1MoreDerived)context.Required1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.Required2s.Single(e => e.Id == new2a.Id);
                     new2b = context.Required2s.Single(e => e.Id == new2b.Id);
+                    new2d = (Required2Derived)context.Required2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (Required2MoreDerived)context.Required2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.Entry(newRoot).State = EntityState.Detached;
                 }
 
@@ -228,45 +268,69 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(new1d.Children, new2d);
+                    Add(new1dd.Children, new2dd);
                     Add(root.RequiredChildren, new1);
+                    Add(root.RequiredChildren, new1d);
+                    Add(root.RequiredChildren, new1dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2d.Parent = new1d;
+                    new2dd.Parent = new1dd;
                     new1.Parent = root;
+                    new1d.Parent = root;
+                    new1dd.Parent = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new2a.ParentId = existing.Id;
                     new2b.ParentId = existing.Id;
+                    new2d.ParentId = new1d.Id;
+                    new2dd.ParentId = new1dd.Id;
                     new1.ParentId = root.Id;
+                    new1d.ParentId = root.Id;
+                    new1dd.ParentId = root.Id;
                 }
 
                 context.SaveChanges();
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2d, new1d.Children);
+                Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.RequiredChildren);
+                Assert.Contains(new1d, root.RequiredChildren);
+                Assert.Contains(new1dd, root.RequiredChildren);
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(new1d, new2d.Parent);
+                Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
+                Assert.Same(root, new1d.Parent);
+                Assert.Same(root, new1dd.Parent);
 
                 Assert.Equal(existing.Id, new2a.ParentId);
                 Assert.Equal(existing.Id, new2b.ParentId);
+                Assert.Equal(new1d.Id, new2d.ParentId);
+                Assert.Equal(new1dd.Id, new2dd.ParentId);
                 Assert.Equal(root.Id, existing.ParentId);
+                Assert.Equal(root.Id, new1d.ParentId);
+                Assert.Equal(root.Id, new1dd.ParentId);
 
-                entityCount = context.ChangeTracker.Entries().Count();
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var loadedRoot = LoadFullGraph(context);
 
-                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
             }
@@ -415,63 +479,104 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Save_changed_optional_one_to_one(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             var new2 = new OptionalSingle2();
+            var new2d = new OptionalSingle2Derived();
+            var new2dd = new OptionalSingle2MoreDerived();
             var new1 = new OptionalSingle1 { Single = new2 };
+            var new1d = new OptionalSingle1Derived { Single = new2d };
+            var new1dd = new OptionalSingle1MoreDerived { Single = new2dd };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new2);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                     context.SaveChanges();
                 }
             }
 
             Root root;
+            IReadOnlyList<EntityEntry> entries;
             OptionalSingle1 old1;
+            OptionalSingle1Derived old1d;
+            OptionalSingle1MoreDerived old1dd;
             OptionalSingle2 old2;
+            OptionalSingle2Derived old2d;
+            OptionalSingle2MoreDerived old2dd;
             using (var context = CreateContext())
             {
                 root = LoadFullGraph(context);
 
                 old1 = root.OptionalSingle;
+                old1d = root.OptionalSingleDerived;
+                old1dd = root.OptionalSingleMoreDerived;
                 old2 = root.OptionalSingle.Single;
+                old2d = (OptionalSingle2Derived)root.OptionalSingleDerived.Single;
+                old2dd = (OptionalSingle2MoreDerived)root.OptionalSingleMoreDerived.Single;
 
                 if (useExistingEntities)
                 {
                     new1 = context.OptionalSingle1s.Single(e => e.Id == new1.Id);
+                    new1d = (OptionalSingle1Derived)context.OptionalSingle1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (OptionalSingle1MoreDerived)context.OptionalSingle1s.Single(e => e.Id == new1dd.Id);
                     new2 = context.OptionalSingle2s.Single(e => e.Id == new2.Id);
+                    new2d = (OptionalSingle2Derived)context.OptionalSingle2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (OptionalSingle2MoreDerived)context.OptionalSingle2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     root.OptionalSingle = new1;
+                    root.OptionalSingleDerived = new1d;
+                    root.OptionalSingleMoreDerived = new1dd;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new1.Root = root;
+                    new1d.DerivedRoot = root;
+                    new1dd.MoreDerivedRoot = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new1.RootId = root.Id;
+                    new1d.DerivedRootId = root.Id;
+                    new1dd.MoreDerivedRootId = root.Id;
                 }
 
                 context.SaveChanges();
 
                 Assert.Equal(root.Id, new1.RootId);
+                Assert.Equal(root.Id, new1d.DerivedRootId);
+                Assert.Equal(root.Id, new1dd.MoreDerivedRootId);
                 Assert.Equal(new1.Id, new2.BackId);
+                Assert.Equal(new1d.Id, new2d.BackId);
+                Assert.Equal(new1dd.Id, new2dd.BackId);
                 Assert.Same(root, new1.Root);
+                Assert.Same(root, new1d.DerivedRoot);
+                Assert.Same(root, new1dd.MoreDerivedRoot);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1d, new2d.Back);
+                Assert.Same(new1dd, new2dd.Back);
 
                 Assert.Null(old1.Root);
-                Assert.Same(old1, old2.Back);
+                Assert.Null(old1d.DerivedRoot);
+                Assert.Null(old1dd.MoreDerivedRoot);
+                Assert.Equal(old1, old2.Back);
+                Assert.Equal(old1d, old2d.Back);
+                Assert.Equal(old1dd, old2dd.Back);
                 Assert.Null(old1.RootId);
+                Assert.Null(old1d.DerivedRootId);
+                Assert.Null(old1dd.MoreDerivedRootId);
                 Assert.Equal(old1.Id, old2.BackId);
+                Assert.Equal(old1d.Id, old2d.BackId);
+                Assert.Equal(old1dd.Id, old2dd.BackId);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
@@ -482,12 +587,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 AssertNavigations(loadedRoot);
 
                 var loaded1 = context.OptionalSingle1s.Single(e => e.Id == old1.Id);
+                var loaded1d = context.OptionalSingle1s.Single(e => e.Id == old1d.Id);
+                var loaded1dd = context.OptionalSingle1s.Single(e => e.Id == old1dd.Id);
                 var loaded2 = context.OptionalSingle2s.Single(e => e.Id == old2.Id);
+                var loaded2d = context.OptionalSingle2s.Single(e => e.Id == old2d.Id);
+                var loaded2dd = context.OptionalSingle2s.Single(e => e.Id == old2dd.Id);
+
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
 
                 Assert.Null(loaded1.Root);
+                Assert.Null(loaded1d.Root);
+                Assert.Null(loaded1dd.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1d, loaded2d.Back);
+                Assert.Same(loaded1dd, loaded2dd.Back);
                 Assert.Null(loaded1.RootId);
+                Assert.Null(loaded1d.RootId);
+                Assert.Null(loaded1dd.RootId);
                 Assert.Equal(loaded1.Id, loaded2.BackId);
+                Assert.Equal(loaded1d.Id, loaded2d.BackId);
+                Assert.Equal(loaded1dd.Id, loaded2dd.BackId);
             }
         }
 
@@ -508,6 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             // done in two steps.
 
             Root oldRoot;
+            IReadOnlyList<EntityEntry> entries;
             RequiredSingle1 old1;
             RequiredSingle2 old2;
             using (var context = CreateContext())
@@ -560,14 +680,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Same(oldRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
-                Assert.Equal(oldRoot.Id, old1.Id);
                 Assert.Equal(old1.Id, old2.Id);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
                 var loadedRoot = LoadFullGraph(context);
 
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(oldRoot, loadedRoot);
                 AssertNavigations(loadedRoot);
             }
@@ -591,74 +713,128 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             var new2 = new RequiredNonPkSingle2();
+            var new2d = new RequiredNonPkSingle2Derived();
+            var new2dd = new RequiredNonPkSingle2MoreDerived();
             var new1 = new RequiredNonPkSingle1 { Single = new2 };
-            var newRoot = new Root { RequiredNonPkSingle = new1 };
+            var new1d = new RequiredNonPkSingle1Derived { Single = new2d, Root = new Root() };
+            var new1dd = new RequiredNonPkSingle1MoreDerived { Single = new2dd, Root = new Root(), DerivedRoot = new Root() };
+            var newRoot = new Root { RequiredNonPkSingle = new1, RequiredNonPkSingleDerived = new1d, RequiredNonPkSingleMoreDerived = new1dd };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new2);
+                    context.AddRange(newRoot, new1, new1d, new1dd, new2, new2d, new2dd);
                     context.SaveChanges();
                 }
             }
 
             Root root;
+            IReadOnlyList<EntityEntry> entries;
             RequiredNonPkSingle1 old1;
+            RequiredNonPkSingle1Derived old1d;
+            RequiredNonPkSingle1MoreDerived old1dd;
             RequiredNonPkSingle2 old2;
+            RequiredNonPkSingle2Derived old2d;
+            RequiredNonPkSingle2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 old1 = root.RequiredNonPkSingle;
+                old1d = root.RequiredNonPkSingleDerived;
+                old1dd = root.RequiredNonPkSingleMoreDerived;
                 old2 = root.RequiredNonPkSingle.Single;
+                old2d = (RequiredNonPkSingle2Derived)root.RequiredNonPkSingleDerived.Single;
+                old2dd = (RequiredNonPkSingle2MoreDerived)root.RequiredNonPkSingleMoreDerived.Single;
+
+                context.RequiredNonPkSingle1s.Remove(old1d);
+                context.RequiredNonPkSingle1s.Remove(old1dd);
 
                 if (useExistingEntities)
                 {
                     new1 = context.RequiredNonPkSingle1s.Single(e => e.Id == new1.Id);
+                    new1d = (RequiredNonPkSingle1Derived)context.RequiredNonPkSingle1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (RequiredNonPkSingle1MoreDerived)context.RequiredNonPkSingle1s.Single(e => e.Id == new1dd.Id);
                     new2 = context.RequiredNonPkSingle2s.Single(e => e.Id == new2.Id);
+                    new2d = (RequiredNonPkSingle2Derived)context.RequiredNonPkSingle2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (RequiredNonPkSingle2MoreDerived)context.RequiredNonPkSingle2s.Single(e => e.Id == new2dd.Id);
+
+                    new1d.RootId = old1d.RootId;
+                    new1dd.RootId = old1dd.RootId;
+                    new1dd.DerivedRootId = old1dd.DerivedRootId;
                 }
                 else
                 {
-                    context.AddRange(newRoot, new1, new2);
+                    new1d.Root = old1d.Root;
+                    new1dd.Root = old1dd.Root;
+                    new1dd.DerivedRoot = old1dd.DerivedRoot;
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     root.RequiredNonPkSingle = new1;
+                    root.RequiredNonPkSingleDerived = new1d;
+                    root.RequiredNonPkSingleMoreDerived = new1dd;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new1.Root = root;
+                    new1d.DerivedRoot = root;
+                    new1dd.MoreDerivedRoot = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new1.RootId = root.Id;
+                    new1d.DerivedRootId = root.Id;
+                    new1dd.MoreDerivedRootId = root.Id;
                 }
 
                 context.SaveChanges();
 
                 Assert.Equal(root.Id, new1.RootId);
+                Assert.Equal(root.Id, new1d.DerivedRootId);
+                Assert.Equal(root.Id, new1dd.MoreDerivedRootId);
                 Assert.Equal(new1.Id, new2.BackId);
+                Assert.Equal(new1d.Id, new2d.BackId);
+                Assert.Equal(new1dd.Id, new2dd.BackId);
                 Assert.Same(root, new1.Root);
+                Assert.Same(root, new1d.DerivedRoot);
+                Assert.Same(root, new1dd.MoreDerivedRoot);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1d, new2d.Back);
+                Assert.Same(new1dd, new2dd.Back);
 
                 Assert.Null(old1.Root);
+                Assert.Null(old1d.DerivedRoot);
+                Assert.Null(old1dd.MoreDerivedRoot);
                 Assert.Null(old2.Back);
+                Assert.Null(old2d.Back);
+                Assert.Null(old2dd.Back);
                 Assert.Equal(old1.Id, old2.BackId);
+                Assert.Equal(old1d.Id, old2d.BackId);
+                Assert.Equal(old1dd.Id, old2dd.BackId);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
 
                 Assert.False(context.RequiredNonPkSingle1s.Any(e => e.Id == old1.Id));
+                Assert.False(context.RequiredNonPkSingle1s.Any(e => e.Id == old1d.Id));
+                Assert.False(context.RequiredNonPkSingle1s.Any(e => e.Id == old1dd.Id));
                 Assert.False(context.RequiredNonPkSingle2s.Any(e => e.Id == old2.Id));
+                Assert.False(context.RequiredNonPkSingle2s.Any(e => e.Id == old2d.Id));
+                Assert.False(context.RequiredNonPkSingle2s.Any(e => e.Id == old2dd.Id));
             }
         }
 
@@ -855,7 +1031,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -889,7 +1065,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -935,7 +1111,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -962,7 +1138,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                                 newRoot.RequiredSingle = root.RequiredSingle;
 
                                 context.SaveChanges();
-
                             }).Message);
             }
         }
@@ -1000,7 +1175,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1034,7 +1209,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1067,21 +1242,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
         public virtual void Save_optional_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
+            var new1 = new OptionalAk1 { AlternateId = Guid.NewGuid() };
+            var new1d = new OptionalAk1Derived { AlternateId = Guid.NewGuid() };
+            var new1dd = new OptionalAk1MoreDerived { AlternateId = Guid.NewGuid() };
             var new2a = new OptionalAk2 { AlternateId = Guid.NewGuid() };
             var new2b = new OptionalAk2 { AlternateId = Guid.NewGuid() };
-            var new1 = new OptionalAk1 { AlternateId = Guid.NewGuid() };
+            var new2d = new OptionalAk2Derived { AlternateId = Guid.NewGuid() };
+            var new2dd = new OptionalAk2MoreDerived { AlternateId = Guid.NewGuid() };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.SaveChanges();
                 }
             }
 
             Root root;
-            int entityCount;
+            IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
                 root = LoadFullGraph(context);
@@ -1090,57 +1269,85 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 if (useExistingEntities)
                 {
                     new1 = context.OptionalAk1s.Single(e => e.Id == new1.Id);
+                    new1d = (OptionalAk1Derived)context.OptionalAk1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (OptionalAk1MoreDerived)context.OptionalAk1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.OptionalAk2s.Single(e => e.Id == new2a.Id);
                     new2b = context.OptionalAk2s.Single(e => e.Id == new2b.Id);
+                    new2d = (OptionalAk2Derived)context.OptionalAk2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (OptionalAk2MoreDerived)context.OptionalAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(new1d.Children, new2d);
+                    Add(new1dd.Children, new2dd);
                     Add(root.OptionalChildrenAk, new1);
+                    Add(root.OptionalChildrenAk, new1d);
+                    Add(root.OptionalChildrenAk, new1dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2d.Parent = new1d;
+                    new2dd.Parent = new1dd;
                     new1.Parent = root;
+                    new1d.Parent = root;
+                    new1dd.Parent = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new2a.ParentId = existing.AlternateId;
                     new2b.ParentId = existing.AlternateId;
+                    new2d.ParentId = new1d.AlternateId;
+                    new2dd.ParentId = new1dd.AlternateId;
                     new1.ParentId = root.AlternateId;
+                    new1d.ParentId = root.AlternateId;
+                    new1dd.ParentId = root.AlternateId;
                 }
 
                 context.SaveChanges();
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2d, new1d.Children);
+                Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.OptionalChildrenAk);
+                Assert.Contains(new1d, root.OptionalChildrenAk);
+                Assert.Contains(new1dd, root.OptionalChildrenAk);
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(new1d, new2d.Parent);
+                Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
+                Assert.Same(root, new1d.Parent);
+                Assert.Same(root, new1dd.Parent);
 
                 Assert.Equal(existing.AlternateId, new2a.ParentId);
                 Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(new1d.AlternateId, new2d.ParentId);
+                Assert.Equal(new1dd.AlternateId, new2dd.ParentId);
                 Assert.Equal(root.AlternateId, existing.ParentId);
+                Assert.Equal(root.AlternateId, new1d.ParentId);
+                Assert.Equal(root.AlternateId, new1dd.ParentId);
 
-                entityCount = context.ChangeTracker.Entries().Count();
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
                 var loadedRoot = LoadFullGraph(context);
 
-                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
             }
@@ -1165,34 +1372,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             var newRoot = new Root { AlternateId = Guid.NewGuid() };
             var new1 = new RequiredAk1 { AlternateId = Guid.NewGuid(), Parent = newRoot };
+            var new1d = new RequiredAk1Derived { AlternateId = Guid.NewGuid(), Parent = newRoot };
+            var new1dd = new RequiredAk1MoreDerived { AlternateId = Guid.NewGuid(), Parent = newRoot };
             var new2a = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
             var new2b = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
+            var new2d = new RequiredAk2Derived { AlternateId = Guid.NewGuid(), Parent = new1 };
+            var new2dd = new RequiredAk2MoreDerived { AlternateId = Guid.NewGuid(), Parent = new1 };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new2a, new2b);
+                    context.AddRange(newRoot, new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.SaveChanges();
                 }
             }
 
             Root root;
-            int entityCount;
+            IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
                 var existing = root.RequiredChildrenAk.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
                 {
                     new1 = context.RequiredAk1s.Single(e => e.Id == new1.Id);
+                    new1d = (RequiredAk1Derived)context.RequiredAk1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (RequiredAk1MoreDerived)context.RequiredAk1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.RequiredAk2s.Single(e => e.Id == new2a.Id);
                     new2b = context.RequiredAk2s.Single(e => e.Id == new2b.Id);
+                    new2d = (RequiredAk2Derived)context.RequiredAk2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (RequiredAk2MoreDerived)context.RequiredAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2a, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                     context.Entry(newRoot).State = EntityState.Detached;
                 }
 
@@ -1200,45 +1415,69 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(new1d.Children, new2d);
+                    Add(new1dd.Children, new2dd);
                     Add(root.RequiredChildrenAk, new1);
+                    Add(root.RequiredChildrenAk, new1d);
+                    Add(root.RequiredChildrenAk, new1dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2d.Parent = new1d;
+                    new2dd.Parent = new1dd;
                     new1.Parent = root;
+                    new1d.Parent = root;
+                    new1dd.Parent = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new2a.ParentId = existing.AlternateId;
                     new2b.ParentId = existing.AlternateId;
+                    new2d.ParentId = new1d.AlternateId;
+                    new2dd.ParentId = new1dd.AlternateId;
                     new1.ParentId = root.AlternateId;
+                    new1d.ParentId = root.AlternateId;
+                    new1dd.ParentId = root.AlternateId;
                 }
 
                 context.SaveChanges();
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2d, new1d.Children);
+                Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.RequiredChildrenAk);
+                Assert.Contains(new1d, root.RequiredChildrenAk);
+                Assert.Contains(new1dd, root.RequiredChildrenAk);
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(new1d, new2d.Parent);
+                Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
+                Assert.Same(root, new1d.Parent);
+                Assert.Same(root, new1dd.Parent);
 
                 Assert.Equal(existing.AlternateId, new2a.ParentId);
                 Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(new1d.AlternateId, new2d.ParentId);
+                Assert.Equal(new1dd.AlternateId, new2dd.ParentId);
                 Assert.Equal(root.AlternateId, existing.ParentId);
+                Assert.Equal(root.AlternateId, new1d.ParentId);
+                Assert.Equal(root.AlternateId, new1dd.ParentId);
 
-                entityCount = context.ChangeTracker.Entries().Count();
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var loadedRoot = LoadFullGraph(context);
 
-                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
             }
@@ -1387,63 +1626,104 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Save_changed_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             var new2 = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() };
+            var new2d = new OptionalSingleAk2Derived { AlternateId = Guid.NewGuid() };
+            var new2dd = new OptionalSingleAk2MoreDerived { AlternateId = Guid.NewGuid() };
             var new1 = new OptionalSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+            var new1d = new OptionalSingleAk1Derived { AlternateId = Guid.NewGuid(), Single = new2d };
+            var new1dd = new OptionalSingleAk1MoreDerived { AlternateId = Guid.NewGuid(), Single = new2dd };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new2);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                     context.SaveChanges();
                 }
             }
 
             Root root;
+            IReadOnlyList<EntityEntry> entries;
             OptionalSingleAk1 old1;
+            OptionalSingleAk1Derived old1d;
+            OptionalSingleAk1MoreDerived old1dd;
             OptionalSingleAk2 old2;
+            OptionalSingleAk2Derived old2d;
+            OptionalSingleAk2MoreDerived old2dd;
             using (var context = CreateContext())
             {
                 root = LoadFullGraph(context);
 
                 old1 = root.OptionalSingleAk;
+                old1d = root.OptionalSingleAkDerived;
+                old1dd = root.OptionalSingleAkMoreDerived;
                 old2 = root.OptionalSingleAk.Single;
+                old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
+                old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
 
                 if (useExistingEntities)
                 {
                     new1 = context.OptionalSingleAk1s.Single(e => e.Id == new1.Id);
+                    new1d = (OptionalSingleAk1Derived)context.OptionalSingleAk1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (OptionalSingleAk1MoreDerived)context.OptionalSingleAk1s.Single(e => e.Id == new1dd.Id);
                     new2 = context.OptionalSingleAk2s.Single(e => e.Id == new2.Id);
+                    new2d = (OptionalSingleAk2Derived)context.OptionalSingleAk2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (OptionalSingleAk2MoreDerived)context.OptionalSingleAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     root.OptionalSingleAk = new1;
+                    root.OptionalSingleAkDerived = new1d;
+                    root.OptionalSingleAkMoreDerived = new1dd;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new1.Root = root;
+                    new1d.DerivedRoot = root;
+                    new1dd.MoreDerivedRoot = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new1.RootId = root.AlternateId;
+                    new1d.DerivedRootId = root.AlternateId;
+                    new1dd.MoreDerivedRootId = root.AlternateId;
                 }
 
                 context.SaveChanges();
 
                 Assert.Equal(root.AlternateId, new1.RootId);
+                Assert.Equal(root.AlternateId, new1d.DerivedRootId);
+                Assert.Equal(root.AlternateId, new1dd.MoreDerivedRootId);
                 Assert.Equal(new1.AlternateId, new2.BackId);
+                Assert.Equal(new1d.AlternateId, new2d.BackId);
+                Assert.Equal(new1dd.AlternateId, new2dd.BackId);
                 Assert.Same(root, new1.Root);
+                Assert.Same(root, new1d.DerivedRoot);
+                Assert.Same(root, new1dd.MoreDerivedRoot);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1d, new2d.Back);
+                Assert.Same(new1dd, new2dd.Back);
 
                 Assert.Null(old1.Root);
+                Assert.Null(old1d.DerivedRoot);
+                Assert.Null(old1dd.MoreDerivedRoot);
                 Assert.Same(old1, old2.Back);
+                Assert.Equal(old1d, old2d.Back);
+                Assert.Equal(old1dd, old2dd.Back);
                 Assert.Null(old1.RootId);
+                Assert.Null(old1d.DerivedRootId);
+                Assert.Null(old1dd.MoreDerivedRootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1d.AlternateId, old2d.BackId);
+                Assert.Equal(old1dd.AlternateId, old2dd.BackId);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
@@ -1454,12 +1734,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 AssertNavigations(loadedRoot);
 
                 var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
+                var loaded1d = context.OptionalSingleAk1s.Single(e => e.Id == old1d.Id);
+                var loaded1dd = context.OptionalSingleAk1s.Single(e => e.Id == old1dd.Id);
                 var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+                var loaded2d = context.OptionalSingleAk2s.Single(e => e.Id == old2d.Id);
+                var loaded2dd = context.OptionalSingleAk2s.Single(e => e.Id == old2dd.Id);
+
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
 
                 Assert.Null(loaded1.Root);
+                Assert.Null(loaded1d.Root);
+                Assert.Null(loaded1dd.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1d, loaded2d.Back);
+                Assert.Same(loaded1dd, loaded2dd.Back);
                 Assert.Null(loaded1.RootId);
+                Assert.Null(loaded1d.RootId);
+                Assert.Null(loaded1dd.RootId);
                 Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+                Assert.Equal(loaded1d.AlternateId, loaded2d.BackId);
+                Assert.Equal(loaded1dd.AlternateId, loaded2dd.BackId);
             }
         }
 
@@ -1487,11 +1781,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
 
             Root root;
+            IReadOnlyList<EntityEntry> entries;
             RequiredSingleAk1 old1;
             RequiredSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 old1 = root.RequiredSingleAk;
                 old2 = root.RequiredSingleAk.Single;
@@ -1503,7 +1798,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
                 else
                 {
-                    context.AddRange(newRoot, new1, new2);
+                    context.AddRange(new1, new2);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -1531,12 +1826,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Null(old1.Root);
                 Assert.Null(old2.Back);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var loadedRoot = LoadFullGraph(context);
 
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
 
@@ -1564,74 +1862,128 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             var new2 = new RequiredNonPkSingleAk2 { AlternateId = Guid.NewGuid() };
+            var new2d = new RequiredNonPkSingleAk2Derived { AlternateId = Guid.NewGuid() };
+            var new2dd = new RequiredNonPkSingleAk2MoreDerived { AlternateId = Guid.NewGuid() };
             var new1 = new RequiredNonPkSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
-            var newRoot = new Root { AlternateId = Guid.NewGuid(), RequiredNonPkSingleAk = new1 };
+            var new1d = new RequiredNonPkSingleAk1Derived { AlternateId = Guid.NewGuid(), Single = new2d, Root = new Root() };
+            var new1dd = new RequiredNonPkSingleAk1MoreDerived { AlternateId = Guid.NewGuid(), Single = new2dd, Root = new Root(), DerivedRoot = new Root() };
+            var newRoot = new Root { AlternateId = Guid.NewGuid(), RequiredNonPkSingleAk = new1, RequiredNonPkSingleAkDerived = new1d, RequiredNonPkSingleAkMoreDerived = new1dd };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new2);
+                    context.AddRange(newRoot, new1, new1d, new1dd, new2, new2d, new2dd);
                     context.SaveChanges();
                 }
             }
 
             Root root;
+            IReadOnlyList<EntityEntry> entries;
             RequiredNonPkSingleAk1 old1;
+            RequiredNonPkSingleAk1Derived old1d;
+            RequiredNonPkSingleAk1MoreDerived old1dd;
             RequiredNonPkSingleAk2 old2;
+            RequiredNonPkSingleAk2Derived old2d;
+            RequiredNonPkSingleAk2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 old1 = root.RequiredNonPkSingleAk;
+                old1d = root.RequiredNonPkSingleAkDerived;
+                old1dd = root.RequiredNonPkSingleAkMoreDerived;
                 old2 = root.RequiredNonPkSingleAk.Single;
+                old2d = (RequiredNonPkSingleAk2Derived)root.RequiredNonPkSingleAkDerived.Single;
+                old2dd = (RequiredNonPkSingleAk2MoreDerived)root.RequiredNonPkSingleAkMoreDerived.Single;
+
+                context.RequiredNonPkSingleAk1s.Remove(old1d);
+                context.RequiredNonPkSingleAk1s.Remove(old1dd);
 
                 if (useExistingEntities)
                 {
                     new1 = context.RequiredNonPkSingleAk1s.Single(e => e.Id == new1.Id);
+                    new1d = (RequiredNonPkSingleAk1Derived)context.RequiredNonPkSingleAk1s.Single(e => e.Id == new1d.Id);
+                    new1dd = (RequiredNonPkSingleAk1MoreDerived)context.RequiredNonPkSingleAk1s.Single(e => e.Id == new1dd.Id);
                     new2 = context.RequiredNonPkSingleAk2s.Single(e => e.Id == new2.Id);
+                    new2d = (RequiredNonPkSingleAk2Derived)context.RequiredNonPkSingleAk2s.Single(e => e.Id == new2d.Id);
+                    new2dd = (RequiredNonPkSingleAk2MoreDerived)context.RequiredNonPkSingleAk2s.Single(e => e.Id == new2dd.Id);
+
+                    new1d.RootId = old1d.RootId;
+                    new1dd.RootId = old1dd.RootId;
+                    new1dd.DerivedRootId = old1dd.DerivedRootId;
                 }
                 else
                 {
-                    context.AddRange(new1, new2);
+                    new1d.Root = old1d.Root;
+                    new1dd.Root = old1dd.Root;
+                    new1dd.DerivedRoot = old1dd.DerivedRoot;
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     root.RequiredNonPkSingleAk = new1;
+                    root.RequiredNonPkSingleAkDerived = new1d;
+                    root.RequiredNonPkSingleAkMoreDerived = new1dd;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     new1.Root = root;
+                    new1d.DerivedRoot = root;
+                    new1dd.MoreDerivedRoot = root;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     new1.RootId = root.AlternateId;
+                    new1d.DerivedRootId = root.AlternateId;
+                    new1dd.MoreDerivedRootId = root.AlternateId;
                 }
 
                 context.SaveChanges();
 
                 Assert.Equal(root.AlternateId, new1.RootId);
+                Assert.Equal(root.AlternateId, new1d.DerivedRootId);
+                Assert.Equal(root.AlternateId, new1dd.MoreDerivedRootId);
                 Assert.Equal(new1.AlternateId, new2.BackId);
+                Assert.Equal(new1d.AlternateId, new2d.BackId);
+                Assert.Equal(new1dd.AlternateId, new2dd.BackId);
                 Assert.Same(root, new1.Root);
+                Assert.Same(root, new1d.DerivedRoot);
+                Assert.Same(root, new1dd.MoreDerivedRoot);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1d, new2d.Back);
+                Assert.Same(new1dd, new2dd.Back);
 
                 Assert.Null(old1.Root);
+                Assert.Null(old1d.DerivedRoot);
+                Assert.Null(old1dd.MoreDerivedRoot);
                 Assert.Null(old2.Back);
+                Assert.Null(old2d.Back);
+                Assert.Null(old2dd.Back);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1d.AlternateId, old2d.BackId);
+                Assert.Equal(old1dd.AlternateId, old2dd.BackId);
+
+                entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var loadedRoot = LoadFullGraph(context);
 
+                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
 
                 Assert.False(context.RequiredNonPkSingleAk1s.Any(e => e.Id == old1.Id));
+                Assert.False(context.RequiredNonPkSingleAk1s.Any(e => e.Id == old1d.Id));
+                Assert.False(context.RequiredNonPkSingleAk1s.Any(e => e.Id == old1dd.Id));
                 Assert.False(context.RequiredNonPkSingleAk2s.Any(e => e.Id == old2.Id));
+                Assert.False(context.RequiredNonPkSingleAk2s.Any(e => e.Id == old2d.Id));
+                Assert.False(context.RequiredNonPkSingleAk2s.Any(e => e.Id == old2dd.Id));
             }
         }
 
@@ -1828,7 +2180,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1862,7 +2214,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1911,7 +2263,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1945,7 +2297,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1994,7 +2346,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                root = LoadFullGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -2028,7 +2380,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+                var loadedRoot = LoadFullGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -2486,7 +2838,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredChildren).Single();
+                var root = context.Roots.Include(e => e.RequiredChildren).Single(IsTheRoot);
 
                 var removed = root.RequiredChildren.Single(e => e.Id == removedId);
 
@@ -2533,7 +2885,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredSingle).Single();
+                var root = context.Roots.Include(e => e.RequiredSingle).Single(IsTheRoot);
 
                 var removed = root.RequiredSingle;
 
@@ -2576,7 +2928,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredNonPkSingle).Single();
+                var root = context.Roots.Include(e => e.RequiredNonPkSingle).Single(IsTheRoot);
 
                 var removed = root.RequiredNonPkSingle;
 
@@ -2621,7 +2973,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredChildrenAk).Single();
+                var root = context.Roots.Include(e => e.RequiredChildrenAk).Single(IsTheRoot);
 
                 var removed = root.RequiredChildrenAk.Single(e => e.Id == removedId);
 
@@ -2668,7 +3020,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredSingleAk).Single();
+                var root = context.Roots.Include(e => e.RequiredSingleAk).Single(IsTheRoot);
 
                 var removed = root.RequiredSingleAk;
 
@@ -2711,7 +3063,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.RequiredNonPkSingleAk).Single();
+                var root = context.Roots.Include(e => e.RequiredNonPkSingleAk).Single(IsTheRoot);
 
                 var removed = root.RequiredNonPkSingleAk;
 
@@ -2756,7 +3108,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.OptionalChildren).Single();
+                var root = context.Roots.Include(e => e.OptionalChildren).Single(IsTheRoot);
 
                 var removed = root.OptionalChildren.First(e => e.Id == removedId);
 
@@ -2809,7 +3161,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.OptionalSingle).Single();
+                var root = context.Roots.Include(e => e.OptionalSingle).Single(IsTheRoot);
 
                 var removed = root.OptionalSingle;
 
@@ -2854,7 +3206,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.OptionalChildrenAk).Single();
+                var root = context.Roots.Include(e => e.OptionalChildrenAk).Single(IsTheRoot);
 
                 var removed = root.OptionalChildrenAk.First(e => e.Id == removedId);
 
@@ -2907,7 +3259,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = context.Roots.Include(e => e.OptionalSingleAk).Single();
+                var root = context.Roots.Include(e => e.OptionalSingleAk).Single(IsTheRoot);
 
                 var removed = root.OptionalSingleAk;
 
@@ -3675,23 +4027,36 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Fk = 4
         }
 
-        protected static Root LoadFullGraph(GraphUpdatesContext context, Expression<Func<Root, bool>> predicate = null)
+        protected Expression<Func<Root, bool>> IsTheRoot => r => r.AlternateId == Fixture.RootAK;
+
+        protected Root LoadFullGraph(GraphUpdatesContext context)
         {
-            var query = context.Roots
+            var loadedGraph = context.Roots
                 .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
                 .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
                 .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingle).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Root)
+                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Root)
+                .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.DerivedRoot)
                 .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
                 .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
                 .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleAk).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single);
-
-            var loadedGraph = predicate == null
-                ? query.Single()
-                : query.Single(predicate);
+                .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Root)
+                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Root)
+                .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.DerivedRoot)
+                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+                .Single(IsTheRoot);
 
             // TODO: Use Include when supported
             context.RequiredAk1s.Load();
@@ -3713,6 +4078,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             context.OptionalAk2s.Load();
 
             return loadedGraph;
+        }
+
+        private static void AssertEntries(IReadOnlyList<EntityEntry> expectedEntries, IReadOnlyList<EntityEntry> actualEntries)
+        {
+            var newEntities = new HashSet<object>(actualEntries.Select(ne => ne.Entity));
+            var missingEntities = expectedEntries.Select(e => e.Entity).Where(e => !newEntities.Contains(e)).ToList();
+            Assert.Equal(new object[0], missingEntities);
+            Assert.Equal(expectedEntries.Count, actualEntries.Count);
         }
 
         private static void AssertKeys(Root expected, Root actual)
@@ -3745,11 +4118,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             Assert.Equal(expected.RequiredSingle?.Id, actual.RequiredSingle?.Id);
             Assert.Equal(expected.OptionalSingle?.Id, actual.OptionalSingle?.Id);
+            Assert.Equal(expected.OptionalSingleDerived?.Id, actual.OptionalSingleDerived?.Id);
+            Assert.Equal(expected.OptionalSingleMoreDerived?.Id, actual.OptionalSingleMoreDerived?.Id);
             Assert.Equal(expected.RequiredNonPkSingle?.Id, actual.RequiredNonPkSingle?.Id);
+            Assert.Equal(expected.RequiredNonPkSingleDerived?.Id, actual.RequiredNonPkSingleDerived?.Id);
+            Assert.Equal(expected.RequiredNonPkSingleMoreDerived?.Id, actual.RequiredNonPkSingleMoreDerived?.Id);
 
             Assert.Equal(expected.RequiredSingle?.Single?.Id, actual.RequiredSingle?.Single?.Id);
             Assert.Equal(expected.OptionalSingle?.Single?.Id, actual.OptionalSingle?.Single?.Id);
+            Assert.Equal(expected.OptionalSingleDerived?.Single?.Id, actual.OptionalSingleDerived?.Single?.Id);
+            Assert.Equal(expected.OptionalSingleMoreDerived?.Single?.Id, actual.OptionalSingleMoreDerived?.Single?.Id);
             Assert.Equal(expected.RequiredNonPkSingle?.Single?.Id, actual.RequiredNonPkSingle?.Single?.Id);
+            Assert.Equal(expected.RequiredNonPkSingleDerived?.Single?.Id, actual.RequiredNonPkSingleDerived?.Single?.Id);
+            Assert.Equal(expected.RequiredNonPkSingleMoreDerived?.Single?.Id, actual.RequiredNonPkSingleMoreDerived?.Single?.Id);
 
             Assert.Equal(expected.AlternateId, actual.AlternateId);
 
@@ -3779,11 +4160,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             Assert.Equal(expected.RequiredSingleAk?.AlternateId, actual.RequiredSingleAk?.AlternateId);
             Assert.Equal(expected.OptionalSingleAk?.AlternateId, actual.OptionalSingleAk?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAkDerived?.AlternateId, actual.OptionalSingleAkDerived?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAkMoreDerived?.AlternateId, actual.OptionalSingleAkMoreDerived?.AlternateId);
             Assert.Equal(expected.RequiredNonPkSingleAk?.AlternateId, actual.RequiredNonPkSingleAk?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAkDerived?.AlternateId, actual.RequiredNonPkSingleAkDerived?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAkMoreDerived?.AlternateId, actual.RequiredNonPkSingleAkMoreDerived?.AlternateId);
 
             Assert.Equal(expected.RequiredSingleAk?.Single?.AlternateId, actual.RequiredSingleAk?.Single?.AlternateId);
             Assert.Equal(expected.OptionalSingleAk?.Single?.AlternateId, actual.OptionalSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAkDerived?.Single?.AlternateId, actual.OptionalSingleAkDerived?.Single?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAkMoreDerived?.Single?.AlternateId, actual.OptionalSingleAkMoreDerived?.Single?.AlternateId);
             Assert.Equal(expected.RequiredNonPkSingleAk?.Single?.AlternateId, actual.RequiredNonPkSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAkDerived?.Single?.AlternateId, actual.RequiredNonPkSingleAkDerived?.Single?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAkMoreDerived?.Single?.AlternateId, actual.RequiredNonPkSingleAkMoreDerived?.Single?.AlternateId);
         }
 
         private static void AssertNavigations(Root root)
@@ -3808,11 +4197,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             Assert.Same(root, root.RequiredSingle.Root);
             Assert.Same(root, root.OptionalSingle.Root);
+            Assert.Same(root, root.OptionalSingleDerived.DerivedRoot);
+            Assert.Same(root, root.OptionalSingleMoreDerived.MoreDerivedRoot);
             Assert.Same(root, root.RequiredNonPkSingle.Root);
+            Assert.Same(root, root.RequiredNonPkSingleDerived.DerivedRoot);
+            Assert.Same(root, root.RequiredNonPkSingleMoreDerived.MoreDerivedRoot);
 
             Assert.Same(root.RequiredSingle, root.RequiredSingle.Single.Back);
             Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
+            Assert.Same(root.OptionalSingleDerived, root.OptionalSingleDerived.Single.Back);
+            Assert.Same(root.OptionalSingleMoreDerived, root.OptionalSingleMoreDerived.Single.Back);
             Assert.Same(root.RequiredNonPkSingle, root.RequiredNonPkSingle.Single.Back);
+            Assert.Same(root.RequiredNonPkSingleDerived, root.RequiredNonPkSingleDerived.Single.Back);
+            Assert.Same(root.RequiredNonPkSingleMoreDerived, root.RequiredNonPkSingleMoreDerived.Single.Back);
 
             foreach (var child in root.RequiredChildrenAk)
             {
@@ -3834,11 +4231,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             Assert.Same(root, root.RequiredSingleAk.Root);
             Assert.Same(root, root.OptionalSingleAk.Root);
+            Assert.Same(root, root.OptionalSingleAkDerived.DerivedRoot);
+            Assert.Same(root, root.OptionalSingleAkMoreDerived.MoreDerivedRoot);
             Assert.Same(root, root.RequiredNonPkSingleAk.Root);
+            Assert.Same(root, root.RequiredNonPkSingleAkDerived.DerivedRoot);
+            Assert.Same(root, root.RequiredNonPkSingleAkMoreDerived.MoreDerivedRoot);
 
             Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
             Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
+            Assert.Same(root.OptionalSingleAkDerived, root.OptionalSingleAkDerived.Single.Back);
+            Assert.Same(root.OptionalSingleAkMoreDerived, root.OptionalSingleAkMoreDerived.Single.Back);
             Assert.Same(root.RequiredNonPkSingleAk, root.RequiredNonPkSingleAk.Single.Back);
+            Assert.Same(root.RequiredNonPkSingleAkDerived, root.RequiredNonPkSingleAkDerived.Single.Back);
+            Assert.Same(root.RequiredNonPkSingleAkMoreDerived, root.RequiredNonPkSingleAkMoreDerived.Single.Back);
         }
 
         private static void AssertPossiblyNullNavigations(Root root)
@@ -3924,12 +4329,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             private IEnumerable<Optional1> _optionalChildren = new ObservableHashSet<Optional1>();
             private RequiredSingle1 _requiredSingle;
             private RequiredNonPkSingle1 _requiredNonPkSingle;
+            private RequiredNonPkSingle1Derived _requiredNonPkSingleDerived;
+            private RequiredNonPkSingle1MoreDerived _requiredNonPkSingleMoreDerived;
             private OptionalSingle1 _optionalSingle;
+            private OptionalSingle1Derived _optionalSingleDerived;
+            private OptionalSingle1MoreDerived _optionalSingleMoreDerived;
             private IEnumerable<RequiredAk1> _requiredChildrenAk = new ObservableHashSet<RequiredAk1>();
             private IEnumerable<OptionalAk1> _optionalChildrenAk = new ObservableHashSet<OptionalAk1>();
             private RequiredSingleAk1 _requiredSingleAk;
             private RequiredNonPkSingleAk1 _requiredNonPkSingleAk;
+            private RequiredNonPkSingleAk1Derived _requiredNonPkSingleAkDerived;
+            private RequiredNonPkSingleAk1MoreDerived _requiredNonPkSingleAkMoreDerived;
             private OptionalSingleAk1 _optionalSingleAk;
+            private OptionalSingleAk1Derived _optionalSingleAkDerived;
+            private OptionalSingleAk1MoreDerived _optionalSingleAkMoreDerived;
 
             public int Id
             {
@@ -3967,10 +4380,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 set { SetWithNotify(value, ref _requiredNonPkSingle); }
             }
 
+            public RequiredNonPkSingle1Derived RequiredNonPkSingleDerived
+            {
+                get { return _requiredNonPkSingleDerived; }
+                set { SetWithNotify(value, ref _requiredNonPkSingleDerived); }
+            }
+
+            public RequiredNonPkSingle1MoreDerived RequiredNonPkSingleMoreDerived
+            {
+                get { return _requiredNonPkSingleMoreDerived; }
+                set { SetWithNotify(value, ref _requiredNonPkSingleMoreDerived); }
+            }
+
             public OptionalSingle1 OptionalSingle
             {
                 get { return _optionalSingle; }
                 set { SetWithNotify(value, ref _optionalSingle); }
+            }
+
+            public OptionalSingle1Derived OptionalSingleDerived
+            {
+                get { return _optionalSingleDerived; }
+                set { SetWithNotify(value, ref _optionalSingleDerived); }
+            }
+
+            public OptionalSingle1MoreDerived OptionalSingleMoreDerived
+            {
+                get { return _optionalSingleMoreDerived; }
+                set { SetWithNotify(value, ref _optionalSingleMoreDerived); }
             }
 
             public IEnumerable<RequiredAk1> RequiredChildrenAk
@@ -3997,11 +4434,43 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 set { SetWithNotify(value, ref _requiredNonPkSingleAk); }
             }
 
+            public RequiredNonPkSingleAk1Derived RequiredNonPkSingleAkDerived
+            {
+                get { return _requiredNonPkSingleAkDerived; }
+                set { SetWithNotify(value, ref _requiredNonPkSingleAkDerived); }
+            }
+
+            public RequiredNonPkSingleAk1MoreDerived RequiredNonPkSingleAkMoreDerived
+            {
+                get { return _requiredNonPkSingleAkMoreDerived; }
+                set { SetWithNotify(value, ref _requiredNonPkSingleAkMoreDerived); }
+            }
+
             public OptionalSingleAk1 OptionalSingleAk
             {
                 get { return _optionalSingleAk; }
                 set { SetWithNotify(value, ref _optionalSingleAk); }
             }
+
+            public OptionalSingleAk1Derived OptionalSingleAkDerived
+            {
+                get { return _optionalSingleAkDerived; }
+                set { SetWithNotify(value, ref _optionalSingleAkDerived); }
+            }
+
+            public OptionalSingleAk1MoreDerived OptionalSingleAkMoreDerived
+            {
+                get { return _optionalSingleAkMoreDerived; }
+                set { SetWithNotify(value, ref _optionalSingleAkMoreDerived); }
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Root;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
         }
 
         protected class Required1 : NotifyingEntity
@@ -4034,6 +4503,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Required1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class Required1Derived : Required1
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Required1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class Required1MoreDerived : Required1Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Required1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class Required2 : NotifyingEntity
@@ -4059,6 +4550,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _parent; }
                 set { SetWithNotify(value, ref _parent); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Required2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class Required2Derived : Required2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Required2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class Required2MoreDerived : Required2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Required2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class Optional1 : NotifyingEntity
@@ -4091,6 +4604,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Optional1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class Optional1Derived : Optional1
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Optional1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class Optional1MoreDerived : Optional1Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Optional1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class Optional2 : NotifyingEntity
@@ -4116,6 +4651,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _parent; }
                 set { SetWithNotify(value, ref _parent); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as Optional2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class Optional2Derived : Optional2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Optional2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class Optional2MoreDerived : Optional2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as Optional2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredSingle1 : NotifyingEntity
@@ -4141,6 +4698,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredSingle1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
         }
 
         protected class RequiredSingle2 : NotifyingEntity
@@ -4159,6 +4724,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredSingle2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
         }
 
         protected class RequiredNonPkSingle1 : NotifyingEntity
@@ -4191,6 +4764,58 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredNonPkSingle1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredNonPkSingle1Derived : RequiredNonPkSingle1
+        {
+            private int _derivedRootId;
+            private Root _derivedRoot;
+
+            public int DerivedRootId
+            {
+                get { return _derivedRootId; }
+                set { SetWithNotify(value, ref _derivedRootId); }
+            }
+
+            public Root DerivedRoot
+            {
+                get { return _derivedRoot; }
+                set { SetWithNotify(value, ref _derivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredNonPkSingle1MoreDerived : RequiredNonPkSingle1Derived
+        {
+            private int _moreDerivedRootId;
+            private Root _moreDerivedRoot;
+
+            public int MoreDerivedRootId
+            {
+                get { return _moreDerivedRootId; }
+                set { SetWithNotify(value, ref _moreDerivedRootId); }
+            }
+
+            public Root MoreDerivedRoot
+            {
+                get { return _moreDerivedRoot; }
+                set { SetWithNotify(value, ref _moreDerivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredNonPkSingle2 : NotifyingEntity
@@ -4216,6 +4841,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredNonPkSingle2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredNonPkSingle2Derived : RequiredNonPkSingle2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredNonPkSingle2MoreDerived : RequiredNonPkSingle2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalSingle1 : NotifyingEntity
@@ -4248,6 +4895,58 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalSingle1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalSingle1Derived : OptionalSingle1
+        {
+            private int? _derivedRootId;
+            private Root _derivedRoot;
+
+            public int? DerivedRootId
+            {
+                get { return _derivedRootId; }
+                set { SetWithNotify(value, ref _derivedRootId); }
+            }
+
+            public Root DerivedRoot
+            {
+                get { return _derivedRoot; }
+                set { SetWithNotify(value, ref _derivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingle1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalSingle1MoreDerived : OptionalSingle1Derived
+        {
+            private Root _moreDerivedRoot;
+            private int? _moreDerivedRootId;
+
+            public int? MoreDerivedRootId
+            {
+                get { return _moreDerivedRootId; }
+                set { SetWithNotify(value, ref _moreDerivedRootId); }
+            }
+
+            public Root MoreDerivedRoot
+            {
+                get { return _moreDerivedRoot; }
+                set { SetWithNotify(value, ref _moreDerivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingle1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalSingle2 : NotifyingEntity
@@ -4273,6 +4972,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalSingle2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalSingle2Derived : OptionalSingle2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingle2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalSingle2MoreDerived : OptionalSingle2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingle2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredAk1 : NotifyingEntity
@@ -4312,6 +5033,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredAk1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredAk1Derived : RequiredAk1
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredAk1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredAk1MoreDerived : RequiredAk1Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredAk1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredAk2 : NotifyingEntity
@@ -4344,6 +5087,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _parent; }
                 set { SetWithNotify(value, ref _parent); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredAk2Derived : RequiredAk2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredAk2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredAk2MoreDerived : RequiredAk2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredAk2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalAk1 : NotifyingEntity
@@ -4383,6 +5148,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalAk1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalAk1Derived : OptionalAk1
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalAk1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalAk1MoreDerived : OptionalAk1Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalAk1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalAk2 : NotifyingEntity
@@ -4415,6 +5202,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _parent; }
                 set { SetWithNotify(value, ref _parent); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalAk2Derived : OptionalAk2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalAk2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalAk2MoreDerived : OptionalAk2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalAk2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredSingleAk1 : NotifyingEntity
@@ -4454,6 +5263,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredSingleAk1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
         }
 
         protected class RequiredSingleAk2 : NotifyingEntity
@@ -4486,6 +5303,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredSingleAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
         }
 
         protected class RequiredNonPkSingleAk1 : NotifyingEntity
@@ -4525,6 +5350,58 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredNonPkSingleAk1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredNonPkSingleAk1Derived : RequiredNonPkSingleAk1
+        {
+            private Guid _derivedRootId;
+            private Root _derivedRoot;
+
+            public Guid DerivedRootId
+            {
+                get { return _derivedRootId; }
+                set { SetWithNotify(value, ref _derivedRootId); }
+            }
+
+            public Root DerivedRoot
+            {
+                get { return _derivedRoot; }
+                set { SetWithNotify(value, ref _derivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredNonPkSingleAk1MoreDerived : RequiredNonPkSingleAk1Derived
+        {
+            private Guid _moreDerivedRootId;
+            private Root _moreDerivedRoot;
+
+            public Guid MoreDerivedRootId
+            {
+                get { return _moreDerivedRootId; }
+                set { SetWithNotify(value, ref _moreDerivedRootId); }
+            }
+
+            public Root MoreDerivedRoot
+            {
+                get { return _moreDerivedRoot; }
+                set { SetWithNotify(value, ref _moreDerivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class RequiredNonPkSingleAk2 : NotifyingEntity
@@ -4557,6 +5434,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredNonPkSingleAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredNonPkSingleAk2Derived : RequiredNonPkSingleAk2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class RequiredNonPkSingleAk2MoreDerived : RequiredNonPkSingleAk2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalSingleAk1 : NotifyingEntity
@@ -4596,6 +5495,58 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalSingleAk1;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalSingleAk1Derived : OptionalSingleAk1
+        {
+            private Guid? _derivedRootId;
+            private Root _derivedRoot;
+
+            public Guid? DerivedRootId
+            {
+                get { return _derivedRootId; }
+                set { SetWithNotify(value, ref _derivedRootId); }
+            }
+
+            public Root DerivedRoot
+            {
+                get { return _derivedRoot; }
+                set { SetWithNotify(value, ref _derivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk1Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalSingleAk1MoreDerived : OptionalSingleAk1Derived
+        {
+            private Guid? _moreDerivedRootId;
+            private Root _moreDerivedRoot;
+
+            public Guid? MoreDerivedRootId
+            {
+                get { return _moreDerivedRootId; }
+                set { SetWithNotify(value, ref _moreDerivedRootId); }
+            }
+
+            public Root MoreDerivedRoot
+            {
+                get { return _moreDerivedRoot; }
+                set { SetWithNotify(value, ref _moreDerivedRoot); }
+            }
+
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk1MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class OptionalSingleAk2 : NotifyingEntity
@@ -4628,6 +5579,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 get { return _back; }
                 set { SetWithNotify(value, ref _back); }
             }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalSingleAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class OptionalSingleAk2Derived : OptionalSingleAk2
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk2Derived);
+
+            public override int GetHashCode() => base.GetHashCode();
+        }
+
+        protected class OptionalSingleAk2MoreDerived : OptionalSingleAk2Derived
+        {
+            public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk2MoreDerived);
+
+            public override int GetHashCode() => base.GetHashCode();
         }
 
         protected class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged
@@ -4680,10 +5653,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public DbSet<OptionalAk2> OptionalAk2s { get; set; }
         }
 
-        protected GraphUpdatesContext CreateContext() 
+        protected GraphUpdatesContext CreateContext()
             => (GraphUpdatesContext)Fixture.CreateContext(TestStore);
 
-        public void Dispose() 
+        public void Dispose()
             => TestStore.Dispose();
 
         protected TFixture Fixture { get; }
@@ -4692,6 +5665,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         public abstract class GraphUpdatesFixtureBase
         {
+            public readonly Guid RootAK = Guid.NewGuid();
+
             public abstract TTestStore CreateTestStore();
 
             public abstract DbContext CreateContext(TTestStore testStore);
@@ -4720,9 +5695,29 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .HasForeignKey<OptionalSingle1>(e => e.RootId)
                             .OnDelete(DeleteBehavior.SetNull);
 
+                        b.HasOne(e => e.OptionalSingleDerived)
+                            .WithOne(e => e.DerivedRoot)
+                            .HasForeignKey<OptionalSingle1Derived>(e => e.DerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
+                        b.HasOne(e => e.OptionalSingleMoreDerived)
+                            .WithOne(e => e.MoreDerivedRoot)
+                            .HasForeignKey<OptionalSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
                         b.HasOne(e => e.RequiredNonPkSingle)
                             .WithOne(e => e.Root)
                             .HasForeignKey<RequiredNonPkSingle1>(e => e.RootId);
+
+                        b.HasOne(e => e.RequiredNonPkSingleDerived)
+                            .WithOne(e => e.DerivedRoot)
+                            .HasForeignKey<RequiredNonPkSingle1Derived>(e => e.DerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
+                        b.HasOne(e => e.RequiredNonPkSingleMoreDerived)
+                            .WithOne(e => e.MoreDerivedRoot)
+                            .HasForeignKey<RequiredNonPkSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
 
                         b.HasMany(e => e.RequiredChildrenAk)
                             .WithOne(e => e.Parent)
@@ -4746,10 +5741,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .HasForeignKey<OptionalSingleAk1>(e => e.RootId)
                             .OnDelete(DeleteBehavior.SetNull);
 
+                        b.HasOne(e => e.OptionalSingleAkDerived)
+                            .WithOne(e => e.DerivedRoot)
+                            .HasPrincipalKey<Root>(e => e.AlternateId)
+                            .HasForeignKey<OptionalSingleAk1Derived>(e => e.DerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
+                        b.HasOne(e => e.OptionalSingleAkMoreDerived)
+                            .WithOne(e => e.MoreDerivedRoot)
+                            .HasPrincipalKey<Root>(e => e.AlternateId)
+                            .HasForeignKey<OptionalSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
                         b.HasOne(e => e.RequiredNonPkSingleAk)
                             .WithOne(e => e.Root)
                             .HasPrincipalKey<Root>(e => e.AlternateId)
                             .HasForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
+
+                        b.HasOne(e => e.RequiredNonPkSingleAkDerived)
+                            .WithOne(e => e.DerivedRoot)
+                            .HasPrincipalKey<Root>(e => e.AlternateId)
+                            .HasForeignKey<RequiredNonPkSingleAk1Derived>(e => e.DerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
+
+                        b.HasOne(e => e.RequiredNonPkSingleAkMoreDerived)
+                            .WithOne(e => e.MoreDerivedRoot)
+                            .HasPrincipalKey<Root>(e => e.AlternateId)
+                            .HasForeignKey<RequiredNonPkSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                            .OnDelete(DeleteBehavior.Restrict);
                     });
 
                 modelBuilder.Entity<Required1>()
@@ -4757,11 +5776,21 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .WithOne(e => e.Parent)
                     .HasForeignKey(e => e.ParentId);
 
+                modelBuilder.Entity<Required1Derived>();
+                modelBuilder.Entity<Required1MoreDerived>();
+                modelBuilder.Entity<Required2Derived>();
+                modelBuilder.Entity<Required2MoreDerived>();
+
                 modelBuilder.Entity<Optional1>()
                     .HasMany(e => e.Children)
                     .WithOne(e => e.Parent)
                     .HasForeignKey(e => e.ParentId)
                     .OnDelete(DeleteBehavior.SetNull);
+
+                modelBuilder.Entity<Optional1Derived>();
+                modelBuilder.Entity<Optional1MoreDerived>();
+                modelBuilder.Entity<Optional2Derived>();
+                modelBuilder.Entity<Optional2MoreDerived>();
 
                 modelBuilder.Entity<RequiredSingle1>()
                     .HasOne(e => e.Single)
@@ -4774,10 +5803,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .HasForeignKey<OptionalSingle2>(e => e.BackId)
                     .OnDelete(DeleteBehavior.SetNull);
 
+                modelBuilder.Entity<OptionalSingle2Derived>();
+                modelBuilder.Entity<OptionalSingle2MoreDerived>();
+
                 modelBuilder.Entity<RequiredNonPkSingle1>()
                     .HasOne(e => e.Single)
                     .WithOne(e => e.Back)
                     .HasForeignKey<RequiredNonPkSingle2>(e => e.BackId);
+
+                modelBuilder.Entity<RequiredNonPkSingle2Derived>();
+                modelBuilder.Entity<RequiredNonPkSingle2MoreDerived>();
 
                 modelBuilder.Entity<RequiredAk1>(b =>
                     {
@@ -4790,6 +5825,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .HasForeignKey(e => e.ParentId);
                     });
 
+                modelBuilder.Entity<RequiredAk1Derived>();
+                modelBuilder.Entity<RequiredAk1MoreDerived>();
+
                 modelBuilder.Entity<OptionalAk1>(b =>
                     {
                         b.Property(e => e.AlternateId)
@@ -4801,6 +5839,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .HasForeignKey(e => e.ParentId)
                             .OnDelete(DeleteBehavior.SetNull);
                     });
+
+                modelBuilder.Entity<OptionalAk1Derived>();
+                modelBuilder.Entity<OptionalAk1MoreDerived>();
 
                 modelBuilder.Entity<RequiredSingleAk1>(b =>
                     {
@@ -4825,6 +5866,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .OnDelete(DeleteBehavior.SetNull);
                     });
 
+                modelBuilder.Entity<OptionalSingleAk2Derived>();
+                modelBuilder.Entity<OptionalSingleAk2MoreDerived>();
+
                 modelBuilder.Entity<RequiredNonPkSingleAk1>(b =>
                     {
                         b.Property(e => e.AlternateId)
@@ -4840,9 +5884,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .Property(e => e.AlternateId)
                     .ValueGeneratedOnAdd();
 
+                modelBuilder.Entity<RequiredAk2Derived>();
+                modelBuilder.Entity<RequiredAk2MoreDerived>();
+
                 modelBuilder.Entity<OptionalAk2>()
                     .Property(e => e.AlternateId)
                     .ValueGeneratedOnAdd();
+
+                modelBuilder.Entity<OptionalAk2Derived>();
+                modelBuilder.Entity<OptionalAk2MoreDerived>();
 
                 modelBuilder.Entity<RequiredSingleAk2>()
                     .Property(e => e.AlternateId)
@@ -4851,6 +5901,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 modelBuilder.Entity<RequiredNonPkSingleAk2>()
                     .Property(e => e.AlternateId)
                     .ValueGeneratedOnAdd();
+
+                modelBuilder.Entity<RequiredNonPkSingleAk2Derived>();
+                modelBuilder.Entity<RequiredNonPkSingleAk2MoreDerived>();
 
                 modelBuilder.Entity<OptionalSingleAk2>()
                     .Property(e => e.AlternateId)
@@ -4861,12 +5914,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 return new Root
                 {
-                    AlternateId = Guid.NewGuid(),
-                    RequiredChildren = new ObservableHashSet<Required1>
+                    AlternateId = RootAK,
+                    RequiredChildren = new ObservableHashSet<Required1>(ReferenceEqualityComparer.Instance)
                     {
                         new Required1
                         {
-                            Children = new ObservableHashSet<Required2>
+                            Children = new ObservableHashSet<Required2>(ReferenceEqualityComparer.Instance)
                             {
                                 new Required2(),
                                 new Required2()
@@ -4874,18 +5927,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         },
                         new Required1
                         {
-                            Children = new ObservableHashSet<Required2>
+                            Children = new ObservableHashSet<Required2>(ReferenceEqualityComparer.Instance)
                             {
                                 new Required2(),
                                 new Required2()
                             }
                         }
                     },
-                    OptionalChildren = new ObservableHashSet<Optional1>
+                    OptionalChildren = new ObservableHashSet<Optional1>(ReferenceEqualityComparer.Instance)
                     {
                         new Optional1
                         {
-                            Children = new ObservableHashSet<Optional2>
+                            Children = new ObservableHashSet<Optional2>(ReferenceEqualityComparer.Instance)
                             {
                                 new Optional2(),
                                 new Optional2()
@@ -4893,7 +5946,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         },
                         new Optional1
                         {
-                            Children = new ObservableHashSet<Optional2>
+                            Children = new ObservableHashSet<Optional2>(ReferenceEqualityComparer.Instance)
                             {
                                 new Optional2(),
                                 new Optional2()
@@ -4908,16 +5961,35 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     {
                         Single = new OptionalSingle2()
                     },
+                    OptionalSingleDerived = new OptionalSingle1Derived
+                    {
+                        Single = new OptionalSingle2Derived()
+                    },
+                    OptionalSingleMoreDerived = new OptionalSingle1MoreDerived
+                    {
+                        Single = new OptionalSingle2MoreDerived()
+                    },
                     RequiredNonPkSingle = new RequiredNonPkSingle1
                     {
                         Single = new RequiredNonPkSingle2()
                     },
-                    RequiredChildrenAk = new ObservableHashSet<RequiredAk1>
+                    RequiredNonPkSingleDerived = new RequiredNonPkSingle1Derived
+                    {
+                        Single = new RequiredNonPkSingle2Derived(),
+                        Root = new Root()
+                    },
+                    RequiredNonPkSingleMoreDerived = new RequiredNonPkSingle1MoreDerived
+                    {
+                        Single = new RequiredNonPkSingle2MoreDerived(),
+                        Root = new Root(),
+                        DerivedRoot = new Root()
+                    },
+                    RequiredChildrenAk = new ObservableHashSet<RequiredAk1>(ReferenceEqualityComparer.Instance)
                     {
                         new RequiredAk1
                         {
                             AlternateId = Guid.NewGuid(),
-                            Children = new ObservableHashSet<RequiredAk2>
+                            Children = new ObservableHashSet<RequiredAk2>(ReferenceEqualityComparer.Instance)
                             {
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() },
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() }
@@ -4926,19 +5998,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         new RequiredAk1
                         {
                             AlternateId = Guid.NewGuid(),
-                            Children = new ObservableHashSet<RequiredAk2>
+                            Children = new ObservableHashSet<RequiredAk2>(ReferenceEqualityComparer.Instance)
                             {
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() },
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() }
                             }
                         }
                     },
-                    OptionalChildrenAk = new ObservableHashSet<OptionalAk1>
+                    OptionalChildrenAk = new ObservableHashSet<OptionalAk1>(ReferenceEqualityComparer.Instance)
                     {
                         new OptionalAk1
                         {
                             AlternateId = Guid.NewGuid(),
-                            Children = new ObservableHashSet<OptionalAk2>
+                            Children = new ObservableHashSet<OptionalAk2>(ReferenceEqualityComparer.Instance)
                             {
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() },
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() }
@@ -4947,7 +6019,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         new OptionalAk1
                         {
                             AlternateId = Guid.NewGuid(),
-                            Children = new ObservableHashSet<OptionalAk2>
+                            Children = new ObservableHashSet<OptionalAk2>(ReferenceEqualityComparer.Instance)
                             {
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() },
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() }
@@ -4964,10 +6036,33 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         AlternateId = Guid.NewGuid(),
                         Single = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() }
                     },
+                    OptionalSingleAkDerived = new OptionalSingleAk1Derived
+                    {
+                        AlternateId = Guid.NewGuid(),
+                        Single = new OptionalSingleAk2Derived { AlternateId = Guid.NewGuid() }
+                    },
+                    OptionalSingleAkMoreDerived = new OptionalSingleAk1MoreDerived
+                    {
+                        AlternateId = Guid.NewGuid(),
+                        Single = new OptionalSingleAk2MoreDerived { AlternateId = Guid.NewGuid() }
+                    },
                     RequiredNonPkSingleAk = new RequiredNonPkSingleAk1
                     {
                         AlternateId = Guid.NewGuid(),
                         Single = new RequiredNonPkSingleAk2 { AlternateId = Guid.NewGuid() }
+                    },
+                    RequiredNonPkSingleAkDerived = new RequiredNonPkSingleAk1Derived
+                    {
+                        AlternateId = Guid.NewGuid(),
+                        Single = new RequiredNonPkSingleAk2Derived { AlternateId = Guid.NewGuid() },
+                        Root = new Root()
+                    },
+                    RequiredNonPkSingleAkMoreDerived = new RequiredNonPkSingleAk1MoreDerived
+                    {
+                        AlternateId = Guid.NewGuid(),
+                        Single = new RequiredNonPkSingleAk2MoreDerived { AlternateId = Guid.NewGuid() },
+                        Root = new Root(),
+                        DerivedRoot = new Root()
                     }
                 };
             }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private readonly LazyRef<IDictionary<object, IList<Tuple<INavigation, InternalEntityEntry>>>> _referencedUntrackedEntities
             = new LazyRef<IDictionary<object, IList<Tuple<INavigation, InternalEntityEntry>>>>(
-                () => new Dictionary<object, IList<Tuple<INavigation, InternalEntityEntry>>>());
+                () => new Dictionary<object, IList<Tuple<INavigation, InternalEntityEntry>>>(ReferenceEqualityComparer.Instance));
 
         private IIdentityMap _identityMap0;
         private IIdentityMap _identityMap1;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<ForeignKey> GetReferencingForeignKeys()
-            => _baseType?.GetDeclaredReferencingForeignKeys().Concat(GetDeclaredReferencingForeignKeys())
+            => _baseType?.GetReferencingForeignKeys().Concat(GetDeclaredReferencingForeignKeys())
                ?? GetDeclaredReferencingForeignKeys();
 
         /// <summary>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -386,7 +386,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         public class ComputedColumnWithFunction
         {
-            //[Fact] Disabled due to issue #6044
+            // #6044
+            [Fact]
             public void Insert_and_update_with_computed_column()
             {
                 using (var context = new BlogContext())
@@ -398,9 +399,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                         creator.Create();
 
                         context.Database.ExecuteSqlCommand
-                            (@"CREATE FUNCTION 
+                            (@"CREATE FUNCTION
 [dbo].[GetFullName](@First NVARCHAR(MAX), @Second NVARCHAR(MAX))
-RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
+RETURNS NVARCHAR(MAX) WITH SCHEMABINDING AS BEGIN RETURN @First + @Second END");
 
                         creator.CreateTables();
                     }
@@ -432,11 +433,6 @@ RETURNS NVARCHAR(MAX) AS BEGIN RETURN @First + @Second END");
 
                     blog.LastName = "Pegasus";
 
-                    // Throws SqlException : Column 'inserted.FullName' cannot be referenced in the OUTPUT clause
-                    // because the column definition contains a subquery or references a function that performs user 
-                    // or system data access. A function is assumed by default to perform data access if it is not 
-                    // schemabound. Consider removing the subquery or function from the column definition or removing 
-                    // the column from the OUTPUT clause.
                     context.SaveChanges();
 
                     Assert.Equal("OnePegasus", blog.FullName);


### PR DESCRIPTION
Use ReferenceEqualityComparer in StateManager

Fixes #6055 

I think this fix should go into 1.0.1