### PR TITLE
Explicitly set the DiscriminatorValueGenerator on the discriminator property

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -248,7 +249,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             // TODO: #2132
             //propertyBuilder.ReadOnlyBeforeSave(true, configurationSource);
             propertyBuilder.ReadOnlyAfterSave(true, configurationSource);
-            propertyBuilder.RequiresValueGenerator(true, configurationSource);
+            propertyBuilder.HasValueGenerator(
+                (property, entityType) => new DiscriminatorValueGenerator(GetAnnotations(entityType).DiscriminatorValue),
+                configurationSource);
 
             return new DiscriminatorBuilder(Annotations, entityBuilder
                 => new RelationalEntityTypeBuilderAnnotations(entityBuilder, Annotations.ConfigurationSource, ProviderFullAnnotationNames));

--- a/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -31,12 +31,6 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
             Check.NotNull(property, nameof(property));
             Check.NotNull(entityType, nameof(entityType));
 
-            if ((property.DeclaringEntityType.BaseType == null)
-                && (RelationalExtensions.For(property.DeclaringEntityType).DiscriminatorProperty == property))
-            {
-                return new DiscriminatorValueGenerator(RelationalExtensions.For(entityType).DiscriminatorValue);
-            }
-
             if (property.ValueGenerated != ValueGenerated.Never)
             {
                 var propertyType = property.ClrType.UnwrapNullableType().UnwrapEnumType();
@@ -61,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
                 if (propertyType == typeof(DateTime))
                 {
-                    return new TemporaryDateTimeOffsetValueGenerator();
+                    return new TemporaryDateTimeValueGenerator();
                 }
 
                 if (propertyType == typeof(DateTimeOffset))

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -54,8 +54,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
 
             var keyConvention = new KeyConvention();
-            conventionSet.KeyAddedConventions.Add(keyConvention);
-
             conventionSet.PrimaryKeySetConventions.Add(keyConvention);
 
             var cascadeDeleteConvention = new CascadeDeleteConvention();

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -201,13 +201,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 Metadata.SetValueGenerated(valueGenerated, configurationSource);
 
-                if (Metadata.IsKey())
-                {
-                    RequiresValueGenerator(
-                        valueGenerated == EntityFrameworkCore.Metadata.ValueGenerated.OnAdd,
-                        ConfigurationSource.Convention);
-                }
-
                 return true;
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    [DebuggerDisplay("{DeclaringEntityType.Name,nq}.{Name,nq} ({ClrType?.Name,nq})")]
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public class Property : PropertyBase, IMutableProperty
     {
         private int _flags;
@@ -316,7 +316,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             UpdateRequiresValueGeneratorConfigurationSource(configurationSource);
         }
 
-        private static bool DefaultRequiresValueGenerator => false;
+        private bool DefaultRequiresValueGenerator
+            => this.IsKey()
+               && !this.IsForeignKey()
+               && ValueGenerated == ValueGenerated.OnAdd;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -460,6 +463,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string Format([NotNull] IEnumerable<IProperty> properties)
             => "{" + string.Join(", ", properties.Select(p => "'" + p.Name + "'")) + "}";
+
+        [UsedImplicitly]
+        private string DebuggerDisplay => $"{DeclaringEntityType.DisplayName()}.{Name} ({ClrType?.ShortDisplayName()})";
 
         IEntityType IPropertyBase.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableProperty.DeclaringEntityType => DeclaringEntityType;

--- a/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/DiscriminatorTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests
     public class DiscriminatorTest
     {
         [Fact]
-        public void Can_save_enities_with_discriminators()
+        public void Can_save_entities_with_discriminators()
         {
             using (var context = new Context4285())
             {
@@ -21,13 +21,17 @@ namespace Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests
             using (var context = new Context4285())
             {
                 var products = context.Products.ToList();
-                Assert.Equal("One", products.OfType<SubProduct>().Single().SomeName);
-                Assert.Equal("Two", products.OfType<SubProduct2>().Single().SomeName2);
+                var productOne = products.OfType<SubProduct>().Single();
+                Assert.Equal("One", productOne.SomeName);
+                Assert.Equal(nameof(SubProduct), context.Entry(productOne).Property<string>("Discriminator").CurrentValue);
+                var productTwo = products.OfType<SubProduct2>().Single();
+                Assert.Equal("Two", productTwo.SomeName2);
+                Assert.Equal(nameof(SubProduct2), context.Entry(productTwo).Property<string>("Discriminator").CurrentValue);
             }
         }
 
         [Fact]
-        public void Can_save_enities_with_int_discriminators()
+        public void Can_save_entities_with_int_discriminators()
         {
             using (var context = new Context4285())
             {
@@ -38,8 +42,12 @@ namespace Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests
             using (var context = new Context4285())
             {
                 var products = context.IntProducts.ToList();
-                Assert.Equal("One", products.OfType<SubIntProduct>().Single().SomeName);
-                Assert.Equal("Two", products.OfType<SubIntProduct2>().Single().SomeName2);
+                var productOne = products.OfType<SubIntProduct>().Single();
+                Assert.Equal("One", productOne.SomeName);
+                Assert.Equal(1, context.Entry(productOne).Property<int>("IntDiscriminator").CurrentValue);
+                var productTwo = products.OfType<SubIntProduct2>().Single();
+                Assert.Equal("Two", productTwo.SomeName2);
+                Assert.Equal(2, context.Entry(productTwo).Property<int>("IntDiscriminator").CurrentValue);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.HasKey(new List<string> { "Id", "SampleEntityId" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.HasKey(new List<string> { "SampleEntityId" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -147,11 +147,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             entityBuilder.Property(properties[0], ConfigurationSource.Convention)
                 .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
 
-            entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).RequiresValueGenerator(false, ConfigurationSource.Explicit);
+            entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention)
+                .RequiresValueGenerator(false, ConfigurationSource.Explicit);
 
             var keyBuilder = entityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -173,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -204,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -238,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -253,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.HasKey(new List<string> { "Number" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -268,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id", "Number" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
@@ -277,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         }
 
         [Fact]
-        public void Identity_not_set_when_primary_key_property_is_non_integer()
+        public void Identity_set_when_primary_key_property_is_non_integer()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
@@ -286,7 +287,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var property = keyBuilder.Metadata.Properties.First();
 
-            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+            Assert.True(property.RequiresValueGenerator);
         }
 
         [Fact]
@@ -309,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
@@ -329,7 +331,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -347,7 +349,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var properties = new List<string> { "Id" };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -374,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var properties = new List<string> { "Id" };
             var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             var property = keyBuilder.Metadata.Properties.First();
 
@@ -391,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+            Assert.True(new KeyConvention().Apply(keyBuilder, null));
 
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
@@ -487,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             var keyConvention = new KeyConvention();
 
-            conventions.KeyAddedConventions.Add(keyConvention);
+            conventions.ForeignKeyAddedConventions.Add(keyConvention);
             conventions.ForeignKeyRemovedConventions.Add(keyConvention);
             conventions.PrimaryKeySetConventions.Add(keyConvention);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -152,7 +152,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 modelBuilder.Entity<Customer>().HasKey(b => b.Name);
 
                 Assert.Same(key, entity.GetKeys().Single());
-                Assert.Equal(Customer.NameProperty.Name, entity.FindPrimaryKey().Properties.Single().Name);
+
+                var nameProperty = entity.FindPrimaryKey().Properties.Single();
+                Assert.Equal(Customer.NameProperty.Name, nameProperty.Name);
+                Assert.True(nameProperty.RequiresValueGenerator);
+                Assert.Equal(ValueGenerated.OnAdd, nameProperty.ValueGenerated);
 
                 var idProperty = (IProperty)entity.FindProperty(Customer.IdProperty);
                 Assert.False(idProperty.RequiresValueGenerator);

--- a/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -1429,7 +1429,8 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrat
                 @"
 builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
-        b.Property<string>(""Id"");
+        b.Property<string>(""Id"")
+            .ValueGeneratedOnAdd();
 
         b.HasKey(""Id"");
 
@@ -1477,7 +1478,8 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrat
                 @"
 builder.Entity(""Microsoft.EntityFrameworkCore.Tools.Core.FunctionalTests.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
-        b.Property<string>(""Id"");
+        b.Property<string>(""Id"")
+            .ValueGeneratedOnAdd();
 
         b.HasKey(""Id"");
 


### PR DESCRIPTION
Change the default of RequiresValueGenerator to simplify KeyConvention

Fixes #5776