### PR TITLE
Add change tracker support for read-only properties with backing fields

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ChangeTracker.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ChangeTracker.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <summary>
         ///     <para>
         ///         Checks if any new, deleted, or changed entities are being tracked
-        ///         such that these changes will sent to the database if <see cref="DbContext.SaveChanges()" />
+        ///         such that these changes will be sent to the database if <see cref="DbContext.SaveChanges()" />
         ///         or <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)" /> is called.
         ///     </para>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -86,8 +86,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddSingleton<IEntityFinderSource, EntityFinderSource>()
                 .AddSingleton<ICollectionTypeFactory, CollectionTypeFactory>()
                 .AddSingleton<IEntityMaterializerSource, EntityMaterializerSource>()
-                .AddSingleton<IMemberMapper, MemberMapper>()
-                .AddSingleton<IFieldMatcher, FieldMatcher>()
                 .AddSingleton<ICoreConventionSetBuilder, CoreConventionSetBuilder>()
                 .AddSingleton<IModelCustomizer, ModelCustomizer>()
                 .AddSingleton<IModelCacheKeyFactory, ModelCacheKeyFactory>()

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
@@ -23,22 +23,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual TAccessor Create([NotNull] IPropertyBase property)
-            => property as TAccessor ?? Create(property.DeclaringEntityType.ClrType.GetAnyProperty(property.Name));
+            => property as TAccessor ?? Create(property.DeclaringEntityType.ClrType.GetAnyProperty(property.Name), property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual TAccessor Create([NotNull] PropertyInfo property)
+        public virtual TAccessor Create([NotNull] PropertyInfo propertyInfo)
+            => Create(propertyInfo, null);
+
+        private TAccessor Create(PropertyInfo propertyInfo, IPropertyBase property)
         {
             var boundMethod = _genericCreate.MakeGenericMethod(
-                property.DeclaringType,
-                property.PropertyType,
-                property.PropertyType.UnwrapNullableType());
+                propertyInfo.DeclaringType,
+                propertyInfo.PropertyType,
+                propertyInfo.PropertyType.UnwrapNullableType());
 
             try
             {
-                return (TAccessor)boundMethod.Invoke(this, new object[] { property });
+                return (TAccessor)boundMethod.Invoke(this, new object[] { propertyInfo, property });
             }
             catch (TargetInvocationException e) when (e.InnerException != null)
             {
@@ -50,7 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected abstract TAccessor CreateGeneric<TEntity, TValue, TNonNullableEnumValue>([NotNull] PropertyInfo property)
+        protected abstract TAccessor CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
+            [NotNull] PropertyInfo propertyInfo,
+            [CanBeNull] IPropertyBase property)
             where TEntity : class;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -10,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ClrCollectionAccessorFactory
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateCollection));
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IClrCollectionAccessor Create([NotNull] INavigation navigation)
@@ -46,9 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.NavigationBadType(
-                        navigation.Name, 
-                        navigation.DeclaringEntityType.DisplayName(), 
-                        property.PropertyType.ShortDisplayName(), 
+                        navigation.Name,
+                        navigation.DeclaringEntityType.DisplayName(),
+                        property.PropertyType.ShortDisplayName(),
                         navigation.GetTargetType().DisplayName()));
             }
 
@@ -56,8 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 throw new InvalidOperationException(
                     CoreStrings.NavigationArray(
-                        navigation.Name, 
-                        navigation.DeclaringEntityType.DisplayName(), 
+                        navigation.Name,
+                        navigation.DeclaringEntityType.DisplayName(),
                         property.PropertyType.ShortDisplayName()));
             }
 
@@ -69,25 +71,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var boundMethod = _genericCreate.MakeGenericMethod(
                 property.DeclaringType, property.PropertyType, elementType);
 
-            return (IClrCollectionAccessor)boundMethod.Invoke(null, new object[] { property });
+            return (IClrCollectionAccessor)boundMethod.Invoke(null, new object[] { navigation });
         }
 
         [UsedImplicitly]
-        private static IClrCollectionAccessor CreateGeneric<TEntity, TCollection, TElement>(PropertyInfo property)
+        private static IClrCollectionAccessor CreateGeneric<TEntity, TCollection, TElement>(INavigation navigation)
             where TEntity : class
             where TCollection : class, IEnumerable<TElement>
         {
+            var property = navigation.GetPropertyInfo();
+
             var getterDelegate = (Func<TEntity, TCollection>)property.GetMethod.CreateDelegate(typeof(Func<TEntity, TCollection>));
 
             Action<TEntity, TCollection> setterDelegate = null;
             Func<TEntity, Action<TEntity, TCollection>, TCollection> createAndSetDelegate = null;
             Func<TCollection> createDelegate = null;
 
-            var setter = property.SetMethod;
-            if (setter != null)
-            {
-                setterDelegate = (Action<TEntity, TCollection>)setter.CreateDelegate(typeof(Action<TEntity, TCollection>));
+            var setterProperty = property.DeclaringType
+                .GetPropertiesInHierarchy(property.Name)
+                .FirstOrDefault(p => p.SetMethod != null);
 
+            if (setterProperty != null)
+            {
+                setterDelegate = (Action<TEntity, TCollection>)property.SetMethod.CreateDelegate(typeof(Action<TEntity, TCollection>));
+            }
+            else
+            {
+                var fieldInfo = navigation.DeclaringEntityType.Model.GetMemberMapper().FindBackingField(navigation);
+                if (fieldInfo != null)
+                {
+                    var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
+                    var valueParameter = Expression.Parameter(typeof(TCollection), "collection");
+
+                    setterDelegate = Expression.Lambda<Action<TEntity, TCollection>>(
+                        Expression.Assign(
+                            Expression.Field(entityParameter, fieldInfo),
+                            valueParameter),
+                        entityParameter,
+                        valueParameter).Compile();
+                }
+            }
+
+            if (setterDelegate != null)
+            {
                 var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(TEntity), typeof(TCollection));
 
                 if (concreteType != null)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertyGetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertyGetterFactory.cs
@@ -16,8 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(PropertyInfo property)
+        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
+            PropertyInfo propertyInfo, IPropertyBase property)
             => new ClrPropertyGetter<TEntity, TValue>(
-                 (Func<TEntity, TValue>)property.GetMethod.CreateDelegate(typeof(Func<TEntity, TValue>)));
+                 (Func<TEntity, TValue>)propertyInfo.GetMethod.CreateDelegate(typeof(Func<TEntity, TValue>)));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -2,43 +2,57 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ClrPropertySetterFactory : ClrAccessorFactory<IClrPropertySetter>
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override IClrPropertySetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>([NotNull] PropertyInfo property)
+        protected override IClrPropertySetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
+            PropertyInfo property, IPropertyBase propertyBase)
         {
-            var setterProperty = property;
-            while (setterProperty.SetMethod == null)
+            var setterProperty = property.DeclaringType
+                .GetPropertiesInHierarchy(property.Name)
+                .FirstOrDefault(p => p.SetMethod != null);
+
+            Action<TEntity, TValue> setter = null;
+
+            if (setterProperty != null)
             {
-                var declaringType = setterProperty.DeclaringType;
-                Debug.Assert(declaringType != null);
-                setterProperty = declaringType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (setterProperty.SetMethod != null)
+                setter = (Action<TEntity, TValue>)setterProperty.SetMethod.CreateDelegate(typeof(Action<TEntity, TValue>));
+            }
+            else
+            {
+                var fieldInfo = propertyBase?.DeclaringEntityType.Model.GetMemberMapper().FindBackingField(propertyBase);
+                if (fieldInfo != null)
                 {
-                    break;
-                }
-                setterProperty = declaringType.GetTypeInfo().BaseType?.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (setterProperty == null)
-                {
-                    throw new InvalidOperationException(CoreStrings.NoClrSetter(property.Name));
+                    var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
+                    var valueParameter = Expression.Parameter(typeof(TValue), "value");
+
+                    setter = Expression.Lambda<Action<TEntity, TValue>>(
+                        Expression.Assign(
+                            Expression.Field(entityParameter, fieldInfo),
+                            valueParameter),
+                        entityParameter,
+                        valueParameter).Compile();
                 }
             }
 
-            var setter = (Action<TEntity, TValue>)setterProperty.SetMethod.CreateDelegate(typeof(Action<TEntity, TValue>));
+            if (setter == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoClrSetter(property.Name));
+            }
 
             return property.PropertyType.IsNullableType() && property.PropertyType.UnwrapNullableType().GetTypeInfo().IsEnum
                 ? new NullableEnumClrPropertySetter<TEntity, TValue, TNonNullableEnumValue>(setter)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -32,5 +32,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string ValueGeneratorFactoryAnnotation = "ValueGeneratorFactory";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string MemberMapperAnnotation = "MemberMapper";
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -21,17 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private static readonly MethodInfo _readValue
             = typeof(ValueBuffer).GetTypeInfo().DeclaredProperties
                 .Single(p => p.GetIndexParameters().Any()).GetMethod;
-
-        private readonly IMemberMapper _memberMapper;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public EntityMaterializerSource([NotNull] IMemberMapper memberMapper)
-        {
-            _memberMapper = memberMapper;
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -153,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 };
 
             blockExpressions.AddRange(
-                from mapping in _memberMapper.MapPropertiesToMembers(entityType)
+                from mapping in entityType.Model.GetMemberMapper().MapPropertiesToMembers(entityType)
                 let propertyInfo = mapping.Item2 as PropertyInfo
                 let targetMember
                     = propertyInfo != null

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/FieldMatcher.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/FieldMatcher.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual FieldInfo TryMatchFieldName(
-            IProperty property, PropertyInfo propertyInfo, Dictionary<string, FieldInfo> declaredFields)
+            IPropertyBase property, PropertyInfo propertyInfo, Dictionary<string, FieldInfo> declaredFields)
         {
             var propertyName = propertyInfo.Name;
             var propertyType = propertyInfo.PropertyType.GetTypeInfo();

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IMemberMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IMemberMapper.cs
@@ -19,5 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         IEnumerable<Tuple<IProperty, MemberInfo>> MapPropertiesToMembers([NotNull] IEntityType entityType);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        FieldInfo FindBackingField([NotNull] IPropertyBase property);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -12,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class MemberMapper : IMemberMapper
@@ -20,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private readonly IFieldMatcher _fieldMatcher;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public MemberMapper([NotNull] IFieldMatcher fieldMatcher)
@@ -31,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         // TODO: Consider doing this at model building time, but also consider mapping to interfaces
         // Issue #757
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<Tuple<IProperty, MemberInfo>> MapPropertiesToMembers(IEntityType entityType)
@@ -41,67 +40,94 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             foreach (var property in entityType.GetProperties().Where(p => !p.IsShadowProperty))
             {
-                var propertyName = property.Name;
-
-                MemberInfo memberInfo = null;
-                foreach (var propertyInfo in entityType.ClrType.GetPropertiesInHierarchy(propertyName))
-                {
-                    Debug.Assert(propertyInfo.DeclaringType != null);
-                    // TODO: Handle cases where backing field is declared in a different class than the property
-                    // Issue #758
-                    Dictionary<string, FieldInfo> fields;
-                    if (!fieldCache.TryGetValue(propertyInfo.DeclaringType, out fields))
-                    {
-                        fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
-                        fieldCache[propertyInfo.DeclaringType] = fields;
-                    }
-
-                    var fieldName = property["BackingField"] as string;
-                    if (fieldName != null)
-                    {
-                        FieldInfo fieldInfo;
-                        if (!fields.TryGetValue(fieldName, out fieldInfo))
-                        {
-                            throw new InvalidOperationException(
-                                CoreStrings.MissingBackingField(entityType.DisplayName(), propertyName, fieldName));
-                        }
-                        if (!fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(property.ClrType.GetTypeInfo()))
-                        {
-                            throw new InvalidOperationException(
-                                CoreStrings.BadBackingFieldType(
-                                    fieldName, 
-                                    fieldInfo.FieldType.ShortDisplayName(), 
-                                    entityType.DisplayName(), 
-                                    propertyName, 
-                                    property.ClrType.ShortDisplayName()));
-                        }
-                        memberInfo = fieldInfo;
-                    }
-                    else
-                    {
-                        memberInfo = _fieldMatcher.TryMatchFieldName(property, propertyInfo, fields);
-                    }
-
-                    if (memberInfo != null)
-                    {
-                        break;
-                    }
-                }
+                var memberInfo = (MemberInfo)FindBackingField(property, fieldCache);
 
                 if (memberInfo == null)
                 {
-                    memberInfo = entityType.ClrType.GetPropertiesInHierarchy(propertyName).FirstOrDefault(p => p.SetMethod != null);
+                    memberInfo = entityType.ClrType.GetPropertiesInHierarchy(property.Name).FirstOrDefault(p => p.SetMethod != null);
+
+                    if (memberInfo == null)
+                    {
+                        throw new InvalidOperationException(CoreStrings.NoFieldOrSetter(entityType.DisplayName(), property.Name));
+                    }
                 }
 
-                if (memberInfo == null)
-                {
-                    throw new InvalidOperationException(CoreStrings.NoFieldOrSetter(entityType.DisplayName(), propertyName));
-                }
 
                 propertyMappings.Add(Tuple.Create(property, memberInfo));
             }
 
             return propertyMappings;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual FieldInfo FindBackingField(IPropertyBase property) 
+            => FindBackingField(property, new Dictionary<Type, Dictionary<string, FieldInfo>>());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        private FieldInfo FindBackingField(
+            IPropertyBase property,
+            IDictionary<Type, Dictionary<string, FieldInfo>> fieldCache)
+        {
+            var typesInHierarchy = property.DeclaringEntityType.ClrType.GetTypesInHierarchy().ToList();
+
+            var fieldName = property["BackingField"] as string;
+            if (fieldName != null)
+            {
+                foreach (var type in typesInHierarchy)
+                {
+                    var fields = GetFields(type, fieldCache);
+                    FieldInfo fieldInfo;
+                    if (fields.TryGetValue(fieldName, out fieldInfo))
+                    {
+                        if (!fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(property.GetClrType().GetTypeInfo()))
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.BadBackingFieldType(
+                                    fieldName,
+                                    fieldInfo.FieldType.ShortDisplayName(),
+                                    property.DeclaringEntityType.DisplayName(),
+                                    property.Name,
+                                    property.GetClrType().ShortDisplayName()));
+                        }
+
+                        return fieldInfo;
+                    }
+                }
+
+                throw new InvalidOperationException(
+                    CoreStrings.MissingBackingField(property.DeclaringEntityType.DisplayName(), property.Name, fieldName));
+            }
+
+            foreach (var type in typesInHierarchy)
+            {
+                var fields = GetFields(type, fieldCache);
+                var fieldInfo = _fieldMatcher.TryMatchFieldName(property, property.GetPropertyInfo(), fields);
+                if (fieldInfo != null)
+                {
+                    return fieldInfo;
+                }
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, FieldInfo> GetFields(
+            Type type, 
+            IDictionary<Type, Dictionary<string, FieldInfo>> fieldCache)
+        {
+            Dictionary<string, FieldInfo> fields;
+            if (!fieldCache.TryGetValue(type, out fields))
+            {
+                fields = type.GetRuntimeFields().ToDictionary(f => f.Name);
+                fieldCache[type] = fields;
+            }
+            return fields;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ModelExtensions.cs
@@ -41,5 +41,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static Model AsModel([NotNull] this IModel model, [CallerMemberName] [NotNull] string methodName = "")
             => model.AsConcreteMetadataType<IModel, Model>(methodName);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IMemberMapper GetMemberMapper([NotNull] this IModel model)
+            => model[CoreAnnotationNames.MemberMapperAnnotation] as IMemberMapper
+               ?? new MemberMapper(new FieldMatcher());
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MutableModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MutableModelExtensions.cs
@@ -1,23 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IFieldMatcher
+    public static class MutableModelExtensions
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        FieldInfo TryMatchFieldName(
-            [NotNull] IPropertyBase property, [NotNull] PropertyInfo propertyInfo, [NotNull] Dictionary<string, FieldInfo> declaredFields);
+        public static void SetMemberMapper([NotNull] this IMutableModel model, [NotNull] IMemberMapper memberMapper)
+            => model[CoreAnnotationNames.MemberMapperAnnotation] = memberMapper;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -64,14 +64,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IClrPropertyGetter Getter
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _getter, PropertyInfo, p => new ClrPropertyGetterFactory().Create(p));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IClrPropertySetter Setter
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _setter, PropertyInfo, p => new ClrPropertySetterFactory().Create(p));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, p => new ClrPropertySetterFactory().Create(p));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Internal\ServiceProviderCache.cs" />
     <Compile Include="Internal\TypeExtensions.cs" />
     <Compile Include="Metadata\Conventions\Internal\IEntityTypeIgnoredConvention.cs" />
+    <Compile Include="Metadata\Internal\MutableModelExtensions.cs" />
     <Compile Include="Storage\DatabaseProvider.cs" />
     <Compile Include="WarningBehavior.cs" />
     <Compile Include="Internal\WarningsConfiguration.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.
+        /// The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter and no backing field was found by convention. Read-only collection navigation properties must be initialized before use.
         /// </summary>
         public static string NavigationNoSetter([CanBeNull] object navigation, [CanBeNull] object entityType)
         {
@@ -1241,7 +1241,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Could not find setter for property {property}
+        /// Could not find setter or matching backing field for property {property}
         /// </summary>
         public static string NoClrSetter([CanBeNull] object property)
         {

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -286,7 +286,7 @@
     <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a getter.</value>
   </data>
   <data name="NavigationNoSetter" xml:space="preserve">
-    <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.</value>
+    <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter and no backing field was found by convention. Read-only collection navigation properties must be initialized before use.</value>
   </data>
   <data name="NavigationCannotCreateType" xml:space="preserve">
     <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
@@ -577,7 +577,7 @@
     <value>The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.</value>
   </data>
   <data name="NoClrSetter" xml:space="preserve">
-    <value>Could not find setter for property {property}</value>
+    <value>Could not find setter or matching backing field for property {property}</value>
   </data>
   <data name="NoPropertyType" xml:space="preserve">
     <value>The property '{property}' cannot be added to the entity type '{entityType}' because there was no property type specified and there is no corresponding CLR property. To add a shadow state property the property type needs to be specified.</value>

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -149,6 +149,16 @@ namespace System
             }
         }
 
+        public static IEnumerable<Type> GetTypesInHierarchy(this Type type)
+        {
+            while (type != null)
+            {
+                yield return type;
+
+                type = type.GetTypeInfo().BaseType;
+            }
+        }
+
         public static ConstructorInfo GetDeclaredConstructor(this Type type, Type[] types)
         {
             types = types ?? new Type[0];
@@ -165,7 +175,7 @@ namespace System
             {
                 var typeInfo = type.GetTypeInfo();
                 var propertyInfo = typeInfo.GetDeclaredProperty(name);
-                if ((propertyInfo != null)
+                if (propertyInfo != null
                     && !(propertyInfo.GetMethod ?? propertyInfo.SetMethod).IsStatic)
                 {
                     yield return propertyInfo;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -21,9 +21,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal, CategoryId = principal.Id };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -34,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -49,9 +50,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -77,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id };
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -89,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -104,9 +106,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                principal.AddProduct(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -117,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -132,8 +134,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id, Category = principal };
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                dependent.SetCategory(principal);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -144,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -159,9 +162,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                principal.AddProduct(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -172,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -187,8 +190,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal };
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                dependent.SetCategory(principal);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -199,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList().ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -214,9 +218,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal, CategoryId = principal.Id };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -227,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -242,9 +247,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -255,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -270,8 +276,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id };
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -282,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -297,9 +303,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                principal.AddProduct(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -310,7 +316,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -325,8 +331,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, CategoryId = principal.Id, Category = principal };
+                var principal = new Category(77);
+                var dependent = new Product(78, principal.Id);
+                dependent.SetCategory(principal);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -337,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -352,9 +359,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
-                principal.Products.Add(dependent);
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                principal.AddProduct(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -365,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -380,8 +387,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78, Category = principal };
+                var principal = new Category(77);
+                var dependent = new Product(78, 0);
+                dependent.SetCategory(principal);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -392,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -418,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -444,7 +452,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -471,7 +479,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -498,7 +506,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -525,7 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -552,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -773,9 +781,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal, ParentId = principal.Id };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -801,9 +810,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -829,8 +839,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id };
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -856,9 +866,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                principal.SetChild(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -884,8 +894,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id, Parent = principal };
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                dependent.SetParent(principal);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -911,9 +922,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                principal.SetChild(dependent);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -939,8 +950,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                dependent.SetParent(principal);
 
                 context.Entry(dependent).State = entityState;
                 context.Entry(principal).State = entityState;
@@ -966,9 +978,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal, ParentId = principal.Id };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -994,9 +1007,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1022,8 +1036,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id };
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1049,9 +1063,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                principal.SetChild(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1077,8 +1091,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, ParentId = principal.Id, Parent = principal };
+                var principal = new Parent(77);
+                var dependent = new Child(78, principal.Id);
+                dependent.SetParent(principal);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1104,9 +1119,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
-                principal.Child = dependent;
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                principal.SetChild(dependent);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1132,8 +1147,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78, Parent = principal };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
+                dependent.SetParent(principal);
 
                 context.Entry(principal).State = entityState;
                 context.Entry(dependent).State = entityState;
@@ -1525,14 +1541,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                dependent.Category = principal;
-                principal.Products.Add(dependent);
+                dependent.SetCategoryId(principal.Id);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1542,7 +1558,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Added, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1557,13 +1573,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.Category = principal;
-                principal.Products.Add(dependent);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1573,7 +1589,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Added, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1588,12 +1604,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.CategoryId = principal.Id;
+                dependent.SetCategoryId(principal.Id);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1603,7 +1619,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Null(dependent.Category);
-                            Assert.Empty(principal.Products);
+                            Assert.Null(principal.Products);
                             Assert.Equal(EntityState.Detached, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1618,13 +1634,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                principal.Products.Add(dependent);
+                dependent.SetCategoryId(principal.Id);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1634,7 +1650,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Null(dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Detached, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1649,13 +1665,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                dependent.Category = principal;
+                dependent.SetCategoryId(principal.Id);
+                dependent.SetCategory(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1665,7 +1681,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Added, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1680,12 +1696,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                principal.Products.Add(dependent);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1695,7 +1711,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(0, dependent.CategoryId);
                             Assert.Null(dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Detached, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -1710,12 +1726,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.Category = principal;
+                dependent.SetCategory(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1725,7 +1741,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Added, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -1740,14 +1756,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                dependent.Category = principal;
-                principal.Products.Add(dependent);
+                dependent.SetCategoryId(principal.Id);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1757,7 +1773,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -1772,13 +1788,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.Category = principal;
-                principal.Products.Add(dependent);
+                dependent.SetCategory(principal);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1788,7 +1804,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -1803,12 +1819,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.CategoryId = principal.Id;
+                dependent.SetCategoryId(principal.Id);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1818,7 +1834,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Null(dependent.Category);
-                            Assert.Empty(principal.Products);
+                            Assert.Null(principal.Products);
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
                         });
@@ -1833,13 +1849,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                principal.Products.Add(dependent);
+                dependent.SetCategoryId(principal.Id);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1849,7 +1865,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -1864,13 +1880,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                dependent.Category = principal;
+                dependent.SetCategoryId(principal.Id);
+                dependent.SetCategory(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1880,7 +1896,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Empty(principal.Products);
+                            Assert.Null(principal.Products);
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
                         });
@@ -1895,13 +1911,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.CategoryId = principal.Id;
-                principal.Products.Add(dependent);
+                dependent.SetCategoryId(principal.Id);
+                principal.AddProduct(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1911,7 +1927,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -1926,12 +1942,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Category { Id = 77 };
-                var dependent = new Product { Id = 78 };
+                var principal = new Category(77);
+                var dependent = new Product(77, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.Category = principal;
+                dependent.SetCategory(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -1941,7 +1957,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                         {
                             Assert.Equal(0, dependent.CategoryId);
                             Assert.Same(principal, dependent.Category);
-                            Assert.Empty(principal.Products);
+                            Assert.Null(principal.Products);
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
                         });
@@ -2029,7 +2045,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Detached, context.Entry(principal).State);
                             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, context.Entry(dependent).State);
                         });
@@ -2058,7 +2074,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(0, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(EntityState.Detached, context.Entry(principal).State);
                             Assert.Equal(entityState, context.Entry(dependent).State);
                         });
@@ -2088,7 +2104,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -2117,7 +2133,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     () =>
                         {
                             Assert.Equal(principal.Id, dependent.CategoryId);
-                            Assert.Equal(new[] { dependent }.ToList(), principal.Products);
+                            Assert.Equal(new[] { dependent }.ToList(), principal.Products.ToList());
                             Assert.Equal(entityState, context.Entry(principal).State);
                             Assert.Equal(EntityState.Added, context.Entry(dependent).State);
                         });
@@ -2364,14 +2380,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                dependent.Parent = principal;
-                principal.Child = dependent;
+                dependent.SetParentId(principal.Id);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2396,13 +2412,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.Parent = principal;
-                principal.Child = dependent;
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2427,12 +2443,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.ParentId = principal.Id;
+                dependent.SetParentId(principal.Id);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2457,13 +2473,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                principal.Child = dependent;
+                dependent.SetParentId(principal.Id);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2488,13 +2504,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                dependent.Parent = principal;
+                dependent.SetParentId(principal.Id);
+                dependent.SetParent(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2519,12 +2535,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                principal.Child = dependent;
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2549,12 +2565,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(dependent).State = entityState;
 
-                dependent.Parent = principal;
+                dependent.SetParent(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2579,14 +2595,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                dependent.Parent = principal;
-                principal.Child = dependent;
+                dependent.SetParentId(principal.Id);
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2611,13 +2627,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.Parent = principal;
-                principal.Child = dependent;
+                dependent.SetParent(principal);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2642,12 +2658,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.ParentId = principal.Id;
+                dependent.SetParentId(principal.Id);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2672,13 +2688,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                principal.Child = dependent;
+                dependent.SetParentId(principal.Id);
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2703,13 +2719,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.ParentId = principal.Id;
-                dependent.Parent = principal;
+                dependent.SetParentId(principal.Id);
+                dependent.SetParent(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2734,12 +2750,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                principal.Child = dependent;
+                principal.SetChild(dependent);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -2764,12 +2780,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var principal = new Parent { Id = 77 };
-                var dependent = new Child { Id = 78 };
+                var principal = new Parent(77);
+                var dependent = new Child(78, 0);
 
                 context.Entry(principal).State = entityState;
 
-                dependent.Parent = principal;
+                dependent.SetParent(principal);
 
                 context.ChangeTracker.DetectChanges();
 
@@ -3199,10 +3215,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var category = new Category { Id = 77 };
-                context.Add(new Product { Id = 777, Category = category });
-                context.Add(new Product { Id = 778, Category = category });
-                context.Add(new Category { Id = 78 });
+                var category = new Category(77);
+                var product1 = new Product(777, 0);
+                var product2 = new Product(778, 0);
+                product1.SetCategory(category);
+                product2.SetCategory(category);
+
+                context.Add(product1);
+                context.Add(product2);
+                context.Add(new Category(78));
+
                 context.SaveChanges();
             }
 
@@ -3214,12 +3236,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 var category2 = context.Set<Category>().ToList().Single(a => a != category);
 
-                Assert.Equal(0, category2.Products.Count);
+                Assert.Null(category2.Products);
 
                 var product = category.Products.First();
                 category.Products.Remove(product);
-                product.Category = category2;
-                category2.Products.Add(product);
+                product.SetCategory(category2);
+                category2.AddProduct(product);
                 Assert.Equal(category.Id, product.CategoryId);
 
                 context.ChangeTracker.DetectChanges();
@@ -3235,30 +3257,30 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                context.Add(new Category { Id = 11 });
-                context.Add(new Category { Id = 12 });
-                context.Add(new Category { Id = 13 });
+                context.Add(new Category(11));
+                context.Add(new Category(12));
+                context.Add(new Category(13));
 
-                context.Add(new Product { Id = 21, CategoryId = 11 });
+                context.Add(new Product(21, 11));
                 AssertAllFixedUp(context);
-                context.Add(new Product { Id = 22, CategoryId = 11 });
+                context.Add(new Product(22, 11));
                 AssertAllFixedUp(context);
-                context.Add(new Product { Id = 23, CategoryId = 11 });
+                context.Add(new Product(23, 11));
                 AssertAllFixedUp(context);
-                context.Add(new Product { Id = 24, CategoryId = 12 });
+                context.Add(new Product(24, 12));
                 AssertAllFixedUp(context);
-                context.Add(new Product { Id = 25, CategoryId = 12 });
+                context.Add(new Product(25, 12));
                 AssertAllFixedUp(context);
 
-                context.Add(new SpecialOffer { Id = 31, ProductId = 22 });
+                context.Add(new SpecialOffer(31, 22));
                 AssertAllFixedUp(context);
-                context.Add(new SpecialOffer { Id = 32, ProductId = 22 });
+                context.Add(new SpecialOffer(32, 22));
                 AssertAllFixedUp(context);
-                context.Add(new SpecialOffer { Id = 33, ProductId = 24 });
+                context.Add(new SpecialOffer(33, 24));
                 AssertAllFixedUp(context);
-                context.Add(new SpecialOffer { Id = 34, ProductId = 24 });
+                context.Add(new SpecialOffer(34, 24));
                 AssertAllFixedUp(context);
-                context.Add(new SpecialOffer { Id = 35, ProductId = 24 });
+                context.Add(new SpecialOffer(35, 24));
                 AssertAllFixedUp(context);
 
                 Assert.Equal(3, context.ChangeTracker.Entries<Category>().Count());
@@ -3280,34 +3302,34 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }), null);
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }), null);
-                stateManager.StartTrackingFromQuery(categoryType, new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }), null);
+                stateManager.StartTrackingFromQuery(categoryType, new Category(11), new ValueBuffer(new object[] { 11 }), null);
+                stateManager.StartTrackingFromQuery(categoryType, new Category(12), new ValueBuffer(new object[] { 12 }), null);
+                stateManager.StartTrackingFromQuery(categoryType, new Category(13), new ValueBuffer(new object[] { 13 }), null);
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }), null);
+                stateManager.StartTrackingFromQuery(productType, new Product(21, 11), new ValueBuffer(new object[] { 21, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }), null);
+                stateManager.StartTrackingFromQuery(productType, new Product(22, 11), new ValueBuffer(new object[] { 22, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }), null);
+                stateManager.StartTrackingFromQuery(productType, new Product(23, 11), new ValueBuffer(new object[] { 23, 11 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }), null);
+                stateManager.StartTrackingFromQuery(productType, new Product(24, 12), new ValueBuffer(new object[] { 24, 12 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(productType, new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }), null);
+                stateManager.StartTrackingFromQuery(productType, new Product(25, 12), new ValueBuffer(new object[] { 25, 12 }), null);
                 AssertAllFixedUp(context);
 
                 stateManager.BeginTrackingQuery();
 
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }), null);
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(31, 22), new ValueBuffer(new object[] { 31, 22 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }), null);
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(32, 22), new ValueBuffer(new object[] { 32, 22 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }), null);
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(33, 24), new ValueBuffer(new object[] { 33, 24 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }), null);
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(34, 24), new ValueBuffer(new object[] { 34, 24 }), null);
                 AssertAllFixedUp(context);
-                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }), null);
+                stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(35, 24), new ValueBuffer(new object[] { 35, 24 }), null);
 
                 AssertAllFixedUp(context);
 
@@ -3322,33 +3344,45 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
-                var category11 = new Category { Id = 11 };
-                var category12 = new Category { Id = 12 };
-                var category13 = new Category { Id = 13 };
+                var category11 = new Category(11);
+                var category12 = new Category(12);
+                var category13 = new Category(13);
 
-                var product21 = new Product { Id = 21, CategoryId = 11, Category = category11 };
-                var product22 = new Product { Id = 22, CategoryId = 11, Category = category11 };
-                var product23 = new Product { Id = 23, CategoryId = 11, Category = category11 };
-                var product24 = new Product { Id = 24, CategoryId = 12, Category = category12 };
-                var product25 = new Product { Id = 25, CategoryId = 12, Category = category12 };
+                var product21 = new Product(21, 11);
+                var product22 = new Product(22, 11);
+                var product23 = new Product(23, 11);
+                var product24 = new Product(24, 12);
+                var product25 = new Product(25, 12);
 
-                category11.Products.Add(product21);
-                category11.Products.Add(product22);
-                category11.Products.Add(product23);
-                category12.Products.Add(product24);
-                category12.Products.Add(product25);
+                product21.SetCategory(category11);
+                product22.SetCategory(category11);
+                product23.SetCategory(category11);
+                product24.SetCategory(category12);
+                product25.SetCategory(category12);
 
-                var specialOffer31 = new SpecialOffer { Id = 31, ProductId = 22, Product = product22 };
-                var specialOffer32 = new SpecialOffer { Id = 32, ProductId = 22, Product = product22 };
-                var specialOffer33 = new SpecialOffer { Id = 33, ProductId = 24, Product = product24 };
-                var specialOffer34 = new SpecialOffer { Id = 34, ProductId = 24, Product = product24 };
-                var specialOffer35 = new SpecialOffer { Id = 35, ProductId = 24, Product = product24 };
+                category11.AddProduct(product21);
+                category11.AddProduct(product22);
+                category11.AddProduct(product23);
+                category12.AddProduct(product24);
+                category12.AddProduct(product25);
 
-                product22.SpecialOffers.Add(specialOffer31);
-                product22.SpecialOffers.Add(specialOffer32);
-                product24.SpecialOffers.Add(specialOffer33);
-                product24.SpecialOffers.Add(specialOffer34);
-                product24.SpecialOffers.Add(specialOffer35);
+                var specialOffer31 = new SpecialOffer(31, 22);
+                var specialOffer32 = new SpecialOffer(32, 22);
+                var specialOffer33 = new SpecialOffer(33, 24);
+                var specialOffer34 = new SpecialOffer(34, 24);
+                var specialOffer35 = new SpecialOffer(35, 24);
+
+                specialOffer31.SetProduct(product22);
+                specialOffer32.SetProduct(product22);
+                specialOffer33.SetProduct(product24);
+                specialOffer34.SetProduct(product24);
+                specialOffer35.SetProduct(product24);
+
+                product22.AddSpecialOffer(specialOffer31);
+                product22.AddSpecialOffer(specialOffer32);
+                product24.AddSpecialOffer(specialOffer33);
+                product24.AddSpecialOffer(specialOffer34);
+                product24.AddSpecialOffer(specialOffer35);
 
                 context.Add(category11);
                 AssertAllFixedUp(context);
@@ -3381,13 +3415,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
                 Assert.Equal(3, category11.Products.Count);
                 Assert.Equal(2, category12.Products.Count);
-                Assert.Equal(0, category13.Products.Count);
+                Assert.Null(category13.Products);
 
-                Assert.Equal(0, product21.SpecialOffers.Count);
+                Assert.Null(product21.SpecialOffers);
                 Assert.Equal(2, product22.SpecialOffers.Count);
-                Assert.Equal(0, product23.SpecialOffers.Count);
+                Assert.Null(product23.SpecialOffers);
                 Assert.Equal(3, product24.SpecialOffers.Count);
-                Assert.Equal(0, product25.SpecialOffers.Count);
+                Assert.Null(product25.SpecialOffers);
 
                 Assert.Equal(3, context.ChangeTracker.Entries<Category>().Count());
                 Assert.Equal(5, context.ChangeTracker.Entries<Product>().Count());
@@ -3430,17 +3464,47 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
         private class Parent
         {
-            public int Id { get; set; }
+            private readonly int _id;
+            private Child _child;
 
-            public Child Child { get; set; }
+            public Parent(int id)
+            {
+                _id = id;
+            }
+
+            // ReSharper disable once ConvertToAutoProperty
+            public int Id => _id;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public Child Child => _child;
+
+            public void SetChild(Child child) => _child = child;
         }
 
         private class Child
         {
-            public int Id { get; set; }
-            public int ParentId { get; set; }
+            private readonly int _id;
+            private int _parentId;
+            private Parent _parent;
 
-            public Parent Parent { get; set; }
+            public Child(int id, int parentId)
+            {
+                _id = id;
+                _parentId = parentId;
+            }
+
+            // ReSharper disable once ConvertToAutoProperty
+            public int Id => _id;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public int ParentId => _parentId;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public Parent Parent => _parent;
+
+            public void SetParent(Parent parent) => _parent = parent;
+
+            public void SetParentId(int parentId) => _parentId = parentId;
         }
 
         private class ParentPN
@@ -3525,36 +3589,96 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
         private class Category
         {
+            // ReSharper disable once FieldCanBeMadeReadOnly.Local
+            private int _id;
+            private ICollection<Product> _products;
+
             public Category()
             {
-                Products = new List<Product>();
             }
 
-            public int Id { get; set; }
+            public Category(int id)
+            {
+                _id = id;
+            }
 
-            public ICollection<Product> Products { get; }
+            // ReSharper disable once ConvertToAutoProperty
+            public int Id => _id;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public ICollection<Product> Products => _products;
+
+            public void AddProduct(Product product)
+                => (_products ?? (_products = new List<Product>())).Add(product);
         }
 
         private class Product
         {
+            // ReSharper disable once FieldCanBeMadeReadOnly.Local
+            private int _id;
+            private int _categoryId;
+            private Category _category;
+            private ICollection<SpecialOffer> _specialOffers;
+
             public Product()
             {
-                SpecialOffers = new List<SpecialOffer>();
             }
 
-            public int Id { get; set; }
-            public int CategoryId { get; set; }
+            public Product(int id, int categoryId)
+            {
+                _id = id;
+                _categoryId = categoryId;
+            }
 
-            public Category Category { get; set; }
-            public ICollection<SpecialOffer> SpecialOffers { get; }
+            // ReSharper disable once ConvertToAutoProperty
+            public int Id => _id;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public int CategoryId => _categoryId;
+
+            public void SetCategoryId(int categoryId) => _categoryId = categoryId;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public Category Category => _category;
+
+            public void SetCategory(Category category) => _category = category;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public ICollection<SpecialOffer> SpecialOffers => _specialOffers;
+
+            public void AddSpecialOffer(SpecialOffer specialOffer)
+                => (_specialOffers ?? (_specialOffers = new List<SpecialOffer>())).Add(specialOffer);
         }
 
         private class SpecialOffer
         {
-            public int Id { get; set; }
-            public int ProductId { get; set; }
+            // ReSharper disable once FieldCanBeMadeReadOnly.Local
+            private int _id;
+            private int _productId;
+            private Product _product;
 
-            public Product Product { get; set; }
+            public SpecialOffer()
+            {
+            }
+
+            public SpecialOffer(int id, int productId)
+            {
+                _id = id;
+                _productId = productId;
+            }
+
+            // ReSharper disable once ConvertToAutoProperty
+            public int Id => _id;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public int ProductId => _productId;
+
+            public void SetProductId(int productId) => _productId = productId;
+
+            // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
+            public Product Product => _product;
+
+            public void SetProduct(Product product) => _product = product;
         }
 
         private class FixupContext : DbContext
@@ -3566,13 +3690,26 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Product>()
-                    .HasMany(e => e.SpecialOffers)
-                    .WithOne(e => e.Product);
+                modelBuilder.Entity<Product>(b =>
+                    {
+                        b.HasKey(e => e.Id);
+                        b.Property(e => e.CategoryId);
+                        b.HasMany(e => e.SpecialOffers)
+                            .WithOne(e => e.Product);
+                    });
 
-                modelBuilder.Entity<Category>()
-                    .HasMany(e => e.Products)
-                    .WithOne(e => e.Category);
+                modelBuilder.Entity<Category>(b =>
+                    {
+                        b.HasKey(e => e.Id);
+                        b.HasMany(e => e.Products)
+                            .WithOne(e => e.Category);
+                    });
+
+                modelBuilder.Entity<SpecialOffer>(b =>
+                {
+                    b.HasKey(e => e.Id);
+                    b.Property(e => e.ProductId);
+                });
 
                 modelBuilder.Entity<CategoryPN>()
                     .HasMany(e => e.Products)
@@ -3589,10 +3726,19 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                     .WithMany()
                     .HasForeignKey(e => e.CategoryId);
 
-                modelBuilder.Entity<Parent>()
-                    .HasOne(e => e.Child)
-                    .WithOne(e => e.Parent)
-                    .HasForeignKey<Child>(e => e.ParentId);
+                modelBuilder.Entity<Parent>(b =>
+                    {
+                        b.HasKey(e => e.Id);
+                        b.HasOne(e => e.Child)
+                            .WithOne(e => e.Parent)
+                            .HasForeignKey<Child>(e => e.ParentId);
+                    });
+
+                modelBuilder.Entity<Child>(b =>
+                    {
+                        b.HasKey(e => e.Id);
+                        b.Property(e => e.ParentId);
+                    });
 
                 modelBuilder.Entity<ParentPN>()
                     .HasOne(e => e.Child)

--- a/test/Microsoft.EntityFrameworkCore.Tests/ContextConfigurationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ContextConfigurationTest.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             var contextServices1 = TestHelpers.Instance.CreateContextServices(provider);
             var contextServices2 = TestHelpers.Instance.CreateContextServices(provider);
 
-            Assert.Same(contextServices1.GetRequiredService<IMemberMapper>(), contextServices2.GetRequiredService<IMemberMapper>());
+            Assert.Same(contextServices1.GetRequiredService<IDbSetSource>(), contextServices2.GetRequiredService<IDbSetSource>());
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -2103,8 +2103,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 .AddSingleton<IDbSetFinder, DbSetFinder>()
                 .AddSingleton<IDbSetSource, DbSetSource>()
                 .AddSingleton<IEntityMaterializerSource, EntityMaterializerSource>()
-                .AddSingleton<IMemberMapper, MemberMapper>()
-                .AddSingleton<IFieldMatcher, FieldMatcher>()
                 .AddSingleton<DatabaseProviderSelector>()
                 .AddScoped<IDbSetInitializer, DbSetInitializer>()
                 .AddScoped<IDbContextServices, DbContextServices>()
@@ -2333,10 +2331,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         private class FakeEntityMaterializerSource : EntityMaterializerSource
         {
-            public FakeEntityMaterializerSource(IMemberMapper memberMapper)
-                : base(memberMapper)
-            {
-            }
         }
 
         private class FakeLoggerFactory : ILoggerFactory

--- a/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -47,8 +47,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
             VerifySingleton<IDbSetSource>();
             VerifySingleton<ICollectionTypeFactory>();
             VerifySingleton<IEntityMaterializerSource>();
-            VerifySingleton<IMemberMapper>();
-            VerifySingleton<IFieldMatcher>();
             VerifySingleton<ILoggerFactory>();
             VerifySingleton<ICoreConventionSetBuilder>();
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -67,6 +67,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
+        public void Delegate_accessor_is_returned_when_no_backing_field_found()
+        {
+            AccessorTest("NoBackingFound", e => e.NoBackingFound);
+        }
+
+        [Fact]
         public void Delegate_accessor_is_returned_when_no_public_constructor()
         {
             AccessorTest("AsMyPrivateCollection", e => e.AsMyPrivateCollection);
@@ -82,6 +88,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Delegate_accessor_is_returned_when_no_parameterless_constructor()
         {
             AccessorTest("AsMyUnavailableCollection", e => e.AsMyUnavailableCollection);
+        }
+
+        [Fact]
+        public void Delegate_accessor_handles_uninitialized_collections_with_no_setter()
+        {
+            AccessorTest("WithNoSetter", e => e.WithNoSetter, initializeCollections: false);
         }
 
         [Fact]
@@ -200,12 +212,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         }
 
         [Fact]
-        public void Initialization_for_navigation_without_setter_throws()
+        public void Initialization_for_navigation_without_backing_field_throws()
         {
-            var accessor = new ClrCollectionAccessorFactory().Create(CreateNavigation("WithNoSetter"));
+            var accessor = new ClrCollectionAccessorFactory().Create(CreateNavigation("NoBackingFound"));
 
             Assert.Equal(
-                CoreStrings.NavigationNoSetter("WithNoSetter", typeof(MyEntity).Name),
+                CoreStrings.NavigationNoSetter("NoBackingFound", typeof(MyEntity).Name),
                 Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(), new MyOtherEntity())).Message);
         }
 
@@ -258,6 +270,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             private IList<MyOtherEntity> _asIList;
             private List<MyOtherEntity> _asList;
             private MyCollection _myCollection;
+            private ICollection<MyOtherEntity> _withNoBackingFieldFound;
             private ICollection<MyOtherEntity> _withNoSetter;
             // ReSharper disable once NotAccessedField.Local
             private ICollection<MyOtherEntity> _withNoGetter;
@@ -274,6 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
                 _asIList = new List<MyOtherEntity>();
                 _asList = new List<MyOtherEntity>();
                 _myCollection = new MyCollection();
+                _withNoBackingFieldFound = new HashSet<MyOtherEntity>();
                 _withNoSetter = new HashSet<MyOtherEntity>();
                 _withNoGetter = new HashSet<MyOtherEntity>();
                 _enumerable = new HashSet<MyOtherEntity>();
@@ -309,6 +323,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             }
 
             internal ICollection<MyOtherEntity> WithNoSetter => _withNoSetter;
+
+            internal ICollection<MyOtherEntity> NoBackingFound => _withNoBackingFieldFound;
 
             internal ICollection<MyOtherEntity> WithNoGetter
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             typeMock.SetupGet(et => et.ClrType).Returns(typeof(string));
 
             var reader = ValueBuffer.Empty;
-            GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), typeMock.Object)(reader);
+            GetMaterializer(new EntityMaterializerSource(), typeMock.Object)(reader);
 
             materializerMock.Verify(m => m.CreateEntity(reader));
         }
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.AddProperty(SomeEntity.IdProperty);
             entityType.AddProperty(SomeEntity.MaybeEnumProperty);
 
-            var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
+            var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
             var gu = Guid.NewGuid();
             var entity = (SomeEntity)factory(new ValueBuffer(new object[] { SomeEnum.EnumValue, "Fu", gu, 77, SomeEnum.EnumValue }));
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.AddProperty(SomeEntityWithFields.IdProperty);
             entityType.AddProperty(SomeEntityWithFields.MaybeEnumProperty);
 
-            var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
+            var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
             var gu = Guid.NewGuid();
             var entity = (SomeEntityWithFields)factory(new ValueBuffer(new object[] { SomeEnum.EnumValue, "Fu", gu, 77, null }));
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.AddProperty(SomeEntity.GooProperty);
             entityType.AddProperty(SomeEntity.IdProperty);
 
-            var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
+            var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
             var entity = (SomeEntity)factory(new ValueBuffer(new object[] { null, null, 77 }));
 
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.AddProperty(SomeEntity.GooProperty);
             entityType.AddProperty("GooShadow", typeof(Guid));
 
-            var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
+            var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
             var gu = Guid.NewGuid();
             var entity = (SomeEntity)factory(new ValueBuffer(new object[] { "Fu", "FuS", gu, Guid.NewGuid(), 77, 777 }));
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.NoParameterlessConstructor(typeof(EntityWithoutParameterlessConstructor).Name),
-                Assert.Throws<InvalidOperationException>(() => GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType)).Message);
+                Assert.Throws<InvalidOperationException>(() => GetMaterializer(new EntityMaterializerSource(), entityType)).Message);
         }
 
         private static readonly ParameterExpression _readerParameter

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/MemberMapperTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/MemberMapperTest.cs
@@ -128,6 +128,33 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal("UsAndThem", mapping.Item2.Name);
         }
 
+        [Fact]
+        public void Named_field_on_base_class_is_found()
+        {
+            var entityType = new Model().AddEntityType(typeof(TheDarkSide));
+            var property = entityType.AddProperty(TheDarkSide.OnBaseNamedProperty);
+            property["BackingField"] = "_namedonBase";
+
+            var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
+
+            Assert.Same(property, mapping.Item1);
+            Assert.IsAssignableFrom<FieldInfo>(mapping.Item2);
+            Assert.Equal("_namedonBase", mapping.Item2.Name);
+        }
+
+        [Fact]
+        public void Matched_field_on_base_class_is_found()
+        {
+            var entityType = new Model().AddEntityType(typeof(TheDarkSide));
+            var property = entityType.AddProperty(TheDarkSide.OnBaseProperty);
+
+            var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
+
+            Assert.Same(property, mapping.Item1);
+            Assert.IsAssignableFrom<FieldInfo>(mapping.Item2);
+            Assert.Equal("_onBase", mapping.Item2.Name);
+        }
+
         private class TheDarkSide : OfTheMoon
         {
             public static readonly PropertyInfo SpeakToMeProperty = typeof(TheDarkSide).GetProperty("SpeakToMe");
@@ -136,6 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             public static readonly PropertyInfo TimeProperty = typeof(TheDarkSide).GetProperty("Time");
             public static readonly PropertyInfo MoneyProperty = typeof(TheDarkSide).GetProperty("Money");
             public static readonly PropertyInfo UsAndThemProperty = typeof(TheDarkSide).GetProperty("UsAndThem");
+            public static readonly PropertyInfo OnBaseNamedProperty = typeof(TheDarkSide).GetProperty("OnBaseNamed");
+            public static readonly PropertyInfo OnBaseProperty = typeof(TheDarkSide).GetProperty("OnBase");
 
             private int? fieldForSpeak;
 #pragma warning disable 169
@@ -163,6 +192,18 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             public override int Money => 0;
 
             public override int UsAndThem => 0;
+
+            public int OnBaseNamed
+            {
+                get {  return _namedonBase; }
+                set { _namedonBase = value; }
+            }
+
+            public int OnBase
+            {
+                get { return _onBase; }
+                set { _onBase = value; }
+            }
         }
 
         private class OfTheMoon
@@ -186,6 +227,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             }
 
             public virtual int UsAndThem { get; private set; }
+
+            protected int _namedonBase;
+
+            protected int _onBase;
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ModelTest.cs
@@ -198,6 +198,23 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Same(foreignKey, entityType1.GetReferencingForeignKeys().Single());
         }
 
+        [Fact]
+        public void Can_get_default_MemberMapper()
+        {
+            Assert.IsType<MemberMapper>(new Model().GetMemberMapper());
+        }
+
+        [Fact]
+        public void Can_change_MemberMapper()
+        {
+            var memberMapper = new MemberMapper(new FieldMatcher());
+            var model = new Model();
+
+            model.SetMemberMapper(memberMapper);
+
+            Assert.Same(memberMapper, model.GetMemberMapper());
+        }
+
         private class Customer
         {
             public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");


### PR DESCRIPTION
Add change tracker support for read-only properties with backing fields

Issue #4461

Previously the materializer would use the backing field, but then when a value needed to be set for fixup, etc, things would fall down. Now we generate delegates everywhere that can use the backing field.

Note that query still prefers the backing field, while fixup prefers the property.

MemberMapper was made a service of the model. Only the minimal done here--we can allow it to be set by convention or fluent API if the need to customize it is requested.

Also fixed #758 - When mapping to backing fields handle cases where field is on base type
