### PR TITLE
Fix to #5672 - Query :: Include with multiple navigations (including optional navigation) fails

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -263,6 +263,7 @@
     <Compile Include="Query\Internal\AsyncIncludeCollectionIterator.cs" />
     <Compile Include="Query\Internal\AsyncQueryingEnumerable.cs" />
     <Compile Include="Query\Internal\GroupJoinInclude.cs" />
+    <Compile Include="Query\Internal\GroupJoinIncludeBase.cs" />
     <Compile Include="Query\Internal\IncludeCollectionIterator.cs" />
     <Compile Include="Query\Internal\IShaperCommandContextFactory.cs" />
     <Compile Include="Query\Internal\IValueBufferCursor.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncGroupJoinInclude.cs
@@ -15,12 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class AsyncGroupJoinInclude : IDisposable
+    public class AsyncGroupJoinInclude : GroupJoinIncludeBase
     {
-        private readonly IReadOnlyList<INavigation> _navigationPath;
         private readonly IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> _relatedEntitiesLoaderFactories;
-        private readonly bool _querySourceRequiresTracking;
-
         private AsyncGroupJoinInclude _previous;
 
         /// <summary>
@@ -31,14 +28,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IReadOnlyList<INavigation> navigationPath,
             [NotNull] IReadOnlyList<Func<QueryContext, IAsyncRelatedEntitiesLoader>> relatedEntitiesLoaderFactories,
             bool querySourceRequiresTracking)
+            : base(navigationPath, querySourceRequiresTracking)
         {
-            _navigationPath = navigationPath;
             _relatedEntitiesLoaderFactories = relatedEntitiesLoaderFactories;
-            _querySourceRequiresTracking = querySourceRequiresTracking;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual AsyncGroupJoinInclude WithEntityAccessor([NotNull] Delegate entityAccessor)
+        {
+            EntityAccessor = entityAccessor;
+
+            return this;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetPrevious([NotNull] AsyncGroupJoinInclude previous)
@@ -61,8 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             var asyncGroupJoinIncludeContext
                 = new AsyncGroupJoinIncludeContext(
-                    _navigationPath,
-                    _querySourceRequiresTracking,
+                    NavigationPath,
+                    QuerySourceRequiresTracking,
                     queryContext,
                     _relatedEntitiesLoaderFactories);
 
@@ -72,15 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             return asyncGroupJoinIncludeContext;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual void Dispose()
-        {
-            // no-op
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinInclude.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinInclude.cs
@@ -13,12 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class GroupJoinInclude : IDisposable
+    public class GroupJoinInclude : GroupJoinIncludeBase
     {
-        private readonly IReadOnlyList<INavigation> _navigationPath;
         private readonly IReadOnlyList<Func<QueryContext, IRelatedEntitiesLoader>> _relatedEntitiesLoaderFactories;
-        private readonly bool _querySourceRequiresTracking;
-
         private GroupJoinInclude _previous;
 
         /// <summary>
@@ -29,10 +26,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IReadOnlyList<INavigation> navigationPath,
             [NotNull] IReadOnlyList<Func<QueryContext, IRelatedEntitiesLoader>> relatedEntitiesLoaderFactories,
             bool querySourceRequiresTracking)
+            : base(navigationPath, querySourceRequiresTracking)
         {
-            _navigationPath = navigationPath;
             _relatedEntitiesLoaderFactories = relatedEntitiesLoaderFactories;
-            _querySourceRequiresTracking = querySourceRequiresTracking;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual GroupJoinInclude WithEntityAccessor([NotNull] Delegate entityAccessor)
+        {
+            EntityAccessor = entityAccessor;
+
+            return this;
         }
 
         /// <summary>
@@ -59,8 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             var groupJoinIncludeContext
                 = new GroupJoinIncludeContext(
-                    _navigationPath,
-                    _querySourceRequiresTracking,
+                    NavigationPath,
+                    QuerySourceRequiresTracking,
                     queryContext,
                     _relatedEntitiesLoaderFactories);
 
@@ -70,15 +77,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             return groupJoinIncludeContext;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual void Dispose()
-        {
-            // no-op
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinIncludeBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/GroupJoinIncludeBase.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public abstract class GroupJoinIncludeBase : IDisposable
+    {
+        protected GroupJoinIncludeBase(
+            [NotNull] IReadOnlyList<INavigation> navigationPath,
+            bool querySourceRequiresTracking)
+        {
+            NavigationPath = navigationPath;
+            QuerySourceRequiresTracking = querySourceRequiresTracking;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IReadOnlyList<INavigation> NavigationPath { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual bool QuerySourceRequiresTracking { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Delegate EntityAccessor { get; [param: NotNull] protected set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            // no-op
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
@@ -272,6 +272,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var outerGroupJoinIncludeContext = outerGroupJoinInclude?.Initialize(queryContext);
             var innerGroupJoinIncludeContext = innerGroupJoinInclude?.Initialize(queryContext);
+            var outerAccessor = outerGroupJoinInclude?.EntityAccessor as Func<TOuter, object>;
+            var innerAccessor = innerGroupJoinInclude?.EntityAccessor as Func<TInner, object>;
 
             var hasOuters = (innerShaper as EntityShaper)?.ValueBufferOffset > 0;
 
@@ -292,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         nextOuter = default(TOuter);
 
-                        outerGroupJoinIncludeContext?.Include(outer);
+                        outerGroupJoinIncludeContext?.Include(outerAccessor != null ? outerAccessor(outer) : outer);
 
                         var inner = innerShaper.Shape(queryContext, sourceEnumerator.Current);
                         var inners = new List<TInner>();
@@ -307,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             var currentGroupKey = innerKeySelector(inner);
 
-                            innerGroupJoinIncludeContext?.Include(inner);
+                            innerGroupJoinIncludeContext?.Include(innerAccessor != null ? innerAccessor(inner) : inner);
 
                             inners.Add(inner);
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryNavigationsTestBase.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class AsyncQueryNavigationsTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        [ConditionalFact]
+        public virtual async Task Include_with_multiple_optional_navigations()
+        {
+            await AssertQuery<OrderDetail>(
+                ods => ods
+                    .Include(od => od.Order.Customer)
+                    .Where(od => od.Order.Customer.City == "London"),
+                entryCount: 164);
+        }
+
+        [ConditionalFact]
+        public virtual async Task Multiple_include_with_multiple_optional_navigations()
+        {
+            await AssertQuery<OrderDetail>(
+                ods => ods
+                    .Include(od => od.Order.Customer)
+                    .Include(od => od.Product)
+                    .Where(od => od.Order.Customer.City == "London"),
+                entryCount: 221);
+        }
+
+        protected NorthwindContext CreateContext()
+        {
+            return Fixture.CreateContext();
+        }
+
+        protected AsyncQueryNavigationsTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected async Task AssertQuery<TItem>(
+            Func<IQueryable<TItem>, IQueryable<object>> query,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<object>, IList<object>> asserter = null)
+            where TItem : class
+            => await AssertQuery(query, query, assertOrder, entryCount, asserter);
+
+        protected async Task AssertQuery<TItem>(
+            Func<IQueryable<TItem>, IQueryable<object>> efQuery,
+            Func<IQueryable<TItem>, IQueryable<object>> l2oQuery,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<object>, IList<object>> asserter = null)
+            where TItem : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
+                    await efQuery(context.Set<TItem>()).ToArrayAsync(),
+                    assertOrder,
+                    asserter);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Compile Include="AsNoTrackingTestBase.cs" />
     <Compile Include="AsTrackingTestBase.cs" />
+    <Compile Include="AsyncQueryNavigationsTestBase.cs" />
     <Compile Include="AsyncQueryTestBase.cs" />
     <Compile Include="BuiltInDataTypesFixtureBase.cs" />
     <Compile Include="BuiltInDataTypesTestBase.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -231,6 +231,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Include_with_multiple_optional_navigations()
+        {
+            AssertQuery<OrderDetail>(
+                ods => ods
+                    .Include(od => od.Order.Customer)
+                    .Where(od => od.Order.Customer.City == "London"),
+                entryCount: 164);
+        }
+
+        [ConditionalFact]
         public virtual void Select_count_plus_sum()
         {
             AssertQuery<Order>(os => os.Select(o => new

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQueryNavigationsSqlServerTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQueryNavigationsSqlServerTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class AsyncQueryNavigationsSqlServerTests : AsyncQueryNavigationsTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public AsyncQueryNavigationsSqlServerTests(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            // TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1316,6 +1316,35 @@ ORDER BY [l1].[Name], [l1].[Id]",
             }
         }
 
+        public override void Multiple_include_with_multiple_optional_navigations()
+        {
+            base.Multiple_include_with_multiple_optional_navigations();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK].[Level1_Optional_Id], [e.OneToOne_Required_FK].[Level1_Required_Id], [e.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[Id], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[Name], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId], [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_InverseId], [l3].[OneToMany_Optional_Self_InverseId], [l3].[OneToMany_Required_InverseId], [l3].[OneToMany_Required_Self_InverseId], [l3].[OneToOne_Optional_PK_InverseId], [l3].[OneToOne_Optional_SelfId], [l4].[Id], [l4].[Level1_Optional_Id], [l4].[Level1_Required_Id], [l4].[Name], [l4].[OneToMany_Optional_InverseId], [l4].[OneToMany_Optional_Self_InverseId], [l4].[OneToMany_Required_InverseId], [l4].[OneToMany_Required_Self_InverseId], [l4].[OneToOne_Optional_PK_InverseId], [l4].[OneToOne_Optional_SelfId], [l5].[Id], [l5].[Level2_Optional_Id], [l5].[Level2_Required_Id], [l5].[Name], [l5].[OneToMany_Optional_InverseId], [l5].[OneToMany_Optional_Self_InverseId], [l5].[OneToMany_Required_InverseId], [l5].[OneToMany_Required_Self_InverseId], [l5].[OneToOne_Optional_PK_InverseId], [l5].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+INNER JOIN [Level2] AS [e.OneToOne_Required_FK] ON [e].[Id] = [e.OneToOne_Required_FK].[Level1_Required_Id]
+LEFT JOIN [Level3] AS [e.OneToOne_Required_FK.OneToOne_Optional_PK] ON [e.OneToOne_Required_FK].[Id] = [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToOne_Optional_PK_InverseId]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Required_Id] = [e].[Id]
+LEFT JOIN [Level2] AS [l2] ON [l2].[Level1_Required_Id] = [e].[Id]
+LEFT JOIN [Level3] AS [l3] ON [l3].[Level2_Optional_Id] = [l2].[Id]
+LEFT JOIN [Level2] AS [l4] ON [l4].[Level1_Optional_Id] = [e].[Id]
+LEFT JOIN [Level3] AS [l5] ON [l5].[Level2_Optional_Id] = [l4].[Id]
+ORDER BY [e].[Id], [e.OneToOne_Required_FK].[Id], [l].[Id]
+
+SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l0]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [e.OneToOne_Required_FK].[Id] AS [Id0], [l].[Id] AS [Id1]
+    FROM [Level1] AS [e]
+    INNER JOIN [Level2] AS [e.OneToOne_Required_FK] ON [e].[Id] = [e.OneToOne_Required_FK].[Level1_Required_Id]
+    LEFT JOIN [Level3] AS [e.OneToOne_Required_FK.OneToOne_Optional_PK] ON [e.OneToOne_Required_FK].[Id] = [e.OneToOne_Required_FK.OneToOne_Optional_PK].[OneToOne_Optional_PK_InverseId]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Required_Id] = [e].[Id]
+) AS [l1] ON [l0].[OneToMany_Optional_InverseId] = [l1].[Id1]
+ORDER BY [l1].[Id], [l1].[Id0], [l1].[Id1]",
+                Sql);
+        }
+
         public override void Correlated_subquery_doesnt_project_unnecessary_columns_in_top_level()
         {
             base.Correlated_subquery_doesnt_project_unnecessary_columns_in_top_level();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="AsTrackingSqlServerTest.cs" />
     <Compile Include="AsyncFromSqlQuerySqlServerTest.cs" />
     <Compile Include="AsyncFromSqlSprocQuerySqlServerTest.cs" />
+    <Compile Include="AsyncQueryNavigationsSqlServerTests.cs" />
     <Compile Include="AsyncQuerySqlServerTest.cs" />
     <Compile Include="BatchingTest.cs" />
     <Compile Include="BuiltInDataTypesSqlServerFixture.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -195,6 +195,21 @@ ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_with_multiple_optional_navigations()
+        {
+            base.Include_with_multiple_optional_navigations();
+
+            Assert.Equal(
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[OrderID], [od.Order].[CustomerID], [od.Order].[EmployeeID], [od.Order].[OrderDate], [od.Order.Customer].[CustomerID], [od.Order.Customer].[Address], [od.Order.Customer].[City], [od.Order.Customer].[CompanyName], [od.Order.Customer].[ContactName], [od.Order.Customer].[ContactTitle], [od.Order.Customer].[Country], [od.Order.Customer].[Fax], [od.Order.Customer].[Phone], [od.Order.Customer].[PostalCode], [od.Order.Customer].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
+INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY [od.Order].[CustomerID]",
+                Sql);
+        }
+
         public override void Select_Navigation()
         {
             base.Select_Navigation();


### PR DESCRIPTION
Problem was that our include logic for groupjoin was expecting outer and inner elements (on which the include was being performed) to be entities. However sometimes those elements would be TransparentIdentifiers (e.g. when the element comes from a result of SelectMany).

Fix is to also store (when necessary) the accessor from the outer/inner element to the entity that we want to include, extract the actual entity in runtime and apply include operations on that entity instead of the actual outer/inner element.