### PR TITLE
Project correct value types into array

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -641,7 +641,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             if (_projection.Any()
                 || !IsProjectStar)
             {
-                return _projection.Select(e => e.Type);
+                return _projection.Select(e =>
+                    e.NodeType == ExpressionType.Convert
+                    && e.Type == typeof(object)
+                        ? ((UnaryExpression)e).Operand.Type
+                        : e.Type);
             }
 
             return _tables.OfType<SelectExpression>().SelectMany(e => e.GetProjectionTypes());

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -889,6 +889,44 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Project_to_object_array()
+        {
+            AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID == 1)
+                .Select(e => new object[] { e.EmployeeID, e.ReportsTo, EF.Property<string>(e, "Title") }),
+                entryCount: 0,
+                asserter: (e, a) => AssertArrays<object>(e, a, 3));
+        }
+
+        private static void AssertArrays<T>(IList<object> e, IList<object> a, int count)
+        {
+            Assert.Equal(1, e.Count);
+            Assert.Equal(1, a.Count);
+
+            var expectedArray = (T[])e[0];
+            var actualArray = (T[])a[0];
+
+            Assert.Equal(count, expectedArray.Length);
+            Assert.Equal(count, actualArray.Length);
+
+            for (var i = 0; i < expectedArray.Length; i++)
+            {
+                Assert.Same(expectedArray[i].GetType(), actualArray[i].GetType());
+                Assert.Equal(expectedArray[i], actualArray[i]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Project_to_int_array()
+        {
+            AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID == 1)
+                .Select(e => new[] { e.EmployeeID, e.ReportsTo }),
+                entryCount: 0,
+                asserter: (e, a) => AssertArrays<int?>(e, a, 2));
+        }
+
+        [ConditionalFact]
         public virtual void Where_simple_shadow()
         {
             AssertQuery<Employee>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -24,6 +24,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
+        public override void Project_to_object_array()
+        {
+            base.Project_to_object_array();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[EmployeeID] = 1",
+                Sql);
+        }
+
+        public override void Project_to_int_array()
+        {
+            base.Project_to_int_array();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[ReportsTo]
+FROM [Employees] AS [e]
+WHERE [e].[EmployeeID] = 1",
+                Sql);
+        }
+
         public override void Local_array()
         {
             base.Local_array();

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/OptimisticConcurrencySqliteTest.cs
@@ -13,21 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
         }
 
-        // Disabled due to Issue #6337
-        public override void Calling_Reload_on_a_Unchanged_entity_makes_the_entity_unchanged()
-        {
-        }
-
-        // Disabled due to Issue #6337
-        public override void Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged()
-        {
-        }
-
-        // Disabled due to Issue #6337
-        public override void Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged()
-        {
-        }
-
         // Override failing tests because SQLite does not allow store-generated row versions.
         // Row version behavior could be imitated on SQLite. See Issue #2195
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values() => Task.FromResult(true);

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/PropertyValuesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/PropertyValuesSqliteTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,32 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             : base(fixture)
         {
         }
-
-        // Disabled due to Issue #6337
-        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_property_dictionary() => Task.FromResult(true);
-        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_property_dictionary() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_into_a_cloned_dictionary() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_into_a_cloned_dictionary_asynchronously() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_as_a_property_dictionary_using_IProperty() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary_using_IProperty() => Task.FromResult(true);
-        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_as_a_non_generic_property_dictionary() => Task.FromResult(true);
-        public override Task Scalar_store_values_of_a_derived_object_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary() => Task.FromResult(true);
-        public override Task Store_values_really_are_store_values_not_current_or_original_values() => Task.FromResult(true);
-        public override Task Store_values_really_are_store_values_not_current_or_original_values_async() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_into_an_object() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_into_an_object_asynchronously() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_as_a_non_generic_property_dictionary_using_IProperty() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_non_generic_property_dictionary_using_IProperty() => Task.FromResult(true);
-        public override Task Store_values_for_derived_object_can_be_copied_into_an_object() => Task.FromResult(true);
-        public override Task Store_values_for_derived_object_can_be_copied_into_an_object_asynchronously() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_as_a_property_dictionary() => Task.FromResult(true);
-        public override Task Scalar_store_values_can_be_accessed_asynchronously_as_a_property_dictionary() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_into_a_non_generic_cloned_dictionary() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_asynchronously_into_a_non_generic_cloned_dictionary() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_non_generic_property_dictionary_into_an_object() => Task.FromResult(true);
-        public override Task Store_values_can_be_copied_asynchronously_non_generic_property_dictionary_into_an_object() => Task.FromResult(true);
 
         public class PropertyValuesSqliteFixture : PropertyValuesFixtureBase
         {


### PR DESCRIPTION
Issue #6337

The expression tree has converts in it to box the returned values. But this means we always ask for object from the reader. Therefore, use the value inside the convert when asking for the value from the data reader.