### PR TITLE
[TINY] SQL Server Migrations: Avoid redundant WHERE..NOT NULL on unique indices

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -348,6 +348,66 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Migrations
         }
 
         [Fact]
+        public virtual void CreateIndexOperation_unique_bound_null()
+        {
+            Generate(
+                modelBuilder => modelBuilder.Entity("People").Property<string>("Name"),
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) WHERE [Name] IS NOT NULL;" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_bound_not_null()
+        {
+            Generate(
+                modelBuilder => modelBuilder.Entity("People").Property<string>("Name").IsRequired(),
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_composite_unique_bound_one_not_null()
+        {
+            Generate(
+                modelBuilder => modelBuilder.Entity(
+                    "People",
+                    x =>
+                    {
+                        x.Property<string>("FirstName");
+                        x.Property<string>("LastName").IsRequired();
+                    }),
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "FirstName", "LastName" },
+                    IsUnique = true
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([FirstName], [LastName]) WHERE [FirstName] IS NOT NULL;" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public virtual void CreateSchemaOperation()
         {
             Generate(new EnsureSchemaOperation { Name = "my" });


### PR DESCRIPTION
Resolves #5532