### PR TITLE
Perf: Query: Avoid revisiting children in visitor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateInExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateInExpressionOptimizer.cs
@@ -29,41 +29,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 case ExpressionType.OrElse:
                 {
-                    var optimized
-                        = TryOptimize(
-                            node,
-                            equalityType: ExpressionType.Equal,
-                            inExpressionFactory: (c, vs) => new InExpression(c, vs));
-
-                    if (optimized != null)
-                    {
-                        return optimized;
-                    }
-
-                    break;
+                    return Optimize(
+                        node,
+                        equalityType: ExpressionType.Equal,
+                        inExpressionFactory: (c, vs) => new InExpression(c, vs));
                 }
 
                 case ExpressionType.AndAlso:
                 {
-                    var optimized
-                        = TryOptimize(
-                            node,
-                            equalityType: ExpressionType.NotEqual,
-                            inExpressionFactory: (c, vs) => Expression.Not(new InExpression(c, vs)));
-
-                    if (optimized != null)
-                    {
-                        return optimized;
-                    }
-
-                    break;
+                    return Optimize(
+                        node,
+                        equalityType: ExpressionType.NotEqual,
+                        inExpressionFactory: (c, vs) => Expression.Not(new InExpression(c, vs)));
                 }
             }
 
             return base.VisitBinary(node);
         }
 
-        private Expression TryOptimize(
+        private Expression Optimize(
             BinaryExpression binaryExpression,
             ExpressionType equalityType,
             Func<AliasExpression, List<Expression>, Expression> inExpressionFactory)
@@ -131,13 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     inArguments);
             }
 
-            if ((leftExpression != binaryExpression.Left)
-                || (rightExpression != binaryExpression.Right))
-            {
-                return binaryExpression.Update(leftExpression, binaryExpression.Conversion, rightExpression);
-            }
-
-            return null;
+            return binaryExpression.Update(leftExpression, binaryExpression.Conversion, rightExpression);
         }
 
         private static AliasExpression MatchEqualityExpression(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -64,6 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         return (bool)constantRight.Value ? newRight : newLeft;
                     }
                 }
+
+                return node.Update(newLeft, node.Conversion, newRight);
             }
 
             // a == true -> a
@@ -85,6 +87,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     return newLeft.Type == typeof(bool) ? newLeft : Expression.Convert(newLeft, typeof(bool));
                 }
+
+                return node.Update(newLeft, node.Conversion, newRight);
             }
 
             return base.VisitBinary(node);


### PR DESCRIPTION
Resolves #6254 
Issue: We visit children and try to optimize but if we cannot then we fall back to base visitor which re-visit the children hence doubling the execution time for every node.
Fix: When we fail to optimize, create return expression using the visited children.