### PR TITLE
[small] polish error handling in ef.exe

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/Design/DbContextOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Design/DbContextOperations.cs
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             {
                 contexts.Add(
                     context,
-                    FindContextFactory(context) ?? (() => (DbContext)_runtimeServices.GetRequiredService(context)));
+                    FindContextFactory(context) ?? (() => (DbContext)ActivatorUtilities.CreateInstance(_runtimeServices, context)));
             }
 
             // Look for DbContext classes in assemblies

--- a/src/Tools.Console/Commands/DatabaseDropCommand.cs
+++ b/src/Tools.Console/Commands/DatabaseDropCommand.cs
@@ -76,8 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             if (!_force)
             {
                 Reporter.Output("Are you sure you want to proceed? (y/N)".MaybeColor(s => s.Bold()));
-                var readedKey = Console.ReadKey().KeyChar;
-                var confirmed = (readedKey == 'y') || (readedKey == 'Y');
+                var readedKey = Console.ReadLine().Trim();
+                var confirmed = (readedKey == "y") || (readedKey == "Y");
                 if (!confirmed)
                 {
                     Reporter.Output("Cancelled");
@@ -98,8 +98,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
 
             Reporter.Output("This command will " + "permanently".MaybeColor(s => s.Bold()) + " drop the database:");
             Reporter.Output("");
-            Reporter.Output($"    {"Database name".MaybeColor(s => s.Bold().Blue())} : {result["DatabaseName"]}");
-            Reporter.Output($"    {"Data source  ".MaybeColor(s => s.Bold().Blue())} : {result["DataSource"]}");
+            Reporter.Output($"    {"Database name".MaybeColor(s => s.Bold().Green())} : {result["DatabaseName"]}");
+            Reporter.Output($"    {"Data source  ".MaybeColor(s => s.Bold().Green())} : {result["DataSource"]}");
             Reporter.Output("");
         }
 

--- a/src/Tools.Console/Internal/OperationExecutorBase.cs
+++ b/src/Tools.Console/Internal/OperationExecutorBase.cs
@@ -5,7 +5,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+#if NET451
+using System.Runtime.Remoting;
+#endif
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Tools.Internal
 {
@@ -83,6 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Tools.Internal
                 {
                     Reporter.Verbose(resultHandler.ErrorStackTrace);
                 }
+#if NET451
+                else if (resultHandler.ErrorType == typeof(RemotingException).FullName)
+                {
+                    Reporter.Verbose(resultHandler.ErrorStackTrace);
+                    throw new OperationErrorException(ToolsStrings.DesignDependencyIncompatible);
+                }
+#endif
                 else
                 {
                     Reporter.Error(resultHandler.ErrorStackTrace, suppressColor: true);

--- a/src/Tools.Console/Internal/OperationExecutorFactory.cs
+++ b/src/Tools.Console/Internal/OperationExecutorFactory.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Tools.Internal;
 
 // ReSharper disable ArgumentsStyleNamedExpression
 // ReSharper disable ArgumentsStyleOther
-namespace Microsoft.EntityFrameworkCore.Tools
+namespace Microsoft.EntityFrameworkCore.Tools.Internal
 {
     public class OperationExecutorFactory
     {
@@ -38,9 +38,13 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     rootNamespace: options.RootNamespace,
                     environment: options.EnvironmentName);
             }
-            catch (FileNotFoundException ex) when (ex.FileName.StartsWith(OperationExecutorBase.DesignAssemblyName))
+            catch (TypeLoadException ex) when (ex.TypeName.StartsWith(OperationExecutorBase.DesignAssemblyName, StringComparison.Ordinal))
             {
-                throw new OperationErrorException(ToolsStrings.DesignDependencyNotFound);
+                throw new OperationErrorException(ToolsStrings.DesignDependencyIncompatible, ex);
+            }
+            catch (FileNotFoundException ex) when (ex.FileName.StartsWith(OperationExecutorBase.DesignAssemblyName, StringComparison.Ordinal))
+            {
+                throw new OperationErrorException(ToolsStrings.DesignDependencyNotFound, ex);
             }
         }
     }

--- a/src/Tools.Console/Program.cs
+++ b/src/Tools.Console/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Tools.Internal;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.EntityFrameworkCore.Tools
@@ -77,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
                 if (!(ex is OperationErrorException)
                     && !(ex is CommandParsingException))
                 {
-                    Reporter.Error(ex.ToString());
+                    Reporter.Error(ex.ToString(), suppressColor: true);
                 }
 
                 Reporter.Error(ex.Message);

--- a/src/Tools.Console/Properties/ToolsStrings.Designer.cs
+++ b/src/Tools.Console/Properties/ToolsStrings.Designer.cs
@@ -17,6 +17,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             = new ResourceManager("Tools.Console.Properties.ToolsStrings", typeof(ToolsStrings).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// Cannot execute this command because the version of Microsoft.EntityFrameworkCore.Design installed is not compatible with this tool.
+        /// </summary>
+        public static string DesignDependencyIncompatible
+        {
+            get { return GetString("DesignDependencyIncompatible"); }
+        }
+
+        /// <summary>
         /// Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed.
         /// </summary>
         public static string DesignDependencyNotFound

--- a/src/Tools.Console/Properties/ToolsStrings.resx
+++ b/src/Tools.Console/Properties/ToolsStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DesignDependencyIncompatible" xml:space="preserve">
+    <value>Cannot execute this command because the version of Microsoft.EntityFrameworkCore.Design installed is not compatible with this tool.</value>
+  </data>
   <data name="DesignDependencyNotFound" xml:space="preserve">
     <value>Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed.</value>
   </data>

--- a/src/Tools.Console/Tools.Console.csproj
+++ b/src/Tools.Console/Tools.Console.csproj
@@ -79,7 +79,7 @@
     <Compile Include="Internal\OperationExecutorBase.cs" />
     <Compile Include="IReporter.cs" />
     <Compile Include="OperationErrorException.cs" />
-    <Compile Include="OperationExecutorFactory.cs" />
+    <Compile Include="Internal\OperationExecutorFactory.cs" />
     <Compile Include="PrefixConsoleReporter.cs" />
     <Compile Include="Properties\ToolsStrings.Designer.cs">
       <DependentUpon>ToolsStrings.resx</DependentUpon>

--- a/src/Tools.DotNet/Internal/DispatchOperationExecutor.cs
+++ b/src/Tools.DotNet/Internal/DispatchOperationExecutor.cs
@@ -65,8 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
             Reporter.Verbose.WriteLine(ToolsDotNetStrings.LogBeginDispatch(startupProject.ProjectName));
 
             return Command.Create(commandSpec)
-                .ForwardStdErr()
-                .ForwardStdOut()
                 .Execute()
                 .ExitCode;
         }


### PR DESCRIPTION
A collection of minor tweaks to polish ef.exe.

Change color output of drop database command so it displays better against default blue PowerShell background

Fix #6371 - always create new instance of DbContext for each design-time operation

cc @bricelam 