### PR TITLE
Query: Clear DbCommand parameters so that FromSql parameters can be u…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalQueryableExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalQueryableExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     <para>
         ///         You can also construct a DbParameter and supply it to as a parameter value. This allows you to use named
         ///         parameters in the SQL query string - 
-        ///         <code>context.Blogs.SqlQuery("SELECT * FROM [dbo].[SearchBlogs]({@searchTerm})", new SqlParameter("@searchTerm", userSuppliedSearchTerm))</code>    
+        ///         <code>context.Blogs.FromSql("SELECT * FROM [dbo].[SearchBlogs]({@searchTerm})", new SqlParameter("@searchTerm", userSuppliedSearchTerm))</code>    
         /// </para>
         /// </summary>
         /// <typeparam name="TEntity"> The type of the elements of <paramref name="source" />. </typeparam>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -276,6 +276,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             finally
             {
+                dbCommand.Parameters.Clear();
+
                 if (closeConnection)
                 {
                     connection.Close();

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameterCollection.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameterCollection.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvi
 
         public override void Clear()
         {
-            throw new NotImplementedException();
+            // no-op to test that parameters are passed correctly to db command.
         }
 
         public override bool Contains(string value)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -367,6 +367,21 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p1",
                 Sql);
         }
 
+        public override void From_sql_with_db_parameters_called_multiple_times()
+        {
+            base.From_sql_with_db_parameters_called_multiple_times();
+
+            Assert.Equal(
+                @"@id: ALFKI (Nullable = false) (Size = 5)
+
+SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @id
+
+@id: ALFKI (Nullable = false) (Size = 5)
+
+SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @id",
+                Sql);
+        }
+
         public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {


### PR DESCRIPTION
Resolves #6249 
The issue: When `DbParameter` added to `DbCommand` the parameter is associated with command's `DbParameterCollection`. When command is disposed the association does not go away. Therefore using the same parameter in another command (different command or instance) throws exception.
The fix: Once we have run the command, clear the parameters for it so that same DbParameters can be added to other commands.