### PR TITLE
Query: Use streaming group by operator only if the query has ordering by key

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -473,10 +473,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var oldGroupByCall = (MethodCallExpression)handlerContext.EvalOnClient();
 
-            return Expression.Call(
-                handlerContext.QueryModelVisitor.QueryCompilationContext.QueryMethodProvider.GroupByMethod
+            return sqlExpression!= null
+                ? Expression.Call(handlerContext.QueryModelVisitor.QueryCompilationContext.QueryMethodProvider.GroupByMethod
                     .MakeGenericMethod(oldGroupByCall.Method.GetGenericArguments()),
-                oldGroupByCall.Arguments);
+                    oldGroupByCall.Arguments)
+                : oldGroupByCall;
         }
 
         private static Expression HandleLast(HandlerContext handlerContext)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -3570,6 +3570,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void GroupBy_DateTimeOffset_Property()
+        {
+            AssertQuery<Order>(os =>
+                os.Where(o => o.OrderDate.HasValue)
+                    .GroupBy(o => o.OrderDate.Value.Month),
+                asserter: (l2oResults, efResults) =>
+                {
+                    var efGroupings = efResults.Cast<IGrouping<int, Order>>().ToList();
+
+                    foreach (IGrouping<int, Order> l2oGrouping in l2oResults)
+                    {
+                        var efGrouping = efGroupings.Single(efg => efg.Key == l2oGrouping.Key);
+
+                        Assert.Equal(l2oGrouping.OrderBy(o => o.OrderID), efGrouping.OrderBy(o => o.OrderID));
+                    }
+                },
+                entryCount: 830);
+        }
+
+        [ConditionalFact]
         public virtual void OrderBy_GroupBy()
         {
             AssertQuery<Order>(os =>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3065,6 +3065,18 @@ ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
+        public override void GroupBy_DateTimeOffset_Property()
+        {
+            base.GroupBy_DateTimeOffset_Property();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] IS NOT NULL
+ORDER BY DATEPART(month, [o].[OrderDate])",
+                Sql);
+        }
+
         public override void Select_GroupBy()
         {
             base.Select_GroupBy();


### PR DESCRIPTION
Resolves #4581 
Issue: For SqlServer, we are able to translate date.month using DatePart which is not available in SQLite at present. When we are able to translate the key successfully, we add order by clause for streaming group by result operator. But we were using the same operator even when key is not translated. Hence the requirement for our streaming group by that records appear in order of their key is broken making more groups than what is expected.
Solution: If we are not able to translate the key to Sql, we should use linq's default group by operator.