### PR TITLE
Fix #6122 - LoadAsync does not work

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -59,6 +59,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task LoadAsync_should_track_results()
+        {
+            using (var context = CreateContext())
+            {
+                await context.Customers.LoadAsync();
+                 
+                Assert.Equal(91, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [ConditionalFact]
         public virtual async Task Where_all_any_client()
         {
             var expectedOrders = new[] {1, 2, 3};

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -572,10 +572,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 public void Dispose() => _source.Dispose();
 
-                public Task<bool> MoveNext(CancellationToken cancellationToken)
-                    => _source.MoveNext(cancellationToken);
+                public async Task<bool> MoveNext(CancellationToken cancellationToken)
+                {
+                    if (await _source.MoveNext(cancellationToken))
+                    {
+                        Current = _selector(_source.Current);
 
-                public TResult Current => _selector(_source.Current);
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                public TResult Current { get; private set; }
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            // TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
     }
 }


### PR DESCRIPTION
Problem: Our async Select operator was too lazy. The projector delegate was only run when the Current property was accessed, but the code in LoadAsync spins the enumerator without accessing the Current property.

Solution: Change our async Select operator to invoke the projector delegate on MoveNext. This is preferred over accessing Current during LoadAsync because it matches L2O behavior and will prevent future instances of this bug.