### PR TITLE
CLI commands: fix search path for locating ef.dll/ef.exe

### DIFF
--- a/src/Tools.DotNet/Internal/EfConsoleCommandResolver.cs
+++ b/src/Tools.DotNet/Internal/EfConsoleCommandResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
@@ -13,12 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
 {
     public class EfConsoleCommandResolver
     {
-        private readonly string _basePath = AppContext.BaseDirectory;
+        private static Assembly s_thisAssembly = typeof(Program).GetTypeInfo().Assembly;
+        private readonly string _basePath = Path.GetDirectoryName(s_thisAssembly.Location);
         protected virtual string NetCoreToolDir
-            => Path.Combine(_basePath, "tools", "netcoreapp1.0");
+            => Path.Combine(_basePath, "..", "..", "tools", "netcoreapp1.0");
         protected virtual string DesktopToolDir
-            => Path.Combine(_basePath, "tools", "net451");
-
+            => Path.Combine(_basePath, "..", "..", "tools", "net451");
 
         public virtual CommandSpec Resolve(ResolverArguments arguments)
             => arguments.IsDesktop

--- a/test/Tools.DotNet.FunctionalTests/EndToEndTests.cs
+++ b/test/Tools.DotNet.FunctionalTests/EndToEndTests.cs
@@ -53,13 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests
             AddAndApplyMigrationImpl("DesktopClassLibrary", "DesktopContext", "initialLibrary", startupProjectName: "DesktopStartupApp");
         }
 
-        [ConditionalFact]
-        [PlatformSkipCondition(TestPlatform.Linux | TestPlatform.Mac)]
-        public void MigrationsOnNetStandardClassLibraryWithDesktopExternalStartup()
-        {
-            AddAndApplyMigrationImpl("DesktopStartupApp", "NetStandardContext", "InitialMigration1");
-        }
-
         [Fact]
         public void AddMigrationToDifferentFolder()
         {

--- a/test/Tools.DotNet.FunctionalTests/TestProjects/DesktopStartupApp/Startup.cs
+++ b/test/Tools.DotNet.FunctionalTests/TestProjects/DesktopStartupApp/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopClassLibrary;
-using NetStandardClassLibrary;
 
 namespace DesktopStartupApp
 {
@@ -13,14 +12,11 @@ namespace DesktopStartupApp
         public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddDbContext<DesktopContext>(o => o.UseSqlite("Filename=./desktop.db"))
-                .AddDbContext<NetStandardContext>(o => o.UseSqlite("Filename=./netstandard.db",
-                    b => b.MigrationsAssembly("DesktopStartupApp")));
+                .AddDbContext<DesktopContext>(o => o.UseSqlite("Filename=./desktop.db"));
         }
 
         public void Configure(IApplicationBuilder app)
         {
-
         }
 
         public static void Main(string[] args)

--- a/test/Tools.DotNet.FunctionalTests/TestProjects/DesktopStartupApp/project.json.ignore
+++ b/test/Tools.DotNet.FunctionalTests/TestProjects/DesktopStartupApp/project.json.ignore
@@ -15,12 +15,9 @@
     "Microsoft.AspNetCore.Hosting": "1.0.0-*",
     "DesktopClassLibrary": {
       "target": "project"
-    },
-    "NetStandardClassLibrary": {
-      "target": "project"
     }
   },
   "frameworks": {
-    "net46": { }
+    "net451": { }
   }
 }

--- a/test/Tools.DotNet.FunctionalTests/Utilities/DotnetEf.cs
+++ b/test/Tools.DotNet.FunctionalTests/Utilities/DotnetEf.cs
@@ -51,7 +51,13 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests.Utilities
                 "--depsfile", _depsJson,
                 "--additionalprobingpath", _nugetPackageDir,
                 s_dotnetEfPath,
-                "--verbose"
+                "--verbose",
+                "--configuration", System.Environment.GetEnvironmentVariable("Configuration")
+#if DEBUG
+                ?? "Debug"
+#else
+                ?? "Release"
+#endif
             }
                 .Concat(_startupArgs)
                 .Concat(BuildArgs())

--- a/test/Tools.DotNet.FunctionalTests/clean-assets.cmd
+++ b/test/Tools.DotNet.FunctionalTests/clean-assets.cmd
@@ -6,9 +6,9 @@ if not "%1" == "" (
     rmdir /s /q %1\TestProjects
 
     :toolsDir
-    if not exist %1\tools goto iterate
-    echo "Deleting %1\tools"
-    rmdir /s /q %1\tools
+    if not exist %1\..\..\tools goto iterate
+    echo "Deleting %1\..\..\tools"
+    rmdir /s /q %1\..\..\tools
 
     :iterate
     shift

--- a/test/Tools.DotNet.FunctionalTests/clean-assets.sh
+++ b/test/Tools.DotNet.FunctionalTests/clean-assets.sh
@@ -3,8 +3,8 @@
 while [ $1 ]; do
     echo "Deleting $1/TestProjects"
     rm -rf $1/TestProjects
-    echo "Deleting $1/tools"
-    rm -rf $1/tools
+    echo "Deleting $1/../../tools"
+    rm -rf $1/../../tools
     shift
 done
 

--- a/test/Tools.DotNet.FunctionalTests/copy-tools.cmd
+++ b/test/Tools.DotNet.FunctionalTests/copy-tools.cmd
@@ -1,9 +1,10 @@
 @ECHO OFF
-mkdir %2\tools
-mkdir %2\tools\net451
-mkdir %2\tools\netcoreapp1.0
+set TOOLS_BASE=%2\..\..\tools
+mkdir %TOOLS_BASE%
+mkdir %TOOLS_BASE%\net451
+mkdir %TOOLS_BASE%\netcoreapp1.0
 dotnet build ..\..\src\Tools.Console -f net451 -c %1
 dotnet build ..\..\src\Tools.Console -f net451 -c %1_x86
-copy ..\..\src\Tools.Console\bin\%1\net451\*.exe %2\tools\net451\
-copy ..\..\src\Tools.Console\bin\%1_x86\net451\*.exe %2\tools\net451\
-copy ..\..\src\Tools.Console\bin\%1\netcoreapp1.0\ef.dll %2\tools\netcoreapp1.0\
+copy ..\..\src\Tools.Console\bin\%1\net451\*.exe %TOOLS_BASE%\net451\
+copy ..\..\src\Tools.Console\bin\%1_x86\net451\*.exe %TOOLS_BASE%\net451\
+copy ..\..\src\Tools.Console\bin\%1\netcoreapp1.0\ef.dll %TOOLS_BASE%\netcoreapp1.0\

--- a/test/Tools.DotNet.FunctionalTests/copy-tools.sh
+++ b/test/Tools.DotNet.FunctionalTests/copy-tools.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir -p $2/tools/netcoreapp1.0
-cp ../../src/Tools.Console/bin/$1/netcoreapp1.0/ef.dll $2/tools/netcoreapp1.0/
+toolsBase="$2/../../tools"
+mkdir -p $toolsBase/netcoreapp1.0
+cp ../../src/Tools.Console/bin/$1/netcoreapp1.0/ef.dll $toolsBase/netcoreapp1.0/


### PR DESCRIPTION
dotnet-ef currently assumes AppContext.BaseDirectory is in the extracted nupkg when really it is inside the special .tools folder in the nuget cache.
```
Expected: <nupkg>/packages/Ms.EfCore.Tools.DotNet/<version>/lib/netcoreapp1.0
Actual  : <nupkg>/packages/.tools/Ms.EfCore.Tools.DotNet/<version>/lib/netcoreapp1.0
```

This updates dotnet-ef to use Assembly.Location instead of AppContext.BaseDirectory to find the location of installed nupkg.

cc @JunTaoLuo @bricelam 