### PR TITLE
Implement IsLoaded flag

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -870,6 +870,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     old1.RootId = null;
                 }
 
+                Assert.False(context.Entry(root).Reference(e => e.OptionalSingle).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+
                 context.SaveChanges();
 
                 Assert.Null(old1.Root);
@@ -926,6 +929,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
 
+                Assert.False(context.Entry(root).Reference(e => e.RequiredSingle).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+
                 context.SaveChanges();
 
                 Assert.Null(old1.Root);
@@ -975,6 +981,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
+
+                Assert.False(context.Entry(root).Reference(e => e.RequiredNonPkSingle).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
 
                 context.SaveChanges();
 
@@ -2098,6 +2107,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     old1.RootId = null;
                 }
 
+                Assert.False(context.Entry(root).Reference(e => e.OptionalSingleAk).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+
                 context.SaveChanges();
 
                 Assert.Null(old1.Root);
@@ -2163,6 +2175,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
 
+                Assert.False(context.Entry(root).Reference(e => e.RequiredSingleAk).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
+
                 context.SaveChanges();
 
                 Assert.Null(old1.Root);
@@ -2216,6 +2231,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 {
                     throw new ArgumentOutOfRangeException(nameof(changeMechanism));
                 }
+
+                Assert.False(context.Entry(root).Reference(e => e.RequiredNonPkSingleAk).IsLoaded);
+                Assert.False(context.Entry(old1).Reference(e => e.Root).IsLoaded);
 
                 context.SaveChanges();
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -5,16 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Xunit;
+
 // ReSharper disable StringStartsWithIsCultureSpecific
 
 #if NETSTANDARD1_3
 using System.Reflection;
 #endif
-
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public abstract class IncludeTestBase<TFixture> : IClassFixture<TFixture>
@@ -97,6 +97,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(2, customer.Orders.First().OrderDetails.Count);
                 Assert.NotNull(customer.Orders.Last().OrderDetails);
                 Assert.Equal(3, customer.Orders.Last().OrderDetails.Count);
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: true,
+                    productLoaded: false);
             }
         }
 
@@ -174,6 +181,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(91 + 830, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -190,6 +207,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(81, customers.Count);
                 Assert.True(customers.All(c => c.Orders != null));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -207,6 +234,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(5, customers.Count);
                 Assert.True(customers.All(c => c.Orders != null));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -221,6 +258,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.Equal(77, products.Count);
+
+                foreach (var product in products)
+                {
+                    CheckIsLoaded(
+                        context,
+                        product,
+                        orderDetailsLoaded: true,
+                        orderLoaded: true);
+                }
             }
         }
 
@@ -235,6 +281,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.Equal(830, orders.Count);
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -250,6 +307,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.Equal(830, orders.Count);
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -268,6 +336,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(0, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -288,6 +366,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(48, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(0, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -312,6 +400,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customer.Orders.Count);
                 Assert.True(customer.Orders.All(o => o.Customer != null));
                 Assert.Equal(6 + 1, context.ChangeTracker.Entries().Count());
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -337,6 +432,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customer.Orders.Count);
                 Assert.True(customer.Orders.All(o => o.Customer != null));
                 Assert.Equal(6, context.ChangeTracker.Entries().Count());
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: false,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -355,6 +457,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(4150, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(455 + 466, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -373,6 +485,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(4150, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(0, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -393,6 +515,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(546, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -410,6 +542,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(455, customers.Count);
                 Assert.True(customers.All(c => c.Orders == null));
                 Assert.Equal(5, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -430,7 +572,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             {
                                 od.Order.CustomerID
                             })
-                            .ToList();
+                        .ToList();
 
                 Assert.Equal(2, orders.Count);
             }
@@ -452,6 +594,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(36, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -472,6 +624,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(36, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -491,6 +653,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customers.SelectMany(c => c.c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(a => a.c))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -511,6 +683,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customers.SelectMany(c => c.g).Count());
                 Assert.True(customers.SelectMany(c => c.g).SelectMany(o => o.OrderDetails).All(od => od.Order != null));
                 Assert.Equal(1 + 6 + 12, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in customers.SelectMany(a => a.c.Orders))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -528,6 +711,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(1, customers.Count);
                 Assert.Equal(6, customers.SelectMany(c => c.Single().Orders).Count());
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(e => e.Single()))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -547,6 +740,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal("WHITC", customer.CustomerID);
                 Assert.NotNull(customer.Orders);
                 Assert.Equal(14, customer.Orders.Count);
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -565,6 +765,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(91 + 830, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -583,6 +793,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(91 + 830, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -602,6 +822,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(116, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(10 + 116, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -621,6 +851,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(714, customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).Count());
                 Assert.True(customers.Where(c => c.Orders != null).SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(81 + 714, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -639,6 +879,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(7, customer.Orders.Count);
                 Assert.True(customer.Orders.All(o => o.Customer != null));
                 Assert.Equal(1 + 7, context.ChangeTracker.Entries().Count());
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -657,6 +904,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.NotNull(customer);
                 Assert.NotNull(customer.Orders);
                 Assert.Equal(6, customer.Orders.Count);
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -680,6 +934,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customer2.Orders.Count);
                 Assert.True(customer2.Orders.All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                CheckIsLoaded(
+                    context,
+                    customer2,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -705,6 +966,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customer2.Orders.Count);
                 Assert.True(customer2.Orders.All(o => o.Customer != null));
                 Assert.Equal(1, context.ChangeTracker.Entries().Count());
+
+                CheckIsLoaded(
+                    context,
+                    customer2,
+                    ordersLoaded: false,
+                    orderDetailsLoaded: false,
+                    productLoaded: false);
             }
         }
 
@@ -753,6 +1021,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -771,6 +1049,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(6, customers.SelectMany(c => c.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.Orders).All(o => o.Customer != null));
                 Assert.Equal(1 + 6, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -798,6 +1086,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(40, customers.SelectMany(c => c.c2.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.c2.Orders).All(o => o.Customer != null));
                 Assert.Equal(34, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(e => e.c1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+
+                foreach (var customer in customers.Select(e => e.c2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -826,6 +1134,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(7, customers.SelectMany(c => c.c2.Orders).Count());
                 Assert.True(customers.SelectMany(c => c.c2.Orders).All(o => o.Customer != null));
                 Assert.Equal(15, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(e => e.c1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+
+                foreach (var customer in customers.Select(e => e.c2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -852,6 +1180,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(customers.SelectMany(c => c.c1.Orders).All(o => o.Customer != null));
                 Assert.True(customers.All(c => c.c2.Orders == null));
                 Assert.Equal(8, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers.Select(e => e.c1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+
+                foreach (var customer in customers.Select(e => e.c2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -879,6 +1227,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(1, orders.Select(o => o.o1.Customer).Distinct().Count());
                 Assert.Equal(1, orders.Select(o => o.o2.Customer).Distinct().Count());
                 Assert.Equal(5, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders.Select(e => e.o1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+
+                foreach (var order in orders.Select(e => e.o2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -904,6 +1274,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders.All(o => o.o2.Customer == null));
                 Assert.Equal(2, orders.Select(o => o.o1.Customer).Distinct().Count());
                 Assert.Equal(6, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders.Select(e => e.o1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+
+                foreach (var order in orders.Select(e => e.o2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -929,6 +1321,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders.All(o => o.o2.Customer != null));
                 Assert.Equal(2, orders.Select(o => o.o2.Customer).Distinct().Count());
                 Assert.Equal(6, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders.Select(e => e.o1))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+
+                foreach (var order in orders.Select(e => e.o2))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -949,6 +1363,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(13, customers.First().Orders.Count); // AROUT
                 Assert.Equal(9, customers.Last().Orders.Count); // SEVES
                 Assert.Equal(6 + 46, context.ChangeTracker.Entries().Count());
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -964,6 +1388,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.NotNull(order.Customer);
                 Assert.True(order.Customer.Orders.All(o => o != null));
+
+                CheckIsLoaded(
+                    context,
+                    order,
+                    orderDetailsLoaded: false,
+                    productLoaded: false,
+                    customerLoaded: true,
+                    ordersLoaded: true);
             }
         }
 
@@ -980,6 +1412,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.NotNull(order.OrderDetails);
                 Assert.True(order.OrderDetails.Count > 0);
                 Assert.True(order.OrderDetails.All(od => od.Product != null));
+
+                CheckIsLoaded(
+                    context,
+                    order,
+                    orderDetailsLoaded: true,
+                    productLoaded: true,
+                    customerLoaded: false,
+                    ordersLoaded: false);
             }
         }
 
@@ -999,6 +1439,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.All(o => o.Product != null));
                 Assert.Equal(830, orderDetails.Select(o => o.Order).Distinct().Count());
                 Assert.True(orderDetails.Select(o => o.Product).Distinct().Any());
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1016,6 +1467,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1033,6 +1495,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1049,6 +1522,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1065,6 +1549,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1082,6 +1577,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders.All(o => o.Customer != null));
                 Assert.Equal(89, orders.Select(o => o.Customer).Distinct().Count());
                 Assert.Equal(830 + 89, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1090,12 +1596,23 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                var orders
+                var orderDetails
                     = context.Set<OrderDetail>()
                         .Include(o => o.Order)
                         .ToList();
 
-                Assert.True(orders.Any());
+                Assert.True(orderDetails.Any());
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1111,6 +1628,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.Equal(830, orders.Count);
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1127,6 +1655,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(6, result.Count);
                 Assert.True(result.SelectMany(r => r.OrderDetails).All(od => od.Order != null));
+
+                foreach (var order in result)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: false,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1144,6 +1683,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(830, orders.Count);
                 Assert.True(orders.All(o => o.Customer != null));
                 Assert.Equal(0, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: false,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1167,6 +1717,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders1.All(o1 => orders2.Contains(o1, ReferenceEqualityComparer.Instance)));
                 Assert.True(orders2.All(o => o.Customer != null));
                 Assert.Equal(830 + 89, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders2)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1213,6 +1774,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(830, orders.Count);
                 Assert.Equal(919, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders.Select(e => e.o))
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1231,6 +1803,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders.All(o => o.Customer != null));
                 Assert.Equal(1, orders.Select(o => o.Customer).Distinct().Count());
                 Assert.Equal(6 + 1, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1249,6 +1832,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orders.All(o => o.Customer != null));
                 Assert.Equal(1, orders.Select(o => o.Customer).Distinct().Count());
                 Assert.Equal(6 + 1, context.ChangeTracker.Entries().Count());
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        customerLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1265,6 +1859,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1281,6 +1886,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(91, customers.Count);
                 Assert.True(customers.All(c => c.Orders != null));
                 Assert.True(customers.All(c => c.Orders.All(o => o.OrderDetails != null)));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: true,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -1297,6 +1912,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(91, customers.Count);
                 Assert.True(customers.All(c => c.Orders != null));
                 Assert.True(customers.All(c => c.Orders.All(o => o.OrderDetails != null)));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: true,
+                        productLoaded: true);
+                }
             }
         }
 
@@ -1313,6 +1938,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.NotNull(customer);
                 Assert.Equal(6, customer.Orders.Count);
                 Assert.True(customer.Orders.SelectMany(o => o.OrderDetails).Count() >= 6);
+
+                CheckIsLoaded(
+                    context,
+                    customer,
+                    ordersLoaded: true,
+                    orderDetailsLoaded: true,
+                    productLoaded: false);
             }
         }
 
@@ -1330,6 +1962,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1345,6 +1988,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1360,6 +2014,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.NotNull(order.Customer);
                 Assert.True(order.Customer.Orders.All(o => o != null));
+
+                CheckIsLoaded(
+                    context,
+                    order,
+                    customerLoaded: true,
+                    orderDetailsLoaded: false,
+                    productLoaded: false,
+                    ordersLoaded: true);
             }
         }
 
@@ -1377,6 +2039,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1394,6 +2067,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1410,6 +2094,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1426,6 +2121,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: true,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1442,6 +2148,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1459,6 +2176,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: true);
+                }
             }
         }
 
@@ -1474,6 +2202,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+
+                foreach (var orderDetail in orderDetails)
+                {
+                    CheckIsLoaded(
+                        context,
+                        orderDetail,
+                        orderLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
             }
         }
 
@@ -1510,6 +2249,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.True(customers.All(c => c.Orders.Count > 0));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
             }
         }
 
@@ -1526,6 +2275,152 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         .ToList();
 
                 Assert.True(customers.All(c => c.Orders.Count > 0));
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
+        private static void CheckIsLoaded(
+            NorthwindContext context,
+            Customer customer,
+            bool ordersLoaded,
+            bool orderDetailsLoaded,
+            bool productLoaded)
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            Assert.Equal(ordersLoaded, context.Entry(customer).Collection(e => e.Orders).IsLoaded);
+            if (customer.Orders != null)
+            {
+                foreach (var order in customer.Orders)
+                {
+                    Assert.Equal(ordersLoaded, context.Entry(order).Reference(e => e.Customer).IsLoaded);
+
+                    Assert.Equal(orderDetailsLoaded, context.Entry(order).Collection(e => e.OrderDetails).IsLoaded);
+                    if (order.OrderDetails != null)
+                    {
+                        foreach (var orderDetail in order.OrderDetails)
+                        {
+                            Assert.Equal(orderDetailsLoaded, context.Entry(orderDetail).Reference(e => e.Order).IsLoaded);
+
+                            Assert.Equal(productLoaded, context.Entry(orderDetail).Reference(e => e.Product).IsLoaded);
+                            if (orderDetail.Product != null)
+                            {
+                                Assert.False(context.Entry(orderDetail.Product).Collection(e => e.OrderDetails).IsLoaded);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void CheckIsLoaded(
+            NorthwindContext context,
+            Product product,
+            bool orderDetailsLoaded,
+            bool orderLoaded)
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            Assert.Equal(orderDetailsLoaded, context.Entry(product).Collection(e => e.OrderDetails).IsLoaded);
+
+            if (product.OrderDetails != null)
+            {
+                foreach (var orderDetail in product.OrderDetails)
+                {
+                    Assert.Equal(orderDetailsLoaded, context.Entry(orderDetail).Reference(e => e.Product).IsLoaded);
+
+                    Assert.Equal(orderLoaded, context.Entry(orderDetail).Reference(e => e.Order).IsLoaded);
+                    if (orderDetail.Order != null)
+                    {
+                        Assert.False(context.Entry(orderDetail.Order).Collection(e => e.OrderDetails).IsLoaded);
+                    }
+                }
+            }
+        }
+
+        private static void CheckIsLoaded(
+            NorthwindContext context,
+            Order order,
+            bool orderDetailsLoaded,
+            bool productLoaded,
+            bool customerLoaded,
+            bool ordersLoaded)
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            Assert.Equal(orderDetailsLoaded, context.Entry(order).Collection(e => e.OrderDetails).IsLoaded);
+            if (order.OrderDetails != null)
+            {
+                foreach (var orderDetail in order.OrderDetails)
+                {
+                    Assert.Equal(orderDetailsLoaded, context.Entry(orderDetail).Reference(e => e.Order).IsLoaded);
+
+                    Assert.Equal(productLoaded, context.Entry(orderDetail).Reference(e => e.Product).IsLoaded);
+                    if (orderDetail.Product != null)
+                    {
+                        Assert.False(context.Entry(orderDetail.Product).Collection(e => e.OrderDetails).IsLoaded);
+                    }
+                }
+            }
+
+            Assert.Equal(customerLoaded, context.Entry(order).Reference(e => e.Customer).IsLoaded);
+            if (order.Customer != null)
+            {
+                Assert.Equal(ordersLoaded, context.Entry(order.Customer).Collection(e => e.Orders).IsLoaded);
+                if (ordersLoaded 
+                    && order.Customer.Orders != null)
+                {
+                    foreach (var backOrder in order.Customer.Orders)
+                    {
+                        Assert.Equal(ordersLoaded, context.Entry(backOrder).Reference(e => e.Customer).IsLoaded);
+                    }
+                }
+            }
+        }
+
+        private static void CheckIsLoaded(
+            NorthwindContext context,
+            OrderDetail orderDetail,
+            bool orderLoaded,
+            bool productLoaded,
+            bool customerLoaded,
+            bool ordersLoaded)
+        {
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            Assert.Equal(orderLoaded, context.Entry(orderDetail).Reference(e => e.Order).IsLoaded);
+            if (orderDetail.Order != null)
+            {
+                Assert.False(context.Entry(orderDetail.Order).Collection(e => e.OrderDetails).IsLoaded);
+
+                Assert.Equal(customerLoaded, context.Entry(orderDetail.Order).Reference(e => e.Customer).IsLoaded);
+                if (orderDetail.Order.Customer != null)
+                {
+                    Assert.Equal(ordersLoaded, context.Entry(orderDetail.Order.Customer).Collection(e => e.Orders).IsLoaded);
+                    if (ordersLoaded
+                        && orderDetail.Order.Customer.Orders != null)
+                    {
+                        foreach (var backOrder in orderDetail.Order.Customer.Orders)
+                        {
+                            Assert.Equal(ordersLoaded, context.Entry(backOrder).Reference(e => e.Customer).IsLoaded);
+                        }
+                    }
+                }
+            }
+
+            Assert.Equal(productLoaded, context.Entry(orderDetail).Reference(e => e.Product).IsLoaded);
+            if (orderDetail.Product != null)
+            {
+                Assert.False(context.Entry(orderDetail.Product).Collection(e => e.OrderDetails).IsLoaded);
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/LoadTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/LoadTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Specification.Tests
@@ -30,14 +31,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.Children).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.Children).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -59,14 +66,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -90,14 +103,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -121,14 +140,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.Single).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.Single).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -152,14 +177,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -183,14 +214,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.SinglePkToPk).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.SinglePkToPk).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -214,9 +251,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.Children).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.Children).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.False(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -240,9 +283,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -265,9 +314,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -290,9 +345,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.Single).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.Single).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -315,9 +376,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -340,9 +407,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.SinglePkToPk).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.SinglePkToPk).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -365,14 +438,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -392,14 +471,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -420,9 +505,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -444,9 +535,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -468,14 +565,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.Children).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.Children).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -495,14 +598,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -522,14 +631,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -550,14 +665,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.Single).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.Single).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -578,9 +699,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.Children).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.Children).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.False(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -602,9 +729,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -626,9 +759,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -650,9 +789,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.Single).Query().SingleOrDefaultAsync()
-                    : context.Entry(parent).Reference(e => e.Single).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -674,14 +819,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.True(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.Children).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.Children).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -703,14 +854,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -734,14 +891,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -765,14 +928,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.Single).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.Single).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -796,14 +965,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -827,14 +1002,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.SinglePkToPk).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.SinglePkToPk).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -858,9 +1039,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.True(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.Children).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.Children).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -884,9 +1071,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -909,9 +1102,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -934,9 +1133,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.Single);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.Single).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.Single).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -959,9 +1164,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -984,9 +1195,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SinglePkToPk);
+
+                Assert.True(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.SinglePkToPk).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.SinglePkToPk).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1009,14 +1226,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Children").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Children").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1038,14 +1261,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1069,14 +1298,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1100,14 +1335,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Single").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Single").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1131,9 +1372,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Navigation("Children").Query().OfType<object>().ToListAsync()
-                    : context.Entry(parent).Navigation("Children").Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
+                    : navigationEntry.Query().OfType<object>().ToList();
+
+                Assert.False(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1157,9 +1404,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Navigation("Parent").Query().OfType<object>().SingleAsync()
-                    : context.Entry(child).Navigation("Parent").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1182,9 +1435,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Navigation("Parent").Query().OfType<object>().SingleAsync()
-                    : context.Entry(single).Navigation("Parent").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1207,9 +1466,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Navigation("Single").Query().OfType<object>().SingleAsync()
-                    : context.Entry(parent).Navigation("Single").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1232,14 +1497,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Children").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Children").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1259,14 +1530,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1286,14 +1563,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1314,14 +1597,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Single").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Single").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1342,9 +1631,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Navigation("Children").Query().OfType<object>().ToListAsync()
-                    : context.Entry(parent).Navigation("Children").Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
+                    : navigationEntry.Query().OfType<object>().ToList();
+
+                Assert.False(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1366,9 +1661,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Navigation("Parent").Query().OfType<object>().SingleOrDefaultAsync()
-                    : context.Entry(child).Navigation("Parent").Query().OfType<object>().SingleOrDefault();
+                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
+                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+
+                Assert.False(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1390,9 +1691,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Navigation("Parent").Query().OfType<object>().SingleOrDefaultAsync()
-                    : context.Entry(single).Navigation("Parent").Query().OfType<object>().SingleOrDefault();
+                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
+                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+
+                Assert.False(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1414,9 +1721,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.False(navigationEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Navigation("Single").Query().OfType<object>().SingleOrDefaultAsync()
-                    : context.Entry(parent).Navigation("Single").Query().OfType<object>().SingleOrDefault();
+                    ? await navigationEntry.Query().OfType<object>().SingleOrDefaultAsync()
+                    : navigationEntry.Query().OfType<object>().SingleOrDefault();
+
+                Assert.False(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1438,14 +1751,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Children").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Children").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1467,14 +1786,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1498,14 +1823,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Navigation("Parent").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Navigation("Parent").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1529,14 +1860,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Navigation("Single").LoadAsync();
+                    await navigationEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Navigation("Single").Load();
+                    navigationEntry.Load();
                 }
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1560,9 +1897,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Children");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Navigation("Children").Query().OfType<object>().ToListAsync()
-                    : context.Entry(parent).Navigation("Children").Query().OfType<object>().ToList();
+                    ? await navigationEntry.Query().OfType<object>().ToListAsync()
+                    : navigationEntry.Query().OfType<object>().ToList();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1586,9 +1929,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(child).Navigation("Parent");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Navigation("Parent").Query().OfType<object>().SingleAsync()
-                    : context.Entry(child).Navigation("Parent").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1611,9 +1960,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(single).Navigation("Parent");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Navigation("Parent").Query().OfType<object>().SingleAsync()
-                    : context.Entry(single).Navigation("Parent").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1636,9 +1991,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var navigationEntry = context.Entry(parent).Navigation("Single");
+
+                Assert.True(navigationEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Navigation("Single").Query().OfType<object>().SingleAsync()
-                    : context.Entry(parent).Navigation("Single").Query().OfType<object>().Single();
+                    ? await navigationEntry.Query().OfType<object>().SingleAsync()
+                    : navigationEntry.Query().OfType<object>().Single();
+
+                Assert.True(navigationEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1661,14 +2022,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenAk);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.ChildrenAk).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.ChildrenAk).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1690,14 +2057,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1721,14 +2094,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1752,14 +2131,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleAk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.SingleAk).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.SingleAk).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1783,9 +2168,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenAk);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.ChildrenAk).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.ChildrenAk).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.False(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1809,9 +2200,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1834,9 +2231,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1859,9 +2262,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleAk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.SingleAk).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.SingleAk).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1884,14 +2293,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1911,14 +2326,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1939,9 +2360,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1963,9 +2390,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -1987,14 +2420,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenShadowFk);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.ChildrenShadowFk).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.ChildrenShadowFk).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2016,14 +2455,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2047,14 +2492,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2078,14 +2529,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleShadowFk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.SingleShadowFk).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.SingleShadowFk).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2109,9 +2566,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenShadowFk);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.ChildrenShadowFk).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.ChildrenShadowFk).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.False(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2135,9 +2598,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2160,9 +2629,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2185,9 +2660,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleShadowFk);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.SingleShadowFk).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.SingleShadowFk).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2210,14 +2691,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2237,14 +2724,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2265,9 +2758,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2289,9 +2788,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2313,14 +2818,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenCompositeKey);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Collection(e => e.ChildrenCompositeKey).LoadAsync();
+                    await collectionEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Collection(e => e.ChildrenCompositeKey).Load();
+                    collectionEntry.Load();
                 }
+
+                Assert.True(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2342,14 +2853,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2373,14 +2890,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2404,14 +2927,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleCompositeKey);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(parent).Reference(e => e.SingleCompositeKey).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(parent).Reference(e => e.SingleCompositeKey).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2435,9 +2964,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var collectionEntry = context.Entry(parent).Collection(e => e.ChildrenCompositeKey);
+
+                Assert.False(collectionEntry.IsLoaded);
+
                 var children = async
-                    ? await context.Entry(parent).Collection(e => e.ChildrenCompositeKey).Query().ToListAsync()
-                    : context.Entry(parent).Collection(e => e.ChildrenCompositeKey).Query().ToList();
+                    ? await collectionEntry.Query().ToListAsync()
+                    : collectionEntry.Query().ToList();
+
+                Assert.False(collectionEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2461,9 +2996,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2486,9 +3027,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2511,9 +3058,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(parent).Reference(e => e.SingleCompositeKey);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var single = async
-                    ? await context.Entry(parent).Reference(e => e.SingleCompositeKey).Query().SingleAsync()
-                    : context.Entry(parent).Reference(e => e.SingleCompositeKey).Query().Single();
+                    ? await referenceEntry.Query().SingleAsync()
+                    : referenceEntry.Query().Single();
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2536,14 +3089,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(child).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(child).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2563,14 +3122,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 if (async)
                 {
-                    await context.Entry(single).Reference(e => e.Parent).LoadAsync();
+                    await referenceEntry.LoadAsync();
                 }
                 else
                 {
-                    context.Entry(single).Reference(e => e.Parent).Load();
+                    referenceEntry.Load();
                 }
+
+                Assert.True(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2591,9 +3156,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(child).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2615,9 +3186,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 ClearLog();
 
+                var referenceEntry = context.Entry(single).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
                 var parent = async
-                    ? await context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefaultAsync()
-                    : context.Entry(single).Reference(e => e.Parent).Query().SingleOrDefault();
+                    ? await referenceEntry.Query().SingleOrDefaultAsync()
+                    : referenceEntry.Query().SingleOrDefault();
+
+                Assert.False(referenceEntry.IsLoaded);
 
                 RecordLog();
 
@@ -2625,6 +3202,79 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Null(single.Parent);
 
                 Assert.Equal(1, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Can_change_IsLoaded_flag_for_collection()
+        {
+            using (var context = CreateContext())
+            {
+                var parent = context.Parents.Single();
+
+                var collectionEntry = context.Entry(parent).Collection(e => e.Children);
+
+                Assert.False(collectionEntry.IsLoaded);
+
+                collectionEntry.IsLoaded = true;
+
+                Assert.True(collectionEntry.IsLoaded);
+
+                collectionEntry.Load();
+
+                Assert.Equal(0, parent.Children.Count());
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
+
+                Assert.True(collectionEntry.IsLoaded);
+
+                collectionEntry.IsLoaded = false;
+
+                Assert.False(collectionEntry.IsLoaded);
+
+                collectionEntry.Load();
+
+                Assert.Equal(2, parent.Children.Count());
+                Assert.All(parent.Children.Select(e => e.Parent), c => Assert.Same(parent, c));
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                Assert.True(collectionEntry.IsLoaded);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_change_IsLoaded_flag_for_reference_only_if_null()
+        {
+            using (var context = CreateContext())
+            {
+                var child = context.Children.Single(e => e.Id == 12);
+
+                var referenceEntry = context.Entry(child).Reference(e => e.Parent);
+
+                Assert.False(referenceEntry.IsLoaded);
+
+                referenceEntry.IsLoaded = true;
+
+                Assert.True(referenceEntry.IsLoaded);
+
+                referenceEntry.Load();
+
+                Assert.True(referenceEntry.IsLoaded);
+
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
+
+                referenceEntry.IsLoaded = true;
+
+                referenceEntry.IsLoaded = false;
+
+                referenceEntry.Load();
+
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                Assert.True(referenceEntry.IsLoaded);
+
+                Assert.Equal(
+                    CoreStrings.ReferenceMustBeLoaded("Parent", typeof(Child).Name),
+                    Assert.Throws<InvalidOperationException>(() => referenceEntry.IsLoaded = false).Message);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry.cs
@@ -55,7 +55,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     <para>
-        ///         Loads the entities referenced by this navigation property.
+        ///         Loads the entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+        ///         is already set to true.
         ///     </para>
         ///     <para>
         ///         Note that entities that are already being tracked are not overwritten with new data from the database.
@@ -70,7 +71,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     <para>
-        ///         Loads entities referenced by this navigation property.
+        ///         Loads entities referenced by this navigation property, unless <see cref="NavigationEntry.IsLoaded" />
+        ///         is already set to true.
         ///     </para>
         ///     <para>
         ///         Note that entities that are already being tracked are not overwritten with new data from the database.

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/CollectionEntry`.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             EnsureInitialized();
 
-            return ((IEntityFinder<TProperty>)Finder(Metadata.GetTargetType().ClrType)).Query(GetLoadProperties(), GetLoadValues());
+            return ((IEntityFinder<TProperty>)Finder(Metadata.GetTargetType().ClrType)).Query(Metadata, InternalEntry);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -19,7 +19,7 @@ using Microsoft.EntityFrameworkCore.Update;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public abstract partial class InternalEntityEntry : IUpdateEntry
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private StoreGeneratedValues _storeGeneratedValues;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected InternalEntityEntry(
@@ -39,29 +39,29 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             StateManager = stateManager;
             EntityType = entityType;
-            _stateData = new StateData(entityType.PropertyCount());
+            _stateData = new StateData(entityType.PropertyCount(), entityType.NavigationCount());
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public abstract object Entity { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEntityType EntityType { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IStateManager StateManager { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetEntityState(EntityState entityState, bool acceptChanges = false)
@@ -77,11 +77,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual async Task SetEntityStateAsync(
-            EntityState entityState, 
+            EntityState entityState,
             bool acceptChanges,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -205,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void MarkUnchangedFromQuery([CanBeNull] ISet<IForeignKey> handledForeignKeys)
@@ -226,13 +226,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityState EntityState => _stateData.EntityState;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsModified(IProperty property)
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetPropertyModified(
@@ -321,7 +321,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool HasConceptualNull
@@ -329,7 +329,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                && _stateData.AnyPropertiesFlagged(PropertyFlag.Null);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsConceptualNull([NotNull] IProperty property)
@@ -337,7 +337,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Null);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool HasTemporaryValue(IProperty property)
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.TemporaryOrModified);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void MarkAsTemporary([NotNull] IProperty property, bool isTemporary = true)
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual void MarkShadowPropertiesNotSet([NotNull] IEntityType entityType)
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue));
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         [UsedImplicitly]
@@ -412,28 +412,28 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 .Single(m => m.Name == nameof(GetCurrentValue) && m.IsGenericMethod);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)
             => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().CurrentValueGetter)(this);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual TProperty GetOriginalValue<TProperty>(IProperty property)
             => ((Func<InternalEntityEntry, TProperty>)property.GetPropertyAccessors().OriginalValueGetter)(this);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual TProperty GetRelationshipSnapshotValue<TProperty>([NotNull] IPropertyBase propertyBase)
             => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().RelationshipSnapshotGetter)(this);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
@@ -444,7 +444,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual void WritePropertyValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value)
@@ -455,7 +455,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object GetCurrentValue(IPropertyBase propertyBase)
@@ -467,28 +467,28 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object GetOriginalValue(IPropertyBase propertyBase)
             => _originalValues.GetValue(this, (IProperty)propertyBase);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object GetRelationshipSnapshotValue([NotNull] IPropertyBase propertyBase)
             => _relationshipsSnapshot.GetValue(this, propertyBase);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetCurrentValue(IPropertyBase propertyBase, object value)
             => this[propertyBase] = value;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetOriginalValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value, int index = -1)
@@ -498,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetRelationshipSnapshotValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value)
@@ -508,7 +508,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void EnsureOriginalValues()
@@ -520,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void EnsureRelationshipSnapshot()
@@ -532,19 +532,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool HasOriginalValuesSnapshot => !_originalValues.IsEmpty;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool HasRelationshipSnapshot => !_relationshipsSnapshot.IsEmpty;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void RemoveFromCollectionSnapshot([NotNull] IPropertyBase propertyBase, [NotNull] object removedEntity)
@@ -554,7 +554,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void AddToCollectionSnapshot([NotNull] IPropertyBase propertyBase, [NotNull] object addedEntity)
@@ -564,7 +564,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void AddRangeToCollectionSnapshot([NotNull] IPropertyBase propertyBase, [NotNull] IEnumerable<object> addedEntities)
@@ -574,7 +574,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object this[[NotNull] IPropertyBase propertyBase]
@@ -590,7 +590,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void SetProperty([NotNull] IPropertyBase propertyBase, [CanBeNull] object value, bool setModified = true)
@@ -638,6 +638,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             _stateData.FlagProperty(propertyIndex.Value, PropertyFlag.Unknown, isFlagged: false);
                         }
 
+                        if (asProperty == null)
+                        {
+                            var navigation = (INavigation)propertyBase;
+                            if (!navigation.IsCollection()
+                                && value == null)
+                            {
+                                SetIsLoaded(navigation, loaded: false);
+                            }
+                        }
+
                         StateManager.Notify.PropertyChanged(this, propertyBase, setModified);
                     }
                 }
@@ -645,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void AcceptChanges()
@@ -686,7 +696,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityEntry PrepareToSave()
@@ -735,7 +745,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void HandleConceptualNulls()
@@ -799,7 +809,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void CascadeDelete()
@@ -838,7 +848,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void DiscardStoreGeneratedValues()
@@ -860,7 +870,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsStoreGenerated(IProperty property)
@@ -874,19 +884,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                || property.ClrType.IsDefaultValue(this[property]);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsKeySet => !EntityType.FindPrimaryKey().Properties.Any(p => p.ClrType.IsDefaultValue(this[p]));
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityEntry ToEntityEntry() => new EntityEntry(this);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void HandleINotifyPropertyChanging([NotNull] object sender, [NotNull] PropertyChangingEventArgs eventArgs)
@@ -898,7 +908,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void HandleINotifyPropertyChanged([NotNull] object sender, [NotNull] PropertyChangedEventArgs eventArgs)
@@ -910,7 +920,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void HandleINotifyCollectionChanged([NotNull] object sender, [NotNull] NotifyCollectionChangedEventArgs eventArgs)
@@ -947,5 +957,35 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void SetIsLoaded([NotNull] INavigation navigation, bool loaded = true)
+        {
+            if (!loaded
+                && !navigation.IsCollection()
+                && this[navigation] != null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ReferenceMustBeLoaded(navigation.Name, navigation.DeclaringEntityType.DisplayName()));
+            }
+
+            _stateData.FlagProperty(GetNavigationStateDataIndex(navigation), PropertyFlag.IsLoaded, isFlagged: loaded);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsLoaded([NotNull] INavigation navigation)
+            => (!navigation.IsCollection()
+                && EntityState != EntityState.Detached
+                && this[navigation] != null)
+               || _stateData.IsPropertyFlagged(GetNavigationStateDataIndex(navigation), PropertyFlag.IsLoaded);
+
+        private int GetNavigationStateDataIndex(INavigation navigation)
+            => navigation.GetIndex() - EntityType.PropertyCount();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -160,6 +160,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         }
                     }
                 }
+
+                if (newValue == null)
+                {
+                    entry.SetIsLoaded(navigation, loaded: false);
+                }
             }
             finally
             {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public abstract partial class InternalEntityEntry
@@ -9,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             TemporaryOrModified = 0,
             Null = 1,
-            Unknown = 2
+            Unknown = 2,
+            IsLoaded = 3
         }
 
         internal struct StateData
@@ -26,9 +29,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             private readonly int[] _bits;
 
-            public StateData(int propertyCount)
+            public StateData(int propertyCount, int navigationCount)
             {
-                _bits = new int[(propertyCount * BitsForPropertyFlags + BitsForAdditionalState - 1) / BitsPerInt + 1];
+                _bits = new int[
+                    (Math.Max(propertyCount, navigationCount) * BitsForPropertyFlags + BitsForAdditionalState - 1)
+                    / BitsPerInt + 1];
             }
 
             public void FlagAllProperties(int propertyCount, PropertyFlag propertyFlag, bool flagged)

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -38,40 +36,5 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             : base(internalEntry, navigation)
         {
         }
-
-        /// <summary>
-        ///     <para>
-        ///         Loads the entity referenced by this navigation property, unless it is already being tracked,
-        ///         in which case calling the method is a no-op.
-        ///     </para>
-        /// </summary>
-        public override void Load()
-        {
-            if (InternalEntry[Metadata] == null)
-            {
-                base.Load();
-            }
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Loads the entity referenced by this navigation property, unless it is already being tracked,
-        ///         in which case calling the method is a no-op.
-        ///     </para>
-        ///     <para>
-        ///         Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
-        ///         that any asynchronous operations have completed before calling another method on this context.
-        ///     </para>
-        /// </summary>
-        /// <param name="cancellationToken">
-        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
-        /// </param>
-        /// <returns>
-        ///     A task that represents the asynchronous save operation.
-        /// </returns>
-        public override Task LoadAsync(CancellationToken cancellationToken = new CancellationToken())
-            => InternalEntry[Metadata] == null
-                ? base.LoadAsync(cancellationToken)
-                : Task.FromResult(0);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ReferenceEntry`.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     <para>
-        ///         Returns the query that would be used by <see cref="ReferenceEntry.Load" /> to load the entity referenced by
+        ///         Returns the query that would be used by <see cref="NavigationEntry.Load" /> to load the entity referenced by
         ///         this navigation property.
         ///     </para>
         ///     <para>
@@ -72,6 +72,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     </para>
         /// </summary>
         public new virtual IQueryable<TProperty> Query()
-            => ((IEntityFinder<TProperty>)Finder(Metadata.GetTargetType().ClrType)).Query(GetLoadProperties(), GetLoadValues());
+            => ((IEntityFinder<TProperty>)Finder(Metadata.GetTargetType().ClrType)).Query(Metadata, InternalEntry);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -32,21 +32,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void Load([NotNull] IReadOnlyList<IProperty> keyProperties, [NotNull] object[] keyValues);
+        void Load([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         Task LoadAsync(
-            [NotNull] IReadOnlyList<IProperty> keyProperties, 
-            [NotNull] object[] keyValues, 
+            [NotNull] INavigation navigation,
+            [NotNull] InternalEntityEntry entry,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        IQueryable Query([NotNull] IReadOnlyList<IProperty> keyProperties, [NotNull] object[] keyValues);
+        IQueryable Query([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder`.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -33,6 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        new IQueryable<TEntity> Query([NotNull] IReadOnlyList<IProperty> keyProperties, [NotNull] object[] keyValues);
+        new IQueryable<TEntity> Query([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -121,6 +121,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// Navigation property '{navigation}' on entity type '{entityType}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.
+        /// </summary>
+        public static string ReferenceMustBeLoaded([CanBeNull] object navigation, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ReferenceMustBeLoaded", "navigation", "entityType"), navigation, entityType);
+        }
+
+        /// <summary>
         /// The collection argument '{argumentName}' must contain at least one element.
         /// </summary>
         public static string CollectionArgumentIsEmpty([CanBeNull] object argumentName)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -156,6 +156,9 @@
   <data name="CollectionIsReference" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation property. Use the '{ReferenceMethod}' method to access reference navigation properties.</value>
   </data>
+  <data name="ReferenceMustBeLoaded" xml:space="preserve">
+    <value>Navigation property '{navigation}' on entity type '{entityType}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.</value>
+  </data>
   <data name="CollectionArgumentIsEmpty" xml:space="preserve">
     <value>The collection argument '{argumentName}' must contain at least one element.</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryBuffer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryBuffer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .StartTracking(_stateManager.Value, entity, (ValueBuffer)boxedValueBuffer);
 
             foreach (var includedEntity
-                in entityTrackingInfo.GetIncludedEntities(entity)
+                in entityTrackingInfo.GetIncludedEntities(_stateManager.Value, entity)
                     .Where(includedEntity
                         => _valueBuffers.TryGetValue(includedEntity.Entity, out boxedValueBuffer)))
             {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         }
 
         [Theory] // Skipped for in-memory. See #6123
-        public override Task Load_many_to_one_reference_to_principal_already_loaded_untyped(bool async) 
+        public override Task Load_many_to_one_reference_to_principal_already_loaded_untyped(bool async)
             => Task.FromResult(0);
 
         [Theory] // Skipped for in-memory. See #6123

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -418,13 +418,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
 
             if (!async)
             {
-                Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
-
-SELECT [e].[Id], [e].[ParentId]
-FROM [Child] AS [e]
-WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                Assert.Equal("", Sql);
             }
         }
 
@@ -864,13 +858,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
 
             if (!async)
             {
-                Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
-
-SELECT [e].[Id], [e].[ParentId]
-FROM [Child] AS [e]
-WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                Assert.Equal("", Sql);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateDataTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateDataTest.cs
@@ -17,7 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     i,
                     InternalEntityEntry.PropertyFlag.TemporaryOrModified,
                     InternalEntityEntry.PropertyFlag.Null,
-                    InternalEntityEntry.PropertyFlag.Unknown);
+                    InternalEntityEntry.PropertyFlag.Unknown,
+                    InternalEntityEntry.PropertyFlag.IsLoaded);
             }
         }
 
@@ -30,7 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     i,
                     InternalEntityEntry.PropertyFlag.Null,
                     InternalEntityEntry.PropertyFlag.TemporaryOrModified,
-                    InternalEntityEntry.PropertyFlag.Unknown);
+                    InternalEntityEntry.PropertyFlag.Unknown,
+                    InternalEntityEntry.PropertyFlag.IsLoaded);
             }
         }
 
@@ -43,7 +45,22 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     i,
                     InternalEntityEntry.PropertyFlag.Unknown,
                     InternalEntityEntry.PropertyFlag.TemporaryOrModified,
-                    InternalEntityEntry.PropertyFlag.Null);
+                    InternalEntityEntry.PropertyFlag.Null,
+                    InternalEntityEntry.PropertyFlag.IsLoaded);
+            }
+        }
+
+        [Fact]
+        public void Can_read_and_manipulate_is_loaded_flags()
+        {
+            for (var i = 0; i < 70; i++)
+            {
+                PropertyManipulation(
+                    i,
+                    InternalEntityEntry.PropertyFlag.IsLoaded,
+                    InternalEntityEntry.PropertyFlag.TemporaryOrModified,
+                    InternalEntityEntry.PropertyFlag.Null,
+                    InternalEntityEntry.PropertyFlag.Unknown);
             }
         }
 
@@ -51,13 +68,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             int propertyCount,
             InternalEntityEntry.PropertyFlag propertyFlag,
             InternalEntityEntry.PropertyFlag unusedFlag1,
-            InternalEntityEntry.PropertyFlag unusedFlag2)
+            InternalEntityEntry.PropertyFlag unusedFlag2,
+            InternalEntityEntry.PropertyFlag unusedFlag3)
         {
-            var data = new InternalEntityEntry.StateData(propertyCount);
+            var data = new InternalEntityEntry.StateData(propertyCount, propertyCount);
 
             Assert.False(data.AnyPropertiesFlagged(propertyFlag));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag3));
 
             for (var i = 0; i < propertyCount; i++)
             {
@@ -68,11 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     Assert.Equal(j <= i, data.IsPropertyFlagged(j, propertyFlag));
                     Assert.False(data.IsPropertyFlagged(j, unusedFlag1));
                     Assert.False(data.IsPropertyFlagged(j, unusedFlag2));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag3));
                 }
 
                 Assert.True(data.AnyPropertiesFlagged(propertyFlag));
                 Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
                 Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag3));
             }
 
             for (var i = 0; i < propertyCount; i++)
@@ -84,11 +105,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     Assert.Equal(j > i, data.IsPropertyFlagged(j, propertyFlag));
                     Assert.False(data.IsPropertyFlagged(j, unusedFlag1));
                     Assert.False(data.IsPropertyFlagged(j, unusedFlag2));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag3));
                 }
 
                 Assert.Equal(i < propertyCount - 1, data.AnyPropertiesFlagged(propertyFlag));
                 Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
                 Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag3));
             }
 
             for (var i = 0; i < propertyCount; i++)
@@ -96,6 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.False(data.IsPropertyFlagged(i, propertyFlag));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag3));
             }
 
             data.FlagAllProperties(propertyCount, propertyFlag, flagged: true);
@@ -103,12 +127,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             Assert.Equal(propertyCount > 0, data.AnyPropertiesFlagged(propertyFlag));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag3));
 
             for (var i = 0; i < propertyCount; i++)
             {
                 Assert.True(data.IsPropertyFlagged(i, propertyFlag));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag3));
             }
 
             data.FlagAllProperties(propertyCount, propertyFlag, flagged: false);
@@ -116,19 +142,21 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             Assert.False(data.AnyPropertiesFlagged(propertyFlag));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
             Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag3));
 
             for (var i = 0; i < propertyCount; i++)
             {
                 Assert.False(data.IsPropertyFlagged(i, propertyFlag));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
                 Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag3));
             }
         }
 
         [Fact]
         public void Can_get_and_set_EntityState()
         {
-            var data = new InternalEntityEntry.StateData(70);
+            var data = new InternalEntityEntry.StateData(70, 0);
 
             Assert.Equal(EntityState.Detached, data.EntityState);
 


### PR DESCRIPTION
Set when an entity is loaded with Include or one Load, regardless of whether or not there are any related entities or not. Always true for reference navigation properties on tracked entities when the reference is non-null.

Issue #625
Issue #1201