### PR TITLE
[TINY] SQL Server Migrations: Ignore default value of added identity columns

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -435,7 +435,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 maxLength,
                 rowVersion,
                 nullable,
-                defaultValue,
+                identity
+                    ? null
+                    : defaultValue,
                 defaultValueSql,
                 computedColumnSql,
                 annotatable,

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -71,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Migrations
                     Name = "Id",
                     ClrType = typeof(int),
                     ColumnType = "int",
+                    DefaultValue = 0,
                     IsNullable = false,
                     [SqlServerFullAnnotationNames.Instance.ValueGenerationStrategy] =
                         SqlServerValueGenerationStrategy.IdentityColumn


### PR DESCRIPTION
Fixes #6035