### PR TITLE
Make it easier to replace internal EF services

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/DbContextOptionsBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptionsBuilder.cs
@@ -183,6 +183,27 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
+        ///         Replaces the internal Entity Framework implementation of a service contract with a different
+        ///         implementation.
+        ///     </para>
+        ///     <para>
+        ///         This method can only be used when EF is building and managing its internal service provider.
+        ///         If the service provider is being built externally and passed to
+        ///         <see cref="UseInternalServiceProvider" />, then replacement services should be configured on
+        ///         that service provider before it is passed to EF.
+        ///     </para>
+        ///     <para>
+        ///         The replacement service gets the same scope as the EF service that it is replacing.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TService"> The type (usually an interface) that defines the contract of the service to replace. </typeparam>
+        /// <typeparam name="TImplementation"> The new implementation type for the service. </typeparam>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public virtual DbContextOptionsBuilder ReplaceService<TService, TImplementation>() where TImplementation : TService
+            => SetOption(e => e.ReplaceService(typeof(TService), typeof(TImplementation)));
+
+        /// <summary>
+        ///     <para>
         ///         Adds the given extension to the options. If an existing extension of the same type already exists, it will be replaced.
         ///     </para>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/DbContextOptionsBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptionsBuilder`.cs
@@ -136,5 +136,26 @@ namespace Microsoft.EntityFrameworkCore
         public new virtual DbContextOptionsBuilder<TContext> ConfigureWarnings(
             [NotNull] Action<WarningsConfigurationBuilder> warningsConfigurationBuilderAction)
             => (DbContextOptionsBuilder<TContext>)base.ConfigureWarnings(warningsConfigurationBuilderAction);
+
+        /// <summary>
+        ///     <para>
+        ///         Replaces the internal Entity Framework implementation of a service contract with a different
+        ///         implementation.
+        ///     </para>
+        ///     <para>
+        ///         This method can only be used when EF is building and managing its internal service provider.
+        ///         If the service provider is being built externally and passed to
+        ///         <see cref="UseInternalServiceProvider" />, then replacement services should be configured on
+        ///         that service provider before it is passed to EF.
+        ///     </para>
+        ///     <para>
+        ///         The replacement service gets the same scope as the EF service that it is replacing.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TService"> The type (usually an interface) that defines the contract of the service to replace. </typeparam>
+        /// <typeparam name="TImplementation"> The new implementation type for the service. </typeparam>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> ReplaceService<TService, TImplementation>() where TImplementation : TService
+            => (DbContextOptionsBuilder<TContext>)base.ReplaceService<TService, TImplementation>();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Internal/CoreOptionsExtension.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/CoreOptionsExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -24,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         private bool _isSensitiveDataLoggingEnabled;
         private WarningsConfiguration _warningsConfiguration;
         private QueryTrackingBehavior _queryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+        private IDictionary<Type, Type> _replacedServices;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -46,6 +48,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             _isSensitiveDataLoggingEnabled = copyFrom.IsSensitiveDataLoggingEnabled;
             _warningsConfiguration = copyFrom.WarningsConfiguration;
             _queryTrackingBehavior = copyFrom.QueryTrackingBehavior;
+
+            if (copyFrom._replacedServices != null)
+            {
+                _replacedServices = new Dictionary<Type, Type>(copyFrom._replacedServices);
+            }
         }
 
         /// <summary>
@@ -123,6 +130,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             get { return _queryTrackingBehavior; }
             set { _queryTrackingBehavior = value; }
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void ReplaceService([NotNull] Type serviceType, [NotNull] Type implementationType)
+            => (_replacedServices ?? (_replacedServices = new Dictionary<Type, Type>()))[serviceType] = implementationType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IReadOnlyDictionary<Type, Type> ReplacedServices => (IReadOnlyDictionary<Type, Type>)_replacedServices;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -329,6 +329,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// A call was made to {replaceService}, but Entity Framework is not building its own internal service provider. Either allow EF to build the service provider by removing the call to {useInternalServiceProvider}, or build replacement services into the service provider before passing it to {useInternalServiceProvider}.
+        /// </summary>
+        public static string InvalidReplaceService([CanBeNull] object replaceService, [CanBeNull] object useInternalServiceProvider)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidReplaceService", "replaceService", "useInternalServiceProvider"), replaceService, useInternalServiceProvider);
+        }
+
+        /// <summary>
         /// The database providers {storeNames}are available. A context can only be configured to use a single database provider. Configure a database provider by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.
         /// </summary>
         public static string MultipleProvidersAvailable([CanBeNull] object storeNames)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -234,6 +234,9 @@
   <data name="NoEfServices" xml:space="preserve">
     <value>Entity Framework services have not been added to the internal service provider. Either remove the call to UseInternalServiceProvider so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. AddEntityFrameworkSqlServer).</value>
   </data>
+  <data name="InvalidReplaceService" xml:space="preserve">
+    <value>A call was made to {replaceService}, but Entity Framework is not building its own internal service provider. Either allow EF to build the service provider by removing the call to {useInternalServiceProvider}, or build replacement services into the service provider before passing it to {useInternalServiceProvider}.</value>
+  </data>
   <data name="MultipleProvidersAvailable" xml:space="preserve">
     <value>The database providers {storeNames}are available. A context can only be configured to use a single database provider. Configure a database provider by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.</value>
   </data>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
@@ -23,12 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 .UseInternalServiceProvider(new ServiceCollection().BuildServiceProvider())
                 .Options;
 
-            using (var context = new ConstructorTestContext1A(options))
-            {
-                Assert.Equal(
-                    CoreStrings.NoEfServices,
-                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
-            }
+            Assert.Equal(
+                CoreStrings.NoEfServices,
+                Assert.Throws<InvalidOperationException>(() => new ConstructorTestContext1A(options)).Message);
         }
 
         [Fact]
@@ -43,11 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
-
                 Assert.Equal(
                     CoreStrings.NoEfServices,
-                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+                    Assert.Throws<InvalidOperationException>(
+                        () => serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>()).Message);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ServiceProviderCacheTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,10 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
     public class ServiceProviderCacheTest
     {
         [Fact]
-        public void Returns_same_provider_for_same_tyoe_of_configured_extensions()
+        public void Returns_same_provider_for_same_type_of_configured_extensions()
         {
-            var config1 = CreateOptions(new FakeDbContextOptionsExtension1());
-            var config2 = CreateOptions(new FakeDbContextOptionsExtension1());
+            var config1 = CreateOptions<FakeDbContextOptionsExtension1>();
+            var config2 = CreateOptions<FakeDbContextOptionsExtension1>();
 
             var cache = new ServiceProviderCache();
 
@@ -22,20 +23,49 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void Returns_different_provider_for_different_tyoe_of_configured_extensions()
+        public void Returns_different_provider_for_different_type_of_configured_extensions()
         {
-            var config1 = CreateOptions(new FakeDbContextOptionsExtension1());
-            var config2 = CreateOptions(new FakeDbContextOptionsExtension2());
+            var config1 = CreateOptions<FakeDbContextOptionsExtension1>();
+            var config2 = CreateOptions<FakeDbContextOptionsExtension2>();
 
             var cache = new ServiceProviderCache();
 
             Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
         }
 
-        private static DbContextOptions CreateOptions(IDbContextOptionsExtension extension)
+        [Fact]
+        public void Returns_same_provider_for_same_type_of_configured_extensions_and_replaced_service_types()
+        {
+            var config1 = CreateOptions<CoreOptionsExtension>();
+            config1.FindExtension<CoreOptionsExtension>().ReplaceService(typeof(object), typeof(Random));
+
+            var config2 = CreateOptions<CoreOptionsExtension>();
+            config2.FindExtension<CoreOptionsExtension>().ReplaceService(typeof(object), typeof(Random));
+
+            var cache = new ServiceProviderCache();
+
+            Assert.Same(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+        }
+
+        [Fact]
+        public void Returns_different_provider_for_different_replaced_service_types()
+        {
+            var config1 = CreateOptions<CoreOptionsExtension>();
+            config1.FindExtension<CoreOptionsExtension>().ReplaceService(typeof(object), typeof(Random));
+
+            var config2 = CreateOptions<CoreOptionsExtension>();
+            config2.FindExtension<CoreOptionsExtension>().ReplaceService(typeof(object), typeof(string));
+
+            var cache = new ServiceProviderCache();
+
+            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+        }
+
+        private static DbContextOptions CreateOptions<TExtension>()
+            where TExtension : class, IDbContextOptionsExtension, new()
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new TExtension());
 
             return optionsBuilder.Options;
         }


### PR DESCRIPTION
Issue #6306

Adds a ReplaceService method to DbContextOptionsBuilder that is used like this:

```C#
protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
  => optionsBuilder
      .ReplaceService<IModelCustomizer, CustomModelCustomizer>()
      .UseInMemoryDatabase();
```

The replacement service automatically gets the scoping of the original registration.

An exception is thrown if this method is used in combination with UseInternalServiceProvider.

\cc @rowanmiller for API, documentation, and exception message