### PR TITLE
Implement CurrentValues, OriginalValues, and GetDatabaseValues

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="OneToOneQueryFixtureBase.cs" />
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyValuesTestBase.cs" />
     <Compile Include="QueryNavigationsTestBase.cs" />
     <Compile Include="QueryTestBase.cs" />
     <Compile Include="StoreGeneratedFixupTestBase.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/PropertyValuesTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/PropertyValuesTestBase.cs
@@ -1,0 +1,2076 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class PropertyValuesTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : PropertyValuesTestBase<TTestStore, TFixture>.PropertyValuesFixtureBase, new()
+    {
+        protected PropertyValuesTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesScalars(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesScalars(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesScalars(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary()
+        {
+            await TestPropertyValuesScalars(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesScalars(Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var values = await getPropertyValues(context.Entry(building));
+
+                Assert.Equal("Building One", values["Name"]);
+                Assert.Equal(1500000m, values["Value"]);
+                Assert.Equal(11, values["Shadow1"]);
+                Assert.Equal("Meadow Drive", values["Shadow2"]);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_can_be_accessed_as_a_property_dictionary_using_IProperty()
+        {
+            await TestPropertyValuesScalarsIProperty(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_can_be_accessed_as_a_property_dictionary_using_IProperty()
+        {
+            await TestPropertyValuesScalarsIProperty(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_as_a_property_dictionary_using_IProperty()
+        {
+            await TestPropertyValuesScalarsIProperty(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary_using_IProperty()
+        {
+            await TestPropertyValuesScalarsIProperty(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesScalarsIProperty(Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var entry = context.Entry(building);
+                var values = await getPropertyValues(entry);
+
+                Assert.Equal("Building One", values[entry.Property(e => e.Name).Metadata]);
+                Assert.Equal(1500000m, values[entry.Property(e => e.Value).Metadata]);
+                Assert.Equal(11, values[entry.Property("Shadow1").Metadata]);
+                Assert.Equal("Meadow Drive", values[entry.Property("Shadow2").Metadata]);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesDerivedScalars(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesDerivedScalars(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary()
+        {
+            await TestPropertyValuesDerivedScalars(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_property_dictionary()
+        {
+            await TestPropertyValuesDerivedScalars(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesDerivedScalars(
+            Func<EntityEntry<CurrentEmployee>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var employee = context.Employees.OfType<CurrentEmployee>().Single(b => b.FirstName == "Rowan");
+
+                var values = await getPropertyValues(context.Entry(employee));
+
+                Assert.Equal("Miller", values["LastName"]);
+                Assert.Equal(45m, values["LeaveBalance"]);
+                Assert.Equal(111, values["Shadow1"]);
+                Assert.Equal("PM", values["Shadow2"]);
+                Assert.Equal(1111, values["Shadow3"]);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesScalars(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesScalars(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesScalars(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesScalars(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestNonGenericPropertyValuesScalars(Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                object building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var values = await getPropertyValues(context.Entry(building));
+
+                Assert.Equal("Building One", values["Name"]);
+                Assert.Equal(1500000m, values["Value"]);
+                Assert.Equal(11, values["Shadow1"]);
+                Assert.Equal("Meadow Drive", values["Shadow2"]);
+
+                Assert.Equal("Building One", values.GetValue<string>("Name"));
+                Assert.Equal(1500000m, values.GetValue<decimal>("Value"));
+                Assert.Equal(11, values.GetValue<int>("Shadow1"));
+                Assert.Equal("Meadow Drive", values.GetValue<string>("Shadow2"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty()
+        {
+            await TestNonGenericPropertyValuesScalarsIProperty(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty()
+        {
+            await TestNonGenericPropertyValuesScalarsIProperty(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty()
+        {
+            await TestNonGenericPropertyValuesScalarsIProperty(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary_using_IProperty()
+        {
+            await TestNonGenericPropertyValuesScalarsIProperty(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestNonGenericPropertyValuesScalarsIProperty(Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                object building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var entry = context.Entry(building);
+                var values = await getPropertyValues(entry);
+
+                Assert.Equal("Building One", values["Name"]);
+                Assert.Equal(1500000m, values["Value"]);
+
+                Assert.Equal("Building One", values.GetValue<string>(entry.Property("Name").Metadata));
+                Assert.Equal(1500000m, values.GetValue<decimal>(entry.Property("Value").Metadata));
+                Assert.Equal(11, values.GetValue<int>(entry.Property("Shadow1").Metadata));
+                Assert.Equal("Meadow Drive", values.GetValue<string>(entry.Property("Shadow2").Metadata));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Scalar_current_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_original_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesDerivedScalars(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary()
+        {
+            await TestNonGenericPropertyValuesDerivedScalars(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestNonGenericPropertyValuesDerivedScalars(Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                object employee = context.Employees.OfType<CurrentEmployee>().Single(b => b.FirstName == "Rowan");
+
+                var values = await getPropertyValues(context.Entry(employee));
+
+                Assert.Equal("Miller", values["LastName"]);
+                Assert.Equal(45m, values["LeaveBalance"]);
+                Assert.Equal(111, values["Shadow1"]);
+                Assert.Equal("PM", values["Shadow2"]);
+                Assert.Equal(1111, values["Shadow3"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Scalar_current_values_can_be_set_using_a_property_dictionary()
+        {
+            TestSetPropertyValuesScalars(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Scalar_original_values_can_be_set_using_a_property_dictionary()
+        {
+            TestSetPropertyValuesScalars(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestSetPropertyValuesScalars(
+            Func<EntityEntry<Building>, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                values["Name"] = "Building 18";
+                values["Value"] = -1000m;
+                values["Shadow1"] = 13;
+                values["Shadow2"] = "Pine Walk";
+
+                Assert.Equal("Building 18", values["Name"]);
+                Assert.Equal(-1000m, values["Value"]);
+                Assert.Equal(13, values["Shadow1"]);
+                Assert.Equal("Pine Walk", values["Shadow2"]);
+
+                var entry = context.Entry(building);
+                Assert.Equal("Building 18", getValue(entry, "Name"));
+                Assert.Equal(-1000m, getValue(entry, "Value"));
+                Assert.Equal(13, getValue(entry, "Shadow1"));
+                Assert.Equal("Pine Walk", getValue(entry, "Shadow2"));
+            }
+        }
+
+        [Fact]
+        public virtual void Scalar_current_values_can_be_set_using_a_property_dictionary_with_IProperty()
+        {
+            TestSetPropertyValuesScalarsIProperty(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Scalar_original_values_can_be_set_using_a_property_dictionary_with_IProperty()
+        {
+            TestSetPropertyValuesScalarsIProperty(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestSetPropertyValuesScalarsIProperty(
+            Func<EntityEntry<Building>, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+                var values = getPropertyValues(entry);
+
+                values[entry.Property(e => e.Name).Metadata] = "Building 18";
+                values[entry.Property(e => e.Value).Metadata] = -1000m;
+                values[entry.Property("Shadow1").Metadata] = 13;
+                values[entry.Property("Shadow2").Metadata] = "Pine Walk";
+
+                Assert.Equal("Building 18", values["Name"]);
+                Assert.Equal(-1000m, values["Value"]);
+                Assert.Equal(13, values["Shadow1"]);
+                Assert.Equal("Pine Walk", values["Shadow2"]);
+
+                Assert.Equal("Building 18", getValue(entry, "Name"));
+                Assert.Equal(-1000m, getValue(entry, "Value"));
+                Assert.Equal(13, getValue(entry, "Shadow1"));
+                Assert.Equal("Pine Walk", getValue(entry, "Shadow2"));
+            }
+        }
+
+        [Fact]
+        public virtual void Scalar_current_values_can_be_set_using_a_non_generic_property_dictionary()
+        {
+            TestSetNonGenericPropertyValuesScalars(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Scalar_original_values_can_be_set_using_a_non_generic_property_dictionary()
+        {
+            TestSetNonGenericPropertyValuesScalars(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestSetNonGenericPropertyValuesScalars(
+            Func<EntityEntry, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                values["Name"] = "Building 18";
+                values["Value"] = -1000m;
+                values["Shadow1"] = 13;
+                values["Shadow2"] = "Pine Walk";
+
+                Assert.Equal("Building 18", values["Name"]);
+                Assert.Equal(-1000m, values["Value"]);
+                Assert.Equal(13, values["Shadow1"]);
+                Assert.Equal("Pine Walk", values["Shadow2"]);
+
+                var entry = context.Entry(building);
+                Assert.Equal("Building 18", getValue(entry, "Name"));
+                Assert.Equal(-1000m, getValue(entry, "Value"));
+                Assert.Equal(13, getValue(entry, "Shadow1"));
+                Assert.Equal("Pine Walk", getValue(entry, "Shadow2"));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesClone(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesClone(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesClone(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_into_an_object_asynchronously()
+        {
+            await TestPropertyValuesClone(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesClone(Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var buildingClone = (Building)(await getPropertyValues(context.Entry(building))).ToObject();
+
+                Assert.Equal("Building One", buildingClone.Name);
+                Assert.Equal(1500000m, buildingClone.Value);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_for_derived_object_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesDerivedClone(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Original_values_for_derived_object_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesDerivedClone(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_for_derived_object_can_be_copied_into_an_object()
+        {
+            await TestPropertyValuesDerivedClone(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_for_derived_object_can_be_copied_into_an_object_asynchronously()
+        {
+            await TestPropertyValuesDerivedClone(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesDerivedClone(
+            Func<EntityEntry<CurrentEmployee>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var employee = context.Employees.OfType<CurrentEmployee>().Single(b => b.FirstName == "Rowan");
+
+                var clone = (CurrentEmployee)(await getPropertyValues(context.Entry(employee))).ToObject();
+
+                Assert.Equal("Rowan", clone.FirstName);
+                Assert.Equal("Miller", clone.LastName);
+                Assert.Equal(45m, clone.LeaveBalance);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_copied_from_a_non_generic_property_dictionary_into_an_object()
+        {
+            await TestNonGenericPropertyValuesClone(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_copied_non_generic_property_dictionary_into_an_object()
+        {
+            await TestNonGenericPropertyValuesClone(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_non_generic_property_dictionary_into_an_object()
+        {
+            await TestNonGenericPropertyValuesClone(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_asynchronously_non_generic_property_dictionary_into_an_object()
+        {
+            await TestNonGenericPropertyValuesClone(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestNonGenericPropertyValuesClone(Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                object building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var buildingClone = (Building)(await getPropertyValues(context.Entry(building))).ToObject();
+
+                Assert.Equal("Building One", buildingClone.Name);
+                Assert.Equal(1500000m, buildingClone.Value);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_copied_into_a_cloned_dictionary()
+        {
+            await TestPropertyValuesCloneToValues(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_copied_into_a_cloned_dictionary()
+        {
+            await TestPropertyValuesCloneToValues(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_into_a_cloned_dictionary()
+        {
+            await TestPropertyValuesCloneToValues(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_into_a_cloned_dictionary_asynchronously()
+        {
+            await TestPropertyValuesCloneToValues(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestPropertyValuesCloneToValues(Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var buildingValues = await getPropertyValues(context.Entry(building));
+                var clonedBuildingValues = buildingValues.Clone();
+
+                Assert.Equal("Building One", clonedBuildingValues["Name"]);
+                Assert.Equal(1500000m, clonedBuildingValues["Value"]);
+                Assert.Equal(11, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", clonedBuildingValues["Shadow2"]);
+
+                // Test modification of cloned property values does not impact original property values
+
+                var newKey = new Guid();
+                clonedBuildingValues["BuildingId"] = newKey; // Can change primary key on clone
+                clonedBuildingValues["Name"] = "Building 18";
+                clonedBuildingValues["Shadow1"] = 13;
+                clonedBuildingValues["Shadow2"] = "Pine Walk";
+
+                Assert.Equal(newKey, clonedBuildingValues["BuildingId"]);
+                Assert.Equal("Building 18", clonedBuildingValues["Name"]);
+                Assert.Equal(13, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Pine Walk", clonedBuildingValues["Shadow2"]);
+
+                Assert.Equal("Building One", buildingValues["Name"]);
+                Assert.Equal(11, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Values_in_cloned_dictionary_can_be_set_with_IProperty()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+
+                var buildingValues = entry.CurrentValues;
+                var clonedBuildingValues = buildingValues.Clone();
+
+                Assert.Equal("Building One", clonedBuildingValues["Name"]);
+                Assert.Equal(1500000m, clonedBuildingValues["Value"]);
+                Assert.Equal(11, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", clonedBuildingValues["Shadow2"]);
+
+                // Test modification of cloned property values does not impact original property values
+
+                var newKey = new Guid();
+                clonedBuildingValues[entry.Property(e => e.BuildingId).Metadata] = newKey; // Can change primary key on clone
+                clonedBuildingValues[entry.Property(e => e.Name).Metadata] = "Building 18";
+                clonedBuildingValues[entry.Property("Shadow1").Metadata] = 13;
+                clonedBuildingValues[entry.Property("Shadow2").Metadata] = "Pine Walk";
+
+                Assert.Equal(newKey, clonedBuildingValues["BuildingId"]);
+                Assert.Equal("Building 18", clonedBuildingValues["Name"]);
+                Assert.Equal(13, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Pine Walk", clonedBuildingValues["Shadow2"]);
+
+                Assert.Equal("Building One", buildingValues["Name"]);
+                Assert.Equal(11, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Using_bad_property_names_throws()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+
+                var buildingValues = entry.CurrentValues;
+                var clonedBuildingValues = buildingValues.Clone();
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Foo", nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => buildingValues["Foo"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Foo", nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues["Foo"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Foo", nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => buildingValues["Foo"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Foo", nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues["Foo"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Foo", nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues.GetValue<string>("Foo")).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Using_bad_IProperty_instances_throws()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+
+                var buildingValues = entry.CurrentValues;
+                var clonedBuildingValues = buildingValues.Clone();
+
+                var property = context.Model.FindEntityType(typeof(Whiteboard)).FindProperty(nameof(Whiteboard.AssetTag));
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("AssetTag", nameof(Whiteboard), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => buildingValues[property]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("AssetTag", nameof(Whiteboard), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues[property]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("AssetTag", nameof(Whiteboard), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => buildingValues[property] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("AssetTag", nameof(Whiteboard), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues[property] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("AssetTag", nameof(Whiteboard), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => clonedBuildingValues.GetValue<string>(property)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Using_bad_property_names_throws_derived()
+        {
+            using (var context = CreateContext())
+            {
+                var employee = context.Employees.OfType<CurrentEmployee>().Single(b => b.FirstName == "Rowan");
+                var entry = context.Entry(employee);
+
+                var values = entry.CurrentValues;
+                var clonedValues = values.Clone();
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Shadow4", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values["Shadow4"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Shadow4", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues["Shadow4"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Shadow4", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values["Shadow4"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Shadow4", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues["Shadow4"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("TerminationDate", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values["TerminationDate"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("TerminationDate", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues["TerminationDate"]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("TerminationDate", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values["TerminationDate"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("TerminationDate", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues["TerminationDate"] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("Shadow4", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues.GetValue<string>("Shadow4")).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotFound("TerminationDate", nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues.GetValue<string>("TerminationDate")).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Using_bad_IProperty_instances_throws_derived()
+        {
+            using (var context = CreateContext())
+            {
+                var employee = context.Employees.OfType<CurrentEmployee>().Single(b => b.FirstName == "Rowan");
+                var entry = context.Entry(employee);
+
+                var values = entry.CurrentValues;
+                var clonedValues = values.Clone();
+
+                var shadowProperty = context.Model.FindEntityType(typeof(PastEmployee)).FindProperty("Shadow4");
+                var termProperty = context.Model.FindEntityType(typeof(PastEmployee)).FindProperty(nameof(PastEmployee.TerminationDate));
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("Shadow4", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values[shadowProperty]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("Shadow4", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues[shadowProperty]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("Shadow4", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values[shadowProperty] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("Shadow4", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues[shadowProperty] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("Shadow4", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues.GetValue<string>(shadowProperty)).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("TerminationDate", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values[termProperty]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("TerminationDate", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues[termProperty]).Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("TerminationDate", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => values[termProperty] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("TerminationDate", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues[termProperty] = "foo").Message);
+
+                Assert.Equal(
+                    CoreStrings.PropertyDoesNotBelong("TerminationDate", nameof(PastEmployee), nameof(CurrentEmployee)),
+                    Assert.Throws<InvalidOperationException>(() => clonedValues.GetValue<string>(termProperty)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_copied_into_a_non_generic_cloned_dictionary()
+        {
+            await TestNonGenericPropertyValuesCloneToValues(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_copied_into_a_non_generic_cloned_dictionary()
+        {
+            await TestNonGenericPropertyValuesCloneToValues(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_into_a_non_generic_cloned_dictionary()
+        {
+            await TestNonGenericPropertyValuesCloneToValues(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_copied_asynchronously_into_a_non_generic_cloned_dictionary()
+        {
+            await TestNonGenericPropertyValuesCloneToValues(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task TestNonGenericPropertyValuesCloneToValues(Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var buildingValues = await getPropertyValues(context.Entry(building));
+
+                var clonedBuildingValues = buildingValues.Clone();
+
+                Assert.Equal("Building One", clonedBuildingValues["Name"]);
+                Assert.Equal(1500000m, clonedBuildingValues["Value"]);
+                Assert.Equal(11, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", clonedBuildingValues["Shadow2"]);
+
+                // Test modification of cloned dictionaries does not impact original property values
+
+                var newKey = new Guid();
+                clonedBuildingValues["BuildingId"] = newKey; // Can change primary key on clone
+                clonedBuildingValues["Name"] = "Building 18";
+                clonedBuildingValues["Shadow1"] = 13;
+                clonedBuildingValues["Shadow2"] = "Pine Walk";
+
+                Assert.Equal(newKey, clonedBuildingValues["BuildingId"]);
+                Assert.Equal("Building 18", clonedBuildingValues["Name"]);
+                Assert.Equal(13, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Pine Walk", clonedBuildingValues["Shadow2"]);
+
+                Assert.Equal("Building One", buildingValues["Name"]);
+                Assert.Equal(11, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_read_or_set_for_an_object_in_the_Deleted_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.CurrentValues), EntityState.Deleted);
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_read_and_set_for_an_object_in_the_Deleted_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.OriginalValues), EntityState.Deleted);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Deleted_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.GetDatabaseValues()), EntityState.Deleted);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Deleted_state_asynchronously()
+        {
+            await TestPropertyValuesPositiveForState(e => e.GetDatabaseValuesAsync(), EntityState.Deleted);
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_read_and_set_for_an_object_in_the_Unchanged_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.CurrentValues), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_read_and_set_for_an_object_in_the_Unchanged_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.OriginalValues), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Unchanged_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.GetDatabaseValues()), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Unchanged_state_asynchronously()
+        {
+            await TestPropertyValuesPositiveForState(e => e.GetDatabaseValuesAsync(), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_read_and_set_for_an_object_in_the_Modified_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.CurrentValues), EntityState.Modified);
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_read_and_set_for_an_object_in_the_Modified_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.OriginalValues), EntityState.Modified);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Modified_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.GetDatabaseValues()), EntityState.Modified);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_and_set_for_an_object_in_the_Modified_state_asynchronously()
+        {
+            await TestPropertyValuesPositiveForState(e => e.GetDatabaseValuesAsync(), EntityState.Modified);
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_read_and_set_for_an_object_in_the_Added_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.CurrentValues), EntityState.Added);
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_read_or_set_for_an_object_in_the_Added_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.OriginalValues), EntityState.Added);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_or_set_for_an_object_in_the_Added_state()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.GetDatabaseValues()), EntityState.Detached);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_or_set_for_an_object_in_the_Added_state_asynchronously()
+        {
+            await TestPropertyValuesPositiveForState(e => e.GetDatabaseValuesAsync(), EntityState.Detached);
+        }
+
+        [Fact]
+        public virtual async Task Current_values_can_be_read_or_set_for_a_Detached_object()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.CurrentValues), EntityState.Detached);
+        }
+
+        [Fact]
+        public virtual async Task Original_values_can_be_read_or_set_for_a_Detached_object()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.OriginalValues), EntityState.Detached);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_can_be_read_or_set_for_a_Detached_object()
+        {
+            await TestPropertyValuesPositiveForState(e => Task.FromResult(e.GetDatabaseValues()), EntityState.Detached);
+        }
+
+        [Fact]
+        public virtual async Task Store_values_cannot_be_read_or_set_for_a_Detached_object_asynchronously()
+        {
+            await TestPropertyValuesPositiveForState(e => e.GetDatabaseValuesAsync(), EntityState.Detached);
+        }
+
+        private async Task TestPropertyValuesPositiveForState(
+            Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues, EntityState state)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+                entry.State = state;
+
+                var values = await getPropertyValues(entry);
+
+                Assert.Equal("Building One", values["Name"]);
+                values["Name"] = "Building One Prime";
+            }
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_an_object_using_generic_dictionary()
+        {
+            TestGenericObjectSetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_an_object_using_generic_dictionary()
+        {
+            TestGenericObjectSetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestGenericObjectSetValues(
+            Func<EntityEntry<Building>, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var newBuilding = Building.Create(
+                    new Guid(building.BuildingId.ToString()),
+                    "Values End",
+                    building.Value);
+
+                buildingValues.SetValues(newBuilding);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal(11, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 11, "Meadow Drive");
+            }
+        }
+
+        private void ValidateBuildingPropereties(
+            EntityEntry buildingEntry,
+            Func<EntityEntry, string, object> getValue,
+            int shadow1,
+            string shadow2)
+        {
+            Assert.Equal("Values End", getValue(buildingEntry, "Name"));
+            Assert.Equal(1500000m, getValue(buildingEntry, "Value"));
+            Assert.Equal(shadow1, getValue(buildingEntry, "Shadow1"));
+            Assert.Equal(shadow2, getValue(buildingEntry, "Shadow2"));
+
+            Assert.True(buildingEntry.Property("Name").IsModified);
+            Assert.False(buildingEntry.Property("BuildingId").IsModified);
+            Assert.False(buildingEntry.Property("Value").IsModified);
+            Assert.Equal(shadow1 != 11, buildingEntry.Property("Shadow1").IsModified);
+            Assert.Equal(shadow2 != "Meadow Drive", buildingEntry.Property("Shadow2").IsModified);
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_an_object_using_non_generic_dictionary()
+        {
+            TestNonGenericObjectSetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_an_object_using_non_generic_dictionary()
+        {
+            TestNonGenericObjectSetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestNonGenericObjectSetValues(
+            Func<EntityEntry, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var newBuilding = Building.Create(
+                    new Guid(building.BuildingId.ToString()),
+                    "Values End",
+                    building.Value);
+
+                buildingValues.SetValues(newBuilding);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal(11, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 11, "Meadow Drive");
+            }
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_DTO_object_using_non_generic_dictionary()
+        {
+            TestNonGenericDtoSetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_DTO_object_using_non_generic_dictionary()
+        {
+            TestNonGenericDtoSetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestNonGenericDtoSetValues(
+            Func<EntityEntry, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var newBuilding = new BuildingDto
+                {
+                    BuildingId = new Guid(building.BuildingId.ToString()),
+                    Name = "Values End",
+                    Value = building.Value,
+                    Shadow1 = 777
+                };
+
+                buildingValues.SetValues(newBuilding);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal(777, buildingValues["Shadow1"]);
+                Assert.Equal("Meadow Drive", buildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 777, "Meadow Drive");
+            }
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_DTO_object_missing_key_using_non_generic_dictionary()
+        {
+            TestNonGenericDtoNoKeySetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_DTO_object_missing_key_using_non_generic_dictionary()
+        {
+            TestNonGenericDtoNoKeySetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestNonGenericDtoNoKeySetValues(
+            Func<EntityEntry, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var newBuilding = new BuildingDtoNoKey
+                {
+                    Name = "Values End",
+                    Value = building.Value,
+                    Shadow2 = "Cheese"
+                };
+
+                buildingValues.SetValues(newBuilding);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal("Cheese", buildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 11, "Cheese");
+            }
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_one_generic_dictionary_to_another_generic_dictionary()
+        {
+            TestGenericValuesSetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_one_generic_dictionary_to_another_generic_dictionary()
+        {
+            TestGenericValuesSetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestGenericValuesSetValues(
+            Func<EntityEntry<Building>, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var clonedBuildingValues = buildingValues.Clone();
+
+                clonedBuildingValues["BuildingId"] = new Guid(building.BuildingId.ToString());
+                clonedBuildingValues["Name"] = "Values End";
+                clonedBuildingValues["Value"] = building.Value;
+                clonedBuildingValues["Shadow1"] = 13;
+                clonedBuildingValues["Shadow2"] = "Pine Walk";
+
+                buildingValues.SetValues(clonedBuildingValues);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal(13, clonedBuildingValues["Shadow1"]);
+                Assert.Equal("Pine Walk", clonedBuildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 13, "Pine Walk");
+            }
+        }
+
+        [Fact]
+        public virtual void Current_values_can_be_set_from_one_non_generic_dictionary_to_another_generic_dictionary()
+        {
+            TestNonGenericValuesSetValues(e => e.CurrentValues, (e, n) => e.Property(n).CurrentValue);
+        }
+
+        [Fact]
+        public virtual void Original_values_can_be_set_from_one_non_generic_dictionary_to_another_generic_dictionary()
+        {
+            TestNonGenericValuesSetValues(e => e.OriginalValues, (e, n) => e.Property(n).OriginalValue);
+        }
+
+        private void TestNonGenericValuesSetValues(
+            Func<EntityEntry, PropertyValues> getPropertyValues,
+            Func<EntityEntry, string, object> getValue)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = getPropertyValues(context.Entry(building));
+
+                var clonedBuildingValues = buildingValues.Clone();
+
+                clonedBuildingValues["BuildingId"] = new Guid(building.BuildingId.ToString());
+                clonedBuildingValues["Name"] = "Values End";
+                clonedBuildingValues["Value"] = building.Value;
+                clonedBuildingValues["Shadow1"] = 13;
+                clonedBuildingValues["Shadow2"] = "Pine Walk";
+
+                buildingValues.SetValues(clonedBuildingValues);
+
+                // Check Values
+
+                Assert.Equal("Values End", buildingValues["Name"]);
+                Assert.Equal(1500000m, buildingValues["Value"]);
+                Assert.Equal(13, buildingValues["Shadow1"]);
+                Assert.Equal("Pine Walk", buildingValues["Shadow2"]);
+
+                ValidateBuildingPropereties(context.Entry(building), getValue, 13, "Pine Walk");
+            }
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_current_values_cannot_be_changed_in_property_dictionary()
+        {
+            TestKeyChange(e => e.CurrentValues);
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_original_values_cannot_be_changed_in_property_dictionary()
+        {
+            TestKeyChange(e => e.OriginalValues);
+        }
+
+        private void TestKeyChange(Func<EntityEntry<Building>, PropertyValues> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                Assert.Equal(
+                    CoreStrings.KeyReadOnly(nameof(Building.BuildingId), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => values["BuildingId"] = new Guid()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Non_nullable_property_in_current_values_results_in_conceptual_null()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+                var values = entry.CurrentValues;
+
+                Assert.False(entry.GetInfrastructure().HasConceptualNull);
+
+                values["Value"] = null;
+
+                Assert.True(entry.GetInfrastructure().HasConceptualNull);
+
+                Assert.Equal(1500000m, values["Value"]);
+                Assert.Equal(1500000m, building.Value);
+            }
+        }
+
+        [Fact]
+        public virtual void Non_nullable_shadow_property_in_current_values_results_in_conceptual_null()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var entry = context.Entry(building);
+                var values = entry.CurrentValues;
+
+                Assert.False(entry.GetInfrastructure().HasConceptualNull);
+
+                values["Shadow1"] = null;
+
+                Assert.True(entry.GetInfrastructure().HasConceptualNull);
+
+                Assert.Equal(11, values["Shadow1"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Non_nullable_property_in_original_values_cannot_be_set_to_null_in_property_dictionary()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = context.Entry(building).OriginalValues;
+
+                Assert.Equal(
+                    CoreStrings.ValueCannotBeNull(nameof(Building.Value), nameof(Building), "decimal"),
+                    Assert.Throws<InvalidOperationException>(() => values["Value"] = null).Message);
+
+                Assert.Equal(1500000m, values["Value"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Non_nullable_shadow_property_in_original_values_cannot_be_set_to_null_in_property_dictionary()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = context.Entry(building).OriginalValues;
+
+                Assert.Equal(
+                    CoreStrings.ValueCannotBeNull("Shadow1", nameof(Building), "int"),
+                    Assert.Throws<InvalidOperationException>(() => values["Shadow1"] = null).Message);
+
+                Assert.Equal(11, values["Shadow1"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Non_nullable_property_in_cloned_dictionary_cannot_be_set_to_null()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = context.Entry(building).CurrentValues.Clone();
+
+                Assert.Equal(
+                    CoreStrings.ValueCannotBeNull(nameof(Building.Value), nameof(Building), "decimal"),
+                    Assert.Throws<InvalidOperationException>(() => values["Value"] = null).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Property_in_current_values_cannot_be_set_to_instance_of_wrong_type()
+        {
+            TestSetWrongType(e => e.CurrentValues);
+        }
+
+        [Fact]
+        public virtual void Property_in_original_values_cannot_be_set_to_instance_of_wrong_type()
+        {
+            TestSetWrongType(e => e.OriginalValues);
+        }
+
+        private void TestSetWrongType(Func<EntityEntry<Building>, PropertyValues> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                Assert.Throws<InvalidCastException>(() => values["Name"] = 1);
+
+                Assert.Equal("Building One", values["Name"]);
+                Assert.Equal("Building One", building.Name);
+            }
+        }
+
+        [Fact]
+        public virtual void Shadow_property_in_current_values_cannot_be_set_to_instance_of_wrong_type()
+        {
+            TestSetWrongTypeShadow(e => e.CurrentValues);
+        }
+
+        [Fact]
+        public virtual void Shadow_property_in_original_values_cannot_be_set_to_instance_of_wrong_type()
+        {
+            TestSetWrongTypeShadow(e => e.OriginalValues);
+        }
+
+        private void TestSetWrongTypeShadow(Func<EntityEntry<Building>, PropertyValues> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                Assert.Throws<InvalidCastException>(() => values["Shadow1"] = "foo");
+
+                Assert.Equal(11, values["Shadow1"]);
+            }
+        }
+
+        [Fact]
+        public virtual void Property_in_cloned_dictionary_cannot_be_set_to_instance_of_wrong_type()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = context.Entry(building).CurrentValues.Clone();
+
+                Assert.Equal(
+                    CoreStrings.InvalidType(nameof(Building.Name), nameof(Building), "int", "string"),
+                    Assert.Throws<InvalidCastException>(() => values["Name"] = 1).Message);
+
+                Assert.Equal("Building One", values["Name"]);
+                Assert.Equal("Building One", building.Name);
+            }
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_current_values_cannot_be_changed_by_setting_values_from_object()
+        {
+            TestKeyChangeByObject(e => e.CurrentValues);
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_original_values_cannot_be_changed_by_setting_values_from_object()
+        {
+            TestKeyChangeByObject(e => e.OriginalValues);
+        }
+
+        private void TestKeyChangeByObject(Func<EntityEntry<Building>, PropertyValues> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var values = getPropertyValues(context.Entry(building));
+
+                var newBuilding = (Building)values.ToObject();
+                newBuilding.BuildingId = new Guid();
+
+                Assert.Equal(
+                    CoreStrings.KeyReadOnly(nameof(Building.BuildingId), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => values.SetValues(newBuilding)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_current_values_cannot_be_changed_by_setting_values_from_another_dictionary()
+        {
+            TestKeyChangeByValues(e => e.CurrentValues);
+        }
+
+        [Fact]
+        public virtual void Primary_key_in_original_values_cannot_be_changed_by_setting_values_from_another_dictionary()
+        {
+            TestKeyChangeByValues(e => e.OriginalValues);
+        }
+
+        private void TestKeyChangeByValues(Func<EntityEntry<Building>, PropertyValues> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var key = building.BuildingId;
+                var values = getPropertyValues(context.Entry(building));
+
+                var clone = values.Clone();
+                clone["BuildingId"] = new Guid();
+
+                Assert.Equal(
+                    CoreStrings.KeyReadOnly(nameof(Building.BuildingId), nameof(Building)),
+                    Assert.Throws<InvalidOperationException>(() => values.SetValues(clone)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual async Task Properties_for_current_values_returns_properties()
+        {
+            await TestProperties(e => Task.FromResult(e.CurrentValues));
+        }
+
+        [Fact]
+        public virtual async Task Properties_for_original_values_returns_properties()
+        {
+            await TestProperties(e => Task.FromResult(e.OriginalValues));
+        }
+
+        [Fact]
+        public virtual async Task Properties_for_store_values_returns_properties()
+        {
+            await TestProperties(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Properties_for_store_values_returns_properties_asynchronously()
+        {
+            await TestProperties(e => e.GetDatabaseValuesAsync());
+        }
+
+        [Fact]
+        public virtual async Task Properties_for_cloned_dictionary_returns_properties()
+        {
+            await TestProperties(e => Task.FromResult(e.CurrentValues.Clone()));
+        }
+
+        private async Task TestProperties(Func<EntityEntry<Building>, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                var buildingValues = await getPropertyValues(context.Entry(building));
+
+                Assert.Equal(
+                    new List<string> { "BuildingId", "Name", "PrincipalMailRoomId", "Shadow1", "Shadow2", "Value" },
+                    buildingValues.Properties.Select(p => p.Name).ToList());
+            }
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValues_for_entity_not_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValuesAsync_for_entity_not_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = (Building)context.Entry(
+                    context.Buildings.Single(b => b.Name == "Building One")).CurrentValues.ToObject();
+
+                building.BuildingId = new Guid();
+
+                context.Buildings.Attach(building);
+
+                Assert.Null(await getPropertyValues(context.Entry(building)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null()
+        {
+            await NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValuesAsync_for_entity_not_in_the_store_returns_null()
+        {
+            await NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task NonGeneric_GetDatabaseValues_for_entity_not_in_the_store_returns_null_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building =
+                    (Building)
+                        context.Entry(context.Buildings.Single(b => b.Name == "Building One")).CurrentValues.ToObject();
+                building.BuildingId = new Guid();
+
+                context.Buildings.Attach(building);
+
+                Assert.Null(await getPropertyValues(context.Entry((object)building)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValuesAsync_for_derived_entity_not_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var employee = (CurrentEmployee)context.Entry(
+                    context.Employees
+                        .OfType<CurrentEmployee>()
+                        .Single(b => b.FirstName == "Rowan"))
+                    .CurrentValues
+                    .ToObject();
+                employee.EmployeeId = -77;
+
+                context.Employees.Attach(employee);
+
+                Assert.Null(await getPropertyValues(context.Entry(employee)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null()
+        {
+            await NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValuesAsync_for_derived_entity_not_in_the_store_returns_null()
+        {
+            await NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
+                e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task NonGeneric_GetDatabaseValues_for_derived_entity_not_in_the_store_returns_null_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var employee = (CurrentEmployee)context.Entry(
+                    context.Employees
+                        .OfType<CurrentEmployee>()
+                        .Single(b => b.FirstName == "Rowan"))
+                    .CurrentValues
+                    .ToObject();
+                employee.EmployeeId = -77;
+
+                context.Employees.Attach(employee);
+
+                Assert.Null(await getPropertyValues(context.Entry((object)employee)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task GetDatabaseValuesAsync_for_the_wrong_type_in_the_store_returns_null()
+        {
+            await GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task GetDatabaseValues_for_the_wrong_type_in_the_store_returns_null_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var pastEmployeeId = context.Employees
+                    .OfType<PastEmployee>()
+                    .AsNoTracking()
+                    .FirstOrDefault()
+                    .EmployeeId;
+
+                var employee = (CurrentEmployee)context.Entry(
+                    context.Employees
+                        .OfType<CurrentEmployee>()
+                        .Single(b => b.FirstName == "Rowan"))
+                    .CurrentValues
+                    .ToObject();
+                employee.EmployeeId = pastEmployeeId;
+
+                context.Employees.Attach(employee);
+
+                Assert.Null(await getPropertyValues(context.Entry(employee)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws()
+        {
+            await NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task NonGeneric_GetDatabaseValuesAsync_for_the_wrong_type_in_the_store_throws()
+        {
+            await NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task NonGeneric_GetDatabaseValues_for_the_wrong_type_in_the_store_throws_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var pastEmployeeId = context.Employees
+                    .OfType<PastEmployee>()
+                    .AsNoTracking()
+                    .FirstOrDefault()
+                    .EmployeeId;
+
+                var employee = (CurrentEmployee)context.Entry(
+                    context.Employees
+                        .OfType<CurrentEmployee>()
+                        .Single(b => b.FirstName == "Rowan"))
+                    .CurrentValues
+                    .ToObject();
+                employee.EmployeeId = pastEmployeeId;
+
+                context.Employees.Attach(employee);
+
+                Assert.Null(await getPropertyValues(context.Entry((object)employee)));
+            }
+        }
+
+        [Fact]
+        public virtual async Task Store_values_really_are_store_values_not_current_or_original_values()
+        {
+            await Store_values_really_are_store_values_not_current_or_original_values_implementation(e => Task.FromResult(e.GetDatabaseValues()));
+        }
+
+        [Fact]
+        public virtual async Task Store_values_really_are_store_values_not_current_or_original_values_async()
+        {
+            await Store_values_really_are_store_values_not_current_or_original_values_implementation(e => e.GetDatabaseValuesAsync());
+        }
+
+        private async Task Store_values_really_are_store_values_not_current_or_original_values_implementation(
+            Func<EntityEntry, Task<PropertyValues>> getPropertyValues)
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+                building.Name = "Values End";
+
+                context.Entry(building).State = EntityState.Unchanged;
+
+                var storeValues = (Building)(await getPropertyValues(context.Entry(building))).ToObject();
+
+                Assert.Equal("Building One", storeValues.Name);
+            }
+        }
+
+        [Fact]
+        public virtual void Setting_store_values_does_not_change_current_or_original_values()
+        {
+            using (var context = CreateContext())
+            {
+                var building = context.Buildings.Single(b => b.Name == "Building One");
+
+                var storeValues = context.Entry(building).GetDatabaseValues();
+                storeValues["Name"] = "Bag End";
+
+                var currentValues = (Building)context.Entry(building).CurrentValues.ToObject();
+                Assert.Equal("Building One", currentValues.Name);
+
+                var originalValues = (Building)context.Entry(building).OriginalValues.ToObject();
+                Assert.Equal("Building One", originalValues.Name);
+            }
+        }
+
+        protected abstract class Employee : UnMappedPersonBase
+        {
+            public int EmployeeId { get; set; }
+        }
+
+        protected class Building
+        {
+            private Building()
+            {
+            }
+
+            public static Building Create(Guid buildingId, string name, decimal value)
+                => new Building
+                {
+                    BuildingId = buildingId,
+                    Name = name,
+                    Value = value
+                };
+
+            public Guid BuildingId { get; set; }
+            public string Name { get; set; }
+            public decimal Value { get; set; }
+            public virtual ICollection<Office> Offices { get; } = new List<Office>();
+            public virtual IList<MailRoom> MailRooms { get; } = new List<MailRoom>();
+
+            public int? PrincipalMailRoomId { get; set; }
+            public MailRoom PrincipalMailRoom { get; set; }
+
+            public string NotInModel { get; set; }
+
+            private string _noGetter = "NoGetter";
+
+            public string NoGetter
+            {
+                set { _noGetter = value; }
+            }
+
+            public string GetNoGetterValue() => _noGetter;
+
+            public string NoSetter => "NoSetter";
+        }
+
+        protected class BuildingDto
+        {
+            public Guid BuildingId { get; set; }
+            public string Name { get; set; }
+            public decimal Value { get; set; }
+
+            public int? PrincipalMailRoomId { get; set; }
+
+            public string NotInModel { get; set; }
+
+            private string _noGetter = "NoGetter";
+
+            public string NoGetter
+            {
+                set { _noGetter = value; }
+            }
+
+            public string GetNoGetterValue() => _noGetter;
+
+            public string NoSetter => "NoSetter";
+
+            public int Shadow1 { get; set; }
+        }
+
+        protected class BuildingDtoNoKey
+        {
+            public string Name { get; set; }
+            public decimal Value { get; set; }
+            public string Shadow2 { get; set; }
+        }
+
+        protected class MailRoom
+        {
+            public int id { get; set; }
+            public Building Building { get; set; }
+            public Guid BuildingId { get; set; }
+        }
+
+        protected class Office : UnMappedOfficeBase
+        {
+            public Guid BuildingId { get; set; }
+            public Building Building { get; set; }
+            public IList<Whiteboard> WhiteBoards { get; } = new List<Whiteboard>();
+        }
+
+        protected abstract class UnMappedOfficeBase
+        {
+            public string Number { get; set; }
+            public string Description { get; set; }
+        }
+
+        protected class BuildingDetail
+        {
+            public Guid BuildingId { get; set; }
+            public Building Building { get; set; }
+            public string Details { get; set; }
+        }
+
+        protected class WorkOrder
+        {
+            public int WorkOrderId { get; set; }
+            public int EmployeeId { get; set; }
+            public Employee Employee { get; set; }
+            public string Details { get; set; }
+        }
+
+        protected class Whiteboard
+        {
+            public byte[] iD { get; set; }
+            public string AssetTag { get; set; }
+            public Office Office { get; set; }
+        }
+
+        protected class UnMappedPersonBase
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+        protected class UnMappedOffice : Office
+        {
+        }
+
+        protected class CurrentEmployee : Employee
+        {
+            public CurrentEmployee Manager { get; set; }
+            public decimal LeaveBalance { get; set; }
+            public Office Office { get; set; }
+        }
+
+        protected class PastEmployee : Employee
+        {
+            public DateTime TerminationDate { get; set; }
+        }
+
+        protected class AdvancedPatternsMasterContext : DbContext
+        {
+            public AdvancedPatternsMasterContext(DbContextOptions options)
+                : base(options)
+            {
+                ChangeTracker.AutoDetectChangesEnabled = false;
+            }
+
+            public DbSet<Employee> Employees { get; set; }
+            public DbSet<Office> Offices { get; set; }
+            public DbSet<Building> Buildings { get; set; }
+            public DbSet<BuildingDetail> BuildingDetails { get; set; }
+            public DbSet<WorkOrder> WorkOrders { get; set; }
+            public DbSet<Whiteboard> Whiteboards { get; set; }
+        }
+
+        protected AdvancedPatternsMasterContext CreateContext()
+            => (AdvancedPatternsMasterContext)Fixture.CreateContext(TestStore);
+
+        public virtual void Dispose() => TestStore.Dispose();
+
+        protected TFixture Fixture { get; }
+
+        protected TTestStore TestStore { get; }
+
+        public abstract class PropertyValuesFixtureBase
+        {
+            public abstract TTestStore CreateTestStore();
+
+            public abstract DbContext CreateContext(TTestStore testStore);
+
+            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Employee>(b =>
+                    {
+                        b.Property(e => e.EmployeeId).ValueGeneratedNever();
+                        b.Property<int>("Shadow1");
+                        b.Property<string>("Shadow2");
+                    });
+
+                modelBuilder.Entity<CurrentEmployee>(b => { b.Property<int>("Shadow3"); });
+
+                modelBuilder.Entity<PastEmployee>(b => { b.Property<string>("Shadow4"); });
+
+                modelBuilder.Entity<Building>()
+                    .HasOne(b => b.PrincipalMailRoom)
+                    .WithMany()
+                    .HasForeignKey(b => b.PrincipalMailRoomId);
+
+                modelBuilder.Entity<MailRoom>()
+                    .HasOne(m => m.Building)
+                    .WithMany(b => b.MailRooms)
+                    .HasForeignKey(m => m.BuildingId);
+
+                modelBuilder.Entity<Office>().HasKey(o => new { o.Number, o.BuildingId });
+
+                modelBuilder.Ignore<UnMappedOffice>();
+
+                modelBuilder.Entity<BuildingDetail>(b =>
+                    {
+                        b.HasKey(d => d.BuildingId);
+                        b.HasOne(d => d.Building).WithOne();
+                    });
+
+                modelBuilder.Entity<Building>(b =>
+                    {
+                        b.Ignore(e => e.NotInModel);
+                        b.Property<int>("Shadow1");
+                        b.Property<string>("Shadow2");
+                    });
+            }
+
+            protected virtual void Seed(DbContext context)
+            {
+                var buildings = new List<Building>
+                {
+                    Building.Create(new Guid("21EC2020-3AEA-1069-A2DD-08002B30309D"), "Building One", 1500000),
+                    Building.Create(Guid.NewGuid(), "Building Two", 1000000m)
+                };
+
+                foreach (var building in buildings)
+                {
+                    context.Add(building);
+                }
+
+                context.Entry(buildings[0]).Property("Shadow1").CurrentValue = 11;
+                context.Entry(buildings[0]).Property("Shadow2").CurrentValue = "Meadow Drive";
+
+                context.Entry(buildings[1]).Property("Shadow1").CurrentValue = 807;
+                context.Entry(buildings[1]).Property("Shadow2").CurrentValue = "Onyx Circle";
+
+                var offices = new List<Office>
+                {
+                    new Office
+                    {
+                        BuildingId = buildings[0].BuildingId,
+                        Number = "1/1221"
+                    },
+                    new Office
+                    {
+                        BuildingId = buildings[0].BuildingId,
+                        Number = "1/1223"
+                    },
+                    new Office
+                    {
+                        BuildingId = buildings[0].BuildingId,
+                        Number = "2/1458"
+                    },
+                    new Office
+                    {
+                        BuildingId = buildings[0].BuildingId,
+                        Number = "2/1789"
+                    }
+                };
+
+                foreach (var office in offices)
+                {
+                    context.Add(office);
+                }
+
+                var employees = new List<Employee>
+                {
+                    new CurrentEmployee
+                    {
+                        EmployeeId = 1,
+                        FirstName = "Rowan",
+                        LastName = "Miller",
+                        LeaveBalance = 45,
+                        Office = offices[0]
+                    },
+                    new CurrentEmployee
+                    {
+                        EmployeeId = 2,
+                        FirstName = "Arthur",
+                        LastName = "Vickers",
+                        LeaveBalance = 62,
+                        Office = offices[1]
+                    },
+                    new PastEmployee
+                    {
+                        EmployeeId = 3,
+                        FirstName = "John",
+                        LastName = "Doe",
+                        TerminationDate = new DateTime(2006, 1, 23)
+                    }
+                };
+
+                context.Entry(employees[0]).Property("Shadow1").CurrentValue = 111;
+                context.Entry(employees[0]).Property("Shadow2").CurrentValue = "PM";
+                context.Entry(employees[0]).Property("Shadow3").CurrentValue = 1111;
+
+                context.Entry(employees[1]).Property("Shadow1").CurrentValue = 222;
+                context.Entry(employees[1]).Property("Shadow2").CurrentValue = "SDE";
+                context.Entry(employees[1]).Property("Shadow3").CurrentValue = 11112;
+
+                context.Entry(employees[2]).Property("Shadow1").CurrentValue = 333;
+                context.Entry(employees[2]).Property("Shadow2").CurrentValue = "SDET";
+                context.Entry(employees[2]).Property("Shadow4").CurrentValue = "BSC";
+
+                foreach (var employee in employees)
+                {
+                    context.Add(employee);
+                }
+
+                var whiteboards = new List<Whiteboard>
+                {
+                    new Whiteboard
+                    {
+                        AssetTag = "WB1973",
+                        iD = new byte[] { 1, 9, 7, 3 },
+                        Office = offices[0]
+                    },
+                    new Whiteboard
+                    {
+                        AssetTag = "WB1977",
+                        iD = new byte[] { 1, 9, 7, 7 },
+                        Office = offices[0]
+                    },
+                    new Whiteboard
+                    {
+                        AssetTag = "WB1970",
+                        iD = new byte[] { 1, 9, 7, 0 },
+                        Office = offices[2]
+                    }
+                };
+
+                foreach (var whiteboard in whiteboards)
+                {
+                    context.Add(whiteboard);
+                }
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ArrayPropertyValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ArrayPropertyValues.cs
@@ -1,0 +1,178 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ArrayPropertyValues : PropertyValues
+    {
+        private readonly object[] _values;
+        private IReadOnlyList<IProperty> _properties;
+        private IEntityMaterializerSource _materializerSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ArrayPropertyValues([NotNull] InternalEntityEntry internalEntry, [NotNull] object[] values)
+            : base(internalEntry)
+        {
+            _values = values;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object ToObject()
+            => MaterializerSource.GetMaterializer(EntityType)(new ValueBuffer(_values));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void SetValues(object obj)
+        {
+            Check.NotNull(obj, nameof(obj));
+
+            if (obj.GetType() == EntityType.ClrType)
+            {
+                for (var i = 0; i < _values.Length; i++)
+                {
+                    if (!Properties[i].IsShadowProperty)
+                    {
+                        SetValue(i, Properties[i].GetGetter().GetClrValue(obj));
+                    }
+                }
+            }
+            else
+            {
+                for (var i = 0; i < _values.Length; i++)
+                {
+                    var getter = obj.GetType().GetAnyProperty(Properties[i].Name)?.FindGetterProperty();
+                    if (getter != null)
+                    {
+                        SetValue(i, getter.GetValue(obj));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override PropertyValues Clone()
+        {
+            var copies = new object[_values.Length];
+            Array.Copy(_values, copies, _values.Length);
+
+            return new ArrayPropertyValues(InternalEntry, copies);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void SetValues(PropertyValues propertyValues)
+        {
+            Check.NotNull(propertyValues, nameof(propertyValues));
+
+            for (var i = 0; i < _values.Length; i++)
+            {
+                SetValue(i, propertyValues[Properties[i].Name]);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override IReadOnlyList<IProperty> Properties
+            => _properties ?? (_properties = EntityType.GetProperties().ToList());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object this[string propertyName]
+        {
+            get { return _values[EntityType.GetProperty(propertyName).GetIndex()]; }
+            set { SetValue(EntityType.GetProperty(propertyName).GetIndex(), value); }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object this[IProperty property]
+        {
+            get { return _values[EntityType.CheckPropertyBelongsToType(property).GetIndex()]; }
+            set { SetValue(EntityType.CheckPropertyBelongsToType(property).GetIndex(), value); }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override TValue GetValue<TValue>(string propertyName)
+            => (TValue)this[propertyName];
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override TValue GetValue<TValue>(IProperty property)
+            => (TValue)this[property];
+
+        private void SetValue(int index, object value)
+        {
+            var property = Properties[index];
+
+            if (value != null)
+            {
+                if (!property.ClrType.IsInstanceOfType(value))
+                {
+                    throw new InvalidCastException(
+                        CoreStrings.InvalidType(
+                            property.Name,
+                            property.DeclaringEntityType.DisplayName(),
+                            value.GetType().DisplayName(),
+                            property.ClrType.DisplayName()));
+                }
+            }
+            else
+            {
+                if (!property.ClrType.IsNullableType())
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ValueCannotBeNull(
+                            property.Name,
+                            property.DeclaringEntityType.DisplayName(),
+                            property.ClrType.DisplayName()));
+                }
+            }
+
+            _values[index] = value;
+        }
+
+        private IEntityMaterializerSource MaterializerSource
+            => _materializerSource
+               ?? (_materializerSource = InternalEntry.StateManager.Context.GetService<IEntityMaterializerSource>());
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CurrentPropertyValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CurrentPropertyValues.cs
@@ -1,48 +1,53 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IEntityMaterializerSource
+    public class CurrentPropertyValues : EntryPropertyValues
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateReadValueExpression(
-            [NotNull] Expression valueBuffer,
-            [NotNull] Type type,
-            int index,
-            [CanBeNull] IProperty property = null);
+        public CurrentPropertyValues([NotNull] InternalEntityEntry internalEntry)
+            : base(internalEntry)
+        {
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateReadValueCallExpression([NotNull] Expression valueBuffer, int index);
+        public override TValue GetValue<TValue>(string propertyName) 
+            => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateMaterializeExpression(
-            [NotNull] IEntityType entityType,
-            [NotNull] Expression valueBufferExpression,
-            [CanBeNull] int[] indexMap = null);
+        public override TValue GetValue<TValue>(IProperty property)
+            => InternalEntry.GetCurrentValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Func<ValueBuffer, object> GetMaterializer([NotNull] IEntityType entityType);
+        protected override void SetValueInternal(IProperty property, object value)
+            => InternalEntry[property] = value;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override object GetValueInternal(IProperty property)
+            => InternalEntry[property];
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntryPropertyValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntryPropertyValues.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class EntryPropertyValues : PropertyValues
+    {
+        private IReadOnlyList<IProperty> _properties;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected EntryPropertyValues([NotNull] InternalEntityEntry internalEntry)
+            : base(internalEntry)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object ToObject()
+            => Clone().ToObject();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void SetValues(object obj)
+        {
+            Check.NotNull(obj, nameof(obj));
+
+            if (obj.GetType() == EntityType.ClrType)
+            {
+                foreach (var property in Properties.Where(p => !p.IsShadowProperty))
+                {
+                    SetValueInternal(property, property.GetGetter().GetClrValue(obj));
+                }
+            }
+            else
+            {
+                foreach (var property in Properties)
+                {
+                    var getter = obj.GetType().GetAnyProperty(property.Name)?.FindGetterProperty();
+                    if (getter != null)
+                    {
+                        SetValueInternal(property, getter.GetValue(obj));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override PropertyValues Clone()
+        {
+            var values = new object[Properties.Count];
+            for (var i = 0; i < values.Length; i++)
+            {
+                values[i] = InternalEntry[Properties[i]];
+            }
+
+            return new ArrayPropertyValues(InternalEntry, values);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void SetValues(PropertyValues propertyValues)
+        {
+            Check.NotNull(propertyValues, nameof(propertyValues));
+
+            foreach (var property in Properties)
+            {
+                SetValueInternal(property, propertyValues[property.Name]);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override IReadOnlyList<IProperty> Properties
+            => _properties ?? (_properties = EntityType.GetProperties().ToList());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object this[string propertyName]
+        {
+            get { return GetValueInternal(EntityType.GetProperty(propertyName)); }
+            set { SetValueInternal(EntityType.GetProperty(propertyName), value); }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override object this[IProperty property]
+        {
+            get { return GetValueInternal(EntityType.CheckPropertyBelongsToType(property)); }
+            set { SetValueInternal(EntityType.CheckPropertyBelongsToType(property), value); }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected abstract void SetValueInternal([NotNull] IProperty property, [CanBeNull] object value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected abstract object GetValueInternal([NotNull] IProperty property);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalPropertyValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalPropertyValues.cs
@@ -1,48 +1,53 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IEntityMaterializerSource
+    public class OriginalPropertyValues : EntryPropertyValues
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateReadValueExpression(
-            [NotNull] Expression valueBuffer,
-            [NotNull] Type type,
-            int index,
-            [CanBeNull] IProperty property = null);
+        public OriginalPropertyValues([NotNull] InternalEntityEntry internalEntry)
+            : base(internalEntry)
+        {
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateReadValueCallExpression([NotNull] Expression valueBuffer, int index);
+        public override TValue GetValue<TValue>(string propertyName)
+            => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.GetProperty(propertyName));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression CreateMaterializeExpression(
-            [NotNull] IEntityType entityType,
-            [NotNull] Expression valueBufferExpression,
-            [CanBeNull] int[] indexMap = null);
+        public override TValue GetValue<TValue>(IProperty property)
+            => InternalEntry.GetOriginalValue<TValue>(InternalEntry.EntityType.CheckPropertyBelongsToType(property));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Func<ValueBuffer, object> GetMaterializer([NotNull] IEntityType entityType);
+        protected override void SetValueInternal(IProperty property, object value)
+            => InternalEntry.SetOriginalValue(property, value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override object GetValueInternal(IProperty property)
+            => InternalEntry.GetOriginalValue(property);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalValues.cs
@@ -59,6 +59,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                 }
 
+                if (value == null
+                    && !property.ClrType.IsNullableType())
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ValueCannotBeNull(
+                            property.Name, property.DeclaringEntityType.DisplayName(), property.ClrType.DisplayName()));
+                }
+
                 _values[index] = value;
             }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyEntry.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -26,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] string name)
-            : this(internalEntry, GetProperty(internalEntry, name))
+            : this(internalEntry, internalEntry.EntityType.GetProperty(name))
         {
         }
 
@@ -37,22 +35,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public PropertyEntry([NotNull] InternalEntityEntry internalEntry, [NotNull] IProperty property)
             : base(internalEntry, property)
         {
-        }
-
-        private static IProperty GetProperty(InternalEntityEntry internalEntry, string name)
-        {
-            var property = internalEntry.EntityType.FindProperty(name);
-            if (property == null)
-            {
-                if (internalEntry.EntityType.FindNavigation(name) != null)
-                {
-                    throw new InvalidOperationException(
-                        CoreStrings.PropertyIsNavigation(name, internalEntry.EntityType.DisplayName(),
-                            nameof(EntityEntry.Property), nameof(EntityEntry.Reference), nameof(EntityEntry.Collection)));
-                }
-                throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, internalEntry.EntityType.DisplayName()));
-            }
-            return property;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/PropertyValues.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         A collection of all property values for an entity.
+    ///     </para>
+    ///     <para>
+    ///         Objects of this type can be obtained from <see cref="EntityEntry.CurrentValues" />,
+    ///         <see cref="EntityEntry.OriginalValues" />,  <see cref="EntityEntry.GetDatabaseValues" />,
+    ///         or <see cref="EntityEntry.GetDatabaseValuesAsync" />.
+    ///         Once obtained, the objects are usually used in various combinations to resolve optimitisic
+    ///         concurrency exceptions signalled by the throwing of a <see cref="DbUpdateConcurrencyException" />.
+    ///     </para>
+    /// </summary>
+    public abstract class PropertyValues
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected PropertyValues([NotNull] InternalEntityEntry internalEntry)
+        {
+            InternalEntry = internalEntry;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual InternalEntityEntry InternalEntry { get; }
+
+        /// <summary>
+        ///     Creates an insatcne of the entity type and sets all its properties using the
+        ///     values from this object.
+        /// </summary>
+        /// <returns> The values of this object copied into a new entity instance. </returns>
+        public abstract object ToObject();
+
+        /// <summary>
+        ///     <para>
+        ///         Sets the values of this object by copying values from the given object.
+        ///     </para>
+        ///     <para>
+        ///         The given object can be of any type.  Any property on the object with a name that
+        ///         matches a property name in the entity type and can be read will be copied.  Other
+        ///         properties will be ignored.  This allows, for example, copying of properties from
+        ///         simple Data Transfer Objects (DTOs).
+        ///     </para>
+        /// </summary>
+        /// <param name="obj"> The object to read values from. </param>
+        public abstract void SetValues([NotNull] object obj);
+
+        /// <summary>
+        ///     Creates a clone of the values in this object. Changes made to the new object will not be
+        ///     reflected in this object and vice versa.
+        /// </summary>
+        /// <returns> A clone of this object. </returns>
+        public abstract PropertyValues Clone();
+
+        /// <summary>
+        ///     <para>
+        ///         Sets the values of this object by reading values from another <see cref="PropertyValues" />
+        ///         object.
+        ///     </para>
+        ///     <para>
+        ///         The other object must be based on the same type as this object, or a type derived
+        ///         from the type for this object.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyValues"> The object from which values should be coiped. </param>
+        public abstract void SetValues([NotNull] PropertyValues propertyValues);
+
+        /// <summary>
+        ///     Gets the properties for which this object is storing values.
+        /// </summary>
+        /// <value> The properties. </value>
+        public abstract IReadOnlyList<IProperty> Properties { get; }
+
+        /// <summary>
+        ///     Gets the underlying entity type for which this object is storing values.
+        /// </summary>
+        public virtual IEntityType EntityType => InternalEntry.EntityType;
+
+        /// <summary>
+        ///     Gets or sets the value of the property with the specified property name.
+        /// </summary>
+        /// <param name="propertyName"> The property name. </param>
+        /// <returns> The value of the property. </returns>
+        public abstract object this[[NotNull] string propertyName] { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Gets or sets the value of the property.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The value of the property. </returns>
+        public abstract object this[[NotNull] IProperty property] { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Gets the value of the property just like using the indexed property getter but
+        ///     typed to the type of the generic parameter.
+        /// </summary>
+        /// <typeparam name="TValue"> The type of the property. </typeparam>
+        /// <param name="propertyName"> The property name. </param>
+        /// <returns> The value of the property. </returns>
+        public abstract TValue GetValue<TValue>([NotNull] string propertyName);
+
+        /// <summary>
+        ///     Gets the value of the property just like using the indexed property getter but
+        ///     typed to the type of the generic parameter.
+        /// </summary>
+        /// <typeparam name="TValue"> The type of the property. </typeparam>
+        /// <param name="property"> The property. </param>
+        /// <returns> The value of the property. </returns>
+        public abstract TValue GetValue<TValue>([NotNull] IProperty property);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IEntityFinder.cs
@@ -48,5 +48,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         IQueryable Query([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        object[] GetDatabaseValues([NotNull] InternalEntityEntry entry);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Task<object[]> GetDatabaseValuesAsync(
+            [NotNull] InternalEntityEntry entry, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -65,16 +65,19 @@
     <Compile Include="ChangeTracking\EntityEntry.cs" />
     <Compile Include="ChangeTracking\EntityEntryGraphNode.cs" />
     <Compile Include="ChangeTracking\EntityEntry`.cs" />
+    <Compile Include="ChangeTracking\Internal\ArrayPropertyValues.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeDetector.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\CompositeDependentValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\CompositePrincipalKeyValueFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\CurrentPropertyValues.cs" />
     <Compile Include="ChangeTracking\Internal\DependentKeyValueFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\DependentsMap.cs" />
     <Compile Include="ChangeTracking\Internal\DependentsMapFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EmptyShadowValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EntityEntryGraphIterator.cs" />
     <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
+    <Compile Include="ChangeTracking\Internal\EntryPropertyValues.cs" />
     <Compile Include="ChangeTracking\Internal\IChangeDetector.cs" />
     <Compile Include="ChangeTracking\Internal\IChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IdentityMap.cs" />
@@ -111,6 +114,7 @@
     <Compile Include="ChangeTracking\Internal\MultiSnapshot.cs" />
     <Compile Include="ChangeTracking\Internal\NavigationFixer.cs" />
     <Compile Include="ChangeTracking\Internal\NullableKeyIdentityMap.cs" />
+    <Compile Include="ChangeTracking\Internal\OriginalPropertyValues.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\RelationshipSnapshotFactoryFactory.cs" />
@@ -134,6 +138,7 @@
     <Compile Include="ChangeTracking\ObservableHashSet.cs" />
     <Compile Include="ChangeTracking\PropertyEntry.cs" />
     <Compile Include="ChangeTracking\PropertyEntry`.cs" />
+    <Compile Include="ChangeTracking\PropertyValues.cs" />
     <Compile Include="ChangeTracking\ReferenceEntry.cs" />
     <Compile Include="ChangeTracking\ReferenceEntry`.cs" />
     <Compile Include="DbContext.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -217,6 +217,30 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// The value for property '{property}' of entity type '{entityType}' cannot be set to null because its type is '{propertyType}' which is not a nullable type.
+        /// </summary>
+        public static string ValueCannotBeNull([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ValueCannotBeNull", "property", "entityType", "propertyType"), property, entityType, propertyType);
+        }
+
+        /// <summary>
+        /// The value for property '{property}' of entity type '{entityType}' cannot be set to a value of type '{valueType}' because its type is '{propertyType}'.
+        /// </summary>
+        public static string InvalidType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object valueType, [CanBeNull] object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidType", "property", "entityType", "valueType", "propertyType"), property, entityType, valueType, propertyType);
+        }
+
+        /// <summary>
+        /// The property '{property}' belongs to entity type '{entityType}' but is being used with an instance of entity type '{expectedType}'.
+        /// </summary>
+        public static string PropertyDoesNotBelong([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object expectedType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyDoesNotBelong", "property", "entityType", "expectedType"), property, entityType, expectedType);
+        }
+
+        /// <summary>
         /// Cannot change ObservableHashSet during a CollectionChanged event.
         /// </summary>
         public static string ObservableCollectionReentrancy

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -192,6 +192,15 @@
   <data name="OriginalValueNotTracked" xml:space="preserve">
     <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. Original values are not recorded for most properties of entities when the 'ChangingAndChangedNotifications' strategy is used. To access all original values use a different change tracking strategy such as 'ChangingAndChangedNotificationsWithOriginalValues'.</value>
   </data>
+  <data name="ValueCannotBeNull" xml:space="preserve">
+    <value>The value for property '{property}' of entity type '{entityType}' cannot be set to null because its type is '{propertyType}' which is not a nullable type.</value>
+  </data>
+  <data name="InvalidType" xml:space="preserve">
+    <value>The value for property '{property}' of entity type '{entityType}' cannot be set to a value of type '{valueType}' because its type is '{propertyType}'.</value>
+  </data>
+  <data name="PropertyDoesNotBelong" xml:space="preserve">
+    <value>The property '{property}' belongs to entity type '{entityType}' but is being used with an instance of entity type '{expectedType}'.</value>
+  </data>
   <data name="ObservableCollectionReentrancy" xml:space="preserve">
     <value>Cannot change ObservableHashSet during a CollectionChanged event.</value>
   </data>

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="FieldMappingInMemoryTest.cs" />
     <Compile Include="FindInMemoryTest.cs" />
     <Compile Include="LoadInMemoryTest.cs" />
+    <Compile Include="PropertyValuesInMemoryTest.cs" />
     <Compile Include="StoreGeneratedFixupInMemoryTest.cs" />
     <Compile Include="WarningsTest.cs" />
     <Compile Include="EndToEndTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/PropertyValuesInMemoryTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class PropertyValuesInMemoryTest
+        : PropertyValuesTestBase<InMemoryTestStore, PropertyValuesInMemoryTest.PropertyValuesInMemoryFixture>
+    {
+        public PropertyValuesInMemoryTest(PropertyValuesInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class PropertyValuesInMemoryFixture : PropertyValuesFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public PropertyValuesInMemoryFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override InMemoryTestStore CreateTestStore()
+            {
+                var store = new InMemoryPropertyValuesTestStore(_serviceProvider);
+
+                using (var context = CreateContext(store))
+                {
+                    Seed(context);
+                }
+
+                return store;
+            }
+
+            public override DbContext CreateContext(InMemoryTestStore testStore)
+                => new AdvancedPatternsMasterContext(new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase()
+                    .UseInternalServiceProvider(_serviceProvider).Options);
+
+            public class InMemoryPropertyValuesTestStore : InMemoryTestStore
+            {
+                private readonly IServiceProvider _serviceProvider;
+
+                public InMemoryPropertyValuesTestStore(IServiceProvider serviceProvider)
+                {
+                    _serviceProvider = serviceProvider;
+                }
+
+                public override void Dispose()
+                {
+                    _serviceProvider.GetRequiredService<IInMemoryStoreSource>().GetGlobalStore().Clear();
+
+                    base.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="OptimisticConcurrencySqlServerTest.cs" />
     <Compile Include="Properties\TestAssemblyConditions.cs" />
     <Compile Include="PropertyEntrySqlServerTest.cs" />
+    <Compile Include="PropertyValuesSqlServerTest.cs" />
     <Compile Include="QueryBugsTest.cs" />
     <Compile Include="QueryLoggingSqlServerTest.cs" />
     <Compile Include="QueryNavigationsSqlServerTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/PropertyValuesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/PropertyValuesSqlServerTest.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class PropertyValuesSqlServerTest
+        : PropertyValuesTestBase<SqlServerTestStore, PropertyValuesSqlServerTest.PropertyValuesSqlServerFixture>
+    {
+        public PropertyValuesSqlServerTest(PropertyValuesSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class PropertyValuesSqlServerFixture : PropertyValuesFixtureBase
+        {
+            private const string DatabaseName = "PropertyValues";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            public PropertyValuesSqlServerFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkSqlServer()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override SqlServerTestStore CreateTestStore()
+            {
+                return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+                    {
+                        var optionsBuilder = new DbContextOptionsBuilder()
+                            .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName))
+                            .UseInternalServiceProvider(_serviceProvider);
+
+                        using (var context = new AdvancedPatternsMasterContext(optionsBuilder.Options))
+                        {
+                            context.Database.EnsureClean();
+                            Seed(context);
+                        }
+                    });
+            }
+
+            public override DbContext CreateContext(SqlServerTestStore testStore)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlServer(testStore.Connection)
+                    .UseInternalServiceProvider(_serviceProvider);
+
+                var context = new AdvancedPatternsMasterContext(optionsBuilder.Options);
+                context.Database.UseTransaction(testStore.Transaction);
+
+                return context;
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="OneToOneQuerySqliteFixture.cs" />
     <Compile Include="OptimisticConcurrencySqliteTest.cs" />
     <Compile Include="PropertyEntrySqliteTest.cs" />
+    <Compile Include="PropertyValuesSqliteTest.cs" />
     <Compile Include="QueryNavigationsSqliteTest.cs" />
     <Compile Include="QueryNoClientEvalSqliteFixture.cs" />
     <Compile Include="QueryNoClientEvalSqliteTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
@@ -13,19 +13,30 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
         }
 
+        // Disabled due to Issue #6337
+        public override void Calling_Reload_on_a_Unchanged_entity_makes_the_entity_unchanged()
+        {
+        }
+
+        // Disabled due to Issue #6337
+        public override void Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged()
+        {
+        }
+
+        // Disabled due to Issue #6337
+        public override void Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged()
+        {
+        }
+
         // Override failing tests because SQLite does not allow store-generated row versions.
         // Row version behavior could be imitated on SQLite. See Issue #2195
-        // TODO move these tests into the testing just for SqlServer since they don't apply to SQLite
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_client_values() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_new_values() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values_using_equivalent_of_accept_changes() => Task.FromResult(true);
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values_using_Reload() => Task.FromResult(true);
-        public override Task Deleting_then_updating_the_same_entity_results_in_DbUpdateConcurrencyException_which_can_be_resolved_with_store_values() => Task.FromResult(true);
-        public override Task Deleting_then_updating_the_same_entity_results_in_DbUpdateConcurrencyException() => Task.FromResult(true);
         public override Task Updating_then_deleting_the_same_entity_results_in_DbUpdateConcurrencyException() => Task.FromResult(true);
         public override Task Updating_then_deleting_the_same_entity_results_in_DbUpdateConcurrencyException_which_can_be_resolved_with_store_values() => Task.FromResult(true);
-        public override Task Deleting_the_same_entity_twice_results_in_DbUpdateConcurrencyException() => Task.FromResult(true);
         public override Task Change_in_independent_association_after_change_in_different_concurrency_token_results_in_independent_association_exception() => Task.FromResult(true);
         public override Task Change_in_independent_association_results_in_independent_association_exception() => Task.FromResult(true);
     }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/PropertyValuesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/PropertyValuesSqliteTest.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class PropertyValuesSqliteTest
+        : PropertyValuesTestBase<SqliteTestStore, PropertyValuesSqliteTest.PropertyValuesSqliteFixture>
+    {
+        public PropertyValuesSqliteTest(PropertyValuesSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        // Disabled due to Issue #6337
+        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary() => Task.FromResult(true);
+        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_property_dictionary() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_into_a_cloned_dictionary() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_into_a_cloned_dictionary_asynchronously() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_as_a_property_dictionary_using_IProperty() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary_using_IProperty() => Task.FromResult(true);
+        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary() => Task.FromResult(true);
+        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary() => Task.FromResult(true);
+        public override Task Store_values_really_are_store_values_not_current_or_original_values() => Task.FromResult(true);
+        public override Task Store_values_really_are_store_values_not_current_or_original_values_async() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_into_an_object() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_into_an_object_asynchronously() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary_using_IProperty() => Task.FromResult(true);
+        public override Task Store_values_for_derived_object_can_be_copied_into_an_object() => Task.FromResult(true);
+        public override Task Store_values_for_derived_object_can_be_copied_into_an_object_asynchronously() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_as_a_property_dictionary() => Task.FromResult(true);
+        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_into_a_non_generic_cloned_dictionary() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_asynchronously_into_a_non_generic_cloned_dictionary() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_non_generic_property_dictionary_into_an_object() => Task.FromResult(true);
+        public override Task Store_values_can_be_copied_asynchronously_non_generic_property_dictionary_into_an_object() => Task.FromResult(true);
+
+        public class PropertyValuesSqliteFixture : PropertyValuesFixtureBase
+        {
+            private const string DatabaseName = "PropertyValues";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            public PropertyValuesSqliteFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkSqlite()
+                    .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override SqliteTestStore CreateTestStore()
+            {
+                return SqliteTestStore.GetOrCreateShared(DatabaseName, () =>
+                    {
+                        var optionsBuilder = new DbContextOptionsBuilder()
+                            .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))
+                            .UseInternalServiceProvider(_serviceProvider);
+
+                        using (var context = new AdvancedPatternsMasterContext(optionsBuilder.Options))
+                        {
+                            context.Database.EnsureClean();
+                            Seed(context);
+                        }
+                    });
+            }
+
+            public override DbContext CreateContext(SqliteTestStore testStore)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlite(testStore.Connection)
+                    .UseInternalServiceProvider(_serviceProvider);
+
+                var context = new AdvancedPatternsMasterContext(optionsBuilder.Options);
+                context.Database.UseTransaction(testStore.Transaction);
+
+                return context;
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -644,10 +644,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetOriginalValue(idProperty, 3);
             entry.SetOriginalValue(nameProperty, "Franks");
 
-            Assert.Equal(3, entry.GetOriginalValue(idProperty));
+            Assert.Equal(1, entry.GetOriginalValue(idProperty));
             Assert.Equal("Franks", entry.GetOriginalValue(nameProperty));
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Beans", entry[nameProperty]);


### PR DESCRIPTION
Issue #1200

Pretty much the same design as EF6. Exposed full property metadata instead of names since we now have nice metadata. Tests were ported from EF6. Not fully functional, especially on SqLite, until #6337 is fixed.