### PR TITLE
Query: Do not show client eval warning for top level Single()

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/WarningsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/WarningsTestBase.cs
@@ -27,6 +27,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [Fact]
+        public virtual void Does_not_throw_for_top_level_single()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders.Single(x => x.OrderID == 10248);
+
+                Assert.NotNull(query);
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected WarningsTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -652,7 +652,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             handlerContext.SelectExpression.Limit = Expression.Constant(2);
 
-            return handlerContext.EvalOnClient(requiresClientResultOperator: true);
+            var returnExpression = handlerContext.EvalOnClient(requiresClientResultOperator: true);
+
+            // For top level single, we do not require client eval
+            if (handlerContext.QueryModelVisitor.ParentQueryModelVisitor == null)
+            {
+                handlerContext.QueryModelVisitor.RequiresClientResultOperator = false;
+            }
+
+            return returnExpression;
         }
 
         private static Expression HandleSkip(HandlerContext handlerContext)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
@@ -11,5 +13,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             : base(fixture)
         {
         }
+
+        public override void Does_not_throw_for_top_level_single()
+        {
+            base.Does_not_throw_for_top_level_single();
+
+            Assert.Equal(
+                @"SELECT TOP(2) [x].[OrderID], [x].[CustomerID], [x].[EmployeeID], [x].[OrderDate]
+FROM [Orders] AS [x]
+WHERE [x].[OrderID] = 10248",
+                Sql);
+        }
+
+        private const string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }
 }


### PR DESCRIPTION
resolves #5897 