### PR TITLE
Query: Use short-circuiting in predicates based on parameter values

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -1043,11 +1043,9 @@ WHERE [e].[NullableBoolA] IS NULL",
             base.Where_equal_using_relational_null_semantics_complex_with_parameter();
 
             Assert.Equal(
-                @"@__prm_0: False
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR (@__prm_0 = 1)",
+WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
                 Sql);
         }
 
@@ -1078,11 +1076,9 @@ WHERE [e].[NullableBoolA] IS NOT NULL",
             base.Where_not_equal_using_relational_null_semantics_complex_with_parameter();
 
             Assert.Equal(
-                @"@__prm_0: False
-
-SELECT [e].[Id]
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (@__prm_0 = 1)",
+WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5928,6 +5928,59 @@ CROSS JOIN [Orders] AS [o]
 CROSS JOIN [Employees] AS [e]",
                 Sql);
         }
+        
+        public override void Parameter_extraction_short_circuits_1()
+        {
+            base.Parameter_extraction_short_circuits_1();
+
+            Assert.Equal(
+                @"@__dateFilter_Value_Month_0: 7
+@__dateFilter_Value_Year_1: 1996
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10400",
+                Sql);
+        }
+
+        public override void Parameter_extraction_short_circuits_2()
+        {
+            base.Parameter_extraction_short_circuits_2();
+
+            Assert.Equal(
+                @"@__dateFilter_Value_Month_0: 7
+@__dateFilter_Value_Year_1: 1996
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE 0 = 1",
+                Sql);
+        }
+
+        public override void Parameter_extraction_short_circuits_3()
+        {
+            base.Parameter_extraction_short_circuits_3();
+
+            Assert.Equal(
+                @"@__dateFilter_Value_Month_0: 7
+@__dateFilter_Value_Year_1: 1996
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
 
         private const string FileLineEnding = @"
 ";


### PR DESCRIPTION
Resolves #5736 
For logical binary expressions, we try to evaluate each child and if it converts to true/false then based on the node type we prune the trees.