### PR TITLE
Remove references to issue #6292

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -4044,9 +4044,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         protected abstract bool EnforcesFKs { get; }
 
-        protected abstract void MarkIdsTemporary(StoreGeneratedFixupContext context, object dependent, object principal);
+        protected virtual void MarkIdsTemporary(StoreGeneratedFixupContext context, object dependent, object principal)
+        {
+        }
 
-        protected abstract void MarkIdsTemporary(StoreGeneratedFixupContext context, object game, object level, object item);
+        protected virtual void MarkIdsTemporary(StoreGeneratedFixupContext context, object game, object level, object item)
+        {
+        }
 
         protected class StoreGeneratedFixupContext : DbContext
         {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
@@ -36,14 +36,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             }
         }
 
-        protected override void MarkIdsTemporary(StoreGeneratedFixupContext context, object dependent, object principal)
-        {
-        }
-
-        protected override void MarkIdsTemporary(StoreGeneratedFixupContext context, object game, object level, object item)
-        {
-        }
-
         protected override bool EnforcesFKs => false;
 
         public class StoreGeneratedFixupInMemoryFixture : StoreGeneratedFixupFixtureBase

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/StoreGeneratedFixupSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/StoreGeneratedFixupSqliteTest.cs
@@ -37,26 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             }
         }
 
-        protected override void MarkIdsTemporary(StoreGeneratedFixupContext context, object dependent, object principal)
-        {
-            // TODO: Uncomment this when #6292 is fixed
-            //var entry = context.Entry(dependent);
-            //entry.Property("Id1").IsTemporary = true;
-
-            //entry = context.Entry(principal);
-            //entry.Property("Id1").IsTemporary = true;
-        }
-
-        protected override void MarkIdsTemporary(StoreGeneratedFixupContext context, object game, object level, object item)
-        {
-            // TODO: Uncomment this when #6292 is fixed
-            //var entry = context.Entry(game);
-            //entry.Property("Id").IsTemporary = true;
-
-            //entry = context.Entry(item);
-            //entry.Property("Id").IsTemporary = true;
-        }
-
         protected override bool EnforcesFKs => true;
 
         public class StoreGeneratedFixupSqliteFixture : StoreGeneratedFixupFixtureBase
@@ -99,47 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
                 context.Database.UseTransaction(testStore.Transaction);
 
                 return context;
-            }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                base.OnModelCreating(modelBuilder);
-
-                modelBuilder.Entity<Parent>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<Child>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ParentPN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ChildPN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ParentDN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ChildDN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ParentNN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ChildNN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<CategoryDN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ProductDN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<CategoryPN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ProductPN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<CategoryNN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<ProductNN>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<Category>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<Product>(b => { b.Property(e => e.Id1).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<Item>(b => { b.Property(e => e.Id).ValueGeneratedOnAdd(); });
-
-                modelBuilder.Entity<Game>(b => { b.Property(e => e.Id).ValueGeneratedOnAdd(); });
             }
         }
     }


### PR DESCRIPTION
We decided that issue #6292 is just a limitation of SQLite and we are therefore not going to do anything in EF about it. Therefore, the SQLite version of the composite key store generated tests will continue to not use store generated values and comments in the code indicating that this should change have been removed.