### PR TITLE
Fix handling of conceptual nulls for composite keys in change tracker

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
                 var existing = root.OptionalChildren.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
                 var existing = root.RequiredChildren.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
@@ -328,7 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -349,7 +349,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 var childCollection = root.OptionalChildren.First().Children;
                 var removed2 = childCollection.First();
@@ -386,13 +386,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
-
-                Assert.Equal(2, loadedRoot.RequiredChildren.Count());
-                Assert.Equal(2, loadedRoot.RequiredChildren.First().Children.Count());
 
                 Assert.Equal(1, loadedRoot.OptionalChildren.Count());
                 Assert.Equal(1, loadedRoot.OptionalChildren.First().Children.Count());
@@ -415,7 +412,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 var childCollection = root.RequiredChildren.First().Children;
                 var removed2 = childCollection.First();
@@ -448,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 AssertNavigations(root);
 
@@ -504,7 +501,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingle2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 old1 = root.OptionalSingle;
                 old1d = root.OptionalSingleDerived;
@@ -581,7 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
@@ -632,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredSingle2 old2;
             using (var context = CreateContext())
             {
-                oldRoot = LoadFullGraph(context);
+                oldRoot = LoadRequiredGraph(context);
 
                 old1 = oldRoot.RequiredSingle;
                 old2 = oldRoot.RequiredSingle.Single;
@@ -640,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 root.RequiredSingle = null;
 
@@ -652,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -687,7 +684,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(oldRoot, loadedRoot);
@@ -739,7 +736,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingle2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkGraph(context);
 
                 old1 = root.RequiredNonPkSingle;
                 old1d = root.RequiredNonPkSingleDerived;
@@ -823,7 +820,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -853,7 +850,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 old1 = root.OptionalSingle;
                 old2 = root.OptionalSingle.Single;
@@ -883,7 +880,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -909,7 +906,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
 
                 old1 = root.RequiredSingle;
                 old2 = root.RequiredSingle.Single;
@@ -938,7 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -959,7 +956,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkGraph(context);
 
                 old1 = root.RequiredNonPkSingle;
                 old2 = root.RequiredNonPkSingle.Single;
@@ -988,7 +985,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1031,7 +1028,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1065,7 +1062,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1111,7 +1108,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1119,26 +1116,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     CoreStrings.KeyReadOnly("Id", typeof(RequiredSingle1).Name),
                     Assert.Throws<InvalidOperationException>(
                         () =>
+                        {
+                            if ((changeMechanism & ChangeMechanism.Principal) != 0)
                             {
-                                if ((changeMechanism & ChangeMechanism.Principal) != 0)
-                                {
-                                    newRoot.RequiredSingle = root.RequiredSingle;
-                                }
-
-                                if ((changeMechanism & ChangeMechanism.Dependent) != 0)
-                                {
-                                    root.RequiredSingle.Root = newRoot;
-                                }
-
-                                if ((changeMechanism & ChangeMechanism.Fk) != 0)
-                                {
-                                    root.RequiredSingle.Id = newRoot.Id;
-                                }
-
                                 newRoot.RequiredSingle = root.RequiredSingle;
+                            }
 
-                                context.SaveChanges();
-                            }).Message);
+                            if ((changeMechanism & ChangeMechanism.Dependent) != 0)
+                            {
+                                root.RequiredSingle.Root = newRoot;
+                            }
+
+                            if ((changeMechanism & ChangeMechanism.Fk) != 0)
+                            {
+                                root.RequiredSingle.Id = newRoot.Id;
+                            }
+
+                            newRoot.RequiredSingle = root.RequiredSingle;
+
+                            context.SaveChanges();
+                        }).Message);
             }
         }
 
@@ -1175,7 +1172,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingle2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -1209,7 +1206,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -1247,6 +1244,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var new1dd = new OptionalAk1MoreDerived { AlternateId = Guid.NewGuid() };
             var new2a = new OptionalAk2 { AlternateId = Guid.NewGuid() };
             var new2b = new OptionalAk2 { AlternateId = Guid.NewGuid() };
+            var new2ca = new OptionalComposite2();
+            var new2cb = new OptionalComposite2();
             var new2d = new OptionalAk2Derived { AlternateId = Guid.NewGuid() };
             var new2dd = new OptionalAk2MoreDerived { AlternateId = Guid.NewGuid() };
 
@@ -1254,7 +1253,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
                     context.SaveChanges();
                 }
             }
@@ -1263,7 +1262,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
                 var existing = root.OptionalChildrenAk.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
@@ -1273,18 +1272,22 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     new1dd = (OptionalAk1MoreDerived)context.OptionalAk1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.OptionalAk2s.Single(e => e.Id == new2a.Id);
                     new2b = context.OptionalAk2s.Single(e => e.Id == new2b.Id);
+                    new2ca = context.OptionalComposite2s.Single(e => e.Id == new2ca.Id);
+                    new2cb = context.OptionalComposite2s.Single(e => e.Id == new2cb.Id);
                     new2d = (OptionalAk2Derived)context.OptionalAk2s.Single(e => e.Id == new2d.Id);
                     new2dd = (OptionalAk2MoreDerived)context.OptionalAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(existing.CompositeChildren, new2ca);
+                    Add(existing.CompositeChildren, new2cb);
                     Add(new1d.Children, new2d);
                     Add(new1dd.Children, new2dd);
                     Add(root.OptionalChildrenAk, new1);
@@ -1296,6 +1299,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2ca.Parent = existing;
+                    new2cb.Parent = existing;
                     new2d.Parent = new1d;
                     new2dd.Parent = new1dd;
                     new1.Parent = root;
@@ -1307,6 +1312,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     new2a.ParentId = existing.AlternateId;
                     new2b.ParentId = existing.AlternateId;
+                    new2ca.ParentId = existing.Id;
+                    new2ca.ParentAlternateId = existing.AlternateId;
+                    new2cb.ParentId = existing.Id;
+                    new2cb.ParentAlternateId = existing.AlternateId;
                     new2d.ParentId = new1d.AlternateId;
                     new2dd.ParentId = new1dd.AlternateId;
                     new1.ParentId = root.AlternateId;
@@ -1318,6 +1327,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2ca, existing.CompositeChildren);
+                Assert.Contains(new2cb, existing.CompositeChildren);
                 Assert.Contains(new2d, new1d.Children);
                 Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.OptionalChildrenAk);
@@ -1326,6 +1337,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(existing, new2ca.Parent);
+                Assert.Same(existing, new2cb.Parent);
                 Assert.Same(new1d, new2d.Parent);
                 Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
@@ -1334,6 +1347,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(existing.AlternateId, new2a.ParentId);
                 Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(existing.Id, new2ca.ParentId);
+                Assert.Equal(existing.Id, new2cb.ParentId);
+                Assert.Equal(existing.AlternateId, new2ca.ParentAlternateId);
+                Assert.Equal(existing.AlternateId, new2cb.ParentAlternateId);
                 Assert.Equal(new1d.AlternateId, new2d.ParentId);
                 Assert.Equal(new1dd.AlternateId, new2dd.ParentId);
                 Assert.Equal(root.AlternateId, existing.ParentId);
@@ -1345,7 +1362,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalAkGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -1376,6 +1393,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var new1dd = new RequiredAk1MoreDerived { AlternateId = Guid.NewGuid(), Parent = newRoot };
             var new2a = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
             var new2b = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
+            var new2ca = new RequiredComposite2 { Parent = new1 };
+            var new2cb = new RequiredComposite2 { Parent = new1 };
             var new2d = new RequiredAk2Derived { AlternateId = Guid.NewGuid(), Parent = new1 };
             var new2dd = new RequiredAk2MoreDerived { AlternateId = Guid.NewGuid(), Parent = new1 };
 
@@ -1383,7 +1402,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(newRoot, new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
                     context.SaveChanges();
                 }
             }
@@ -1392,7 +1411,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IReadOnlyList<EntityEntry> entries;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
                 var existing = root.RequiredChildrenAk.OrderBy(e => e.Id).First();
 
                 if (useExistingEntities)
@@ -1402,12 +1421,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     new1dd = (RequiredAk1MoreDerived)context.RequiredAk1s.Single(e => e.Id == new1dd.Id);
                     new2a = context.RequiredAk2s.Single(e => e.Id == new2a.Id);
                     new2b = context.RequiredAk2s.Single(e => e.Id == new2b.Id);
+                    new2ca = context.RequiredComposite2s.Single(e => e.Id == new2ca.Id);
+                    new2cb = context.RequiredComposite2s.Single(e => e.Id == new2cb.Id);
                     new2d = (RequiredAk2Derived)context.RequiredAk2s.Single(e => e.Id == new2d.Id);
                     new2dd = (RequiredAk2MoreDerived)context.RequiredAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
                     context.Entry(newRoot).State = EntityState.Detached;
                 }
 
@@ -1415,6 +1436,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     Add(existing.Children, new2a);
                     Add(existing.Children, new2b);
+                    Add(existing.CompositeChildren, new2ca);
+                    Add(existing.CompositeChildren, new2cb);
                     Add(new1d.Children, new2d);
                     Add(new1dd.Children, new2dd);
                     Add(root.RequiredChildrenAk, new1);
@@ -1426,6 +1449,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     new2a.Parent = existing;
                     new2b.Parent = existing;
+                    new2ca.Parent = existing;
+                    new2cb.Parent = existing;
                     new2d.Parent = new1d;
                     new2dd.Parent = new1dd;
                     new1.Parent = root;
@@ -1437,6 +1462,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     new2a.ParentId = existing.AlternateId;
                     new2b.ParentId = existing.AlternateId;
+                    new2ca.ParentId = existing.Id;
+                    new2cb.ParentId = existing.Id;
+                    new2ca.ParentAlternateId = existing.AlternateId;
+                    new2cb.ParentAlternateId = existing.AlternateId;
                     new2d.ParentId = new1d.AlternateId;
                     new2dd.ParentId = new1dd.AlternateId;
                     new1.ParentId = root.AlternateId;
@@ -1448,6 +1477,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Contains(new2a, existing.Children);
                 Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new2ca, existing.CompositeChildren);
+                Assert.Contains(new2cb, existing.CompositeChildren);
                 Assert.Contains(new2d, new1d.Children);
                 Assert.Contains(new2dd, new1dd.Children);
                 Assert.Contains(new1, root.RequiredChildrenAk);
@@ -1456,6 +1487,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Same(existing, new2a.Parent);
                 Assert.Same(existing, new2b.Parent);
+                Assert.Same(existing, new2ca.Parent);
+                Assert.Same(existing, new2cb.Parent);
                 Assert.Same(new1d, new2d.Parent);
                 Assert.Same(new1dd, new2dd.Parent);
                 Assert.Same(root, existing.Parent);
@@ -1464,6 +1497,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(existing.AlternateId, new2a.ParentId);
                 Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(existing.Id, new2ca.ParentId);
+                Assert.Equal(existing.Id, new2cb.ParentId);
+                Assert.Equal(existing.AlternateId, new2ca.ParentAlternateId);
+                Assert.Equal(existing.AlternateId, new2cb.ParentAlternateId);
                 Assert.Equal(new1d.AlternateId, new2d.ParentId);
                 Assert.Equal(new1dd.AlternateId, new2dd.ParentId);
                 Assert.Equal(root.AlternateId, existing.ParentId);
@@ -1475,7 +1512,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredAkGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -1496,27 +1533,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 var childCollection = root.OptionalChildrenAk.First().Children;
+                var childCompositeCollection = root.OptionalChildrenAk.First().CompositeChildren;
                 var removed2 = childCollection.First();
                 var removed1 = root.OptionalChildrenAk.Skip(1).First();
+                var removed2c = childCompositeCollection.First();
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     Remove(childCollection, removed2);
+                    Remove(childCompositeCollection, removed2c);
                     Remove(root.OptionalChildrenAk, removed1);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     removed2.Parent = null;
+                    removed2c.Parent = null;
                     removed1.Parent = null;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
                     removed2.ParentId = null;
+                    removed2c.ParentId = null;
                     removed1.ParentId = null;
                 }
 
@@ -1524,22 +1566,23 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.DoesNotContain(removed1, root.OptionalChildrenAk);
                 Assert.DoesNotContain(removed2, childCollection);
+                Assert.DoesNotContain(removed2c, childCompositeCollection);
 
                 Assert.Null(removed1.Parent);
                 Assert.Null(removed2.Parent);
+                Assert.Null(removed2c.Parent);
+
                 Assert.Null(removed1.ParentId);
                 Assert.Null(removed2.ParentId);
+                Assert.Null(removed2c.ParentId);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
-
-                Assert.Equal(2, loadedRoot.RequiredChildrenAk.Count());
-                Assert.Equal(2, loadedRoot.RequiredChildrenAk.First().Children.Count());
 
                 Assert.Equal(1, loadedRoot.OptionalChildrenAk.Count());
                 Assert.Equal(1, loadedRoot.OptionalChildrenAk.First().Children.Count());
@@ -1554,25 +1597,30 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             Root root;
             RequiredAk2 removed2;
+            RequiredComposite2 removed2c;
             RequiredAk1 removed1;
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 var childCollection = root.RequiredChildrenAk.First().Children;
+                var childCompositeCollection = root.RequiredChildrenAk.First().CompositeChildren;
                 removed2 = childCollection.First();
+                removed2c = childCompositeCollection.First();
                 removed1 = root.RequiredChildrenAk.Skip(1).First();
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
                     Remove(childCollection, removed2);
+                    Remove(childCompositeCollection, removed2c);
                     Remove(root.RequiredChildrenAk, removed1);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
                     removed2.Parent = null;
+                    removed2c.Parent = null;
                     removed1.Parent = null;
                 }
 
@@ -1585,26 +1633,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.DoesNotContain(removed1, root.RequiredChildrenAk);
                 Assert.DoesNotContain(removed2, childCollection);
+                Assert.DoesNotContain(removed2c, childCompositeCollection);
 
                 Assert.Null(removed1.Parent);
                 Assert.Null(removed2.Parent);
+                Assert.Null(removed2c.Parent);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
 
                 Assert.False(context.RequiredAk1s.Any(e => e.Id == removed1.Id));
                 Assert.False(context.RequiredAk2s.Any(e => e.Id == removed2.Id));
+                Assert.False(context.RequiredComposite2s.Any(e => e.Id == removed2c.Id));
 
                 Assert.Equal(1, loadedRoot.RequiredChildrenAk.Count());
                 Assert.Equal(1, loadedRoot.RequiredChildrenAk.First().Children.Count());
-
-                Assert.Equal(2, loadedRoot.OptionalChildrenAk.Count());
-                Assert.Equal(2, loadedRoot.OptionalChildrenAk.First().Children.Count());
+                Assert.Equal(1, loadedRoot.RequiredChildrenAk.First().CompositeChildren.Count());
             }
         }
 
@@ -1628,7 +1677,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var new2 = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() };
             var new2d = new OptionalSingleAk2Derived { AlternateId = Guid.NewGuid() };
             var new2dd = new OptionalSingleAk2MoreDerived { AlternateId = Guid.NewGuid() };
-            var new1 = new OptionalSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+            var new2c = new OptionalSingleComposite2();
+            var new1 = new OptionalSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2, SingleComposite = new2c };
             var new1d = new OptionalSingleAk1Derived { AlternateId = Guid.NewGuid(), Single = new2d };
             var new1dd = new OptionalSingleAk1MoreDerived { AlternateId = Guid.NewGuid(), Single = new2dd };
 
@@ -1636,7 +1686,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd, new2c);
                     context.SaveChanges();
                 }
             }
@@ -1647,16 +1697,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             OptionalSingleAk1Derived old1d;
             OptionalSingleAk1MoreDerived old1dd;
             OptionalSingleAk2 old2;
+            OptionalSingleComposite2 old2c;
             OptionalSingleAk2Derived old2d;
             OptionalSingleAk2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 old1 = root.OptionalSingleAk;
                 old1d = root.OptionalSingleAkDerived;
                 old1dd = root.OptionalSingleAkMoreDerived;
                 old2 = root.OptionalSingleAk.Single;
+                old2c = root.OptionalSingleAk.SingleComposite;
                 old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
                 old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
 
@@ -1666,12 +1718,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     new1d = (OptionalSingleAk1Derived)context.OptionalSingleAk1s.Single(e => e.Id == new1d.Id);
                     new1dd = (OptionalSingleAk1MoreDerived)context.OptionalSingleAk1s.Single(e => e.Id == new1dd.Id);
                     new2 = context.OptionalSingleAk2s.Single(e => e.Id == new2.Id);
+                    new2c = context.OptionalSingleComposite2s.Single(e => e.Id == new2c.Id);
                     new2d = (OptionalSingleAk2Derived)context.OptionalSingleAk2s.Single(e => e.Id == new2d.Id);
                     new2dd = (OptionalSingleAk2MoreDerived)context.OptionalSingleAk2s.Single(e => e.Id == new2dd.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
+                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd, new2c);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -1701,12 +1754,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(root.AlternateId, new1d.DerivedRootId);
                 Assert.Equal(root.AlternateId, new1dd.MoreDerivedRootId);
                 Assert.Equal(new1.AlternateId, new2.BackId);
+                Assert.Equal(new1.Id, new2c.BackId);
+                Assert.Equal(new1.AlternateId, new2c.ParentAlternateId);
                 Assert.Equal(new1d.AlternateId, new2d.BackId);
                 Assert.Equal(new1dd.AlternateId, new2dd.BackId);
                 Assert.Same(root, new1.Root);
                 Assert.Same(root, new1d.DerivedRoot);
                 Assert.Same(root, new1dd.MoreDerivedRoot);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1, new2c.Back);
                 Assert.Same(new1d, new2d.Back);
                 Assert.Same(new1dd, new2dd.Back);
 
@@ -1714,12 +1770,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Null(old1d.DerivedRoot);
                 Assert.Null(old1dd.MoreDerivedRoot);
                 Assert.Same(old1, old2.Back);
+                Assert.Same(old1, old2c.Back);
                 Assert.Equal(old1d, old2d.Back);
                 Assert.Equal(old1dd, old2dd.Back);
                 Assert.Null(old1.RootId);
                 Assert.Null(old1d.DerivedRootId);
                 Assert.Null(old1dd.MoreDerivedRootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.ParentAlternateId);
                 Assert.Equal(old1d.AlternateId, old2d.BackId);
                 Assert.Equal(old1dd.AlternateId, old2dd.BackId);
 
@@ -1728,7 +1787,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertNavigations(loadedRoot);
@@ -1739,6 +1798,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
                 var loaded2d = context.OptionalSingleAk2s.Single(e => e.Id == old2d.Id);
                 var loaded2dd = context.OptionalSingleAk2s.Single(e => e.Id == old2dd.Id);
+                var loaded2c = context.OptionalSingleComposite2s.Single(e => e.Id == old2c.Id);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
 
@@ -1746,12 +1806,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Null(loaded1d.Root);
                 Assert.Null(loaded1dd.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1, loaded2c.Back);
                 Assert.Same(loaded1d, loaded2d.Back);
                 Assert.Same(loaded1dd, loaded2dd.Back);
                 Assert.Null(loaded1.RootId);
                 Assert.Null(loaded1d.RootId);
                 Assert.Null(loaded1dd.RootId);
                 Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+                Assert.Equal(loaded1.Id, loaded2c.BackId);
+                Assert.Equal(loaded1.AlternateId, loaded2c.ParentAlternateId);
                 Assert.Equal(loaded1d.AlternateId, loaded2d.BackId);
                 Assert.Equal(loaded1dd.AlternateId, loaded2dd.BackId);
             }
@@ -1768,14 +1831,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             var new2 = new RequiredSingleAk2 { AlternateId = Guid.NewGuid() };
-            var new1 = new RequiredSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+            var new2c = new RequiredSingleComposite2();
+            var new1 = new RequiredSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2, SingleComposite = new2c };
             var newRoot = new Root { AlternateId = Guid.NewGuid(), RequiredSingleAk = new1 };
 
             if (useExistingEntities)
             {
                 using (var context = CreateContext())
                 {
-                    context.AddRange(newRoot, new1, new2);
+                    context.AddRange(newRoot, new1, new2, new2c);
                     context.SaveChanges();
                 }
             }
@@ -1784,21 +1848,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IReadOnlyList<EntityEntry> entries;
             RequiredSingleAk1 old1;
             RequiredSingleAk2 old2;
+            RequiredSingleComposite2 old2c;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 old1 = root.RequiredSingleAk;
                 old2 = root.RequiredSingleAk.Single;
+                old2c = root.RequiredSingleAk.SingleComposite;
 
                 if (useExistingEntities)
                 {
                     new1 = context.RequiredSingleAk1s.Single(e => e.Id == new1.Id);
                     new2 = context.RequiredSingleAk2s.Single(e => e.Id == new2.Id);
+                    new2c = context.RequiredSingleComposite2s.Single(e => e.Id == new2c.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2);
+                    context.AddRange(new1, new2, new2c);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -1820,19 +1887,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(root.AlternateId, new1.RootId);
                 Assert.Equal(new1.AlternateId, new2.BackId);
+                Assert.Equal(new1.Id, new2c.BackId);
+                Assert.Equal(new1.AlternateId, new2c.BackAlternateId);
                 Assert.Same(root, new1.Root);
                 Assert.Same(new1, new2.Back);
+                Assert.Same(new1, new2c.Back);
 
                 Assert.Null(old1.Root);
                 Assert.Null(old2.Back);
+                Assert.Null(old2c.Back);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.BackAlternateId);
 
                 entries = context.ChangeTracker.Entries().ToList();
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredAkGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -1840,6 +1913,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.False(context.RequiredSingleAk1s.Any(e => e.Id == old1.Id));
                 Assert.False(context.RequiredSingleAk2s.Any(e => e.Id == old2.Id));
+                Assert.False(context.RequiredSingleComposite2s.Any(e => e.Id == old2c.Id));
             }
         }
 
@@ -1888,7 +1962,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingleAk2MoreDerived old2dd;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkAkGraph(context);
 
                 old1 = root.RequiredNonPkSingleAk;
                 old1d = root.RequiredNonPkSingleAkDerived;
@@ -1972,7 +2046,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkAkGraph(context);
 
                 AssertEntries(entries, context.ChangeTracker.Entries().ToList());
                 AssertKeys(root, loadedRoot);
@@ -2000,12 +2074,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             OptionalSingleAk1 old1;
             OptionalSingleAk2 old2;
+            OptionalSingleComposite2 old2c;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 old1 = root.OptionalSingleAk;
                 old2 = root.OptionalSingleAk.Single;
+                old2c = root.OptionalSingleAk.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -2026,24 +2102,31 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Null(old1.Root);
                 Assert.Same(old1, old2.Back);
+                Assert.Same(old1, old2c.Back);
                 Assert.Null(old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.ParentAlternateId);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
                 var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+                var loaded2c = context.OptionalSingleComposite2s.Single(e => e.Id == old2c.Id);
 
                 Assert.Null(loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1, loaded2c.Back);
                 Assert.Null(loaded1.RootId);
                 Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+                Assert.Equal(loaded1.Id, loaded2c.BackId);
+                Assert.Equal(loaded1.AlternateId, loaded2c.ParentAlternateId);
             }
         }
 
@@ -2056,12 +2139,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             RequiredSingleAk1 old1;
             RequiredSingleAk2 old2;
+            RequiredSingleComposite2 old2c;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 old1 = root.RequiredSingleAk;
                 old2 = root.RequiredSingleAk.Single;
+                old2c = root.RequiredSingleAk.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -2082,18 +2167,22 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Null(old1.Root);
                 Assert.Null(old2.Back);
+                Assert.Null(old2c.Back);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.BackAlternateId);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 Assert.False(context.RequiredSingleAk1s.Any(e => e.Id == old1.Id));
                 Assert.False(context.RequiredSingleAk2s.Any(e => e.Id == old2.Id));
+                Assert.False(context.RequiredSingleComposite2s.Any(e => e.Id == old2c.Id));
             }
         }
 
@@ -2108,7 +2197,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkAkGraph(context);
 
                 old1 = root.RequiredNonPkSingleAk;
                 old2 = root.RequiredNonPkSingleAk.Single;
@@ -2137,7 +2226,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -2178,14 +2267,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             OptionalSingleAk1 old1;
             OptionalSingleAk2 old2;
+            OptionalSingleComposite2 old2c;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.OptionalSingleAk;
                 old2 = root.OptionalSingleAk.Single;
+                old2c = root.OptionalSingleAk.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -2208,13 +2299,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
+                Assert.Same(old1, old2c.Back);
                 Assert.Equal(newRoot.AlternateId, old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.ParentAlternateId);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadOptionalAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -2222,11 +2316,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
                 var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
                 var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+                var loaded2c = context.OptionalSingleComposite2s.Single(e => e.Id == old2c.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1, loaded2c.Back);
                 Assert.Equal(newRoot.AlternateId, loaded1.RootId);
                 Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+                Assert.Equal(loaded1.Id, loaded2c.BackId);
+                Assert.Equal(loaded1.AlternateId, loaded2c.ParentAlternateId);
             }
         }
 
@@ -2261,14 +2359,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Root root;
             RequiredSingleAk1 old1;
             RequiredSingleAk2 old2;
+            RequiredSingleComposite2 old2c;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.RequiredSingleAk;
                 old2 = root.RequiredSingleAk.Single;
+                old2c = root.RequiredSingleAk.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -2291,13 +2391,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
+                Assert.Same(old1, old2c.Back);
                 Assert.Equal(newRoot.AlternateId, old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
+                Assert.Equal(old1.Id, old2c.BackId);
+                Assert.Equal(old1.AlternateId, old2c.BackAlternateId);
             }
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -2305,11 +2408,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
                 var loaded1 = context.RequiredSingleAk1s.Single(e => e.Id == old1.Id);
                 var loaded2 = context.RequiredSingleAk2s.Single(e => e.Id == old2.Id);
+                var loaded2c = context.RequiredSingleComposite2s.Single(e => e.Id == old2c.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
+                Assert.Same(loaded1, loaded2c.Back);
                 Assert.Equal(newRoot.AlternateId, loaded1.RootId);
                 Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+                Assert.Equal(loaded1.Id, loaded2c.BackId);
+                Assert.Equal(loaded1.AlternateId, loaded2c.BackAlternateId);
             }
         }
 
@@ -2346,7 +2453,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             RequiredNonPkSingleAk2 old2;
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkAkGraph(context);
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
@@ -2380,7 +2487,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var loadedRoot = LoadFullGraph(context);
+                var loadedRoot = LoadRequiredNonPkAkGraph(context);
 
                 AssertKeys(root, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
@@ -2404,7 +2511,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Equal(2, root.RequiredChildren.Count());
 
@@ -2432,7 +2539,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Equal(1, root.RequiredChildren.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
@@ -2450,7 +2557,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 Assert.Equal(2, root.OptionalChildren.Count());
 
@@ -2478,7 +2585,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 Assert.Equal(1, root.OptionalChildren.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
@@ -2496,7 +2603,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 var removed = root.OptionalSingle;
 
@@ -2519,7 +2626,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 Assert.Null(root.OptionalSingle);
 
@@ -2536,7 +2643,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 var removed = root.RequiredSingle;
 
@@ -2559,7 +2666,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Null(root.RequiredSingle);
 
@@ -2576,7 +2683,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkGraph(context);
 
                 var removed = root.RequiredNonPkSingle;
 
@@ -2599,7 +2706,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingle);
 
@@ -2616,7 +2723,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 Assert.Equal(2, root.OptionalChildrenAk.Count());
 
@@ -2644,7 +2751,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 Assert.Equal(1, root.OptionalChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
@@ -2659,10 +2766,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(2, root.RequiredChildrenAk.Count());
 
@@ -2670,9 +2778,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var cascadeRemoved = removed.Children.ToList();
+                var cascadeRemovedC = removed.CompositeChildren.ToList();
                 orphanedIds = cascadeRemoved.Select(e => e.Id).ToList();
+                orphanedIdCs = cascadeRemovedC.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIdCs.Count);
 
                 context.Remove(removed);
 
@@ -2680,6 +2791,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Detached));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Detached));
 
                 Assert.Equal(1, root.RequiredChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
@@ -2690,13 +2802,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(1, root.RequiredChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.RequiredAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredAk2s.Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.RequiredComposite2s.Where(e => orphanedIdCs.Contains(e.Id)));
             }
         }
 
@@ -2705,16 +2818,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 var removed = root.OptionalSingleAk;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
+                var orphanedC = removed.SingleComposite;
                 orphanedId = orphaned.Id;
+                orphanedIdC = orphanedC.Id;
 
                 context.Remove(removed);
 
@@ -2722,21 +2838,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(orphanedC).State);
 
                 Assert.Null(root.OptionalSingleAk);
 
                 Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Equal(1, context.OptionalSingleAk2s.Count(e => e.Id == orphanedId));
+                Assert.Equal(1, context.OptionalSingleComposite2s.Count(e => e.Id == orphanedIdC));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 Assert.Null(root.OptionalSingleAk);
 
                 Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Equal(1, context.OptionalSingleAk2s.Count(e => e.Id == orphanedId));
+                Assert.Equal(1, context.OptionalSingleComposite2s.Count(e => e.Id == orphanedIdC));
             }
         }
 
@@ -2745,16 +2864,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 var removed = root.RequiredSingleAk;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
+                var orphanedC = removed.SingleComposite;
                 orphanedId = orphaned.Id;
+                orphanedIdC = orphanedC.Id;
 
                 context.Remove(removed);
 
@@ -2762,21 +2884,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Detached, context.Entry(orphanedC).State);
 
                 Assert.Null(root.RequiredSingleAk);
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Null(root.RequiredSingleAk);
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
         }
 
@@ -2788,7 +2913,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkAkGraph(context);
 
                 var removed = root.RequiredNonPkSingleAk;
 
@@ -2811,7 +2936,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkAkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingleAk);
 
@@ -2828,7 +2953,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredChildren.First();
+                var removed = LoadRequiredGraph(context).RequiredChildren.First();
 
                 removedId = removed.Id;
                 orphanedIds = removed.Children.Select(e => e.Id).ToList();
@@ -2859,7 +2984,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Equal(1, root.RequiredChildren.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
@@ -2877,7 +3002,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredSingle;
+                var removed = LoadRequiredGraph(context).RequiredSingle;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -2903,7 +3028,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Null(root.RequiredSingle);
 
@@ -2920,7 +3045,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredNonPkSingle;
+                var removed = LoadRequiredNonPkGraph(context).RequiredNonPkSingle;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -2946,7 +3071,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingle);
 
@@ -2960,15 +3085,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredChildrenAk.First();
+                var removed = LoadRequiredAkGraph(context).RequiredChildrenAk.First();
 
                 removedId = removed.Id;
                 orphanedIds = removed.Children.Select(e => e.Id).ToList();
+                orphanedIdCs = removed.CompositeChildren.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIdCs.Count);
             }
 
             using (var context = CreateContext())
@@ -2976,8 +3104,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var root = context.Roots.Include(e => e.RequiredChildrenAk).Single(IsTheRoot);
 
                 var removed = root.RequiredChildrenAk.Single(e => e.Id == removedId);
-
-                Assert.Equal(2, orphanedIds.Count);
 
                 context.Remove(removed);
 
@@ -2990,17 +3116,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Empty(context.RequiredAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredAk2s.Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.RequiredComposite2s.Where(e => orphanedIdCs.Contains(e.Id)));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(1, root.RequiredChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.RequiredAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredAk2s.Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.RequiredComposite2s.Where(e => orphanedIdCs.Contains(e.Id)));
             }
         }
 
@@ -3009,13 +3137,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredSingleAk;
+                var removed = LoadRequiredAkGraph(context).RequiredSingleAk;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
+                orphanedIdC = removed.SingleComposite.Id;
             }
 
             using (var context = CreateContext())
@@ -3034,16 +3164,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Null(root.RequiredSingleAk);
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
         }
 
@@ -3055,7 +3187,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).RequiredNonPkSingleAk;
+                var removed = LoadRequiredNonPkAkGraph(context).RequiredNonPkSingleAk;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -3081,7 +3213,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkAkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingleAk);
 
@@ -3098,7 +3230,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).OptionalChildren.First();
+                var removed = LoadOptionalGraph(context).OptionalChildren.First();
 
                 removedId = removed.Id;
                 orphanedIds = removed.Children.Select(e => e.Id).ToList();
@@ -3132,7 +3264,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 Assert.Equal(1, root.OptionalChildren.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
@@ -3153,7 +3285,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).OptionalSingle;
+                var removed = LoadOptionalGraph(context).OptionalSingle;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -3179,7 +3311,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalGraph(context);
 
                 Assert.Null(root.OptionalSingle);
 
@@ -3193,15 +3325,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).OptionalChildrenAk.First();
+                var removed = LoadOptionalAkGraph(context).OptionalChildrenAk.First();
 
                 removedId = removed.Id;
                 orphanedIds = removed.Children.Select(e => e.Id).ToList();
+                orphanedIdCs = removed.CompositeChildren.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIdCs.Count);
             }
 
             using (var context = CreateContext())
@@ -3210,9 +3345,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 var removed = root.OptionalChildrenAk.First(e => e.Id == removedId);
 
-                Assert.Equal(2, orphanedIds.Count);
-
                 context.Remove(removed);
+
+                // Cannot have SET NULL action in the store because one of the FK columns
+                // is not nullable, so need to do this on the EF side.
+                foreach (var toOrphan in context.OptionalComposite2s.Where(e => orphanedIdCs.Contains(e.Id)).ToList())
+                {
+                    toOrphan.ParentId = null;
+                }
 
                 context.SaveChanges();
 
@@ -3226,11 +3366,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var orphaned = context.OptionalAk2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
                 Assert.Equal(orphanedIds.Count, orphaned.Count);
                 Assert.True(orphaned.All(e => e.ParentId == null));
+
+                var orphanedC = context.OptionalComposite2s.Where(e => orphanedIdCs.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                Assert.True(orphanedC.All(e => e.ParentId == null));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 Assert.Equal(1, root.OptionalChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
@@ -3240,6 +3384,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var orphaned = context.OptionalAk2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
                 Assert.Equal(orphanedIds.Count, orphaned.Count);
                 Assert.True(orphaned.All(e => e.ParentId == null));
+
+                var orphanedC = context.OptionalComposite2s.Where(e => orphanedIdCs.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                Assert.True(orphanedC.All(e => e.ParentId == null));
             }
         }
 
@@ -3248,13 +3396,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
 
             using (var context = CreateContext())
             {
-                var removed = LoadFullGraph(context).OptionalSingleAk;
+                var removed = LoadOptionalAkGraph(context).OptionalSingleAk;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
+                orphanedIdC = removed.SingleComposite.Id;
             }
 
             using (var context = CreateContext())
@@ -3265,6 +3415,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 context.Remove(removed);
 
+                // Cannot have SET NULL action in the store because one of the FK columns
+                // is not nullable, so need to do this on the EF side.
+                context.OptionalSingleComposite2s.Single(e => e.Id == orphanedIdC).BackId = null;
+
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
@@ -3273,16 +3427,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Null(context.OptionalSingleAk2s.Single(e => e.Id == orphanedId).BackId);
+                Assert.Null(context.OptionalSingleComposite2s.Single(e => e.Id == orphanedIdC).BackId);
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadOptionalAkGraph(context);
 
                 Assert.Null(root.OptionalSingleAk);
 
                 Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Null(context.OptionalSingleAk2s.Single(e => e.Id == orphanedId).BackId);
+                Assert.Null(context.OptionalSingleComposite2s.Single(e => e.Id == orphanedIdC).BackId);
             }
         }
 
@@ -3295,7 +3451,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
 
                 Assert.Equal(2, root.RequiredChildren.Count());
             }
@@ -3323,7 +3479,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
 
                 Assert.Equal(1, root.RequiredChildren.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
@@ -3342,7 +3498,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 Assert.Equal(2, root.OptionalChildren.Count());
             }
@@ -3370,7 +3526,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 Assert.Equal(1, root.OptionalChildren.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
@@ -3389,7 +3545,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3413,7 +3569,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalGraph(context);
 
                 Assert.Null(root.OptionalSingle);
 
@@ -3431,7 +3587,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3455,7 +3611,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3476,7 +3632,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3500,7 +3656,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingle);
 
@@ -3514,11 +3670,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
             Root root;
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 Assert.Equal(2, root.OptionalChildrenAk.Count());
             }
@@ -3529,30 +3686,36 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var orphaned = removed.Children.ToList();
+                var orphanedC = removed.CompositeChildren.ToList();
                 orphanedIds = orphaned.Select(e => e.Id).ToList();
+                orphanedIdCs = orphanedC.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIdCs.Count);
 
                 context.Remove(removed);
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.True(orphaned.All(e => context.Entry(e).State == EntityState.Unchanged));
+                Assert.True(orphanedC.All(e => context.Entry(e).State == EntityState.Unchanged));
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.True(orphaned.All(e => context.Entry(e).State == EntityState.Unchanged));
+                Assert.True(orphanedC.All(e => context.Entry(e).State == EntityState.Unchanged));
             }
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 Assert.Equal(1, root.OptionalChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.OptionalAk1s.Where(e => e.Id == removedId));
                 Assert.Equal(orphanedIds.Count, context.OptionalAk2s.Count(e => orphanedIds.Contains(e.Id)));
+                Assert.Equal(orphanedIdCs.Count, context.OptionalComposite2s.Count(e => orphanedIdCs.Contains(e.Id)));
             }
         }
 
@@ -3561,11 +3724,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
             Root root;
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(2, root.RequiredChildrenAk.Count());
             }
@@ -3576,7 +3740,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var cascadeRemoved = removed.Children.ToList();
+                var cascadeRemovedC = removed.CompositeChildren.ToList();
                 orphanedIds = cascadeRemoved.Select(e => e.Id).ToList();
+                orphanedIdCs = cascadeRemovedC.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
 
@@ -3584,22 +3750,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Unchanged));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Unchanged));
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Detached));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Detached));
             }
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(1, root.RequiredChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.RequiredAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredAk2s.Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.RequiredComposite2s.Where(e => orphanedIdCs.Contains(e.Id)));
             }
         }
 
@@ -3608,11 +3777,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
             Root root;
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3621,27 +3791,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
+                var orphanedC = removed.SingleComposite;
                 orphanedId = orphaned.Id;
+                orphanedIdC = orphanedC.Id;
 
                 context.Remove(removed);
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(orphanedC).State);
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(orphanedC).State);
             }
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadOptionalAkGraph(context);
 
                 Assert.Null(root.OptionalSingleAk);
 
                 Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Equal(1, context.OptionalSingleAk2s.Count(e => e.Id == orphanedId));
+                Assert.Equal(1, context.OptionalSingleComposite2s.Count(e => e.Id == orphanedIdC));
             }
         }
 
@@ -3650,11 +3825,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
             Root root;
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3663,27 +3839,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
+                var orphanedC = removed.SingleComposite;
                 orphanedId = orphaned.Id;
+                orphanedIdC = orphanedC.Id;
 
                 context.Remove(removed);
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(orphanedC).State);
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Detached, context.Entry(orphanedC).State);
             }
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredAkGraph(context);
 
                 Assert.Null(root.RequiredSingleAk);
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
         }
 
@@ -3696,7 +3877,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkAkGraph(context);
             }
 
             using (var context = CreateContext())
@@ -3720,7 +3901,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                root = LoadFullGraph(context);
+                root = LoadRequiredNonPkAkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingleAk);
 
@@ -3737,7 +3918,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Equal(2, root.RequiredChildren.Count());
 
@@ -3776,7 +3957,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Equal(1, root.RequiredChildren.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
@@ -3794,7 +3975,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 var removed = root.RequiredSingle;
 
@@ -3820,7 +4001,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredGraph(context);
 
                 Assert.Null(root.RequiredSingle);
 
@@ -3837,7 +4018,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkGraph(context);
 
                 var removed = root.RequiredNonPkSingle;
 
@@ -3863,7 +4044,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingle);
 
@@ -3877,10 +4058,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             List<int> orphanedIds;
+            List<int> orphanedIdCs;
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(2, root.RequiredChildrenAk.Count());
 
@@ -3888,12 +4070,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 removedId = removed.Id;
                 var cascadeRemoved = removed.Children.ToList();
+                var cascadeRemovedC = removed.CompositeChildren.ToList();
                 orphanedIds = cascadeRemoved.Select(e => e.Id).ToList();
+                orphanedIdCs = cascadeRemovedC.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIdCs.Count);
 
                 var added = new RequiredAk2();
+                var addedC = new RequiredComposite2();
                 Add(removed.Children, added);
+                Add(removed.CompositeChildren, addedC);
 
                 if (context.ChangeTracker.AutoDetectChangesEnabled)
                 {
@@ -3902,30 +4089,37 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(EntityState.Unchanged, context.Entry(removed).State);
                 Assert.Equal(EntityState.Added, context.Entry(added).State);
+                Assert.Equal(EntityState.Added, context.Entry(addedC).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Unchanged));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Unchanged));
 
                 context.Remove(removed);
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.Equal(EntityState.Added, context.Entry(added).State);
+                Assert.Equal(EntityState.Added, context.Entry(addedC).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Unchanged));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Unchanged));
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Detached, context.Entry(added).State);
+                Assert.Equal(EntityState.Detached, context.Entry(addedC).State);
                 Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Detached));
+                Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Detached));
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Equal(1, root.RequiredChildrenAk.Count());
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.RequiredAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredAk2s.Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.RequiredComposite2s.Where(e => orphanedIdCs.Contains(e.Id)));
             }
         }
 
@@ -3934,41 +4128,49 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             int removedId;
             int orphanedId;
+            int orphanedIdC;
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 var removed = root.RequiredSingleAk;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
+                var orphanedC = removed.SingleComposite;
                 orphanedId = orphaned.Id;
+                orphanedIdC = orphanedC.Id;
 
                 context.Entry(orphaned).State = EntityState.Added;
+                context.Entry(orphanedC).State = EntityState.Added;
 
                 Assert.Equal(EntityState.Unchanged, context.Entry(removed).State);
                 Assert.Equal(EntityState.Added, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Added, context.Entry(orphanedC).State);
 
                 context.Remove(removed);
 
                 Assert.Equal(EntityState.Deleted, context.Entry(removed).State);
                 Assert.Equal(EntityState.Added, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Added, context.Entry(orphanedC).State);
 
                 context.SaveChanges();
 
                 Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                 Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
+                Assert.Equal(EntityState.Detached, context.Entry(orphanedC).State);
             }
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredAkGraph(context);
 
                 Assert.Null(root.RequiredSingleAk);
 
                 Assert.Empty(context.RequiredSingleAk1s.Where(e => e.Id == removedId));
                 Assert.Empty(context.RequiredSingleAk2s.Where(e => e.Id == orphanedId));
+                Assert.Empty(context.RequiredSingleComposite2s.Where(e => e.Id == orphanedIdC));
             }
         }
 
@@ -3980,7 +4182,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkAkGraph(context);
 
                 var removed = root.RequiredNonPkSingleAk;
 
@@ -4006,7 +4208,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             using (var context = CreateContext())
             {
-                var root = LoadFullGraph(context);
+                var root = LoadRequiredNonPkAkGraph(context);
 
                 Assert.Null(root.RequiredNonPkSingleAk);
 
@@ -4029,56 +4231,57 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         protected Expression<Func<Root, bool>> IsTheRoot => r => r.AlternateId == Fixture.RootAK;
 
-        protected Root LoadFullGraph(GraphUpdatesContext context)
-        {
-            var loadedGraph = context.Roots
+        protected Root LoadRequiredGraph(GraphUpdatesContext context)
+            => context.Roots
                 .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
                 .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
+                .Single(IsTheRoot);
+
+        protected Root LoadOptionalGraph(GraphUpdatesContext context)
+            => context.Roots
+                .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
+                .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+                .Single(IsTheRoot);
+
+        protected Root LoadRequiredNonPkGraph(GraphUpdatesContext context)
+            => context.Roots
                 .Include(e => e.RequiredNonPkSingle).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.DerivedRoot)
-                .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+                .Single(IsTheRoot);
+
+        protected Root LoadRequiredAkGraph(GraphUpdatesContext context)
+            => context.Roots
                 .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
-                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
+                .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.CompositeChildren)
                 .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
+                .Single(IsTheRoot);
+
+        protected Root LoadOptionalAkGraph(GraphUpdatesContext context)
+            => context.Roots
+                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
+                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
+                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
+                .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+                .Single(IsTheRoot);
+
+        protected Root LoadRequiredNonPkAkGraph(GraphUpdatesContext context)
+            => context.Roots
                 .Include(e => e.RequiredNonPkSingleAk).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleAkDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.DerivedRoot)
-                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
-                .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
                 .Single(IsTheRoot);
-
-            // TODO: Use Include when supported
-            context.RequiredAk1s.Load();
-            context.OptionalAk1s.Load();
-            context.RequiredSingleAk1s.Load();
-            context.OptionalSingleAk1s.Load();
-            context.RequiredNonPkSingleAk1s.Load();
-
-            context.RequiredSingle2s.Load();
-            context.RequiredNonPkSingle2s.Load();
-            context.OptionalSingle2s.Load();
-            context.Required2s.Load();
-            context.Optional2s.Load();
-
-            context.RequiredSingleAk2s.Load();
-            context.RequiredNonPkSingleAk2s.Load();
-            context.OptionalSingleAk2s.Load();
-            context.RequiredAk2s.Load();
-            context.OptionalAk2s.Load();
-
-            return loadedGraph;
-        }
 
         private static void AssertEntries(IReadOnlyList<EntityEntry> expectedEntries, IReadOnlyList<EntityEntry> actualEntries)
         {
@@ -4147,6 +4350,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 actual.RequiredChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId));
 
             Assert.Equal(
+                expected.RequiredChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.CompositeChildren).OrderBy(e => e.Id).Select(e => e.Id),
+                actual.RequiredChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.CompositeChildren).OrderBy(e => e.Id).Select(e => e.Id));
+
+            Assert.Equal(
                 expected.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId),
                 actual.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId));
 
@@ -4155,8 +4362,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 actual.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.Children.Count()));
 
             Assert.Equal(
+                expected.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.CompositeChildren.Count()),
+                actual.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.CompositeChildren.Count()));
+
+            Assert.Equal(
                 expected.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId),
                 actual.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId));
+
+            Assert.Equal(
+                expected.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.CompositeChildren).OrderBy(e => e.Id).Select(e => e.Id),
+                actual.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.CompositeChildren).OrderBy(e => e.Id).Select(e => e.Id));
 
             Assert.Equal(expected.RequiredSingleAk?.AlternateId, actual.RequiredSingleAk?.AlternateId);
             Assert.Equal(expected.OptionalSingleAk?.AlternateId, actual.OptionalSingleAk?.AlternateId);
@@ -4167,7 +4382,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Assert.Equal(expected.RequiredNonPkSingleAkMoreDerived?.AlternateId, actual.RequiredNonPkSingleAkMoreDerived?.AlternateId);
 
             Assert.Equal(expected.RequiredSingleAk?.Single?.AlternateId, actual.RequiredSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.RequiredSingleAk?.SingleComposite?.Id, actual.RequiredSingleAk?.SingleComposite?.Id);
             Assert.Equal(expected.OptionalSingleAk?.Single?.AlternateId, actual.OptionalSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAk?.SingleComposite?.Id, actual.OptionalSingleAk?.SingleComposite?.Id);
             Assert.Equal(expected.OptionalSingleAkDerived?.Single?.AlternateId, actual.OptionalSingleAkDerived?.Single?.AlternateId);
             Assert.Equal(expected.OptionalSingleAkMoreDerived?.Single?.AlternateId, actual.OptionalSingleAkMoreDerived?.Single?.AlternateId);
             Assert.Equal(expected.RequiredNonPkSingleAk?.Single?.AlternateId, actual.RequiredNonPkSingleAk?.Single?.AlternateId);
@@ -4189,61 +4406,73 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
             }
 
-            foreach (var child in root.OptionalChildren)
+            if (root.RequiredSingle != null)
             {
-                Assert.Same(root, child.Parent);
-                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.Same(root, root.RequiredSingle.Root);
+                Assert.Same(root.RequiredSingle, root.RequiredSingle.Single.Back);
             }
 
-            Assert.Same(root, root.RequiredSingle.Root);
-            Assert.Same(root, root.OptionalSingle.Root);
-            Assert.Same(root, root.OptionalSingleDerived.DerivedRoot);
-            Assert.Same(root, root.OptionalSingleMoreDerived.MoreDerivedRoot);
-            Assert.Same(root, root.RequiredNonPkSingle.Root);
-            Assert.Same(root, root.RequiredNonPkSingleDerived.DerivedRoot);
-            Assert.Same(root, root.RequiredNonPkSingleMoreDerived.MoreDerivedRoot);
+            if (root.OptionalSingle != null)
+            {
+                Assert.Same(root, root.OptionalSingle.Root);
+                Assert.Same(root, root.OptionalSingleDerived.DerivedRoot);
+                Assert.Same(root, root.OptionalSingleMoreDerived.MoreDerivedRoot);
+                Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
+                Assert.Same(root.OptionalSingleDerived, root.OptionalSingleDerived.Single.Back);
+                Assert.Same(root.OptionalSingleMoreDerived, root.OptionalSingleMoreDerived.Single.Back);
+            }
 
-            Assert.Same(root.RequiredSingle, root.RequiredSingle.Single.Back);
-            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
-            Assert.Same(root.OptionalSingleDerived, root.OptionalSingleDerived.Single.Back);
-            Assert.Same(root.OptionalSingleMoreDerived, root.OptionalSingleMoreDerived.Single.Back);
-            Assert.Same(root.RequiredNonPkSingle, root.RequiredNonPkSingle.Single.Back);
-            Assert.Same(root.RequiredNonPkSingleDerived, root.RequiredNonPkSingleDerived.Single.Back);
-            Assert.Same(root.RequiredNonPkSingleMoreDerived, root.RequiredNonPkSingleMoreDerived.Single.Back);
+            if (root.RequiredNonPkSingle != null)
+            {
+                Assert.Same(root, root.RequiredNonPkSingle.Root);
+                Assert.Same(root, root.RequiredNonPkSingleDerived.DerivedRoot);
+                Assert.Same(root, root.RequiredNonPkSingleMoreDerived.MoreDerivedRoot);
+                Assert.Same(root.RequiredNonPkSingle, root.RequiredNonPkSingle.Single.Back);
+                Assert.Same(root.RequiredNonPkSingleDerived, root.RequiredNonPkSingleDerived.Single.Back);
+                Assert.Same(root.RequiredNonPkSingleMoreDerived, root.RequiredNonPkSingleMoreDerived.Single.Back);
+            }
 
             foreach (var child in root.RequiredChildrenAk)
             {
                 Assert.Same(root, child.Parent);
                 Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.All(child.CompositeChildren.Select(e => e.Parent), e => Assert.Same(child, e));
             }
 
             foreach (var child in root.OptionalChildrenAk)
             {
                 Assert.Same(root, child.Parent);
                 Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.All(child.CompositeChildren.Select(e => e.Parent), e => Assert.Same(child, e));
             }
 
-            foreach (var child in root.OptionalChildrenAk)
+            if (root.RequiredSingleAk != null)
             {
-                Assert.Same(root, child.Parent);
-                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.Same(root, root.RequiredSingleAk.Root);
+                Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
+                Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.SingleComposite.Back);
             }
 
-            Assert.Same(root, root.RequiredSingleAk.Root);
-            Assert.Same(root, root.OptionalSingleAk.Root);
-            Assert.Same(root, root.OptionalSingleAkDerived.DerivedRoot);
-            Assert.Same(root, root.OptionalSingleAkMoreDerived.MoreDerivedRoot);
-            Assert.Same(root, root.RequiredNonPkSingleAk.Root);
-            Assert.Same(root, root.RequiredNonPkSingleAkDerived.DerivedRoot);
-            Assert.Same(root, root.RequiredNonPkSingleAkMoreDerived.MoreDerivedRoot);
+            if (root.OptionalSingleAk != null)
+            {
+                Assert.Same(root, root.OptionalSingleAk.Root);
+                Assert.Same(root, root.OptionalSingleAkDerived.DerivedRoot);
+                Assert.Same(root, root.OptionalSingleAkMoreDerived.MoreDerivedRoot);
+                Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
+                Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite.Back);
+                Assert.Same(root.OptionalSingleAkDerived, root.OptionalSingleAkDerived.Single.Back);
+                Assert.Same(root.OptionalSingleAkMoreDerived, root.OptionalSingleAkMoreDerived.Single.Back);
+            }
 
-            Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
-            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
-            Assert.Same(root.OptionalSingleAkDerived, root.OptionalSingleAkDerived.Single.Back);
-            Assert.Same(root.OptionalSingleAkMoreDerived, root.OptionalSingleAkMoreDerived.Single.Back);
-            Assert.Same(root.RequiredNonPkSingleAk, root.RequiredNonPkSingleAk.Single.Back);
-            Assert.Same(root.RequiredNonPkSingleAkDerived, root.RequiredNonPkSingleAkDerived.Single.Back);
-            Assert.Same(root.RequiredNonPkSingleAkMoreDerived, root.RequiredNonPkSingleAkMoreDerived.Single.Back);
+            if (root.RequiredNonPkSingleAk != null)
+            {
+                Assert.Same(root, root.RequiredNonPkSingleAk.Root);
+                Assert.Same(root, root.RequiredNonPkSingleAkDerived.DerivedRoot);
+                Assert.Same(root, root.RequiredNonPkSingleAkMoreDerived.MoreDerivedRoot);
+                Assert.Same(root.RequiredNonPkSingleAk, root.RequiredNonPkSingleAk.Single.Back);
+                Assert.Same(root.RequiredNonPkSingleAkDerived, root.RequiredNonPkSingleAkDerived.Single.Back);
+                Assert.Same(root.RequiredNonPkSingleAkMoreDerived, root.RequiredNonPkSingleAkMoreDerived.Single.Back);
+            }
         }
 
         private static void AssertPossiblyNullNavigations(Root root)
@@ -4288,30 +4517,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 Assert.Same(root, child.Parent);
                 Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.All(child.CompositeChildren.Select(e => e.Parent), e => Assert.Same(child, e));
             }
 
             foreach (var child in root.OptionalChildrenAk)
             {
                 Assert.Same(root, child.Parent);
                 Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
-            }
-
-            foreach (var child in root.OptionalChildrenAk)
-            {
-                Assert.Same(root, child.Parent);
-                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+                Assert.All(child.CompositeChildren.Select(e => e.Parent), e => Assert.Same(child, e));
             }
 
             if (root.RequiredSingleAk != null)
             {
                 Assert.Same(root, root.RequiredSingleAk.Root);
                 Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
+                Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.SingleComposite.Back);
             }
 
             if (root.OptionalSingleAk != null)
             {
                 Assert.Same(root, root.OptionalSingleAk.Root);
                 Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
+                Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite.Back);
             }
 
             if (root.RequiredNonPkSingleAk != null)
@@ -5003,6 +5230,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             private Guid _parentId;
             private Root _parent;
             private IEnumerable<RequiredAk2> _children = new ObservableHashSet<RequiredAk2>();
+            private IEnumerable<RequiredComposite2> _compositeChildren = new ObservableHashSet<RequiredComposite2>();
 
             public int Id
             {
@@ -5032,6 +5260,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
+            }
+
+            public IEnumerable<RequiredComposite2> CompositeChildren
+            {
+                get { return _compositeChildren; }
+                set { SetWithNotify(value, ref _compositeChildren); }
             }
 
             public override bool Equals(object obj)
@@ -5097,6 +5331,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public override int GetHashCode() => _id;
         }
 
+        protected class RequiredComposite2 : NotifyingEntity
+        {
+            private int _id;
+            private Guid _alternateId;
+            private int _parentId;
+            private RequiredAk1 _parent;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public Guid ParentAlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
+            }
+
+            public int ParentId
+            {
+                get { return _parentId; }
+                set { SetWithNotify(value, ref _parentId); }
+            }
+
+            public RequiredAk1 Parent
+            {
+                get { return _parent; }
+                set { SetWithNotify(value, ref _parent); }
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredComposite2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
         protected class RequiredAk2Derived : RequiredAk2
         {
             public override bool Equals(object obj) => base.Equals(obj as RequiredAk2Derived);
@@ -5118,6 +5392,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             private Guid? _parentId;
             private Root _parent;
             private IEnumerable<OptionalAk2> _children = new ObservableHashSet<OptionalAk2>();
+            private IEnumerable<OptionalComposite2> _compositeChildren = new ObservableHashSet<OptionalComposite2>();
 
             public int Id
             {
@@ -5147,6 +5422,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 get { return _children; }
                 set { SetWithNotify(value, ref _children); }
+            }
+
+            public IEnumerable<OptionalComposite2> CompositeChildren
+            {
+                get { return _compositeChildren; }
+                set { SetWithNotify(value, ref _compositeChildren); }
             }
 
             public override bool Equals(object obj)
@@ -5212,6 +5493,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public override int GetHashCode() => _id;
         }
 
+        protected class OptionalComposite2 : NotifyingEntity
+        {
+            private int _id;
+            private Guid _alternateId;
+            private int? _parentId;
+            private OptionalAk1 _parent;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public Guid ParentAlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
+            }
+
+            public int? ParentId
+            {
+                get { return _parentId; }
+                set { SetWithNotify(value, ref _parentId); }
+            }
+
+            public OptionalAk1 Parent
+            {
+                get { return _parent; }
+                set { SetWithNotify(value, ref _parent); }
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalComposite2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
         protected class OptionalAk2Derived : OptionalAk2
         {
             public override bool Equals(object obj) => base.Equals(obj as OptionalAk2Derived);
@@ -5233,6 +5554,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             private Guid _rootId;
             private Root _root;
             private RequiredSingleAk2 _single;
+            private RequiredSingleComposite2 _singleComposite;
 
             public int Id
             {
@@ -5262,6 +5584,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 get { return _single; }
                 set { SetWithNotify(value, ref _single); }
+            }
+
+            public RequiredSingleComposite2 SingleComposite
+            {
+                get { return _singleComposite; }
+                set { SetWithNotify(value, ref _singleComposite); }
             }
 
             public override bool Equals(object obj)
@@ -5307,6 +5635,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public override bool Equals(object obj)
             {
                 var other = obj as RequiredSingleAk2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
+        protected class RequiredSingleComposite2 : NotifyingEntity
+        {
+            private int _id;
+            private Guid _alternateId;
+            private int _backId;
+            private RequiredSingleAk1 _back;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public Guid BackAlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
+            }
+
+            public int BackId
+            {
+                get { return _backId; }
+                set { SetWithNotify(value, ref _backId); }
+            }
+
+            public RequiredSingleAk1 Back
+            {
+                get { return _back; }
+                set { SetWithNotify(value, ref _back); }
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as RequiredSingleComposite2;
                 return _id == other?.Id;
             }
 
@@ -5465,6 +5833,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             private Guid? _rootId;
             private Root _root;
             private OptionalSingleAk2 _single;
+            private OptionalSingleComposite2 _singleComposite;
 
             public int Id
             {
@@ -5488,6 +5857,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 get { return _root; }
                 set { SetWithNotify(value, ref _root); }
+            }
+
+            public OptionalSingleComposite2 SingleComposite
+            {
+                get { return _singleComposite; }
+                set { SetWithNotify(value, ref _singleComposite); }
             }
 
             public OptionalSingleAk2 Single
@@ -5589,6 +5964,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public override int GetHashCode() => _id;
         }
 
+        protected class OptionalSingleComposite2 : NotifyingEntity
+        {
+            private int _id;
+            private Guid _alternateId;
+            private int? _backId;
+            private OptionalSingleAk1 _back;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public Guid ParentAlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
+            }
+
+            public int? BackId
+            {
+                get { return _backId; }
+                set { SetWithNotify(value, ref _backId); }
+            }
+
+            public OptionalSingleAk1 Back
+            {
+                get { return _back; }
+                set { SetWithNotify(value, ref _back); }
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as OptionalSingleComposite2;
+                return _id == other?.Id;
+            }
+
+            public override int GetHashCode() => _id;
+        }
+
         protected class OptionalSingleAk2Derived : OptionalSingleAk2
         {
             public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk2Derived);
@@ -5643,14 +6058,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             public DbSet<RequiredSingleAk1> RequiredSingleAk1s { get; set; }
             public DbSet<RequiredSingleAk2> RequiredSingleAk2s { get; set; }
+            public DbSet<RequiredSingleComposite2> RequiredSingleComposite2s { get; set; }
             public DbSet<RequiredNonPkSingleAk1> RequiredNonPkSingleAk1s { get; set; }
             public DbSet<RequiredNonPkSingleAk2> RequiredNonPkSingleAk2s { get; set; }
             public DbSet<OptionalSingleAk1> OptionalSingleAk1s { get; set; }
             public DbSet<OptionalSingleAk2> OptionalSingleAk2s { get; set; }
+            public DbSet<OptionalSingleComposite2> OptionalSingleComposite2s { get; set; }
             public DbSet<RequiredAk1> RequiredAk1s { get; set; }
             public DbSet<OptionalAk1> OptionalAk1s { get; set; }
             public DbSet<RequiredAk2> RequiredAk2s { get; set; }
+            public DbSet<RequiredComposite2> RequiredComposite2s { get; set; }
             public DbSet<OptionalAk2> OptionalAk2s { get; set; }
+            public DbSet<OptionalComposite2> OptionalComposite2s { get; set; }
         }
 
         protected GraphUpdatesContext CreateContext()
@@ -5674,102 +6093,102 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             protected virtual void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Root>(b =>
-                    {
-                        b.Property(e => e.AlternateId).ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId).ValueGeneratedOnAdd();
 
-                        b.HasMany(e => e.RequiredChildren)
-                            .WithOne(e => e.Parent)
-                            .HasForeignKey(e => e.ParentId);
+                    b.HasMany(e => e.RequiredChildren)
+                        .WithOne(e => e.Parent)
+                        .HasForeignKey(e => e.ParentId);
 
-                        b.HasMany(e => e.OptionalChildren)
-                            .WithOne(e => e.Parent)
-                            .HasForeignKey(e => e.ParentId)
-                            .OnDelete(DeleteBehavior.SetNull);
+                    b.HasMany(e => e.OptionalChildren)
+                        .WithOne(e => e.Parent)
+                        .HasForeignKey(e => e.ParentId)
+                        .OnDelete(DeleteBehavior.SetNull);
 
-                        b.HasOne(e => e.RequiredSingle)
-                            .WithOne(e => e.Root)
-                            .HasForeignKey<RequiredSingle1>(e => e.Id);
+                    b.HasOne(e => e.RequiredSingle)
+                        .WithOne(e => e.Root)
+                        .HasForeignKey<RequiredSingle1>(e => e.Id);
 
-                        b.HasOne(e => e.OptionalSingle)
-                            .WithOne(e => e.Root)
-                            .HasForeignKey<OptionalSingle1>(e => e.RootId)
-                            .OnDelete(DeleteBehavior.SetNull);
+                    b.HasOne(e => e.OptionalSingle)
+                        .WithOne(e => e.Root)
+                        .HasForeignKey<OptionalSingle1>(e => e.RootId)
+                        .OnDelete(DeleteBehavior.SetNull);
 
-                        b.HasOne(e => e.OptionalSingleDerived)
-                            .WithOne(e => e.DerivedRoot)
-                            .HasForeignKey<OptionalSingle1Derived>(e => e.DerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.OptionalSingleDerived)
+                        .WithOne(e => e.DerivedRoot)
+                        .HasForeignKey<OptionalSingle1Derived>(e => e.DerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.OptionalSingleMoreDerived)
-                            .WithOne(e => e.MoreDerivedRoot)
-                            .HasForeignKey<OptionalSingle1MoreDerived>(e => e.MoreDerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.OptionalSingleMoreDerived)
+                        .WithOne(e => e.MoreDerivedRoot)
+                        .HasForeignKey<OptionalSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.RequiredNonPkSingle)
-                            .WithOne(e => e.Root)
-                            .HasForeignKey<RequiredNonPkSingle1>(e => e.RootId);
+                    b.HasOne(e => e.RequiredNonPkSingle)
+                        .WithOne(e => e.Root)
+                        .HasForeignKey<RequiredNonPkSingle1>(e => e.RootId);
 
-                        b.HasOne(e => e.RequiredNonPkSingleDerived)
-                            .WithOne(e => e.DerivedRoot)
-                            .HasForeignKey<RequiredNonPkSingle1Derived>(e => e.DerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.RequiredNonPkSingleDerived)
+                        .WithOne(e => e.DerivedRoot)
+                        .HasForeignKey<RequiredNonPkSingle1Derived>(e => e.DerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.RequiredNonPkSingleMoreDerived)
-                            .WithOne(e => e.MoreDerivedRoot)
-                            .HasForeignKey<RequiredNonPkSingle1MoreDerived>(e => e.MoreDerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.RequiredNonPkSingleMoreDerived)
+                        .WithOne(e => e.MoreDerivedRoot)
+                        .HasForeignKey<RequiredNonPkSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasMany(e => e.RequiredChildrenAk)
-                            .WithOne(e => e.Parent)
-                            .HasPrincipalKey(e => e.AlternateId)
-                            .HasForeignKey(e => e.ParentId);
+                    b.HasMany(e => e.RequiredChildrenAk)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => e.AlternateId)
+                        .HasForeignKey(e => e.ParentId);
 
-                        b.HasMany(e => e.OptionalChildrenAk)
-                            .WithOne(e => e.Parent)
-                            .HasPrincipalKey(e => e.AlternateId)
-                            .HasForeignKey(e => e.ParentId)
-                            .OnDelete(DeleteBehavior.SetNull);
+                    b.HasMany(e => e.OptionalChildrenAk)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => e.AlternateId)
+                        .HasForeignKey(e => e.ParentId)
+                        .OnDelete(DeleteBehavior.SetNull);
 
-                        b.HasOne(e => e.RequiredSingleAk)
-                            .WithOne(e => e.Root)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<RequiredSingleAk1>(e => e.RootId);
+                    b.HasOne(e => e.RequiredSingleAk)
+                        .WithOne(e => e.Root)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<RequiredSingleAk1>(e => e.RootId);
 
-                        b.HasOne(e => e.OptionalSingleAk)
-                            .WithOne(e => e.Root)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<OptionalSingleAk1>(e => e.RootId)
-                            .OnDelete(DeleteBehavior.SetNull);
+                    b.HasOne(e => e.OptionalSingleAk)
+                        .WithOne(e => e.Root)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<OptionalSingleAk1>(e => e.RootId)
+                        .OnDelete(DeleteBehavior.SetNull);
 
-                        b.HasOne(e => e.OptionalSingleAkDerived)
-                            .WithOne(e => e.DerivedRoot)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<OptionalSingleAk1Derived>(e => e.DerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.OptionalSingleAkDerived)
+                        .WithOne(e => e.DerivedRoot)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<OptionalSingleAk1Derived>(e => e.DerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.OptionalSingleAkMoreDerived)
-                            .WithOne(e => e.MoreDerivedRoot)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<OptionalSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.OptionalSingleAkMoreDerived)
+                        .WithOne(e => e.MoreDerivedRoot)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<OptionalSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.RequiredNonPkSingleAk)
-                            .WithOne(e => e.Root)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
+                    b.HasOne(e => e.RequiredNonPkSingleAk)
+                        .WithOne(e => e.Root)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
 
-                        b.HasOne(e => e.RequiredNonPkSingleAkDerived)
-                            .WithOne(e => e.DerivedRoot)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<RequiredNonPkSingleAk1Derived>(e => e.DerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
+                    b.HasOne(e => e.RequiredNonPkSingleAkDerived)
+                        .WithOne(e => e.DerivedRoot)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<RequiredNonPkSingleAk1Derived>(e => e.DerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
 
-                        b.HasOne(e => e.RequiredNonPkSingleAkMoreDerived)
-                            .WithOne(e => e.MoreDerivedRoot)
-                            .HasPrincipalKey<Root>(e => e.AlternateId)
-                            .HasForeignKey<RequiredNonPkSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
-                            .OnDelete(DeleteBehavior.Restrict);
-                    });
+                    b.HasOne(e => e.RequiredNonPkSingleAkMoreDerived)
+                        .WithOne(e => e.MoreDerivedRoot)
+                        .HasPrincipalKey<Root>(e => e.AlternateId)
+                        .HasForeignKey<RequiredNonPkSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                        .OnDelete(DeleteBehavior.Restrict);
+                });
 
                 modelBuilder.Entity<Required1>()
                     .HasMany(e => e.Children)
@@ -5815,70 +6234,90 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 modelBuilder.Entity<RequiredNonPkSingle2MoreDerived>();
 
                 modelBuilder.Entity<RequiredAk1>(b =>
-                    {
-                        b.Property(e => e.AlternateId)
-                            .ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
 
-                        b.HasMany(e => e.Children)
-                            .WithOne(e => e.Parent)
-                            .HasPrincipalKey(e => e.AlternateId)
-                            .HasForeignKey(e => e.ParentId);
-                    });
+                    b.HasMany(e => e.Children)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => e.AlternateId)
+                        .HasForeignKey(e => e.ParentId);
+
+                    b.HasMany(e => e.CompositeChildren)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => new { e.Id, e.AlternateId })
+                        .HasForeignKey(e => new { e.ParentId, e.ParentAlternateId });
+                });
 
                 modelBuilder.Entity<RequiredAk1Derived>();
                 modelBuilder.Entity<RequiredAk1MoreDerived>();
 
                 modelBuilder.Entity<OptionalAk1>(b =>
-                    {
-                        b.Property(e => e.AlternateId)
-                            .ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
 
-                        b.HasMany(e => e.Children)
-                            .WithOne(e => e.Parent)
-                            .HasPrincipalKey(e => e.AlternateId)
-                            .HasForeignKey(e => e.ParentId)
-                            .OnDelete(DeleteBehavior.SetNull);
-                    });
+                    b.HasMany(e => e.Children)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => e.AlternateId)
+                        .HasForeignKey(e => e.ParentId)
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasMany(e => e.CompositeChildren)
+                        .WithOne(e => e.Parent)
+                        .HasPrincipalKey(e => new { e.Id, e.AlternateId })
+                        .HasForeignKey(e => new { e.ParentId, e.ParentAlternateId });
+                });
 
                 modelBuilder.Entity<OptionalAk1Derived>();
                 modelBuilder.Entity<OptionalAk1MoreDerived>();
 
                 modelBuilder.Entity<RequiredSingleAk1>(b =>
-                    {
-                        b.Property(e => e.AlternateId)
-                            .ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
 
-                        b.HasOne(e => e.Single)
-                            .WithOne(e => e.Back)
-                            .HasForeignKey<RequiredSingleAk2>(e => e.BackId)
-                            .HasPrincipalKey<RequiredSingleAk1>(e => e.AlternateId);
-                    });
+                    b.HasOne(e => e.Single)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<RequiredSingleAk2>(e => e.BackId)
+                        .HasPrincipalKey<RequiredSingleAk1>(e => e.AlternateId);
+
+                    b.HasOne(e => e.SingleComposite)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<RequiredSingleComposite2>(e => new { e.BackId, e.BackAlternateId })
+                        .HasPrincipalKey<RequiredSingleAk1>(e => new { e.Id, e.AlternateId });
+                });
 
                 modelBuilder.Entity<OptionalSingleAk1>(b =>
-                    {
-                        b.Property(e => e.AlternateId)
-                            .ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
 
-                        b.HasOne(e => e.Single)
-                            .WithOne(e => e.Back)
-                            .HasForeignKey<OptionalSingleAk2>(e => e.BackId)
-                            .HasPrincipalKey<OptionalSingleAk1>(e => e.AlternateId)
-                            .OnDelete(DeleteBehavior.SetNull);
-                    });
+                    b.HasOne(e => e.Single)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<OptionalSingleAk2>(e => e.BackId)
+                        .HasPrincipalKey<OptionalSingleAk1>(e => e.AlternateId)
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne(e => e.SingleComposite)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<OptionalSingleComposite2>(e => new { e.BackId, e.ParentAlternateId })
+                        .HasPrincipalKey<OptionalSingleAk1>(e => new { e.Id, e.AlternateId });
+                });
 
                 modelBuilder.Entity<OptionalSingleAk2Derived>();
                 modelBuilder.Entity<OptionalSingleAk2MoreDerived>();
 
                 modelBuilder.Entity<RequiredNonPkSingleAk1>(b =>
-                    {
-                        b.Property(e => e.AlternateId)
-                            .ValueGeneratedOnAdd();
+                {
+                    b.Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
 
-                        b.HasOne(e => e.Single)
-                            .WithOne(e => e.Back)
-                            .HasForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
-                            .HasPrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId);
-                    });
+                    b.HasOne(e => e.Single)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
+                        .HasPrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId);
+                });
 
                 modelBuilder.Entity<RequiredAk2>()
                     .Property(e => e.AlternateId)
@@ -5911,8 +6350,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
 
             protected virtual object CreateFullGraph()
-            {
-                return new Root
+                => new Root
                 {
                     AlternateId = RootAK,
                     RequiredChildren = new ObservableHashSet<Required1>(ReferenceEqualityComparer.Instance)
@@ -5993,6 +6431,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             {
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() },
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() }
+                            },
+                            CompositeChildren = new ObservableHashSet<RequiredComposite2>(ReferenceEqualityComparer.Instance)
+                            {
+                                new RequiredComposite2(),
+                                new RequiredComposite2()
                             }
                         },
                         new RequiredAk1
@@ -6002,6 +6445,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             {
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() },
                                 new RequiredAk2 { AlternateId = Guid.NewGuid() }
+                            },
+                            CompositeChildren = new ObservableHashSet<RequiredComposite2>(ReferenceEqualityComparer.Instance)
+                            {
+                                new RequiredComposite2(),
+                                new RequiredComposite2()
                             }
                         }
                     },
@@ -6014,6 +6462,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             {
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() },
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() }
+                            },
+                            CompositeChildren = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance)
+                            {
+                                new OptionalComposite2(),
+                                new OptionalComposite2()
                             }
                         },
                         new OptionalAk1
@@ -6023,18 +6476,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             {
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() },
                                 new OptionalAk2 { AlternateId = Guid.NewGuid() }
+                            },
+                            CompositeChildren = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance)
+                            {
+                                new OptionalComposite2(),
+                                new OptionalComposite2()
                             }
                         }
                     },
                     RequiredSingleAk = new RequiredSingleAk1
                     {
                         AlternateId = Guid.NewGuid(),
-                        Single = new RequiredSingleAk2 { AlternateId = Guid.NewGuid() }
+                        Single = new RequiredSingleAk2 { AlternateId = Guid.NewGuid() },
+                        SingleComposite = new RequiredSingleComposite2()
                     },
                     OptionalSingleAk = new OptionalSingleAk1
                     {
                         AlternateId = Guid.NewGuid(),
-                        Single = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() }
+                        Single = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() },
+                        SingleComposite = new OptionalSingleComposite2()
                     },
                     OptionalSingleAkDerived = new OptionalSingleAk1Derived
                     {
@@ -6065,7 +6525,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         DerivedRoot = new Root()
                     }
                 };
-            }
 
             protected virtual void Seed(DbContext context)
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -12,8 +12,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
-using Microsoft.EntityFrameworkCore.ValueGeneration;
-using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -1068,6 +1066,39 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             return modelBuilder.Model;
         }
 
+        private static IModel BuildOneToOneCompositeModel(bool required)
+        {
+            var modelBuilder = TestHelpers.Instance.CreateConventionBuilder();
+
+            modelBuilder
+                .Entity<CompositeRoot>()
+                .HasKey(e => new { e.Id1, e.Id2 });
+
+            modelBuilder
+                .Entity<CompositeFirstDependent>()
+                .HasKey(e => new { e.Id1, e.Id2 });
+
+            modelBuilder
+                .Entity<CompositeSecondDependent>()
+                .HasKey(e => new { e.Id1, e.Id2 });
+
+            modelBuilder
+                .Entity<CompositeRoot>()
+                .HasOne(e => e.First)
+                .WithOne(e => e.Root)
+                .HasForeignKey<CompositeFirstDependent>(e => new { e.RootId1, e.RootId2 })
+                .IsRequired(required);
+
+            modelBuilder
+                .Entity<CompositeFirstDependent>()
+                .HasOne(e => e.Second)
+                .WithOne(e => e.First)
+                .HasForeignKey<CompositeSecondDependent>(e => new { e.FirstId1, e.FirstId2 })
+                .IsRequired(required);
+
+            return modelBuilder.Model;
+        }
+
         [Fact]
         public void Unchanged_entity_with_conceptually_null_FK_with_cascade_delete_is_marked_Deleted()
         {
@@ -1102,6 +1133,49 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entry.HandleConceptualNulls();
 
             Assert.Equal(EntityState.Detached, entry.EntityState);
+        }
+
+        [Fact]
+        public void Entity_with_partially_null_composite_FK_with_cascade_delete_is_marked_Deleted()
+        {
+            var model = BuildOneToOneCompositeModel(required: true);
+            var entityType = model.FindEntityType(typeof(CompositeSecondDependent).FullName);
+            var fkProperty1 = entityType.FindProperty("FirstId1");
+            var fkProperty2 = entityType.FindProperty("FirstId2");
+
+            var entry = CreateInternalEntry(TestHelpers.Instance.CreateContextServices(model), entityType, new CompositeSecondDependent());
+
+            entry[fkProperty1] = 77;
+            entry[fkProperty2] = "Foo";
+            entry.SetEntityState(EntityState.Unchanged);
+
+            entry[fkProperty1] = null;
+            entry.HandleConceptualNulls();
+
+            Assert.Equal(EntityState.Deleted, entry.EntityState);
+        }
+
+        [Fact]
+        public void Entity_with_partially_null_composite_FK_without_cascade_delete_is_orphaned()
+        {
+            var model = BuildOneToOneCompositeModel(required: false);
+            var entityType = model.FindEntityType(typeof(CompositeSecondDependent).FullName);
+            var fkProperty1 = entityType.FindProperty("FirstId1");
+            var fkProperty2 = entityType.FindProperty("FirstId2");
+
+            var entry = CreateInternalEntry(TestHelpers.Instance.CreateContextServices(model), entityType, new CompositeSecondDependent());
+
+            entry[fkProperty1] = 77;
+            entry[fkProperty2] = "Foo";
+            entry.SetEntityState(EntityState.Unchanged);
+
+            entry[fkProperty1] = null;
+            entry.HandleConceptualNulls();
+
+            Assert.Equal(EntityState.Modified, entry.EntityState);
+
+            Assert.Equal(77, entry[fkProperty1]);
+            Assert.Null(entry[fkProperty2]);
         }
 
         [Fact]
@@ -1171,6 +1245,36 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             public int Id { get; set; }
 
             public FirstDependent First { get; set; }
+        }
+
+        private class CompositeRoot
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+
+            public CompositeFirstDependent First { get; set; }
+        }
+
+        private class CompositeFirstDependent
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+
+            public int RootId1 { get; set; }
+            public string RootId2 { get; set; }
+            public CompositeRoot Root { get; set; }
+
+            public CompositeSecondDependent Second { get; set; }
+        }
+
+        private class CompositeSecondDependent
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+
+            public int FirstId1 { get; set; }
+            public string FirstId2 { get; set; }
+            public CompositeFirstDependent First { get; set; }
         }
 
         protected virtual InternalEntityEntry CreateInternalEntry(IServiceProvider contextServices, IEntityType entityType, object entity)


### PR DESCRIPTION
Issue #6109

Fix is to clear any conceptual null if any part of the composite key is nullable, and to instead make sure that that part is null.

Also added more coverage for update scenarios with composite keys and improved perf of GraphUpdatesTest.