### PR TITLE
Make fixup consistent for 1:1 relationships changed in store

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -516,6 +516,22 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         var principalToDependent = foreignKey.PrincipalToDependent;
                         if (principalToDependent != null)
                         {
+                            if (!principalToDependent.IsCollection())
+                            {
+                                var oldDependent = principalEntry[principalToDependent];
+                                if (oldDependent != null
+                                    && !ReferenceEquals(entry.Entity, oldDependent))
+                                {
+                                    var oldDependentEntry = stateManager.TryGetEntry(oldDependent);
+                                    if (oldDependentEntry != null
+                                        && oldDependentEntry.EntityState != EntityState.Detached)
+                                    {
+                                        ConditionallyNullForeignKeyProperties(oldDependentEntry, null, foreignKey);
+                                        SetNavigation(principalEntry, principalToDependent, null);
+                                    }
+                                }
+                            }
+
                             SetReferenceOrAddToCollection(
                                 principalEntry,
                                 principalToDependent,


### PR DESCRIPTION
Issue #6171

The fix is to to make sure that any existing dependent that points to the same principal has its FK and nav props nulled out.