### PR TITLE
[1.0.1] Fix to #4858 - Select after complex GroupJoin lead to unpredictable result

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -2725,5 +2725,89 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
             }
         }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_on_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected()
+        {
+            List<string> expected;
+
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne.ToList()
+                    .GroupJoin(
+                        context.LevelTwo.ToList().Where(l2 => l2.Name != "L2 01"),
+                        l1 => l1.Id,
+                        l2 => l2.Level1_Optional_Id,
+                        (l1, l2s) => new { l1, l2s })
+                    .Where(r => r.l2s.Any())
+                    .Select(r => r.l1.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.GroupJoin(
+                        context.LevelTwo.Where(l2 => l2.Name != "L2 01"),
+                        l1 => l1.Id,
+                        l2 => l2.Level1_Optional_Id,
+                        (l1, l2s) => new { l1, l2s })
+                        .Where(r => r.l2s.Any())
+                        .Select(r => r.l1);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Name));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_on_complex_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected()
+        {
+            List<string> expected;
+
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne.ToList()
+                    .GroupJoin(
+                        context.LevelOne
+                            .Include(l1 => l1.OneToOne_Required_FK)
+                            .ToList()
+                            .Where(l1 => l1.Name != "L1 01")
+                            .Select(l1 => l1.OneToOne_Required_FK),
+                        l1 => l1.Id,
+                        l2 => l2.Level1_Optional_Id,
+                        (l1, l2s) => new { l1, l2s })
+                    .Where(r => r.l2s.Any())
+                    .Select(r => r.l1.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.GroupJoin(
+                        context.LevelOne.Where(l1 => l1.Name != "L1 01").Select(l1 => l1.OneToOne_Required_FK),
+                        l1 => l1.Id,
+                        l2 => l2.Level1_Optional_Id,
+                        (l1, l2s) => new { l1, l2s })
+                        .Where(r => r.l2s.Any())
+                        .Select(r => r.l1);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Name));
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryCompilationContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryCompilationContext.cs
@@ -327,6 +327,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             foreach (var groupJoinClause in queryModel.BodyClauses.OfType<GroupJoinClause>())
             {
                 _querySourcesRequiringMaterialization.Add(groupJoinClause.JoinClause);
+
+                var subQueryInnerSequence = groupJoinClause.JoinClause.InnerSequence as SubQueryExpression;
+                if (subQueryInnerSequence != null)
+                {
+                    var subQuerySourcesRequiringMaterialization
+                        = _requiresMaterializationExpressionVisitorFactory
+                            .Create(queryModelVisitor)
+                            .FindQuerySourcesRequiringMaterialization(subQueryInnerSequence.QueryModel);
+
+                    foreach (var subQuerySource in subQuerySourcesRequiringMaterialization)
+                    {
+                        _querySourcesRequiringMaterialization.Add(subQuerySource);
+                    }
+                }
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1512,6 +1512,43 @@ END",
                 Sql);
         }
 
+        public override void GroupJoin_on_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected()
+        {
+            base.GroupJoin_on_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected();
+
+            Assert.Equal(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [l20].[Id], [l20].[Date], [l20].[Level1_Optional_Id], [l20].[Level1_Required_Id], [l20].[Name], [l20].[OneToMany_Optional_InverseId], [l20].[OneToMany_Optional_Self_InverseId], [l20].[OneToMany_Required_InverseId], [l20].[OneToMany_Required_Self_InverseId], [l20].[OneToOne_Optional_PK_InverseId], [l20].[OneToOne_Optional_SelfId]
+    FROM [Level2] AS [l20]
+    WHERE ([l20].[Name] <> N'L2 01') OR [l20].[Name] IS NULL
+) AS [t] ON [l1].[Id] = [t].[Level1_Optional_Id]
+ORDER BY [l1].[Id]",
+                Sql);
+        }
+
+        public override void GroupJoin_on_complex_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected()
+        {
+            base.GroupJoin_on_complex_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected();
+
+            Assert.Contains(
+                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
+FROM (
+    SELECT [l1.OneToOne_Required_FK0].[Id], [l1.OneToOne_Required_FK0].[Date], [l1.OneToOne_Required_FK0].[Level1_Optional_Id], [l1.OneToOne_Required_FK0].[Level1_Required_Id], [l1.OneToOne_Required_FK0].[Name], [l1.OneToOne_Required_FK0].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK0].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK0].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK0].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK0].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK0].[OneToOne_Optional_SelfId]
+    FROM [Level1] AS [l11]
+    INNER JOIN [Level2] AS [l1.OneToOne_Required_FK0] ON [l11].[Id] = [l1.OneToOne_Required_FK0].[Level1_Required_Id]
+    WHERE ([l11].[Name] <> N'L1 01') OR [l11].[Name] IS NULL
+) AS [t]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]",
+                Sql);
+
+        }
+
         private const string FileLineEnding = @"
 ";
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1165,9 +1165,9 @@ ORDER BY [od1].[OrderID], [od1].[ProductID]",
             base.GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened();
 
             Assert.Contains(
-                @"SELECT [t].[CustomerID]
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
-    SELECT [c20].*
+    SELECT [c20].[CustomerID], [c20].[Address], [c20].[City], [c20].[CompanyName], [c20].[ContactName], [c20].[ContactTitle], [c20].[Country], [c20].[Fax], [c20].[Phone], [c20].[PostalCode], [c20].[Region]
     FROM [Order Details] AS [od0]
     INNER JOIN [Orders] AS [o0] ON [od0].[OrderID] = 10260
     INNER JOIN [Customers] AS [c20] ON [o0].[CustomerID] = [c20].[CustomerID]


### PR DESCRIPTION
Problem exists for complex query with groupjoin, where the inner element is a subquery, then we apply collection operator on the inner collection, but project only the outer element like so:

context.LevelOne
  .GroupJoin(
    context.LevelTwo.Where(l2 => l2.Name != "L2 01"),
    l1 => l1.Id,
    l2 => l2.Level1_Optional_Id,
    (l1, l2s) => new { l1, l2s })
  .Where(r => r.l2s.Any())
  Select(r => r.l1);

What happens is that we look at which query sources we need to materialize (based on final projection), deduce that we don't need to materialize the elements of the inner collection, so it's being represented as value buffer. Problem is that currently value buffer can't represent a null-value element, so Any() always returns true (even for empty collection), which leads to incorrect results.

Fix is to force materialization of inner collection elements as entities. We already did that, but missed the case where the inner collection was a subquery.