### PR TITLE
Fix incorrect timestamp conversion to milliseconds in logging

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
@@ -130,7 +131,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             logger.Log<object>(LogLevel.Warning, (int)eventId, eventId, null, (_, __) => formatter());
         }
 
+        private static readonly double TimestampToMilliseconds = (double)TimeSpan.TicksPerSecond / (Stopwatch.Frequency * TimeSpan.TicksPerMillisecond);
         private static long DeriveTimespan(long startTimestamp, long currentTimestamp)
-            => (currentTimestamp - startTimestamp) / TimeSpan.TicksPerMillisecond;
+            => (long)((currentTimestamp - startTimestamp) * TimestampToMilliseconds);
     }
 }


### PR DESCRIPTION
I noticed that the logged times for the executed commands are way off what they should be and found a small bug in the source code.

The problem is that TimeSpan ticks does not always equate to Stopwatch ticks so a conversion based on the Stopwatch.Frequency is necessary.

On my macbook running osx the reported times are 100 times slower and on my windows 10 desktop they are 3 times slower.

This is by no means a serious bug but its definitely annoying.