### PR TITLE
Fix: 6198 - NotImplementedException for GroupJoin

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -59,6 +59,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Mixed_sync_async_query()
+        {
+            using (var context = CreateContext())
+            {
+                var results
+                    = (await context.Customers
+                        .Select(c => new
+                        {
+                            c.CustomerID,
+                            Orders = context.Orders.Where(o => o.Customer.CustomerID == c.CustomerID)
+                        }).ToListAsync())
+                        .Select(x => new
+                        {
+                            Orders = x.Orders
+                                .GroupJoin(new[] { "ALFKI" }, y => x.CustomerID, y => y, (h, id) => new
+                                {
+                                    h.Customer
+                                })
+                        })
+                        .ToList();
+
+                Assert.Equal(546, results.SelectMany(r => r.Orders).ToList().Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual async Task LoadAsync_should_track_results()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -210,6 +210,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual ILinqOperatorProvider LinqOperatorProvider { get; private set; }
 
         /// <summary>
+        ///     Gets the <see cref="IQueryProvider"/> being used for this query.
+        /// </summary>
+        public virtual IQueryProvider QueryProvider { get; [param: NotNull] set; }
+
+        /// <summary>
         ///     Creates an action to execute this query.
         /// </summary>
         /// <typeparam name="TResult"> The type of results that the query returns. </typeparam>
@@ -305,7 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
-        ///     Populates <see cref="QueryCompilationContext.QueryAnnotations"/> based on annotations found in the query.
+        ///     Populates <see cref="Query.QueryCompilationContext.QueryAnnotations"/> based on annotations found in the query.
         /// </summary>
         /// <param name="queryModel"> The query. </param>
         protected virtual void ExtractQueryAnnotations([NotNull] QueryModel queryModel)

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/EntityQueryableExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/EntityQueryableExpressionVisitor.cs
@@ -32,10 +32,19 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <param name="constantExpression"> The node being visited. </param>
         /// <returns> An expression to use in place of the node. </returns>
         protected override Expression VisitConstant(ConstantExpression constantExpression)
-            => constantExpression.Type.GetTypeInfo().IsGenericType
-               && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>)
-                   ? VisitEntityQueryable(((IQueryable)constantExpression.Value).ElementType)
-                   : constantExpression;
+        {
+            if (constantExpression.Type.GetTypeInfo().IsGenericType
+                && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>))
+            {
+                var queryable = (IQueryable)constantExpression.Value;
+
+                QueryModelVisitor.QueryProvider = queryable.Provider;
+
+                return VisitEntityQueryable(queryable.ElementType);
+            }
+
+            return constantExpression;
+        }
 
         /// <summary>
         ///     Visits entity type roots.

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -241,12 +241,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     propertyType);
                             }
                             
-                            var maybeMethodCallExpression= newExpression.Arguments[0] as MethodCallExpression;
+                            var maybeMethodCallExpression = newExpression.Arguments[0] as MethodCallExpression;
 
-                            if (maybeMethodCallExpression != null
+                            if ((maybeMethodCallExpression != null
                                 && maybeMethodCallExpression.Method.IsGenericMethod
                                 && maybeMethodCallExpression.Method.GetGenericMethodDefinition()
                                 == DefaultQueryExpressionVisitor.GetParameterValueMethodInfo)
+                                || (newExpression.Arguments[0].NodeType == ExpressionType.Parameter
+                                    && !property.IsShadowProperty))
                             {
                                 // The target is a parameter, try and get the value from it directly.
                                 return Expression.Call(
@@ -255,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     Expression.Constant(property.GetGetter()),
                                     newExpression.Arguments[0]);
                             }
-                            
+
                             return Expression.Call(
                                 _getValueMethodInfo.MakeGenericMethod(propertyType),
                                 EntityQueryModelVisitor.QueryContextParameter,

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses.Expressions;
 
@@ -52,7 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         = Expression.Call(
                             QueryModelVisitor.LinqOperatorProvider.ToQueryable
                                 .MakeGenericMethod(expression.Type.GetSequenceType()),
-                            subExpression);
+                            subExpression,
+                            Expression.Constant(QueryModelVisitor.QueryProvider));
                 }
                 else if (subQueryExpressionTypeInfo.IsGenericType)
                 {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -91,11 +91,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        public override Task Select_nested_collection_deep()
-        {
-            return base.Select_nested_collection_deep();
-        }
-
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {


### PR DESCRIPTION
- Corrects handling of nested IQueryables in projections.
- Fixes a small bug in member binding to do with our new parameter injector.

@maumar 