### PR TITLE
Query: Handle | and & operator for boolean values properly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1619,7 +1619,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             {
                 if (_isSearchCondition)
                 {
-                    if (expression.IsComparisonOperation())
+                    if (expression.IsComparisonOperation()
+                        || expression.NodeType == ExpressionType.Or
+                        || expression.NodeType == ExpressionType.And)
                     {
                         var parentIsSearchCondition = _isSearchCondition;
                         _isSearchCondition = false;
@@ -1632,10 +1634,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 }
                 else
                 {
-                    if (expression.IsLogicalOperation())
+                    if (expression.IsLogicalOperation()
+                        || expression.NodeType == ExpressionType.Or
+                        || expression.NodeType == ExpressionType.And)
                     {
                         var parentIsSearchCondition = _isSearchCondition;
-                        _isSearchCondition = true;
+                        _isSearchCondition = expression.IsLogicalOperation();
                         var left = Visit(expression.Left);
                         var right = Visit(expression.Right);
                         _isSearchCondition = parentIsSearchCondition;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5707,6 +5707,114 @@ ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
+        public override void Bitwise_or_with_boolean_operators_in_predicate()
+        {
+            base.Bitwise_or_with_boolean_operators_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END | CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) = 1",
+                Sql);
+        }
+
+        public override void Bitwise_and_with_boolean_operators_in_predicate()
+        {
+            base.Bitwise_and_with_boolean_operators_in_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END & CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) = 1",
+                Sql);
+        }
+
+        public override void Bitwise_or_with_boolean_operators_in_projection()
+        {
+            base.Bitwise_or_with_boolean_operators_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END | CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void Bitwise_or_multiple_with_boolean_operators_in_projection()
+        {
+            base.Bitwise_or_multiple_with_boolean_operators_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END | CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) | CASE
+    WHEN [c].[CustomerID] = N'ANTON'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void Bitwise_and_with_boolean_operators_in_projection()
+        {
+            base.Bitwise_and_with_boolean_operators_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END & CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void Bitwise_and_or_with_boolean_operators_in_projection()
+        {
+            base.Bitwise_and_or_with_boolean_operators_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END & CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) | CASE
+    WHEN [c].[CustomerID] = N'ANTON'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Fixes #5930 
Difference between logical and bitwise operators is, logical operators can short-circuit. In order to prevent short-circuiting and also producing a valid query, converted the Boolean conditions to values.