### PR TITLE
[1.0.1] Throw a better exception when shadow keys are detected

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Internal/ModelValidator.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/ModelValidator.cs
@@ -27,8 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public virtual void Validate(IModel model)
         {
             EnsureNoShadowEntities(model);
-            EnsureNoShadowKeys(model);
             EnsureNonNullPrimaryKeys(model);
+            EnsureNoShadowKeys(model);
             EnsureClrInheritance(model);
             EnsureChangeTrackingStrategy(model);
         }
@@ -52,15 +52,38 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         protected virtual void EnsureNoShadowKeys([NotNull] IModel model)
         {
-            var messages = KeyConvention.GetShadowKeyExceptionMessage(model, key => key.Properties.Any(p => p.IsShadowProperty));
-            if (messages == null)
+            foreach (var entityType in model.GetEntityTypes().Where(t => t.ClrType != null))
             {
-                return;
-            }
+                foreach (var key in entityType.GetDeclaredKeys())
+                {
+                    if (key.Properties.Any(p => p.IsShadowProperty))
+                    {
+                        var referencingFk = key.GetReferencingForeignKeys().FirstOrDefault();
+                        var conventionalKey = key as Key;
+                        if (referencingFk != null
+                            && conventionalKey != null
+                            && ConfigurationSource.Convention.Overrides(conventionalKey.GetConfigurationSource()))
+                        {
+                            ShowError(CoreStrings.ReferencedShadowKey(
+                                referencingFk.DeclaringEntityType.DisplayName() +
+                                (referencingFk.DependentToPrincipal == null
+                                    ? ""
+                                    : "." + referencingFk.DependentToPrincipal.Name),
+                                entityType.DisplayName() +
+                                (referencingFk.PrincipalToDependent == null
+                                    ? ""
+                                    : "." + referencingFk.PrincipalToDependent.Name),
+                                Property.Format(referencingFk.Properties, includeTypes: true),
+                                Property.Format(key.Properties, includeTypes: true)));
+                            continue;
+                        }
 
-            foreach (var message in messages)
-            {
-                ShowWarning(message);
+                        ShowWarning(CoreStrings.ShadowKey(
+                            Property.Format(key.Properties),
+                            entityType.DisplayName(),
+                            Property.Format(key.Properties)));
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
-            conventionSet.ModelBuiltConventions.Add(keyConvention);
             conventionSet.ModelBuiltConventions.Add(new PropertyMappingValidationConvention());
             conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class KeyConvention
-        : IKeyConvention, IPrimaryKeyConvention, IForeignKeyConvention, IForeignKeyRemovedConvention, IModelConvention
+        : IKeyConvention, IPrimaryKeyConvention, IForeignKeyConvention, IForeignKeyRemovedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -123,82 +123,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 propertyBuilder?.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
                 propertyBuilder?.RequiresValueGenerator(true, ConfigurationSource.Convention);
             }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
-        {
-            var messages = GetShadowKeyExceptionMessage(
-                modelBuilder.Metadata,
-                key => key.Properties.Any(p => p.IsShadowProperty
-                                               && ConfigurationSource.Convention.Overrides(((Property)p).GetConfigurationSource())));
-            if (messages != null
-                && messages.Any())
-            {
-                throw new InvalidOperationException(messages.First());
-            }
-
-            return modelBuilder;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static List<string> GetShadowKeyExceptionMessage([NotNull] IModel model, [NotNull] Func<IKey, bool> keyPredicate)
-        {
-            List<string> messages = null;
-            foreach (var entityType in model.GetEntityTypes())
-            {
-                foreach (var key in entityType.GetDeclaredKeys())
-                {
-                    if (keyPredicate(key))
-                    {
-                        string message;
-                        var referencingFk = key.GetReferencingForeignKeys().FirstOrDefault();
-                        if (referencingFk != null)
-                        {
-                            if (referencingFk.DependentToPrincipal == null
-                                && referencingFk.PrincipalToDependent == null)
-                            {
-                                message = CoreStrings.ReferencedShadowKeyWithoutNavigations(
-                                    Property.Format(key.Properties),
-                                    entityType.DisplayName(),
-                                    Property.Format(referencingFk.Properties),
-                                    referencingFk.DeclaringEntityType.DisplayName());
-                            }
-                            else
-                            {
-                                message = CoreStrings.ReferencedShadowKey(
-                                    Property.Format(key.Properties),
-                                    entityType.DisplayName() +
-                                    (referencingFk.PrincipalToDependent == null
-                                        ? ""
-                                        : "." + referencingFk.PrincipalToDependent.Name),
-                                    referencingFk.DeclaringEntityType.DisplayName() +
-                                    (referencingFk.DependentToPrincipal == null
-                                        ? ""
-                                        : "." + referencingFk.DependentToPrincipal.Name));
-                            }
-                        }
-                        else
-                        {
-                            message = CoreStrings.ShadowKey(
-                                Property.Format(key.Properties),
-                                entityType.DisplayName(),
-                                Property.Format(key.Properties));
-                        }
-
-                        messages = messages ?? new List<string>();
-                        messages.Add(message);
-                    }
-                }
-            }
-
-            return messages;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -969,16 +969,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalIndexBuilder HasIndex([NotNull] IReadOnlyList<string> propertyNames, ConfigurationSource configurationSource)
-            => HasIndex(GetOrCreateProperties(propertyNames, configurationSource), null, configurationSource);
+            => HasIndex(GetOrCreateProperties(propertyNames, configurationSource), configurationSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalIndexBuilder HasIndex([NotNull] IReadOnlyList<PropertyInfo> clrProperties, ConfigurationSource configurationSource)
-            => HasIndex(GetOrCreateProperties(clrProperties, configurationSource), null, configurationSource);
+            => HasIndex(GetOrCreateProperties(clrProperties, configurationSource), configurationSource);
 
-        private InternalIndexBuilder HasIndex(IReadOnlyList<Property> properties, bool? unique, ConfigurationSource configurationSource)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalIndexBuilder HasIndex([NotNull] IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
         {
             if (properties == null)
             {
@@ -994,10 +998,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
             else if (existingIndex.DeclaringEntityType != Metadata)
             {
-                return existingIndex.DeclaringEntityType.Builder.HasIndex(existingIndex, properties, unique, configurationSource);
+                return existingIndex.DeclaringEntityType.Builder.HasIndex(existingIndex, properties, configurationSource);
             }
 
-            var indexBuilder = HasIndex(existingIndex, properties, unique, configurationSource);
+            var indexBuilder = HasIndex(existingIndex, properties, configurationSource);
 
             detachedIndexes?.Attach();
 
@@ -1005,7 +1009,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private InternalIndexBuilder HasIndex(
-            Index index, IReadOnlyList<Property> properties, bool? unique, ConfigurationSource configurationSource)
+            Index index, IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
         {
             if (index == null)
             {
@@ -1014,11 +1018,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 index.UpdateConfigurationSource(configurationSource);
-            }
-
-            if (unique.HasValue)
-            {
-                index.SetIsUnique(unique.Value, configurationSource);
             }
 
             return index.Builder;
@@ -1234,7 +1233,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreignKey.UpdateConfigurationSource(configurationSource);
             principalType.UpdateConfigurationSource(configurationSource);
 
-            HasIndex(dependentProperties, foreignKey.IsUnique, ConfigurationSource.Convention);
+            HasIndex(dependentProperties, ConfigurationSource.Convention)
+                ?.IsUnique(foreignKey.IsUnique, ConfigurationSource.Convention);
 
             var value = foreignKey.Builder;
             if (runConventions)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -2257,6 +2257,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 temporaryProperty.UpdateConfigurationSource(ConfigurationSource.DataAnnotation);
             }
 
+            var temporaryKeyProperties = principalProperties?.Where(p => p.GetConfigurationSource() == ConfigurationSource.Convention
+                                                                      && p.IsShadowProperty).ToList();
+            var keyTempIndex = temporaryKeyProperties != null
+                               && temporaryKeyProperties.Any()
+                               && principalEntityType.FindIndex(temporaryKeyProperties) == null
+                ? principalEntityType.Builder.HasIndex(temporaryKeyProperties, ConfigurationSource.Convention).Metadata
+                : null;
+
             if (Metadata.Builder != null)
             {
                 RemoveForeignKey(Metadata, removedNavigations, removedForeignKeys);
@@ -2418,6 +2426,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     existingRelationshipInverted = false;
                 }
+            }
+
+            if (keyTempIndex?.Builder != null)
+            {
+                keyTempIndex.DeclaringEntityType.Builder.RemoveIndex(keyTempIndex, ConfigurationSource.Convention);
             }
 
             return newRelationshipBuilder;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -454,8 +454,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
         }
 
-        internal static string Format(IEnumerable<IProperty> properties)
-            => "{" + string.Join(", ", properties.Select(p => "'" + p.Name + "'")) + "}";
+        internal static string Format(IEnumerable<IProperty> properties, bool includeTypes = false)
+            => "{"
+               + string.Join(", ",
+                   properties.Select(p => "'" + p.Name + "'" + (includeTypes ? " : " + p.ClrType.DisplayName(fullName: false) : "")))
+               + "}";
 
         IEntityType IPropertyBase.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableProperty.DeclaringEntityType => DeclaringEntityType;

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The entity type '{entityType}' requires a key to be defined.
+        /// The entity type '{entityType}' requires a primary key to be defined.
         /// </summary>
         public static string EntityRequiresKey([CanBeNull] object entityType)
         {
@@ -633,19 +633,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The key {key} contains properties in shadow state and is referenced by a relationship from '{referencingEntityTypeWithNavigation}' to '{referencedEntityTypeWithNavigation}'. Configure a non-shadow principal key for this relationship.
+        /// The relationship from '{referencingEntityTypeOrNavigation}' to '{referencedEntityTypeOrNavigation}' with foreign key properties {foreignKeyPropertiesWithTypes} cannot target the primary key {primaryKeyPropertiesWithTypes} because it is not compatible. Configure a principal key or a set of compatible foreign key properties for this relationship.
         /// </summary>
-        public static string ReferencedShadowKey([CanBeNull] object key, [CanBeNull] object referencingEntityTypeWithNavigation, [CanBeNull] object referencedEntityTypeWithNavigation)
+        public static string ReferencedShadowKey([CanBeNull] object referencingEntityTypeOrNavigation, [CanBeNull] object referencedEntityTypeOrNavigation, [CanBeNull] object foreignKeyPropertiesWithTypes, [CanBeNull] object primaryKeyPropertiesWithTypes)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ReferencedShadowKey", "key", "referencingEntityTypeWithNavigation", "referencedEntityTypeWithNavigation"), key, referencingEntityTypeWithNavigation, referencedEntityTypeWithNavigation);
-        }
-
-        /// <summary>
-        /// The key {key} on entity type '{entityType}' contains properties in shadow state and is referenced by the foreign key {foreignKey} from entity type '{referencingEntityType}'. Configure a non-shadow principal key for this relationship.
-        /// </summary>
-        public static string ReferencedShadowKeyWithoutNavigations([CanBeNull] object key, [CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object referencingEntityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ReferencedShadowKeyWithoutNavigations", "key", "entityType", "foreignKey", "referencingEntityType"), key, entityType, foreignKey, referencingEntityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("ReferencedShadowKey", "referencingEntityTypeOrNavigation", "referencedEntityTypeOrNavigation", "foreignKeyPropertiesWithTypes", "primaryKeyPropertiesWithTypes"), referencingEntityTypeOrNavigation, referencedEntityTypeOrNavigation, foreignKeyPropertiesWithTypes, primaryKeyPropertiesWithTypes);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -148,7 +148,7 @@
     <value>The collection argument '{argumentName}' must contain at least one element.</value>
   </data>
   <data name="EntityRequiresKey" xml:space="preserve">
-    <value>The entity type '{entityType}' requires a key to be defined.</value>
+    <value>The entity type '{entityType}' requires a primary key to be defined.</value>
   </data>
   <data name="KeyPropertiesWrongEntity" xml:space="preserve">
     <value>The specified key properties {key} are not declared on the entity type '{entityType}'. Ensure key properties are declared on the target entity type.</value>
@@ -349,10 +349,7 @@
     <value>The entity type '{type}' provided for the argument '{argumentName}' must be a reference type.</value>
   </data>
   <data name="ReferencedShadowKey" xml:space="preserve">
-    <value>The key {key} contains properties in shadow state and is referenced by a relationship from '{referencingEntityTypeWithNavigation}' to '{referencedEntityTypeWithNavigation}'. Configure a non-shadow principal key for this relationship.</value>
-  </data>
-  <data name="ReferencedShadowKeyWithoutNavigations" xml:space="preserve">
-    <value>The key {key} on entity type '{entityType}' contains properties in shadow state and is referenced by the foreign key {foreignKey} from entity type '{referencingEntityType}'. Configure a non-shadow principal key for this relationship.</value>
+    <value>The relationship from '{referencingEntityTypeOrNavigation}' to '{referencedEntityTypeOrNavigation}' with foreign key properties {foreignKeyPropertiesWithTypes} cannot target the primary key {primaryKeyPropertiesWithTypes} because it is not compatible. Configure a principal key or a set of compatible foreign key properties for this relationship.</value>
   </data>
   <data name="ShadowKey" xml:space="preserve">
     <value>The key {key} on entity type '{entityType}' contains properties in shadow state - {shadowProperties}.</value>

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyConventionTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -394,86 +393,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
-        }
-
-        #endregion
-
-        #region ShadowKeys
-
-        [Fact]
-        public void Throws_an_exception_when_shadow_key_is_defined_by_convention()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
-            entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.Convention);
-
-            Assert.Equal(CoreStrings.ShadowKey("{'Foo'}", typeof(SampleEntity).Name, "{'Foo'}"),
-                Assert.Throws<InvalidOperationException>(() => new KeyConvention().Apply(modelBuilder)).Message);
-        }
-
-        [Fact]
-        public void Does_not_throw_an_exception_when_shadow_key_is_not_defined_by_convention()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
-            entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.DataAnnotation);
-
-            Assert.Same(modelBuilder, new KeyConvention().Apply(modelBuilder));
-        }
-
-        [Fact]
-        public void Does_not_throw_an_exception_when_key_is_defined_on_shadow_properties_which_are_not_defined_by_convention()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
-            entityTypeBuilder.HasKey(new List<string> { "Foo" }, ConfigurationSource.Convention);
-
-            Assert.Same(modelBuilder, new KeyConvention().Apply(modelBuilder));
-        }
-
-        [Fact]
-        public void Throws_an_exception_when_shadow_key_is_referenced_by_foreign_key()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
-
-            referencedEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.Convention);
-            var properties = new List<string> { "Foo" };
-            referencedEntityBuilder.HasForeignKey(
-                principalEntityBuilder,
-                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
-
-            Assert.Equal(CoreStrings.ReferencedShadowKeyWithoutNavigations(
-                "{'Foo'}",
-                typeof(SampleEntity).Name,
-                "{'Foo'}",
-                typeof(ReferencedEntity).Name),
-                Assert.Throws<InvalidOperationException>(() => new KeyConvention().Apply(modelBuilder)).Message);
-        }
-
-        [Fact]
-        public void Does_not_throw_an_exception_when_key_is_referenced_by_foreign_key_and_defined_on_shadow_properties_which_are_not_defined_by_convention()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
-
-            principalEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
-            referencedEntityBuilder.Property("Foo", typeof(string), ConfigurationSource.DataAnnotation);
-            var properties = new List<string> { "Foo" };
-            referencedEntityBuilder.HasForeignKey(
-                principalEntityBuilder,
-                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-                ConfigurationSource.Convention)
-                .HasPrincipalKey(principalEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-                    ConfigurationSource.Convention);
-
-            Assert.Same(modelBuilder, new KeyConvention().Apply(modelBuilder));
         }
 
         #endregion

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -30,9 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal("Orders", modelBuilder.Model.FindEntityType("Customer")?.GetNavigations().Single().Name);
                 Assert.False(foreignKey.IsUnique);
 
-                // TODO: Issue#4016 - The Exception message here should be about shadow entity type instead of shadow key.
                 Assert.Equal(
-                    CoreStrings.ReferencedShadowKey("{'TempId'}", "Customer.Orders", "Order.Customer"),
+                    CoreStrings.ShadowEntity("Customer"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
             }
 
@@ -76,9 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal("Orders", modelBuilder.Model.FindEntityType("Customer")?.GetNavigations().Single().Name);
                 Assert.False(foreignKey.IsUnique);
 
-                // TODO: Issue#4016 - The Exception message here should be about shadow entity type instead of shadow key.
                 Assert.Equal(
-                    CoreStrings.ReferencedShadowKey("{'TempId'}", "Customer.Orders", "Order.Customer"),
+                    CoreStrings.ShadowEntity("Customer"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
             }
 
@@ -116,15 +114,15 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var foreignKey = modelBuilder.Entity("Order")
                     .HasOne("OrderDetails", "OrderDetails")
                     .WithOne("Order")
+                    .HasForeignKey("OrderDetails", "OrderId")
                     .Metadata;
 
                 Assert.Equal("OrderDetails", modelBuilder.Model.FindEntityType("Order")?.GetNavigations().Single().Name);
                 Assert.Equal("Order", modelBuilder.Model.FindEntityType("OrderDetails")?.GetNavigations().Single().Name);
                 Assert.True(foreignKey.IsUnique);
 
-                // TODO: Issue#4016 - The Exception message here should be about shadow entity type instead of shadow key.
                 Assert.Equal(
-                    CoreStrings.ReferencedShadowKey("{'TempId'}", "OrderDetails.Order", "Order.OrderDetails"),
+                    CoreStrings.ShadowEntity("Order"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
             }
 
@@ -290,6 +288,16 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 ReferenceReferenceBuilder = referenceReferenceBuilder;
             }
+
+            public NonGenericStringTestReferenceReferenceBuilder HasForeignKey(
+                string dependentEntityTypeName, params string[] foreignKeyPropertyNames)
+                => new NonGenericStringTestReferenceReferenceBuilder(
+                    ReferenceReferenceBuilder.HasForeignKey(dependentEntityTypeName, foreignKeyPropertyNames));
+
+            public NonGenericStringTestReferenceReferenceBuilder HasPrincipalKey(
+                string principalEntityTypeName, params string[] keyPropertyNames)
+                => new NonGenericStringTestReferenceReferenceBuilder
+                    (ReferenceReferenceBuilder.HasPrincipalKey(principalEntityTypeName, keyPropertyNames));
 
             private ReferenceReferenceBuilder ReferenceReferenceBuilder { get; }
             public IMutableForeignKey Metadata => ReferenceReferenceBuilder.Metadata;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -7,9 +7,11 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 // ReSharper disable once CheckNamespace
@@ -127,7 +129,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 where TEntity : class;
 
             public virtual TestModelBuilder Validate()
-                => ((IInfrastructure<InternalModelBuilder>)ModelBuilder).Instance.Validate() == null ? null : this;
+            {
+                var modelBuilder = ((IInfrastructure<InternalModelBuilder>)ModelBuilder).Instance.Validate();
+                new LoggingModelValidator(new Logger<LoggingModelValidator>(new LoggerFactory())).Validate(modelBuilder.Metadata);
+                return modelBuilder == null ? null : this;
+            }
         }
 
         public abstract class TestEntityTypeBuilder<TEntity>

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -711,20 +711,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 Assert.Empty(modelBuilder.Model.FindEntityType(typeof(EntityBase)).GetProperties());
             }
-
-            [Fact]
-            public virtual void Throws_for_shadow_key()
-            {
-                var modelBuilder = CreateModelBuilder();
-                var entityType = (EntityType)modelBuilder.Entity<SelfRef>().Metadata;
-                var shadowProperty = entityType.AddProperty("ShadowProperty", typeof(string), configurationSource: ConfigurationSource.Convention);
-                shadowProperty.IsNullable = false;
-                entityType.AddKey(shadowProperty);
-
-                Assert.Equal(
-                    CoreStrings.ShadowKey("{'ShadowProperty'}", typeof(SelfRef).Name, "{'ShadowProperty'}"),
-                    Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
-            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1776,9 +1776,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 Assert.Equal(
                     CoreStrings.ReferencedShadowKey(
-                        "{'AnotherCustomerId'}",
+                        typeof(Order).Name + "." + nameof(Order.Customer),
                         typeof(Customer).Name + "." + nameof(Customer.Orders),
-                        typeof(Order).Name + "." + nameof(Order.Customer)),
+                        "{'AnotherCustomerId' : Guid}",
+                        "{'AnotherCustomerId' : Guid}"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
             }
 


### PR DESCRIPTION
Reorder the validation rules so this exception is thrown less frequently.

Fixes #6260