### PR TITLE
Fix to #474 - Query: Improve translation of String's StartsWith, EndsWith and Contains

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/RelationalEventId.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/RelationalEventId.cs
@@ -57,6 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         PossibleUnintendedUseOfEqualsWarning,
 
         /// <summary>
+        ///     Linq translation of 'Contains', 'EndsWith' and 'StartsWith' functions may produce incorrect results 
+        ///     when searched value contains wildcard characters.
+        /// </summary>
+        PossibleIncorrectResultsUsingLikeOperator,
+
+        /// <summary>
         ///     An ambient transaction is present, which is not fully supported by Entity Framework Core.
         /// </summary>
         AmbientTransactionWarning

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -233,6 +233,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// Linq translation for method '{function}' used by this database provider can return incorrect results when the value argument contains wildcard characters (e.g. '%' or '_').
+        /// </summary>
+        public static string PossibleIncorrectResultsUsingLikeOperator([CanBeNull] object function)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PossibleIncorrectResultsUsingLikeOperator", "function", "right"), function);
+        }
+
+        /// <summary>
         /// The Include operation is not supported when calling a stored procedure.
         /// </summary>
         public static string StoredProcedureIncludeNotSupported

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
@@ -198,6 +198,9 @@
   <data name="PossibleUnintendedUseOfEquals" xml:space="preserve">
     <value>Possible unintended use of method Equals(object) for arguments of different types: '{left}', '{right}'. This comparison will always return 'false'.</value>
   </data>
+  <data name="PossibleIncorrectResultsUsingLikeOperator" xml:space="preserve">
+    <value>Linq translation for method '{function}' used by this database provider can return incorrect results when the value argument contains wildcard characters (e.g. '%' or '_').</value>
+  </data>
   <data name="StoredProcedureIncludeNotSupported" xml:space="preserve">
     <value>The Include operation is not supported when calling a stored procedure.</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/ContainsTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/ContainsTranslator.cs
@@ -3,8 +3,13 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 {
@@ -14,6 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class ContainsTranslator : IMethodCallTranslator
     {
+        private readonly ILogger _logger;
+
         private static readonly MethodInfo _methodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) });
 
@@ -24,12 +31,29 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public ContainsTranslator([NotNull] ILogger logger)
+        {
+            Check.NotNull(logger, nameof(logger));
+
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            return ReferenceEquals(methodCallExpression.Method, _methodInfo)
-                ? new LikeExpression(
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                _logger.LogWarning(
+                    RelationalEventId.PossibleIncorrectResultsUsingLikeOperator,
+                    () => RelationalStrings.PossibleIncorrectResultsUsingLikeOperator(
+                        nameof(string.Contains)));
+
+                return new LikeExpression(
                     // ReSharper disable once AssignNullToNotNullAttribute
                     methodCallExpression.Object,
                     Expression.Add(
@@ -38,8 +62,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                             methodCallExpression.Arguments[0],
                             _concat),
                         Expression.Constant("%", typeof(string)),
-                        _concat))
-                : null;
+                        _concat));
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
@@ -6,7 +6,6 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StartsWithTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StartsWithTranslator.cs
@@ -3,8 +3,13 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 {
@@ -14,6 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class StartsWithTranslator : IMethodCallTranslator
     {
+        private readonly ILogger _logger;
+
         private static readonly MethodInfo _methodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) });
 
@@ -24,15 +31,35 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public StartsWithTranslator([NotNull] ILogger logger)
+        {
+            Check.NotNull(logger, nameof(logger));
+
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            return ReferenceEquals(methodCallExpression.Method, _methodInfo)
-                ? new LikeExpression(
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                _logger.LogWarning(
+                    RelationalEventId.PossibleIncorrectResultsUsingLikeOperator,
+                    () => RelationalStrings.PossibleIncorrectResultsUsingLikeOperator(
+                        nameof(string.StartsWith)));
+
+                return new LikeExpression(
+                    // ReSharper disable once AssignNullToNotNullAttribute
                     methodCallExpression.Object,
-                    Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat))
-                : null;
+                    Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat));
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -27,11 +27,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
             _methodCallTranslators
                 = new List<IMethodCallTranslator>
                 {
-                    new ContainsTranslator(),
-                    new EndsWithTranslator(),
+                    new ContainsTranslator(logger),
+                    new EndsWithTranslator(logger),
                     new EqualsTranslator(logger),
                     new IsNullOrEmptyTranslator(),
-                    new StartsWithTranslator()
+                    new StartsWithTranslator(logger)
                 };
         }
 
@@ -55,6 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// </summary>
         /// <param name="translators"> The translators. </param>
         protected virtual void AddTranslators([NotNull] IEnumerable<IMethodCallTranslator> translators)
-            => _methodCallTranslators.AddRange(translators);
+            => _methodCallTranslators.InsertRange(0, translators);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
@@ -98,9 +99,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     return Visit(innerUnary.Operand);
                 }
 
-                var innerBinary = node.Operand as BinaryExpression;
+                var notNullableExpression = node.Operand as NotNullableExpression;
+                var innerBinary = (notNullableExpression?.Operand ?? node.Operand) as BinaryExpression;
                 if (innerBinary != null)
                 {
+                    Expression result = null;
                     if ((innerBinary.NodeType == ExpressionType.Equal)
                         || (innerBinary.NodeType == ExpressionType.NotEqual))
                     {
@@ -108,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         // if user opts-out of the null semantics, we should not apply this rule
                         // !(a == b) -> a != b
                         // !(a != b) -> a == b
-                        return innerBinary.NodeType == ExpressionType.Equal
+                        result = innerBinary.NodeType == ExpressionType.Equal
                             ? Visit(Expression.NotEqual(innerBinary.Left, innerBinary.Right))
                             : Visit(Expression.Equal(innerBinary.Left, innerBinary.Right));
                     }
@@ -116,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     if (innerBinary.NodeType == ExpressionType.AndAlso)
                     {
                         // !(a && b) -> !a || !b
-                        return Visit(
+                        result = Visit(
                             Expression.MakeBinary(
                                 ExpressionType.OrElse,
                                 Expression.Not(innerBinary.Left),
@@ -126,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     if (innerBinary.NodeType == ExpressionType.OrElse)
                     {
                         // !(a || b) -> !a && !b
-                        return Visit(
+                        result = Visit(
                             Expression.MakeBinary(
                                 ExpressionType.AndAlso,
                                 Expression.Not(innerBinary.Left),
@@ -136,11 +139,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     if (_nodeTypeMapping.ContainsKey(innerBinary.NodeType))
                     {
                         // e.g. !(a > b) -> a <= b
-                        return Visit(
+                        result = Visit(
                             Expression.MakeBinary(
                                 _nodeTypeMapping[innerBinary.NodeType],
                                 innerBinary.Left,
                                 innerBinary.Right));
+                    }
+
+                    if (result != null)
+                    {
+                        return notNullableExpression != null
+                            ? new NotNullableExpression(result)
+                            : result;
                     }
                 }
             }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
@@ -114,13 +114,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitExtension(Expression node)
-        {
-            var notNullableExpression = node as NotNullableExpression;
-
-            return notNullableExpression != null
+            => node is NotNullableExpression
                 ? node
                 : base.VisitExtension(node);
-        }
 
         private static Expression UnwrapConvertExpression(Expression expression, out Type conversionResultType)
         {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FunkyDataQueryFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FunkyDataQueryFixtureBase.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class FunkyDataQueryFixtureBase<TTestStore>
+        where TTestStore : TestStore
+    {
+        public abstract TTestStore CreateTestStore();
+
+        public abstract FunkyDataContext CreateContext(TTestStore testStore);
+
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FunkyDataQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FunkyDataQueryTestBase.cs
@@ -1,0 +1,515 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class FunkyDataQueryTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : FunkyDataQueryFixtureBase<TTestStore>, new()
+    {
+        protected FunkyDataContext CreateContext() => Fixture.CreateContext(TestStore);
+        protected FunkyDataQueryTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        [ConditionalFact]
+        public virtual void String_contains_on_argument_with_wildcard_constant()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains("%B"));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains("a_"));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains("")).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains("_Ba_"));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains("%B%a%r")).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.Contains("%B%a%r"));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains("")).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_contains_on_argument_with_wildcard_parameter()
+        {
+            using (var ctx = CreateContext())
+            {
+                var prm1 = "%B";
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains(prm1));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var prm2 = "a_";
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains(prm2));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var prm3 = (string)null;
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(prm3)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var prm4 = "";
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(prm4)).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var prm5 = "_Ba_";
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.Contains(prm5));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var prm6 = "%B%a%r";
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains(prm6)).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.Contains(prm6));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var prm7 = "";
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains(prm7)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var prm8 = (string)null;
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.Contains(prm8)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_contains_on_argument_with_wildcard_column()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => r.fn.Contains(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln == "" || (r.fn != null && r.ln != null && r.fn.Contains(r.ln)))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_contains_on_argument_with_wildcard_column_negated()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => !r.fn.Contains(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln != "" && r.fn != null && r.ln != null && !r.fn.Contains(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_starts_with_on_argument_with_wildcard_constant()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("%B"));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("a_"));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("_Ba_"));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith("%B%a%r"));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_starts_with_on_argument_with_wildcard_parameter()
+        {
+            using (var ctx = CreateContext())
+            {
+                var prm1 = "%B";
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm1));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var prm2 = "a_";
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm2));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var prm3 = (string)null;
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm3)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var prm4 = "";
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm4)).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var prm5 = "_Ba_";
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm5));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var prm6 = "%B%a%r";
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith(prm6));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var prm7 = "";
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm7)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var prm8 = (string)null;
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm8)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_starts_with_on_argument_with_wildcard_column()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => r.fn.StartsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln == "" || (r.fn != null && r.ln != null && r.fn.StartsWith(r.ln)))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_starts_with_on_argument_with_wildcard_column_negated()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => !r.fn.StartsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln != "" && r.fn != null && r.ln != null && !r.fn.StartsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_on_argument_with_wildcard_constant()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("%B"));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("_r")).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("_r"));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("a__r_")).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("a__r_"));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith("%B%a%r"));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_on_argument_with_wildcard_parameter()
+        {
+            using (var ctx = CreateContext())
+            {
+                var prm1 = "%B";
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm1));
+                Assert.True(expected1.Count() == result1.Count);
+
+                var prm2 = "_r";
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm2));
+                Assert.True(expected2.Count() == result2.Count);
+
+                var prm3 = (string)null;
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm3)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result3.Count);
+
+                var prm4 = "";
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm4)).Select(c => c.FirstName).ToList();
+                Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
+
+                var prm5 = "a__r_";
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm5));
+                Assert.True(expected5.Count() == result5.Count);
+
+                var prm6 = "%B%a%r";
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith(prm6));
+                Assert.True(expected6.Count() == result6.Count);
+
+                var prm7 = "";
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm7)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result7.Count);
+
+                var prm8 = (string)null;
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm8)).Select(c => c.FirstName).ToList();
+                Assert.True(0 == result8.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_on_argument_with_wildcard_column()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => r.fn.EndsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln == "" || (r.fn != null && r.ln != null && r.fn.EndsWith(r.ln)))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_on_argument_with_wildcard_column_negated()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => !r.fn.EndsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => r.ln != "" && r.fn != null && r.ln != null && !r.fn.EndsWith(r.ln))
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_inside_conditional()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => r.fn.EndsWith(r.ln) ? true : false)
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => (r.ln == "" || (r.fn != null && r.ln != null && r.fn.EndsWith(r.ln))) ? true : false)
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_inside_conditional_negated()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = ctx.FunkyCustomers.Select(c => c.FirstName)
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
+                    .Where(r => !r.fn.EndsWith(r.ln) ? true : false)
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                var expected = ctx.FunkyCustomers.Select(c => c.FirstName).ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.Select(c2 => c2.LastName).ToList(), (fn, ln) => new { fn, ln })
+                    .Where(r => (r.ln != "" && r.fn != null && r.ln != null && !r.fn.EndsWith(r.ln)) ? true : false)
+                    .ToList().OrderBy(r => r.fn).ThenBy(r => r.ln).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].fn == result[i].fn);
+                    Assert.True(expected[i].ln == result[i].ln);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_equals_nullable_column()
+        {
+            using (var ctx = CreateContext())
+            {
+                var expected = ctx.FunkyCustomers.ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.ToList(), (c1, c2) => new { c1, c2 })
+                    .Where(r => (r.c2.LastName != null && r.c1.FirstName != null && r.c1.NullableBool.HasValue && r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value) || (r.c2.LastName == null && r.c1.NullableBool == false))
+                    .ToList().Select(r => new { r.c1.FirstName, r.c2.LastName, r.c1.NullableBool }).OrderBy(r => r.FirstName).ThenBy(r => r.LastName).ToList();
+
+                ClearLog();
+
+                var result = ctx.FunkyCustomers
+                    .SelectMany(c => ctx.FunkyCustomers, (c1, c2) => new { c1, c2 })
+                    .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value)
+                    .ToList().Select(r => new { r.c1.FirstName, r.c2.LastName, r.c1.NullableBool }).OrderBy(r => r.FirstName).ThenBy(r => r.LastName).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].FirstName == result[i].FirstName);
+                    Assert.True(expected[i].LastName == result[i].LastName);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_ends_with_not_equals_nullable_column()
+        {
+            using (var ctx = CreateContext())
+            {
+                var expected = ctx.FunkyCustomers.ToList()
+                    .SelectMany(c => ctx.FunkyCustomers.ToList(), (c1, c2) => new { c1, c2 })
+                    .Where(r =>
+                        (r.c2.LastName != null && r.c1.FirstName != null && r.c1.NullableBool.HasValue && r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value)
+                        || r.c1.NullableBool == null
+                        || (r.c2.LastName == null && r.c1.NullableBool == true))
+                    .ToList().Select(r => new { r.c1.FirstName, r.c2.LastName, r.c1.NullableBool }).OrderBy(r => r.FirstName).ThenBy(r => r.LastName).ToList();
+
+                ClearLog();
+
+                var result = ctx.FunkyCustomers
+                    .SelectMany(c => ctx.FunkyCustomers, (c1, c2) => new { c1, c2 })
+                    .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value)
+                    .ToList().Select(r => new { r.c1.FirstName, r.c2.LastName, r.c1.NullableBool }).OrderBy(r => r.FirstName).ThenBy(r => r.LastName).ToList();
+
+                Assert.Equal(result.Count, expected.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected[i].FirstName == result[i].FirstName);
+                    Assert.True(expected[i].LastName == result[i].LastName);
+                }
+            }
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected TTestStore TestStore { get; }
+
+        protected virtual void ClearLog()
+        {
+        }
+
+        public void Dispose() => TestStore.Dispose();
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -50,6 +50,8 @@
     <Compile Include="DataAnnotationTestBase.cs" />
     <Compile Include="F1FixtureBase.cs" />
     <Compile Include="FindTestBase.cs" />
+    <Compile Include="FunkyDataQueryFixtureBase.cs" />
+    <Compile Include="FunkyDataQueryTestBase.cs" />
     <Compile Include="GearsOfWarQueryFixtureBase.cs" />
     <Compile Include="GearsOfWarQueryTestBase.cs" />
     <Compile Include="GraphUpdatesTestBase.cs" />
@@ -99,6 +101,9 @@
     <Compile Include="TestModels\ConcurrencyModel\Team.cs" />
     <Compile Include="TestModels\ConcurrencyModel\TestDriver.cs" />
     <Compile Include="TestModels\ConcurrencyModel\TitleSponsor.cs" />
+    <Compile Include="TestModels\FunkyDataModel\FunkyDataContext.cs" />
+    <Compile Include="TestModels\FunkyDataModel\FunkyCustomer.cs" />
+    <Compile Include="TestModels\FunkyDataModel\FunkyDataModelInitializer.cs" />
     <Compile Include="TestModels\GearsOfWarModel\AmmunitionType.cs" />
     <Compile Include="TestModels\GearsOfWarModel\City.cs" />
     <Compile Include="TestModels\GearsOfWarModel\CogTag.cs" />
@@ -208,6 +213,7 @@
       <Name>Microsoft.EntityFrameworkCore</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -427,6 +427,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void All_top_level_column()
+        {
+            AssertQuery<Customer>(
+                cs => cs.All(c => c.ContactName.StartsWith(c.ContactName)));
+        }
+
+        [ConditionalFact]
         public virtual void All_top_level_subquery()
         {
             AssertQuery<Customer>(

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyCustomer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyCustomer.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel
+{
+    public class FunkyCustomer
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+        public bool? NullableBool { get; set; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataContext.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel
+{
+    public class FunkyDataContext : DbContext
+    {
+        public static readonly string StoreName = "FunkyData";
+
+        public FunkyDataContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<FunkyCustomer> FunkyCustomers { get; set; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataModelInitializer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataModelInitializer.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel
+{
+    public class FunkyDataModelInitializer
+    {
+        public static void Seed(FunkyDataContext context)
+        {
+            var c11 = new FunkyCustomer { FirstName = "%Bar", LastName = "%B", NullableBool = true };
+            var c12 = new FunkyCustomer { FirstName = "Ba%r", LastName = "a%", NullableBool = true };
+            var c13 = new FunkyCustomer { FirstName = "Bar%", LastName = "%B%", NullableBool = true };
+            var c14 = new FunkyCustomer { FirstName = "%Ba%r%", LastName = null, NullableBool = false };
+            var c15 = new FunkyCustomer { FirstName = "B%a%%r%", LastName = "r%", NullableBool = false };
+            var c16 = new FunkyCustomer { FirstName = null, LastName = "%B%a%r" };
+            var c17 = new FunkyCustomer { FirstName = "%B%a%r", LastName = "" };
+            var c18 = new FunkyCustomer { FirstName = "", LastName = "%%r%" };
+
+            var c21 = new FunkyCustomer { FirstName = "_Bar", LastName = "_B", NullableBool = false };
+            var c22 = new FunkyCustomer { FirstName = "Ba_r", LastName = "a_", NullableBool = false };
+            var c23 = new FunkyCustomer { FirstName = "Bar_", LastName = "_B_", NullableBool = false };
+            var c24 = new FunkyCustomer { FirstName = "_Ba_r_", LastName = null, NullableBool = true };
+            var c25 = new FunkyCustomer { FirstName = "B_a__r_", LastName = "r_", NullableBool = true };
+            var c26 = new FunkyCustomer { FirstName = null, LastName = "_B_a_r" };
+            var c27 = new FunkyCustomer { FirstName = "_B_a_r", LastName = "" };
+            var c28 = new FunkyCustomer { FirstName = "", LastName = "__r_" };
+
+            context.FunkyCustomers.AddRange(c11, c12, c13, c14, c15, c16, c17, c18, c21, c22, c23, c24, c25, c26, c27, c28);
+
+            context.SaveChanges();
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -106,9 +106,11 @@
     <Compile Include="Query\Expressions\Internal\RowNumberExpression.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerCompositeMemberTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerCompositeMethodCallTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerContainsOptimizedTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerConvertTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerDateTimeDateComponentTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerDateTimeNowTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerEndsWithOptimizedTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathAbsTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathCeilingTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathFloorTranslator.cs" />
@@ -116,6 +118,7 @@
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathRoundTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerMathTruncateTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerNewGuidTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStartsWithOptimizedTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringLengthTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringReplaceTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqlServerStringTrimEndTranslator.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
@@ -14,6 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     {
         private static readonly IMethodCallTranslator[] _methodCallTranslators =
         {
+            new SqlServerContainsOptimizedTranslator(),
+            new SqlServerConvertTranslator(),
+            new SqlServerEndsWithOptimizedTranslator(),
             new SqlServerMathAbsTranslator(),
             new SqlServerMathCeilingTranslator(),
             new SqlServerMathFloorTranslator(),
@@ -21,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             new SqlServerMathRoundTranslator(),
             new SqlServerMathTruncateTranslator(),
             new SqlServerNewGuidTranslator(),
+            new SqlServerStartsWithOptimizedTranslator(),
             new SqlServerStringIsNullOrWhiteSpaceTranslator(),
             new SqlServerStringReplaceTranslator(),
             new SqlServerStringSubstringTranslator(),
@@ -29,7 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             new SqlServerStringTrimEndTranslator(),
             new SqlServerStringTrimStartTranslator(),
             new SqlServerStringTrimTranslator(),
-            new SqlServerConvertTranslator()
         };
 
         // ReSharper disable once SuggestBaseTypeForParameter

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerContainsOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var charIndexExpression = Expression.GreaterThan(
+                    new SqlFunctionExpression("CHARINDEX", typeof(int), new[] { patternExpression, methodCallExpression.Object }),
+                    Expression.Constant(0));
+
+                return
+                    patternConstantExpression != null
+                    ? (string)patternConstantExpression.Value == string.Empty
+                        ? (Expression)Expression.Constant(true)
+                        : charIndexExpression
+                    : Expression.OrElse(
+                        charIndexExpression,
+                        Expression.Equal(patternExpression, Expression.Constant(string.Empty)));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerEndsWithOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var endsWithExpression = Expression.Equal(
+                    new SqlFunctionExpression(
+                        "RIGHT",
+                        // ReSharper disable once PossibleNullReferenceException
+                        methodCallExpression.Object.Type,
+                        new[]
+                        {
+                            methodCallExpression.Object,
+                            new SqlFunctionExpression("LEN", typeof(int), new[] { patternExpression })
+                        }),
+                    patternExpression);
+
+                return new NotNullableExpression(
+                        patternConstantExpression != null
+                        ? (string)patternConstantExpression.Value == string.Empty
+                            ? (Expression)Expression.Constant(true)
+                            : endsWithExpression
+                        : Expression.OrElse(
+                            endsWithExpression,
+                            Expression.Equal(patternExpression, Expression.Constant(string.Empty))));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerStartsWithOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) });
+
+        private static readonly MethodInfo _concat
+            = typeof(string).GetRuntimeMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var startsWithExpression = Expression.AndAlso(
+                    new LikeExpression(
+                        // ReSharper disable once AssignNullToNotNullAttribute
+                        methodCallExpression.Object,
+                        Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat)),
+                    Expression.Equal(
+                        new SqlFunctionExpression("CHARINDEX", typeof(int), new[] { patternExpression, methodCallExpression.Object }),
+                        Expression.Constant(1)));
+
+                return patternConstantExpression != null
+                    ? (string)patternConstantExpression.Value == string.Empty
+                        ? (Expression)Expression.Constant(true)
+                        : startsWithExpression
+                    : Expression.OrElse(
+                        startsWithExpression,
+                        Expression.Equal(patternExpression, Expression.Constant(string.Empty)));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
@@ -83,7 +83,10 @@
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteCompositeMemberTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteCompositeMethodCallTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteContainsOptimizedTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteEndsWithOptimizedTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteMathAbsTranslator.cs" />
+    <Compile Include="Query\ExpressionTranslators\Internal\SqliteStartsWithOptimizedTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringLengthTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringToLowerTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\Internal\SqliteStringToUpperTranslator.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
@@ -14,7 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     {
         private static readonly IMethodCallTranslator[] _sqliteTranslators =
         {
+            new SqliteContainsOptimizedTranslator(),
+            new SqliteEndsWithOptimizedTranslator(),
             new SqliteMathAbsTranslator(),
+            new SqliteStartsWithOptimizedTranslator(),
             new SqliteStringIsNullOrWhiteSpaceTranslator(),
             new SqliteStringToLowerTranslator(),
             new SqliteStringToUpperTranslator(),

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteContainsOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var charIndexExpression = Expression.GreaterThan(
+                    new SqlFunctionExpression("instr", typeof(int), new[] { methodCallExpression.Object, patternExpression }),
+                    Expression.Constant(0));
+
+                return
+                    patternConstantExpression != null
+                    ? (string)patternConstantExpression.Value == string.Empty
+                        ? (Expression)Expression.Constant(true)
+                        : charIndexExpression
+                    : Expression.OrElse(
+                        charIndexExpression,
+                        Expression.Equal(patternExpression, Expression.Constant(string.Empty)));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteEndsWithOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var endsWithExpression = Expression.Equal(
+                    new SqlFunctionExpression(
+                        "substr",
+                        // ReSharper disable once PossibleNullReferenceException
+                        methodCallExpression.Object.Type,
+                        new[]
+                        {
+                            methodCallExpression.Object,
+                            Expression.Negate(new SqlFunctionExpression("length", typeof(int), new[] { patternExpression }))
+                        }),
+                    patternExpression);
+
+                return new NotNullableExpression(
+                        patternConstantExpression != null
+                        ? (string)patternConstantExpression.Value == string.Empty
+                            ? (Expression)Expression.Constant(true)
+                            : endsWithExpression
+                        : Expression.OrElse(
+                            endsWithExpression,
+                            Expression.Equal(patternExpression, Expression.Constant(string.Empty))));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteStartsWithOptimizedTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) });
+
+        private static readonly MethodInfo _concat
+            = typeof(string).GetRuntimeMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var patternExpression = methodCallExpression.Arguments[0];
+                var patternConstantExpression = patternExpression as ConstantExpression;
+
+                var startsWithExpression = Expression.AndAlso(
+                    new LikeExpression(
+                        // ReSharper disable once AssignNullToNotNullAttribute
+                        methodCallExpression.Object,
+                        Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat)),
+                    Expression.Equal(
+                        new SqlFunctionExpression("instr", typeof(int), new[] { methodCallExpression.Object, patternExpression }),
+                        Expression.Constant(1)));
+
+                return patternConstantExpression != null
+                    ? (string)patternConstantExpression.Value == string.Empty
+                        ? (Expression)Expression.Constant(true)
+                        : startsWithExpression
+                    : Expression.OrElse(
+                        startsWithExpression,
+                        Expression.Equal(patternExpression, Expression.Constant(string.Empty)));
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -288,7 +288,8 @@ WHERE [e2].[Id] > 5", Sql);
                 @"SELECT [e1].[Id], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e1.OneToOne_Required_FK] ON [e1].[Id] = [e1.OneToOne_Required_FK].[Level1_Required_Id]
-WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%'", Sql);
+WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e1.OneToOne_Required_FK].[Name]) = 1)", 
+                Sql);
         }
 
         public override void Join_navigation_in_outer_selector_translated_to_extra_join()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 FROM (
     SELECT * FROM ""Customers""
 ) AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + N'z') + N'%'",
+WHERE CHARINDEX(N'z', [c].[ContactName]) > 0",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerFixture.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class FunkyDataQuerySqlServerFixture : FunkyDataQueryFixtureBase<SqlServerTestStore>
+    {
+        public const string DatabaseName = "FunkyDataQueryTest";
+
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
+
+        public FunkyDataQuerySqlServerFixture()
+        {
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
+                .BuildServiceProvider();
+        }
+
+        public override SqlServerTestStore CreateTestStore()
+        {
+            return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+            {
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlServer(_connectionString)
+                    .UseInternalServiceProvider(_serviceProvider);
+
+                using (var context = new FunkyDataContext(optionsBuilder.Options))
+                {
+                    context.Database.EnsureClean();
+                    FunkyDataModelInitializer.Seed(context);
+
+                    TestSqlLoggerFactory.Reset();
+                }
+            });
+        }
+
+        public override FunkyDataContext CreateContext(SqlServerTestStore testStore)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            optionsBuilder
+                .EnableSensitiveDataLogging()
+                .UseInternalServiceProvider(_serviceProvider)
+                .UseSqlServer(testStore.Connection);
+
+            var context = new FunkyDataContext(optionsBuilder.Options);
+
+            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+            context.Database.UseTransaction(testStore.Transaction);
+
+            return context;
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class FunkyDataQuerySqlServerTest : FunkyDataQueryTestBase<SqlServerTestStore, FunkyDataQuerySqlServerFixture>
+    {
+        public FunkyDataQuerySqlServerTest(FunkyDataQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        public override void String_ends_with_equals_nullable_column()
+        {
+            base.String_ends_with_equals_nullable_column();
+
+            Assert.Equal(
+                @"SELECT [c].[Id], [c].[FirstName], [c].[LastName], [c].[NullableBool], [c2].[Id], [c2].[FirstName], [c2].[LastName], [c2].[NullableBool]
+FROM [FunkyCustomer] AS [c]
+CROSS JOIN [FunkyCustomer] AS [c2]
+WHERE CASE
+    WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END = [c].[NullableBool]",
+                Sql);
+        }
+
+        public override void String_ends_with_not_equals_nullable_column()
+        {
+            base.String_ends_with_not_equals_nullable_column();
+
+            Assert.Equal(
+                @"SELECT [c].[Id], [c].[FirstName], [c].[LastName], [c].[NullableBool], [c2].[Id], [c2].[FirstName], [c2].[LastName], [c2].[NullableBool]
+FROM [FunkyCustomer] AS [c]
+CROSS JOIN [FunkyCustomer] AS [c2]
+WHERE (CASE
+    WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END <> [c].[NullableBool]) OR [c].[NullableBool] IS NULL",
+                Sql);
+        }
+
+        protected override void ClearLog() => TestSqlLoggerFactory.Reset();
+
+        private const string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -882,7 +882,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] = N'
             Assert.Equal(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%' + N'us'",
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND RIGHT([g].[LeaderNickname], LEN(N'us')) = N'us'",
                 Sql);
         }
 
@@ -894,7 +894,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE
             Assert.Equal(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[LeaderNickname] LIKE N'%' + N'us'",
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND RIGHT([g].[LeaderNickname], LEN(N'us')) = N'us'",
                 Sql);
         }
 
@@ -1248,7 +1248,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Nickname] = N'Marc
             Assert.Equal(
                 @"SELECT [c].[Name], [c].[Location]
 FROM [City] AS [c]
-WHERE [c].[Location] LIKE ('%' + 'Jacinto') + '%'",
+WHERE CHARINDEX(N'Jacinto', [c].[Location]) > 0",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -274,7 +274,7 @@ ORDER BY [o0].[OrderID]",
             Assert.Equal(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%'
+WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -292,7 +292,7 @@ INNER JOIN (
         ORDER BY [oo].[OrderDate] DESC
     ) AS [c0_0], [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] LIKE N'W' + N'%'
+    WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
     ORDER BY [c0_0] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ORDER BY [c0].[c0_0] DESC, [c0].[CustomerID]",
@@ -1252,9 +1252,9 @@ ORDER BY [c0].[ContactName], [c0].[CustomerID]",
             base.Then_include_collection_order_by_collection_column();
 
             Assert.Equal(
-    @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%'
+WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -1272,7 +1272,7 @@ INNER JOIN (
         ORDER BY [oo].[OrderDate] DESC
     ) AS [c0_0], [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] LIKE N'W' + N'%'
+    WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
     ORDER BY [c0_0] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ORDER BY [c0].[c0_0] DESC, [c0].[CustomerID], [o].[OrderID]
@@ -1290,12 +1290,12 @@ INNER JOIN (
             ORDER BY [oo].[OrderDate] DESC
         ) AS [c0_0], [c].[CustomerID]
         FROM [Customers] AS [c]
-        WHERE [c].[CustomerID] LIKE N'W' + N'%'
+        WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
         ORDER BY [c0_0] DESC, [c].[CustomerID]
     ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
 ORDER BY [o1].[c0_0] DESC, [o1].[CustomerID], [o1].[OrderID]",
-    Sql);
+                Sql);
         }
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -362,7 +362,7 @@ VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6);
 
 SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'
+WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')
 
 @p1: Apteryx owenii (Nullable = false) (Size = 100)
 @p0: Aquila chrysaetos canadensis (Size = 100)
@@ -374,7 +374,7 @@ SELECT @@ROWCOUNT;
 
 SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'
+WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')
 
 @p0: Apteryx owenii (Nullable = false) (Size = 100)
 
@@ -385,7 +385,7 @@ SELECT @@ROWCOUNT;
 
 SELECT COUNT(*)
 FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND [k].[Species] LIKE N'%' + N'owenii'",
+WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -62,6 +62,8 @@
     <Compile Include="FindSqlServerTest.cs" />
     <Compile Include="FromSqlQuerySqlServerTest.cs" />
     <Compile Include="FromSqlSprocQuerySqlServerTest.cs" />
+    <Compile Include="FunkyDataQuerySqlServerTest.cs" />
+    <Compile Include="FunkyDataQuerySqlServerFixture.cs" />
     <Compile Include="GearsOfWarFromSqlQuerySqlServerTest.cs" />
     <Compile Include="GearsOfWarQuerySqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -913,7 +913,7 @@ END) OR [e].[NullableStringC] IS NULL",
             Assert.Equal(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] LIKE (N'%' + [e].[NullableStringB]) + N'%' AND ([e].[BoolA] = 1)",
+WHERE ((CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) OR ([e].[NullableStringB] = N'')) AND ([e].[BoolA] = 1)",
                 Sql);
         }
 
@@ -941,7 +941,7 @@ FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN @__prm_0 = 0
     THEN CAST(1 AS BIT) ELSE CASE
-        WHEN [e].[StringA] LIKE N'A' + N'%'
+        WHEN [e].[StringA] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[StringA]) = 1)
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 END = 1",
@@ -965,7 +965,7 @@ WHERE CASE
         THEN CASE
             WHEN [e].[BoolA] = 1
             THEN CASE
-                WHEN [e].[StringA] LIKE N'A' + N'%'
+                WHEN [e].[StringA] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[StringA]) = 1)
                 THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
             END ELSE CAST(0 AS BIT)
         END ELSE CAST(1 AS BIT)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -305,20 +305,20 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext925(sp),
                 context =>
-                    {
-                        var order11 = new Order { Name = "Order11" };
-                        var order12 = new Order { Name = "Order12" };
-                        var order21 = new Order { Name = "Order21" };
-                        var order22 = new Order { Name = "Order22" };
-                        var order23 = new Order { Name = "Order23" };
+                {
+                    var order11 = new Order { Name = "Order11" };
+                    var order12 = new Order { Name = "Order12" };
+                    var order21 = new Order { Name = "Order21" };
+                    var order22 = new Order { Name = "Order22" };
+                    var order23 = new Order { Name = "Order23" };
 
-                        var customer1 = new Customer { FirstName = "Customer", LastName = "One", Orders = new List<Order> { order11, order12 } };
-                        var customer2 = new Customer { FirstName = "Customer", LastName = "Two", Orders = new List<Order> { order21, order22, order23 } };
+                    var customer1 = new Customer { FirstName = "Customer", LastName = "One", Orders = new List<Order> { order11, order12 } };
+                    var customer2 = new Customer { FirstName = "Customer", LastName = "Two", Orders = new List<Order> { order21, order22, order23 } };
 
-                        context.Customers.AddRange(customer1, customer2);
-                        context.Orders.AddRange(order11, order12, order21, order22, order23);
-                        context.SaveChanges();
-                    });
+                    context.Customers.AddRange(customer1, customer2);
+                    context.Orders.AddRange(order11, order12, order21, order22, order23);
+                    context.SaveChanges();
+                });
         }
 
         public class Customer
@@ -356,11 +356,11 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Customer>(m =>
-                    {
-                        m.ToTable("Customer");
-                        m.HasKey(c => new { c.FirstName, c.LastName });
-                        m.HasMany(c => c.Orders).WithOne(o => o.Customer);
-                    });
+                {
+                    m.ToTable("Customer");
+                    m.HasKey(c => new { c.FirstName, c.LastName });
+                    m.HasMany(c => c.Orders).WithOne(o => o.Customer);
+                });
 
                 modelBuilder.Entity<Order>().ToTable("Order");
             }
@@ -430,26 +430,26 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext963(sp),
                 context =>
+                {
+                    var drogon = new Dragon { Name = "Drogon" };
+                    var rhaegal = new Dragon { Name = "Rhaegal" };
+                    var viserion = new Dragon { Name = "Viserion" };
+                    var balerion = new Dragon { Name = "Balerion" };
+
+                    var aerys = new Targaryen { Name = "Aerys II" };
+                    var details = new Details
                     {
-                        var drogon = new Dragon { Name = "Drogon" };
-                        var rhaegal = new Dragon { Name = "Rhaegal" };
-                        var viserion = new Dragon { Name = "Viserion" };
-                        var balerion = new Dragon { Name = "Balerion" };
-
-                        var aerys = new Targaryen { Name = "Aerys II" };
-                        var details = new Details
-                        {
-                            FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen, 
+                        FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen, 
 Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Grass Sea, Breaker of Chains, and Mother of Dragons"
-                        };
+                    };
 
-                        var daenerys = new Targaryen { Name = "Daenerys", Details = details, Dragons = new List<Dragon> { drogon, rhaegal, viserion } };
-                        context.Targaryens.AddRange(daenerys, aerys);
-                        context.Dragons.AddRange(drogon, rhaegal, viserion, balerion);
-                        context.Details.Add(details);
+                    var daenerys = new Targaryen { Name = "Daenerys", Details = details, Dragons = new List<Dragon> { drogon, rhaegal, viserion } };
+                    context.Targaryens.AddRange(daenerys, aerys);
+                    context.Dragons.AddRange(drogon, rhaegal, viserion, balerion);
+                    context.Details.Add(details);
 
-                        context.SaveChanges();
-                    });
+                    context.SaveChanges();
+                });
         }
 
         public class Targaryen
@@ -500,12 +500,12 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Targaryen>(m =>
-                    {
-                        m.ToTable("Targaryen");
-                        m.HasKey(t => t.Id);
-                        m.HasMany(t => t.Dragons).WithOne(d => d.Mother).HasForeignKey(d => d.MotherId);
-                        m.HasOne(t => t.Details).WithOne(d => d.Targaryen).HasForeignKey<Details>(d => d.TargaryenId);
-                    });
+                {
+                    m.ToTable("Targaryen");
+                    m.HasKey(t => t.Id);
+                    m.HasMany(t => t.Dragons).WithOne(d => d.Mother).HasForeignKey(d => d.MotherId);
+                    m.HasOne(t => t.Details).WithOne(d => d.Targaryen).HasForeignKey<Details>(d => d.TargaryenId);
+                });
 
                 modelBuilder.Entity<Dragon>().ToTable("Dragon");
             }
@@ -622,14 +622,14 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Customer3758>(b =>
-                    {
-                        b.ToTable("Customer3758");
+                {
+                    b.ToTable("Customer3758");
 
-                        b.HasMany(e => e.Orders1).WithOne();
-                        b.HasMany(e => e.Orders2).WithOne();
-                        b.HasMany(e => e.Orders3).WithOne();
-                        b.HasMany(e => e.Orders4).WithOne();
-                    });
+                    b.HasMany(e => e.Orders1).WithOne();
+                    b.HasMany(e => e.Orders2).WithOne();
+                    b.HasMany(e => e.Orders3).WithOne();
+                    b.HasMany(e => e.Orders4).WithOne();
+                });
 
                 modelBuilder.Entity<Order3758>().ToTable("Order3758");
             }
@@ -674,54 +674,54 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext3758(sp),
                 context =>
+                {
+                    var o111 = new Order3758 { Name = "O111" };
+                    var o112 = new Order3758 { Name = "O112" };
+                    var o121 = new Order3758 { Name = "O121" };
+                    var o122 = new Order3758 { Name = "O122" };
+                    var o131 = new Order3758 { Name = "O131" };
+                    var o132 = new Order3758 { Name = "O132" };
+                    var o141 = new Order3758 { Name = "O141" };
+
+                    var o211 = new Order3758 { Name = "O211" };
+                    var o212 = new Order3758 { Name = "O212" };
+                    var o221 = new Order3758 { Name = "O221" };
+                    var o222 = new Order3758 { Name = "O222" };
+                    var o231 = new Order3758 { Name = "O231" };
+                    var o232 = new Order3758 { Name = "O232" };
+                    var o241 = new Order3758 { Name = "O241" };
+
+                    var c1 = new Customer3758
                     {
-                        var o111 = new Order3758 { Name = "O111" };
-                        var o112 = new Order3758 { Name = "O112" };
-                        var o121 = new Order3758 { Name = "O121" };
-                        var o122 = new Order3758 { Name = "O122" };
-                        var o131 = new Order3758 { Name = "O131" };
-                        var o132 = new Order3758 { Name = "O132" };
-                        var o141 = new Order3758 { Name = "O141" };
+                        Name = "C1",
+                        Orders1 = new List<Order3758> { o111, o112 },
+                        Orders2 = new MyGenericCollection3758<Order3758>(),
+                        Orders3 = new MyNonGenericCollection3758(),
+                        Orders4 = new MyInvalidCollection3758<Order3758>(42)
+                    };
 
-                        var o211 = new Order3758 { Name = "O211" };
-                        var o212 = new Order3758 { Name = "O212" };
-                        var o221 = new Order3758 { Name = "O221" };
-                        var o222 = new Order3758 { Name = "O222" };
-                        var o231 = new Order3758 { Name = "O231" };
-                        var o232 = new Order3758 { Name = "O232" };
-                        var o241 = new Order3758 { Name = "O241" };
+                    c1.Orders2.AddRange(new[] { o121, o122 });
+                    c1.Orders3.AddRange(new[] { o131, o132 });
+                    c1.Orders4.Add(o141);
 
-                        var c1 = new Customer3758
-                        {
-                            Name = "C1",
-                            Orders1 = new List<Order3758> { o111, o112 },
-                            Orders2 = new MyGenericCollection3758<Order3758>(),
-                            Orders3 = new MyNonGenericCollection3758(),
-                            Orders4 = new MyInvalidCollection3758<Order3758>(42)
-                        };
+                    var c2 = new Customer3758
+                    {
+                        Name = "C2",
+                        Orders1 = new List<Order3758> { o211, o212 },
+                        Orders2 = new MyGenericCollection3758<Order3758>(),
+                        Orders3 = new MyNonGenericCollection3758(),
+                        Orders4 = new MyInvalidCollection3758<Order3758>(42)
+                    };
 
-                        c1.Orders2.AddRange(new[] { o121, o122 });
-                        c1.Orders3.AddRange(new[] { o131, o132 });
-                        c1.Orders4.Add(o141);
+                    c2.Orders2.AddRange(new[] { o221, o222 });
+                    c2.Orders3.AddRange(new[] { o231, o232 });
+                    c2.Orders4.Add(o241);
 
-                        var c2 = new Customer3758
-                        {
-                            Name = "C2",
-                            Orders1 = new List<Order3758> { o211, o212 },
-                            Orders2 = new MyGenericCollection3758<Order3758>(),
-                            Orders3 = new MyNonGenericCollection3758(),
-                            Orders4 = new MyInvalidCollection3758<Order3758>(42)
-                        };
+                    context.Customers.AddRange(c1, c2);
+                    context.Orders.AddRange(o111, o112, o121, o122, o131, o132, o141, o211, o212, o221, o222, o231, o232, o241);
 
-                        c2.Orders2.AddRange(new[] { o221, o222 });
-                        c2.Orders3.AddRange(new[] { o231, o232 });
-                        c2.Orders4.Add(o241);
-
-                        context.Customers.AddRange(c1, c2);
-                        context.Orders.AddRange(o111, o112, o121, o122, o131, o132, o141, o211, o212, o221, o222, o231, o232, o241);
-
-                        context.SaveChanges();
-                    });
+                    context.SaveChanges();
+                });
         }
 
         [Fact]
@@ -834,21 +834,21 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext3409(sp),
                 context =>
-                    {
-                        var parent1 = new Parent3409();
+                {
+                    var parent1 = new Parent3409();
 
-                        var child1 = new Child3409();
-                        var child2 = new Child3409();
-                        var child3 = new Child3409();
+                    var child1 = new Child3409();
+                    var child2 = new Child3409();
+                    var child3 = new Child3409();
 
-                        parent1.ChildCollection = new List<IChild3409> { child1 };
-                        child1.SelfReferenceCollection = new List<IChild3409> { child2, child3 };
+                    parent1.ChildCollection = new List<IChild3409> { child1 };
+                    child1.SelfReferenceCollection = new List<IChild3409> { child2, child3 };
 
-                        context.Parents.AddRange(parent1);
-                        context.Children.AddRange(child1, child2, child3);
+                    context.Parents.AddRange(parent1);
+                    context.Children.AddRange(child1, child2, child3);
 
-                        context.SaveChanges();
-                    });
+                    context.SaveChanges();
+                });
         }
 
         [Fact]
@@ -1081,6 +1081,8 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
         private const string FileLineEnding = @"
 ";
 
+        protected virtual void ClearLog() => TestSqlLoggerFactory.Reset();
+
         private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
 
         private void CreateDatabase3101()
@@ -1090,26 +1092,26 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext3101(sp),
                 context =>
-                    {
-                        var c11 = new Child3101 { Name = "c11" };
-                        var c12 = new Child3101 { Name = "c12" };
-                        var c13 = new Child3101 { Name = "c13" };
-                        var c21 = new Child3101 { Name = "c21" };
-                        var c22 = new Child3101 { Name = "c22" };
-                        var c31 = new Child3101 { Name = "c31" };
-                        var c32 = new Child3101 { Name = "c32" };
+                {
+                    var c11 = new Child3101 { Name = "c11" };
+                    var c12 = new Child3101 { Name = "c12" };
+                    var c13 = new Child3101 { Name = "c13" };
+                    var c21 = new Child3101 { Name = "c21" };
+                    var c22 = new Child3101 { Name = "c22" };
+                    var c31 = new Child3101 { Name = "c31" };
+                    var c32 = new Child3101 { Name = "c32" };
 
-                        context.Children.AddRange(c11, c12, c13, c21, c22, c31, c32);
+                    context.Children.AddRange(c11, c12, c13, c21, c22, c31, c32);
 
-                        var e1 = new Entity3101 { Id = 1, Children = new[] { c11, c12, c13 } };
-                        var e2 = new Entity3101 { Id = 2, Children = new[] { c21, c22 } };
-                        var e3 = new Entity3101 { Id = 3, Children = new[] { c31, c32 } };
+                    var e1 = new Entity3101 { Id = 1, Children = new[] { c11, c12, c13 } };
+                    var e2 = new Entity3101 { Id = 2, Children = new[] { c21, c22 } };
+                    var e3 = new Entity3101 { Id = 3, Children = new[] { c31, c32 } };
 
-                        e2.RootEntity = e1;
+                    e2.RootEntity = e1;
 
-                        context.Entities.AddRange(e1, e2, e3);
-                        context.SaveChanges();
-                    });
+                    context.Entities.AddRange(e1, e2, e3);
+                    context.SaveChanges();
+                });
         }
 
         public class MyContext3101 : DbContext
@@ -1330,18 +1332,18 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
         {
             var connectionString = SqlServerTestStore.CreateConnectionString(databaseName);
             SqlServerTestStore.GetOrCreateShared(databaseName, () =>
+            {
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseSqlServer(connectionString);
+
+                using (var context = contextCreator(serviceProvider, optionsBuilder.Options))
                 {
-                    var optionsBuilder = new DbContextOptionsBuilder();
-                    optionsBuilder.UseSqlServer(connectionString);
+                    context.Database.EnsureClean();
+                    contextInitializer(context);
 
-                    using (var context = contextCreator(serviceProvider, optionsBuilder.Options))
-                    {
-                        context.Database.EnsureClean();
-                        contextInitializer(context);
-
-                        TestSqlLoggerFactory.Reset();
-                    }
-                });
+                    TestSqlLoggerFactory.Reset();
+                }
+            });
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -405,7 +405,7 @@ WHERE [e].[ReportsTo] IS NULL",
             Assert.Equal(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%'
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
@@ -538,7 +538,7 @@ WHERE EXISTS (
         WHEN NOT EXISTS (
             SELECT 1
             FROM [Orders] AS [o0]
-            WHERE (([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) AND NOT (([o0].[CustomerID] = N'ALFKI') AND [o0].[CustomerID] IS NOT NULL))
+            WHERE (([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) AND (([o0].[CustomerID] <> N'ALFKI') OR [o0].[CustomerID] IS NULL))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 )
@@ -579,7 +579,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND NOT (([o].[CustomerID] = N'ALFKI') AND [o].[CustomerID] IS NOT NULL))",
+    WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))",
                 Sql);
         }
 
@@ -713,7 +713,7 @@ END, [o].[OrderID], (
     WHERE [o].[OrderID] = [o3].[OrderID]
 )
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%'",
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)",
                 Sql);
         }
 
@@ -776,7 +776,7 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%'
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
 ORDER BY [e].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
@@ -804,7 +804,7 @@ ORDER BY [e0].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%'
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
@@ -827,7 +827,7 @@ ORDER BY [o].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%'
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
@@ -850,7 +850,7 @@ ORDER BY [o].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%'
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
 
 SELECT [oo].[OrderID], [oo].[CustomerID], [oo].[EmployeeID], [oo].[OrderDate], [oo.Customer].[CustomerID], [oo.Customer].[Address], [oo.Customer].[City], [oo.Customer].[CompanyName], [oo.Customer].[ContactName], [oo.Customer].[ContactTitle], [oo.Customer].[Country], [oo.Customer].[Fax], [oo.Customer].[Phone], [oo.Customer].[PostalCode], [oo.Customer].[Region]
 FROM [Orders] AS [oo]
@@ -873,7 +873,7 @@ ORDER BY [oo].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%'
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
@@ -1094,7 +1094,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%'
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1619,7 +1619,7 @@ END",
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] LIKE N'A' + N'%')
+        WHERE [c].[ContactName] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[ContactName]) = 1))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -1635,7 +1635,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%')",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
                 Sql);
         }
 
@@ -1649,7 +1649,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%')",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
                 Sql);
         }
 
@@ -1663,7 +1663,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%') AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
                 Sql);
         }
 
@@ -1677,7 +1677,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%')",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
                 Sql);
         }
 
@@ -1691,7 +1691,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%')",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
                 Sql);
         }
 
@@ -1705,7 +1705,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%') AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
                 Sql);
         }
 
@@ -1732,7 +1732,22 @@ WHERE ([c].[City] = N'London') AND EXISTS (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE NOT ([c].[ContactName] LIKE N'A' + N'%'))
+        WHERE NOT ([c].[ContactName] LIKE N'A' + N'%') OR (CHARINDEX(N'A', [c].[ContactName]) <> 1))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
+        public override void All_top_level_column()
+        {
+            base.All_top_level_column();
+
+            Assert.Equal(
+                @"SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        WHERE (NOT ([c].[ContactName] LIKE [c].[ContactName] + N'%') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) <> 1)) AND (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -3977,7 +3992,7 @@ WHERE [p].[UnitsInStock] > 10",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'%' + N'KI'",
+WHERE RIGHT([c].[CustomerID], LEN(N'KI')) = N'KI'",
                 Sql);
         }
 
@@ -4112,7 +4127,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'M' + N'%'",
+WHERE [c].[ContactName] LIKE N'M' + N'%' AND (CHARINDEX(N'M', [c].[ContactName]) = 1)",
                 Sql);
         }
 
@@ -4123,7 +4138,7 @@ WHERE [c].[ContactName] LIKE N'M' + N'%'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
+WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[ContactName], [c].[ContactName]) = 1)) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4134,7 +4149,7 @@ WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
+WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[ContactName], [c].[ContactName]) = 1)) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4147,7 +4162,7 @@ WHERE [c].[ContactName] LIKE [c].[ContactName] + N'%'",
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE @__LocalMethod1_0 + N'%'",
+WHERE ([c].[ContactName] LIKE @__LocalMethod1_0 + N'%' AND (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) = 1)) OR (@__LocalMethod1_0 = N'')",
                 Sql);
         }
 
@@ -4158,7 +4173,7 @@ WHERE [c].[ContactName] LIKE @__LocalMethod1_0 + N'%'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'%' + N'b'",
+WHERE RIGHT([c].[ContactName], LEN(N'b')) = N'b'",
                 Sql);
         }
 
@@ -4169,7 +4184,7 @@ WHERE [c].[ContactName] LIKE N'%' + N'b'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
+WHERE (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4180,7 +4195,7 @@ WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
+WHERE (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4193,7 +4208,7 @@ WHERE [c].[ContactName] LIKE N'%' + [c].[ContactName]",
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'%' + @__LocalMethod2_0",
+WHERE (RIGHT([c].[ContactName], LEN(@__LocalMethod2_0)) = @__LocalMethod2_0) OR (@__LocalMethod2_0 = N'')",
                 Sql);
         }
 
@@ -4207,7 +4222,7 @@ WHERE [c].[ContactName] LIKE N'%' + @__LocalMethod2_0",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
+WHERE CHARINDEX(N'M', [c].[ContactName]) > 0",
                 Sql);
         }
 
@@ -4218,7 +4233,7 @@ WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
+WHERE (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4229,7 +4244,7 @@ WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
+WHERE (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4245,7 +4260,7 @@ WHERE [c].[ContactName] LIKE (N'%' + [c].[ContactName]) + N'%'",
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + @__LocalMethod1_0) + N'%'",
+WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_0 = N'')",
                 Sql);
         }
 
@@ -5697,11 +5712,11 @@ FROM [Orders] AS [o]",
 
             Assert.Equal(
                 @"@__NewLine_0: 
- (Size = 450)
+ (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE (N'%' + @__NewLine_0) + N'%'",
+WHERE (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0) OR (@__NewLine_0 = N'')",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -208,7 +208,7 @@ WHERE [t0].[__RowNumber__] > @__p_1",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
+WHERE CHARINDEX(N'M', [c].[ContactName]) > 0",
                 Sql);
         }
 
@@ -224,7 +224,7 @@ WHERE [c].[ContactName] LIKE (N'%' + N'M') + N'%'",
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE (N'%' + @__LocalMethod1_0) + N'%'",
+WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_0 = N'')",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
@@ -31,23 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             //base.Projection_when_arithmetic_mixed_subqueries();
         }
 
-        public override async Task String_Contains_Literal()
-        {
-            await AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains("M")
-                                    || c.ContactName.Contains("m")), // case-sensitive
-                entryCount: 34);
-        }
-
-        public override async Task String_Contains_MethodCall()
-        {
-            await AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
-                entryCount: 34);
-        }
-
         public async Task Skip_when_no_order_by()
         {
             await Assert.ThrowsAsync<Exception>(async () => await AssertQuery<Customer>(cs => cs.Skip(5).Take(10)));

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FunkyDataQuerySqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FunkyDataQuerySqliteFixture.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.FunkyDataModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class FunkyDataQuerySqliteFixture : FunkyDataQueryFixtureBase<SqliteTestStore>
+    {
+        public static readonly string DatabaseName = "FunkyDataQueryTest";
+
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly string _connectionString = SqliteTestStore.CreateConnectionString(DatabaseName);
+
+        public FunkyDataQuerySqliteFixture()
+        {
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlite()
+                .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
+                .BuildServiceProvider();
+        }
+
+        public override SqliteTestStore CreateTestStore()
+        {
+            return SqliteTestStore.GetOrCreateShared(DatabaseName, () =>
+            {
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlite(_connectionString)
+                    .UseInternalServiceProvider(_serviceProvider);
+
+                using (var context = new FunkyDataContext(optionsBuilder.Options))
+                {
+                    context.Database.EnsureClean();
+                    FunkyDataModelInitializer.Seed(context);
+
+                    TestSqlLoggerFactory.Reset();
+                }
+            });
+        }
+
+        public override FunkyDataContext CreateContext(SqliteTestStore testStore)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder()
+                .UseSqlite(testStore.Connection)
+                .UseInternalServiceProvider(_serviceProvider);
+
+            var context = new FunkyDataContext(optionsBuilder.Options);
+
+            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+            context.Database.UseTransaction(testStore.Transaction);
+
+            return context;
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FunkyDataQuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/FunkyDataQuerySqliteTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class FunkyDataQuerySqliteTest : FunkyDataQueryTestBase<SqliteTestStore, FunkyDataQuerySqliteFixture>
+    {
+        public FunkyDataQuerySqliteTest(FunkyDataQuerySqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -51,6 +51,8 @@
     <Compile Include="F1SqliteFixture.cs" />
     <Compile Include="FindSqliteTest.cs" />
     <Compile Include="FromSqlQuerySqliteTest.cs" />
+    <Compile Include="FunkyDataQuerySqliteFixture.cs" />
+    <Compile Include="FunkyDataQuerySqliteTest.cs" />
     <Compile Include="GearsOfWarFromSqlQuerySqliteTest.cs" />
     <Compile Include="GearsOfWarQuerySqliteFixture.cs" />
     <Compile Include="GearsOfWarQuerySqliteTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -20,22 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
         }
 
-        public override void String_Contains_Literal()
-        {
-            AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains("M") || c.ContactName.Contains("m")), // case-sensitive
-                entryCount: 34);
-        }
-
-        public override void String_Contains_MethodCall()
-        {
-            AssertQuery<Customer>(
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
-                entryCount: 34);
-        }
-
         public override void Take_Skip()
         {
             base.Take_Skip();


### PR DESCRIPTION
**PROVIDERS BEWARE:**

Linq translation for methods Contains, EndsWith and StartsWith that we have in the Relational package uses LIKE operator, which may return incorrect results if the value parameter (what we are searching for) contains wildcard characters, e.g. '%' or '_'.

This issue addresses SqlServer and Sqlite providers, but all other providers will still use the old translation. 

**Each provider that can be affected by this should implement their own MethodCallTranslators for Contains, EndsWith and StartsWith.**



We were returning wrong results for StartsWith, EndsWith and Contains with patters containing wildcard characters (%, _)

Fix is to improve the translation as follows:

Contains:
(CHARINDEX(pattern, string) > 0) OR pattern = ''

StartsWith:
(string LIKE pattern + "%" AND CHARINDEX(pattern, string) = 1) OR pattern = ''

EndsWith:
(RIGHT(string, LEN(pattern) = pattern) OR pattern = ''

We can sometimes remove the final term (pattern = ''), i.e. when the pattern is a constant. If it's value is '', we just return true, otherwise the final term is redundant and will not be generated.
We can't really do same trick for parameters without changing the way caching works (currently it only looks at the nullability of the parameter, but in this case the value itself is important)
