### PR TITLE
Implementation of DbSet.Local and data binding support

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DatabindingTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DatabindingTestBase.cs
@@ -1,0 +1,760 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ConcurrencyModel;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class DatabindingTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : F1FixtureBase<TTestStore>, new()
+    {
+        protected DatabindingTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        protected const int DeletedTeam = Team.Hispania;
+        protected const int DeletedCount = 4;
+
+        protected const int ModifedTeam = Team.Lotus;
+        protected const int ModifiedCount = 3;
+
+        protected const int AddedTeam = Team.Sauber;
+        protected const int AddedCount = 2;
+
+        protected const int UnchangedTeam = Team.Mercedes;
+        protected const int UnchangedCount = 3;
+
+        protected void SetupContext(F1Context context)
+        {
+            var drivers = context.Drivers;
+            drivers.Load();
+
+            foreach (var driver in drivers.Local.Where(d => d.TeamId == DeletedTeam).ToList())
+            {
+                drivers.Remove(driver);
+            }
+
+            foreach (var driver in drivers.Local.Where(d => d.TeamId == ModifedTeam).ToList())
+            {
+                driver.Races = 5;
+            }
+
+            drivers.Add(
+                new Driver
+                {
+                    Name = "Pedro de la Rosa",
+                    TeamId = AddedTeam,
+                    CarNumber = 13
+                });
+            drivers.Add(
+                new Driver
+                {
+                    Name = "Kamui Kobayashi",
+                    TeamId = AddedTeam,
+                    CarNumber = null
+                });
+        }
+
+        [Fact]
+        public virtual void DbSet_Local_contains_Unchanged_Modified_and_Added_entities_but_not_Deleted_entities()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                Assert.Equal(0, local.Count(d => d.TeamId == DeletedTeam));
+                Assert.Equal(ModifiedCount, local.Count(d => d.TeamId == ModifedTeam));
+                Assert.Equal(UnchangedCount, local.Count(d => d.TeamId == UnchangedTeam));
+                Assert.Equal(AddedCount, local.Count(d => d.TeamId == AddedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_context_is_reflected_in_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Drivers.Local;
+
+                var larry = new Driver
+                {
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                context.Drivers.Add(larry);
+
+                Assert.True(local.Contains(larry));
+            }
+        }
+
+        [Fact]
+        public virtual void Attaching_entity_to_context_is_reflected_in_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Drivers.Local;
+
+                var larry = new Driver
+                {
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                context.Drivers.Attach(larry);
+
+                Assert.True(local.Contains(larry));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_materialized_into_context_are_reflected_in_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Drivers.Local;
+
+                context.Drivers.Where(d => d.TeamId == UnchangedTeam).Load();
+
+                Assert.Equal(UnchangedCount, local.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_detached_from_context_are_removed_from_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Detached;
+                }
+
+                Assert.Equal(0, local.Cast<Driver>().Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_deleted_from_context_are_removed_from_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Drivers.Remove(driver);
+                }
+
+                Assert.Equal(0, local.Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_with_state_changed_to_deleted_are_removed_from_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Deleted;
+                }
+
+                Assert.Equal(0, local.Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_with_state_changed_to_detached_are_removed_from_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Detached;
+                }
+
+                Assert.Equal(0, local.Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_with_state_changed_from_deleted_to_added_are_added_to_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Where(d => d.TeamId == DeletedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Added;
+                }
+
+                Assert.Equal(DeletedCount, local.Count(d => d.TeamId == DeletedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_with_state_changed_from_deleted_to_unchanged_are_added_to_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                foreach (var driver in context.Drivers.Where(d => d.TeamId == DeletedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Unchanged;
+                }
+
+                Assert.Equal(DeletedCount, local.Count(d => d.TeamId == DeletedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_added_to_local_view_are_added_to_state_manager()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Drivers.Local;
+
+                var larry = new Driver
+                {
+                    Id = -1,
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                local.Add(larry);
+
+                Assert.Same(larry, context.Drivers.Find(-1));
+                Assert.Equal(EntityState.Added, context.Entry(larry).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_removed_from_the_local_view_are_marked_deleted_in_the_state_manager()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                var alonso = local.Cast<Driver>().Single(d => d.Name == "Fernando Alonso");
+                local.Remove(alonso);
+
+                Assert.Equal(EntityState.Deleted, context.Entry(alonso).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_local_view_that_is_already_in_the_state_manager_and_not_Deleted_is_noop()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                var alonso = local.Cast<Driver>().Single(d => d.Name == "Fernando Alonso");
+                local.Add(alonso);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(alonso).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_local_view_that_is_Deleted_in_the_state_manager_makes_entity_Added()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+
+                var deletedDrivers = context.Drivers.Where(d => d.TeamId == DeletedTeam).ToList();
+
+                foreach (var driver in deletedDrivers)
+                {
+                    local.Add(driver);
+                }
+
+                Assert.True(deletedDrivers.TrueForAll(d => context.Entry(d).State == EntityState.Added));
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_state_manager_of_different_type_than_local_view_type_has_no_effect_on_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var local = context.Drivers.Local;
+                var count = local.Count;
+
+                context.Teams.Add(
+                    new Team
+                    {
+                        Id = -1,
+                        Name = "Wubbsy Racing"
+                    });
+
+                Assert.Equal(count, local.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_state_manager_of_subtype_still_shows_up_in_local_view()
+        {
+            using (var context = CreateF1Context())
+            {
+                context.Drivers.Load();
+                var local = context.Drivers.Local;
+
+                var newDriver = new TestDriver();
+                context.Drivers.Add(newDriver);
+
+                Assert.True(local.Contains(newDriver));
+            }
+        }
+
+        [Fact]
+        public virtual void DbSet_Local_is_cached_on_the_set()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Drivers.Local;
+
+                Assert.Same(local, context.Drivers.Local);
+            }
+        }
+
+        [Fact]
+        public virtual void DbSet_Local_does_not_call_DetectChanges()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+
+                var alonso = context.Drivers.Single(d => d.Name == "Fernando Alonso");
+                alonso.CarNumber = 13;
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(alonso).State);
+
+                context.ChangeTracker.AutoDetectChangesEnabled = true;
+
+                var _ = context.Drivers.Local;
+
+                context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(alonso).State);
+
+                context.ChangeTracker.AutoDetectChangesEnabled = true;
+
+                Assert.Equal(EntityState.Modified, context.Entry(alonso).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Local_view_used_in_database_initializer_is_reset_for_use_with_real_context()
+        {
+            using (var context = CreateF1Context())
+            {
+                var local = context.Teams.Local;
+
+                Assert.Equal(0, local.Count);
+
+                context.Teams.Add(
+                    new Team
+                    {
+                        Id = -1,
+                        Name = "Wubbsy Racing"
+                    });
+
+                Assert.Equal(1, local.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Load_executes_query_on_DbQuery()
+        {
+            using (var context = CreateF1Context())
+            {
+                context.Drivers.Where(d => d.TeamId == UnchangedTeam).Load();
+
+                Assert.Equal(UnchangedCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public void LocalView_is_initialized_with_entities_from_the_context()
+        {
+            using (var context = CreateF1Context())
+            {
+                context.Drivers.Load();
+                context.Set<TestDriver>().Load();
+                context.Teams.Load();
+
+                var driversLocal = context.Drivers.Local;
+                var testDriversLocal = context.Set<TestDriver>().Local;
+                var teamsLocal = context.Teams.Local;
+
+                Assert.Equal(42, driversLocal.Count);
+                Assert.Equal(20, testDriversLocal.Count);
+                Assert.Equal(12, teamsLocal.Count);
+
+                Assert.All(context.ChangeTracker.Entries<Driver>().Select(e => e.Entity), e => Assert.True(driversLocal.Contains(e)));
+                Assert.All(context.ChangeTracker.Entries<TestDriver>().Select(e => e.Entity), e => Assert.True(driversLocal.Contains(e)));
+                Assert.All(context.ChangeTracker.Entries<TestDriver>().Select(e => e.Entity), e => Assert.True(testDriversLocal.Contains(e)));
+                Assert.All(context.ChangeTracker.Entries<Team>().Select(e => e.Entity), e => Assert.True(teamsLocal.Contains(e)));
+
+                Assert.All(context.ChangeTracker.Entries<Driver>().Select(e => e.Entity), e => Assert.False(teamsLocal.Contains((object)e)));
+            }
+        }
+
+#if NET451
+
+        [Fact]
+        public virtual void DbSet_Local_ToBindingList_contains_Unchanged_Modified_and_Added_entities_but_not_Deleted_entities()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                Assert.Equal(0, bindingList.Count(d => d.TeamId == DeletedTeam));
+                Assert.Equal(ModifiedCount, bindingList.Count(d => d.TeamId == ModifedTeam));
+                Assert.Equal(UnchangedCount, bindingList.Count(d => d.TeamId == UnchangedTeam));
+                Assert.Equal(AddedCount, bindingList.Count(d => d.TeamId == AddedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_context_is_reflected_in_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var larry = new Driver
+                {
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                context.Drivers.Add(larry);
+
+                Assert.True(bindingList.Contains(larry));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_materialized_into_context_are_reflected_in_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                context.Drivers.Where(d => d.TeamId == UnchangedTeam).Load();
+
+                Assert.Equal(UnchangedCount, bindingList.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_detached_from_context_are_removed_from_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Entry(driver).State = EntityState.Detached;
+                }
+
+                Assert.Equal(0, bindingList.Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_deleted_from_context_are_removed_from_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                foreach (var driver in context.Drivers.Local.Where(d => d.TeamId == UnchangedTeam).ToList())
+                {
+                    context.Drivers.Remove(driver);
+                }
+
+                Assert.Equal(0, bindingList.Count(d => d.TeamId == UnchangedTeam));
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_added_to_local_binding_list_are_added_to_state_manager()
+        {
+            using (var context = CreateF1Context())
+            {
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var larry = new Driver
+                {
+                    Id = -1,
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                bindingList.Add(larry);
+
+                Assert.Same(larry, context.Drivers.Find(-1));
+                Assert.Equal(EntityState.Added, context.Entry(larry).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Entities_removed_from_the_local_binding_list_are_marked_deleted_in_the_state_manager()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var alonso = bindingList.Single(d => d.Name == "Fernando Alonso");
+                bindingList.Remove(alonso);
+
+                Assert.Equal(EntityState.Deleted, context.Entry(alonso).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_local_binding_list_that_is_already_in_the_state_manager_and_not_Deleted_is_noop()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var alonso = bindingList.Single(d => d.Name == "Fernando Alonso");
+                bindingList.Add(alonso);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(alonso).State);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_local_binding_list_that_is_Deleted_in_the_state_manager_makes_entity_Added()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var deletedDrivers = context.Drivers.Where(d => d.TeamId == DeletedTeam).ToList();
+
+                foreach (var driver in deletedDrivers)
+                {
+                    bindingList.Add(driver);
+                }
+
+                Assert.True(deletedDrivers.TrueForAll(d => context.Entry(d).State == EntityState.Added));
+            }
+        }
+
+        [Fact]
+        public void
+            Adding_entity_to_state_manager_of_different_type_than_local_view_type_has_no_effect_on_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                SetupContext(context);
+                var bindingList = context.Drivers.Local.ToBindingList();
+                var count = bindingList.Count;
+
+                context.Teams.Add(
+                    new Team
+                    {
+                        Id = -1,
+                        Name = "Wubbsy Racing"
+                    });
+
+                Assert.Equal(count, bindingList.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Adding_entity_to_state_manager_of_subtype_still_shows_up_in_local_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                context.Drivers.Load();
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                var testDriver = new TestDriver();
+                context.Drivers.Add(testDriver);
+
+                Assert.True(bindingList.Contains(testDriver));
+            }
+        }
+
+        [Fact]
+        public virtual void Sets_of_subtypes_can_still_be_sorted()
+        {
+            using (var context = CreateF1Context())
+            {
+                var testDrivers = context.Set<TestDriver>();
+                testDrivers.Attach(new TestDriver { Id = 3 });
+                testDrivers.Attach(new TestDriver { Id = 1 });
+                testDrivers.Attach(new TestDriver { Id = 4 });
+
+                var bindingList = testDrivers.Local.ToBindingList();
+
+                ((IBindingList)bindingList).ApplySort(
+                    TypeDescriptor.GetProperties(typeof(Driver))["Id"],
+                    ListSortDirection.Ascending);
+
+                Assert.Equal(1, bindingList[0].Id);
+                Assert.Equal(3, bindingList[1].Id);
+                Assert.Equal(4, bindingList[2].Id);
+            }
+        }
+
+        [Fact]
+        public virtual void Sets_containing_instances_of_subtypes_can_still_be_sorted()
+        {
+            using (var context = CreateF1Context())
+            {
+                context.Drivers.Attach(new TestDriver { Id = 3 });
+                context.Drivers.Attach(new TestDriver { Id = 1 });
+                context.Drivers.Attach(new TestDriver { Id = 4 });
+
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                ((IBindingList)bindingList).ApplySort(
+                    TypeDescriptor.GetProperties(typeof(Driver))["Id"],
+                    ListSortDirection.Ascending);
+
+                Assert.Equal(1, bindingList[0].Id);
+                Assert.Equal(3, bindingList[1].Id);
+                Assert.Equal(4, bindingList[2].Id);
+            }
+        }
+
+        [Fact]
+        public virtual void DbSet_Local_ToBindingList_is_cached_on_the_set()
+        {
+            using (var context = CreateF1Context())
+            {
+                var bindingList = context.Drivers.Local.ToBindingList();
+
+                Assert.Same(bindingList, context.Drivers.Local.ToBindingList());
+            }
+        }
+
+        [Fact]
+        public virtual void Entity_added_to_context_is_added_to_navigation_property_binding_list()
+        {
+            using (var context = CreateF1Context())
+            {
+                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var navBindingList = ((IListSource)ferrari.Drivers).GetList();
+
+                var larry = new Driver
+                {
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                context.Drivers.Add(larry);
+
+                Assert.True(navBindingList.Contains(larry));
+            }
+        }
+
+        [Fact]
+        public virtual void Entity_added_to_navigation_property_binding_list_is_added_to_context_after_DetectChanges()
+        {
+            using (var context = CreateF1Context())
+            {
+                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var navBindingList = ((IListSource)ferrari.Drivers).GetList();
+                var localDrivers = context.Drivers.Local;
+
+                var larry = new Driver
+                {
+                    Id = -1,
+                    Name = "Larry David",
+                    TeamId = Team.Ferrari,
+                    CarNumber = 13
+                };
+                navBindingList.Add(larry);
+
+                Assert.False(localDrivers.Contains(larry));
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(localDrivers.Contains(larry));
+                Assert.Same(larry, context.Drivers.Find(-1));
+            }
+        }
+
+        [Fact]
+        public virtual void Entity_removed_from_navigation_property_binding_list_is_removed_from_nav_property_but_not_marked_Deleted()
+        {
+            using (var context = CreateF1Context())
+            {
+                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var navBindingList = ((IListSource)ferrari.Drivers).GetList();
+                var localDrivers = context.Drivers.Local;
+
+                var alonso = localDrivers.Single(d => d.Name == "Fernando Alonso");
+                navBindingList.Remove(alonso);
+
+                Assert.True(localDrivers.Contains(alonso));
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(localDrivers.Contains(alonso)); // Because it is not marked as Deleted
+
+                Assert.False(ferrari.Drivers.Contains(alonso)); // But has been removed from nav prop
+            }
+        }
+
+#endif
+
+        protected F1Context CreateF1Context()
+        {
+            var context = Fixture.CreateContext(TestStore);
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+            return context;
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected TTestStore TestStore { get; }
+
+        public virtual void Dispose() => TestStore.Dispose();
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ComplexNavigationsQueryTestBase.cs" />
     <Compile Include="DataAnnotationFixtureBase.cs" />
     <Compile Include="DataAnnotationTestBase.cs" />
+    <Compile Include="DatabindingTestBase.cs" />
     <Compile Include="F1FixtureBase.cs" />
     <Compile Include="FieldMappingTestBase.cs" />
     <Compile Include="FindTestBase.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -4,12 +4,17 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ConcurrencyModel
 {
     public class Team
     {
+#if NET451
+        private readonly ObservableCollection<Driver> _drivers = new ObservableCollectionListSource<Driver>();
+#else
         private readonly ObservableCollection<Driver> _drivers = new ObservableCollection<Driver>();
+#endif
         private readonly ObservableCollection<Sponsor> _sponsors = new ObservableCollection<Sponsor>();
         
         public int Id { get; set; }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ILocalViewListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ILocalViewListener.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface ILocalViewListener : IEntityStateListener
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void RegisterView([NotNull] Action<InternalEntityEntry, EntityState> viewAction);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/LocalViewListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/LocalViewListener.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class LocalViewListener : ILocalViewListener
+    {
+        private readonly IList<Action<InternalEntityEntry, EntityState>> _viewActions
+            = new List<Action<InternalEntityEntry, EntityState>>();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void RegisterView(Action<InternalEntityEntry, EntityState> viewAction)
+            => _viewActions.Add(viewAction);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void StateChanged(InternalEntityEntry entry, EntityState oldState, bool fromQuery)
+        {
+            foreach (var viewAction in _viewActions)
+            {
+                viewAction(entry, oldState);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void StateChanging(InternalEntityEntry entry, EntityState newState)
+        {
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
@@ -1,0 +1,261 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ObservableBackedBindingList<T> : SortableBindingList<T>
+    {
+        private bool _addingNewInstance;
+        private T _addNewInstance;
+        private T _cancelNewInstance;
+
+        private readonly ICollection<T> _obervableCollection;
+        private bool _inCollectionChanged;
+        private bool _changingObservableCollection;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ObservableBackedBindingList([NotNull] ICollection<T> obervableCollection)
+            : base(obervableCollection.ToList())
+        {
+            _obervableCollection = obervableCollection;
+
+            Debug.Assert(obervableCollection is INotifyCollectionChanged);
+
+            ((INotifyCollectionChanged)obervableCollection).CollectionChanged += ObservableCollectionChanged;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override object AddNewCore()
+        {
+            _addingNewInstance = true;
+            _addNewInstance = (T)base.AddNewCore();
+            return _addNewInstance;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void CancelNew(int itemIndex)
+        {
+            if (itemIndex >= 0
+                && itemIndex < Count
+                && Equals(base[itemIndex], _addNewInstance))
+            {
+                _cancelNewInstance = _addNewInstance;
+                _addNewInstance = default(T);
+                _addingNewInstance = false;
+            }
+            base.CancelNew(itemIndex);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void ClearItems()
+        {
+            foreach (var entity in Items)
+            {
+                RemoveFromObservableCollection(entity);
+            }
+            base.ClearItems();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void EndNew(int itemIndex)
+        {
+            if (itemIndex >= 0
+                && itemIndex < Count
+                && Equals(base[itemIndex], _addNewInstance))
+            {
+                AddToObservableCollection(_addNewInstance);
+                _addNewInstance = default(T);
+                _addingNewInstance = false;
+            }
+            base.EndNew(itemIndex);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void InsertItem(int index, T item)
+        {
+            base.InsertItem(index, item);
+            if (!_addingNewInstance
+                && index >= 0
+                && index <= Count)
+            {
+                AddToObservableCollection(item);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void RemoveItem(int index)
+        {
+            if (index >= 0
+                && index < Count
+                && Equals(base[index], _cancelNewInstance))
+            {
+                _cancelNewInstance = default(T);
+            }
+            else
+            {
+                RemoveFromObservableCollection(base[index]);
+            }
+            base.RemoveItem(index);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void SetItem(int index, T item)
+        {
+            var entity = base[index];
+            base.SetItem(index, item);
+
+            if (index >= 0
+                && index < Count)
+            {
+                // Check to see if the user is trying to set an item that is currently being added via AddNew
+                // If so then the list should not continue the AddNew; but instead add the item
+                // that is being passed in.
+                if (Equals(entity, _addNewInstance))
+                {
+                    _addNewInstance = default(T);
+                    _addingNewInstance = false;
+                }
+                else
+                {
+                    RemoveFromObservableCollection(entity);
+                }
+                AddToObservableCollection(item);
+            }
+        }
+
+        private void ObservableCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            // Don't try to change the binding list if the original change came from the binding list
+            // and the ObervableCollection is just being changed to match it.
+            if (!_changingObservableCollection)
+            {
+                try
+                {
+                    // We are about to change the underlying binding list.  We want to prevent those
+                    // changes trying to go back into the ObservableCollection, so we set a flag
+                    // to prevent that.
+                    _inCollectionChanged = true;
+
+                    if (e.Action
+                        == NotifyCollectionChangedAction.Reset)
+                    {
+                        Clear();
+                    }
+
+                    if (e.Action == NotifyCollectionChangedAction.Remove
+                        ||
+                        e.Action == NotifyCollectionChangedAction.Replace)
+                    {
+                        foreach (T entity in e.OldItems)
+                        {
+                            Remove(entity);
+                        }
+                    }
+
+                    if (e.Action == NotifyCollectionChangedAction.Add
+                        ||
+                        e.Action == NotifyCollectionChangedAction.Replace)
+                    {
+                        foreach (T entity in e.NewItems)
+                        {
+                            Add(entity);
+                        }
+                    }
+                }
+                finally
+                {
+                    _inCollectionChanged = false;
+                }
+            }
+        }
+
+        // <summary>
+        // Adds the item to the underlying observable collection.
+        // </summary>
+        // <param name="item"> The item. </param>
+        private void AddToObservableCollection(T item)
+        {
+            // Don't try to change the ObervableCollection if the original change
+            // came from the ObservableCollection
+            if (!_inCollectionChanged)
+            {
+                try
+                {
+                    // We are about to change the ObservableCollection based on the binding list.
+                    // We don't want to try to put that change into the ObservableCollection again,
+                    // so we set a flag to prevent this.
+                    _changingObservableCollection = true;
+                    _obervableCollection.Add(item);
+                }
+                finally
+                {
+                    _changingObservableCollection = false;
+                }
+            }
+        }
+
+        // <summary>
+        // Removes the item from the underlying from observable collection.
+        // </summary>
+        // <param name="item"> The item. </param>
+        private void RemoveFromObservableCollection(T item)
+        {
+            // Don't try to change the ObervableCollection if the original change
+            // came from the ObservableCollection
+            if (!_inCollectionChanged)
+            {
+                try
+                {
+                    // We are about to change the ObservableCollection based on the binding list.
+                    // We don't want to try to put that change into the ObservableCollection again,
+                    // so we set a flag to prevent this.
+                    _changingObservableCollection = true;
+                    _obervableCollection.Remove(item);
+                }
+                finally
+                {
+                    _changingObservableCollection = false;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SortableBindingList.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SortableBindingList.cs
@@ -1,0 +1,121 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SortableBindingList<T> : BindingList<T>
+    {
+        private bool _isSorted;
+        private ListSortDirection _sortDirection;
+        private PropertyDescriptor _sortProperty;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SortableBindingList([NotNull] List<T> list)
+            : base(list)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void ApplySortCore(PropertyDescriptor prop, ListSortDirection direction)
+        {
+            if (PropertyComparer.CanSort(prop.PropertyType))
+            {
+                ((List<T>)Items).Sort(new PropertyComparer(prop, direction));
+                _sortDirection = direction;
+                _sortProperty = prop;
+                _isSorted = true;
+                OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void RemoveSortCore()
+        {
+            _isSorted = false;
+            _sortProperty = null;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool IsSortedCore => _isSorted;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override ListSortDirection SortDirectionCore => _sortDirection;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override PropertyDescriptor SortPropertyCore => _sortProperty;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool SupportsSortingCore => true;
+
+        private class PropertyComparer : Comparer<T>
+        {
+            private readonly IComparer _comparer;
+            private readonly ListSortDirection _direction;
+            private readonly PropertyDescriptor _prop;
+
+            public PropertyComparer(PropertyDescriptor prop, ListSortDirection direction)
+            {
+                if (!prop.ComponentType.IsAssignableFrom(typeof(T)))
+                {
+                    throw new MissingMemberException(typeof(T).Name, prop.Name);
+                }
+
+                _prop = prop;
+                _direction = direction;
+
+                var property = typeof(Comparer<>).MakeGenericType(prop.PropertyType).GetTypeInfo().GetDeclaredProperty("Default");
+                _comparer = (IComparer)property.GetValue(null, null);
+            }
+
+            public override int Compare(T left, T right)
+            {
+                var leftValue = _prop.GetValue(left);
+                var rightValue = _prop.GetValue(right);
+
+                return _direction == ListSortDirection.Ascending
+                    ? _comparer.Compare(leftValue, rightValue)
+                    : _comparer.Compare(rightValue, leftValue);
+            }
+
+            public static bool CanSort(Type type)
+                => type.GetInterface("IComparable") != null ||
+                   (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/LocalView.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/LocalView.cs
@@ -1,0 +1,305 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         A collection that stays in sync with entities of a given type being tracked by
+    ///         a <see cref="DbContext" />. Call <see cref="DbSet{TEntity}.Local" /> to obtain a
+    ///         local view.
+    ///     </para>
+    ///     <para>
+    ///         This local view will stay in sync as entities are added or removed from the context. Likewise, entities
+    ///         added to or removed from the local view will automatically be added to or removed
+    ///         from the context.
+    ///     </para>
+    ///     <para>
+    ///         Adding an entity to this collection will cause it to be tracked in the <see cref="EntityState.Added" />
+    ///         state by the context unless it is already being tracked.
+    ///     </para>
+    ///     <para>
+    ///         Removing an entity from this collection will cause it to be marked as <see cref="EntityState.Deleted" />,
+    ///         unless it was previously in the Added state, in which case it will be detached from the context.
+    ///     </para>
+    ///     <para>
+    ///         The collection implements <see cref="INotifyCollectionChanged" />,
+    ///         <see cref="INotifyPropertyChanging" />, and <see cref="INotifyPropertyChanging" /> such that
+    ///         notifications are generated when an entity starts being tracked by the context or is
+    ///         marked as <see cref="EntityState.Deleted" /> or <see cref="EntityState.Detached" />.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entity in the local view.</typeparam>
+    public class LocalView<TEntity> : ICollection<TEntity>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
+        where TEntity : class
+    {
+#if NET451
+        private ObservableBackedBindingList<TEntity> _bindingList;
+#endif
+        private readonly IStateManager _stateManager;
+        private int _count;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public LocalView([NotNull] DbSet<TEntity> set)
+        {
+            _stateManager = set.GetService<IStateManager>();
+            set.GetService<ILocalViewListener>().RegisterView(StateManagerChangedHandler);
+
+            _count = _stateManager.Entries
+                .Count(e => e.Entity is TEntity && e.EntityState != EntityState.Deleted);
+        }
+
+        /// <summary>
+        ///     Returns an <see cref="IEnumerator{T}" /> for all tracked entities of type TEntity
+        ///     that are not marked as deleted.
+        /// </summary>
+        /// <returns> An enumerator for the collection. </returns>
+        public virtual IEnumerator<TEntity> GetEnumerator()
+            => _stateManager.Entries.Where(e => e.EntityState != EntityState.Deleted)
+                .Select(e => e.Entity)
+                .OfType<TEntity>()
+                .GetEnumerator();
+
+        /// <summary>
+        ///     Returns an <see cref="IEnumerator{T}" /> for all tracked entities of type TEntity
+        ///     that are not marked as deleted.
+        /// </summary>
+        /// <returns> An enumerator for the collection. </returns>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        ///     <para>
+        ///         Adds a new entity to the <see cref="DbContext" />. If the entity is not being tracked or is currently
+        ///         marked as deleted, then it becomes tracked as <see cref="EntityState.Added" />.
+        ///     </para>
+        ///     <para>
+        ///         Note that only the given entity is tracked. Any related entities discoverable from
+        ///         the given entity are not automatically tracked.
+        ///     </para>
+        /// </summary>
+        /// <param name="item">The item to start tracking. </param>
+        public virtual void Add(TEntity item)
+        {
+            // For something that is already in the state manager as Unchanged or Modified we don't try
+            // to Add it again since doing so would change its state to Added, which is probably not what
+            // was wanted in this case.
+            var entry = _stateManager.GetOrCreateEntry(item);
+            if (entry.EntityState == EntityState.Deleted
+                || entry.EntityState == EntityState.Detached)
+            {
+                OnCountPropertyChanging();
+
+                entry.SetEntityState(EntityState.Added);
+
+                _count++;
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, item);
+
+                OnCountPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Marks all entities of type TEntity being tracked by the <see cref="DbContext" />
+        ///         as <see cref="EntityState.Deleted" />.
+        ///     </para>
+        ///     <para>
+        ///         Entities that are currently marked as <see cref="EntityState.Added" /> will be marked
+        ///         as <see cref="EntityState.Detached" /> since the Added state indicates that the entity
+        ///         has not been saved to the database and hence it does not make sense to attempt to
+        ///         delete it from the database.
+        ///     </para>
+        /// </summary>
+        public virtual void Clear()
+        {
+            foreach (var entry in _stateManager.Entries
+                .Where(e => e.Entity is TEntity && e.EntityState != EntityState.Deleted)
+                .ToList())
+            {
+                Remove((TEntity)entry.Entity);
+            }
+        }
+
+        /// <summary>
+        ///     Returns true if the entity is being tracked by the context and has not been
+        ///     marked as Deleted.
+        /// </summary>
+        /// <param name="item"> The entity to check. </param>
+        /// <returns></returns>
+        public virtual bool Contains(TEntity item)
+        {
+            var entry = _stateManager.TryGetEntry(item);
+
+            return entry != null && entry.EntityState != EntityState.Deleted;
+        }
+
+        /// <summary>
+        ///     Copies to an array all entities of type TEntity that are being tracked and are
+        ///     not marked as Deleted.
+        /// </summary>
+        /// <param name="array"> The array into which to copy entities. </param>
+        /// <param name="arrayIndex"> The index into the array to start copying. </param>
+        public virtual void CopyTo(TEntity[] array, int arrayIndex)
+        {
+            foreach (var entry in _stateManager.Entries)
+            {
+                if (entry.EntityState != EntityState.Deleted)
+                {
+                    var entity = entry.Entity as TEntity;
+                    if (entity != null)
+                    {
+                        array[arrayIndex++] = entity;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Marks the given entity as <see cref="EntityState.Deleted" />.
+        ///     </para>
+        ///     <para>
+        ///         Entities that are currently marked as <see cref="EntityState.Added" /> will be marked
+        ///         as <see cref="EntityState.Detached" /> since the Added state indicates that the entity
+        ///         has not been saved to the database and hence it does not make sense to attempt to
+        ///         delete it from the database.
+        ///     </para>
+        /// </summary>
+        /// <param name="item"> The entity to delete. </param>
+        /// <returns>True if the entity was being tracked and was not already Deleted. </returns>
+        public virtual bool Remove(TEntity item)
+        {
+            var entry = _stateManager.TryGetEntry(item);
+            if (entry != null
+                && entry.EntityState != EntityState.Deleted)
+            {
+                OnCountPropertyChanging();
+
+                entry.SetEntityState(entry.EntityState == EntityState.Added
+                    ? EntityState.Detached
+                    : EntityState.Deleted);
+
+                _count--;
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Remove, item);
+
+                OnCountPropertyChanged();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private void StateManagerChangedHandler(InternalEntityEntry entry, EntityState previousState)
+        {
+            var entity = entry.Entity as TEntity;
+            if (entity != null)
+            {
+                var wasIn = previousState != EntityState.Detached
+                            && previousState != EntityState.Deleted;
+
+                var isIn = entry.EntityState != EntityState.Detached
+                           && entry.EntityState != EntityState.Deleted;
+
+                if (wasIn != isIn)
+                {
+                    OnCountPropertyChanging();
+
+                    if (isIn)
+                    {
+                        _count++;
+
+                        OnCollectionChanged(NotifyCollectionChangedAction.Add, entity);
+                    }
+                    else
+                    {
+                        _count--;
+
+                        OnCollectionChanged(NotifyCollectionChangedAction.Remove, entity);
+                    }
+
+                    OnCountPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     The number of entities of type TEntity that are being tracked and are not marked
+        ///     as Deleted.
+        /// </summary>
+        public virtual int Count => _count;
+
+        /// <summary>
+        ///     False, since the collection is not read-only.
+        /// </summary>
+        public virtual bool IsReadOnly => false;
+
+        /// <summary>
+        ///     Occurs when a property of this collection (such as <see cref="Count" />) changes.
+        /// </summary>
+        public virtual event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        ///     Occurs when a property of this collection (such as <see cref="Count" />) is changing.
+        /// </summary>
+        public virtual event PropertyChangingEventHandler PropertyChanging;
+
+        /// <summary>
+        ///     Occurs when the contents of the collection changes, either because an entity
+        ///     has been directly added or removed from the collection, or because an entity
+        ///     starts being tracked, or because an entity is marked as Deleted.
+        /// </summary>
+        public virtual event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <summary>
+        ///     Raises the <see cref="PropertyChanged" /> event.
+        /// </summary>
+        /// <param name="e"> Details of the property that changed. </param>
+        protected virtual void OnPropertyChanged([NotNull] PropertyChangedEventArgs e)
+            => PropertyChanged?.Invoke(this, e);
+
+        /// <summary>
+        ///     Raises the <see cref="PropertyChanging" /> event.
+        /// </summary>
+        /// <param name="e"> Details of the property that is changing. </param>
+        protected virtual void OnPropertyChanging([NotNull] PropertyChangingEventArgs e)
+            => PropertyChanging?.Invoke(this, e);
+
+        /// <summary>
+        ///     Raises the <see cref="CollectionChanged" /> event.
+        /// </summary>
+        /// <param name="e"> Details of the change. </param>
+        protected virtual void OnCollectionChanged([NotNull] NotifyCollectionChangedEventArgs e)
+            => CollectionChanged?.Invoke(this, e);
+
+        private void OnCountPropertyChanged() => OnPropertyChanged(ObservableHashSetSingletons._countPropertyChanged);
+
+        private void OnCountPropertyChanging() => OnPropertyChanging(ObservableHashSetSingletons._countPropertyChanging);
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, object item)
+            => OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, item));
+
+#if NET451
+        /// <summary>
+        ///     Returns an <see cref="BindingList{T}" /> implementation that stays in sync with this collection.
+        /// </summary>
+        /// <returns> The binding list. </returns>
+        public virtual BindingList<TEntity> ToBindingList()
+            => _bindingList ?? (_bindingList = new ObservableBackedBindingList<TEntity>(this));
+#endif
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableCollectionListSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableCollectionListSource.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Extends <see cref="ObservableCollection{T}" /> and adds an explicit implementation of <see cref="IListSource" />.
+    ///     </para>
+    ///     <para>
+    ///         The method <see cref="IListSource.GetList" /> is implemented to return an <see cref="IBindingList" />
+    ///         implementation that stays in sync with the ObservableCollection.
+    ///     </para>
+    ///     <para>
+    ///         This class can be used to implement navigation properties on entities for use in Windows Forms data binding.
+    ///         For WPF data binding use an ObservableCollection rather than an instance of this class.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="T"> </typeparam>
+    public class ObservableCollectionListSource<T> : ObservableCollection<T>, IListSource
+        where T : class
+    {
+        private IBindingList _bindingList;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ObservableCollectionListSource{T}" /> class.
+        /// </summary>
+        public ObservableCollectionListSource()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ObservableCollectionListSource{T}" /> class that
+        ///     contains elements copied from the specified collection.
+        /// </summary>
+        /// <param name="collection"> The collection from which the elements are copied. </param>
+        public ObservableCollectionListSource([NotNull] IEnumerable<T> collection)
+            : base(collection)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ObservableCollectionListSource{T}" /> class that
+        ///     contains elements copied from the specified list.
+        /// </summary>
+        /// <param name="list"> The list from which the elements are copied. </param>
+        public ObservableCollectionListSource([NotNull] List<T> list)
+            : base(list)
+        {
+        }
+
+        /// <summary>
+        ///     Always false because there is never a contained collection.
+        /// </summary>
+        bool IListSource.ContainsListCollection => false;
+
+        /// <summary>
+        ///     Returns an <see cref="IBindingList" /> implementation that stays in sync with
+        ///     this <see cref="ObservableCollection{T}" />. The returned list is cached on this object
+        ///     such that the same list is returned each time this method is called.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="IBindingList" /> in sync with the ObservableCollection.
+        /// </returns>
+        IList IListSource.GetList() => _bindingList ?? (_bindingList = this.ToBindingList());
+    }
+}
+
+#endif

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableHashSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableHashSet.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
@@ -20,9 +21,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         : ISet<T>, IReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
     {
         private HashSet<T> _set;
+#if NET451
+        private ObservableBackedBindingList<T> _bindingList;
+#endif
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}"/> class
+        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}" /> class
         ///     that is empty and uses the default equality comparer for the set type.
         /// </summary>
         public ObservableHashSet()
@@ -31,12 +35,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}"/> class
+        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}" /> class
         ///     that is empty and uses the specified equality comparer for the set type.
         /// </summary>
         /// <param name="comparer">
-        ///     The <see cref="IEqualityComparer{T}"/> implementation to use when
-        ///     comparing values in the set, or null to use the default <see cref="IEqualityComparer{T}"/>
+        ///     The <see cref="IEqualityComparer{T}" /> implementation to use when
+        ///     comparing values in the set, or null to use the default <see cref="IEqualityComparer{T}" />
         ///     implementation for the set type.
         /// </param>
         public ObservableHashSet([NotNull] IEqualityComparer<T> comparer)
@@ -45,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}"/> class
+        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}" /> class
         ///     that uses the default equality comparer for the set type, contains elements copied
         ///     from the specified collection, and has sufficient capacity to accommodate the
         ///     number of elements copied.
@@ -57,15 +61,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}"/> class
+        ///     Initializes a new instance of the <see cref="ObservableHashSet{T}" /> class
         ///     that uses the specified equality comparer for the set type, contains elements
         ///     copied from the specified collection, and has sufficient capacity to accommodate
         ///     the number of elements copied.
         /// </summary>
         /// <param name="collection"> The collection whose elements are copied to the new set. </param>
         /// <param name="comparer">
-        ///     The <see cref="IEqualityComparer{T}"/> implementation to use when
-        ///     comparing values in the set, or null to use the default <see cref="IEqualityComparer{T}"/>
+        ///     The <see cref="IEqualityComparer{T}" /> implementation to use when
+        ///     comparing values in the set, or null to use the default <see cref="IEqualityComparer{T}" />
         ///     implementation for the set type.
         /// </param>
         public ObservableHashSet([NotNull] IEnumerable<T> collection, [NotNull] IEqualityComparer<T> comparer)
@@ -74,12 +78,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Occurs when a property of this hash set (such as <see cref="Count"/>) changes.
+        ///     Occurs when a property of this hash set (such as <see cref="Count" />) changes.
         /// </summary>
         public virtual event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
-        ///     Occurs when a property of this hash set (such as <see cref="Count"/>) is changing.
+        ///     Occurs when a property of this hash set (such as <see cref="Count" />) is changing.
         /// </summary>
         public virtual event PropertyChangingEventHandler PropertyChanging;
 
@@ -283,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Modifies the current hash set to contain only elements that are present either in that 
+        ///     Modifies the current hash set to contain only elements that are present either in that
         ///     object or in the specified collection, but not both.
         /// </summary>
         /// <param name="other"> The collection to compare to the current hash set. </param>
@@ -390,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     from the hash set.
         /// </summary>
         /// <param name="match">
-        ///     The <see cref="Predicate{T}"/> delegate that defines the conditions of the elements to remove.
+        ///     The <see cref="Predicate{T}" /> delegate that defines the conditions of the elements to remove.
         /// </param>
         /// <returns> The number of elements that were removed from the hash set. </returns>
         public virtual int RemoveWhere([NotNull] Predicate<T> match)
@@ -418,25 +422,25 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Gets the <see cref="IEqualityComparer{T}"/> object that is used to determine equality for the values in the set.
+        ///     Gets the <see cref="IEqualityComparer{T}" /> object that is used to determine equality for the values in the set.
         /// </summary>
         public virtual IEqualityComparer<T> Comparer => _set.Comparer;
 
         /// <summary>
-        ///     Sets the capacity of the hash set to the actual number of elements it contains, rounded up to a nearby, 
+        ///     Sets the capacity of the hash set to the actual number of elements it contains, rounded up to a nearby,
         ///     implementation-specific value.
         /// </summary>
         public virtual void TrimExcess() => _set.TrimExcess();
 
         /// <summary>
-        ///     Raises the <see cref="PropertyChanged"/> event.
+        ///     Raises the <see cref="PropertyChanged" /> event.
         /// </summary>
         /// <param name="e"> Details of the property that changed. </param>
         protected virtual void OnPropertyChanged([NotNull] PropertyChangedEventArgs e)
             => PropertyChanged?.Invoke(this, e);
 
         /// <summary>
-        ///     Raises the <see cref="PropertyChanging"/> event.
+        ///     Raises the <see cref="PropertyChanging" /> event.
         /// </summary>
         /// <param name="e"> Details of the property that is changing. </param>
         protected virtual void OnPropertyChanging([NotNull] PropertyChangingEventArgs e)
@@ -453,11 +457,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             => OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, oldItems));
 
         /// <summary>
-        ///     Raises the <see cref="CollectionChanged"/> event.
+        ///     Raises the <see cref="CollectionChanged" /> event.
         /// </summary>
         /// <param name="e"> Details of the change. </param>
         protected virtual void OnCollectionChanged([NotNull] NotifyCollectionChangedEventArgs e)
             => CollectionChanged?.Invoke(this, e);
+
+#if NET451
+        /// <summary>
+        ///     Returns an <see cref="BindingList{T}" /> implementation that stays in sync with this collection.
+        /// </summary>
+        /// <returns> The binding list. </returns>
+        public virtual BindingList<T> ToBindingList()
+            => _bindingList ?? (_bindingList = new ObservableBackedBindingList<T>(this));
+#endif
     }
 
     internal class ObservableHashSetSingletons

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableHashSetListSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/ObservableHashSetListSource.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Extends <see cref="ObservableHashSet{T}" /> and adds an explicit implementation of <see cref="IListSource" />.
+    ///     </para>
+    ///     <para>
+    ///         The method <see cref="IListSource.GetList" /> is implemented to return an <see cref="IBindingList" />
+    ///         implementation that stays in sync with the ObservableHashSet.
+    ///     </para>
+    ///     <para>
+    ///         This class can be used to implement navigation properties on entities for use in Windows Forms data binding.
+    ///         For WPF data binding use an ObservableHashSet rather than an instance of this class.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="T"> </typeparam>
+    public class ObservableHashSetListSource<T> : ObservableHashSet<T>, IListSource
+        where T : class
+    {
+        private IBindingList _bindingList;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ObservableHashSetListSource{T}" /> class.
+        /// </summary>
+        public ObservableHashSetListSource()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ObservableHashSetListSource{T}" /> class that
+        ///     contains elements copied from the specified collection.
+        /// </summary>
+        /// <param name="collection"> The collection from which the elements are copied. </param>
+        public ObservableHashSetListSource([NotNull] IEnumerable<T> collection)
+            : base(collection)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.ObservableHashSetListSource{T}" /> class that
+        ///     contains elements copied from the specified list.
+        /// </summary>
+        /// <param name="list"> The list from which the elements are copied. </param>
+        public ObservableHashSetListSource([NotNull] List<T> list)
+            : base(list)
+        {
+        }
+
+        /// <summary>
+        ///     Always false because there is never a contained collection.
+        /// </summary>
+        bool IListSource.ContainsListCollection => false;
+
+        /// <summary>
+        ///     Returns an <see cref="IBindingList" /> implementation that stays in sync with
+        ///     this <see cref="ObservableHashSet{T}" />. The returned list is cached on this object
+        ///     such that the same list is returned each time this method is called.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="IBindingList" /> in sync with the ObservableHashSet.
+        /// </returns>
+        IList IListSource.GetList() => _bindingList ?? (_bindingList = ToBindingList());
+    }
+}
+
+#endif

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -264,13 +264,11 @@ namespace Microsoft.EntityFrameworkCore
         [DebuggerStepThrough]
         public virtual int SaveChanges(bool acceptAllChangesOnSuccess)
         {
-            var stateManager = StateManager;
-
-            TryDetectChanges(stateManager);
+            TryDetectChanges();
 
             try
             {
-                return stateManager.SaveChanges(acceptAllChangesOnSuccess);
+                return StateManager.SaveChanges(acceptAllChangesOnSuccess);
             }
             catch (Exception exception)
             {
@@ -284,11 +282,11 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        private void TryDetectChanges(IStateManager stateManager)
+        private void TryDetectChanges()
         {
             if (ChangeTracker.AutoDetectChangesEnabled)
             {
-                ChangeDetector.DetectChanges(stateManager);
+                ChangeTracker.DetectChanges();
             }
         }
 
@@ -340,16 +338,11 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var stateManager = StateManager;
-
-            if (ChangeTracker.AutoDetectChangesEnabled)
-            {
-                ChangeDetector.DetectChanges(stateManager);
-            }
+            TryDetectChanges();
 
             try
             {
-                return await stateManager.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+                return await StateManager.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
             }
             catch (Exception exception)
             {
@@ -395,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entity, nameof(entity));
 
-            TryDetectChanges(StateManager);
+            TryDetectChanges();
 
             return EntryWithoutDetectChanges(entity);
         }
@@ -420,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entity, nameof(entity));
 
-            TryDetectChanges(StateManager);
+            TryDetectChanges();
 
             return EntryWithoutDetectChanges(entity);
         }

--- a/src/Microsoft.EntityFrameworkCore/DbSet`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbSet`.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -45,6 +46,28 @@ namespace Microsoft.EntityFrameworkCore
         : IQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IInfrastructure<IServiceProvider>
         where TEntity : class
     {
+        /// <summary>
+        ///     <para>
+        ///         Gets an <see cref="LocalView{T}" /> that represents a local view of all Added, Unchanged,
+        ///         and Modified entities in this set.
+        ///     </para>
+        ///     <para>
+        ///         This local view will stay in sync as entities are added or removed from the context. Likewise, entities
+        ///         added to or removed from the local view will automatically be added to or removed
+        ///         from the context.
+        ///     </para>
+        ///     <para>
+        ///         This property can be used for data binding by populating the set with data, for example by using the
+        ///         <see cref="EntityFrameworkQueryableExtensions.Load{TSource}" /> extension method,
+        ///         and then binding to the local data through this property.  For WPF bind to this property
+        ///         directly.  For Windows Forms bind to the result of calling ToBindingList on this property.
+        ///     </para>
+        /// </summary>
+        public virtual LocalView<TEntity> Local
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
         ///     is being tracked by the context, then it is returned immediately without making a request to the

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ObservableCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ObservableCollectionExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Extension methods for <see cref="ObservableCollection{T}" />.
+    /// </summary>
+    public static class ObservableCollectionExtensions
+    {
+        /// <summary>
+        ///     Returns an <see cref="BindingList{T}" /> implementation that stays in sync with the given
+        ///     <see cref="ObservableCollection{T}" />.
+        /// </summary>
+        /// <typeparam name="T"> The element type. </typeparam>
+        /// <param name="source"> The collection that the binding list will stay in sync with. </param>
+        /// <returns> The binding list. </returns>
+        public static BindingList<T> ToBindingList<T>([NotNull] this ObservableCollection<T> source) where T : class
+        {
+            Check.NotNull(source, nameof(source));
+
+            return new ObservableBackedBindingList<T>(source);
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -77,7 +77,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped<INavigationListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
                 .AddScoped<IKeyListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
                 .AddScoped<IQueryTrackingListener, INavigationFixer>(p => p.GetService<INavigationFixer>())
-                .AddScoped<IPropertyListener, IChangeDetector>(p => p.GetService<IChangeDetector>()));
+                .AddScoped<IPropertyListener, IChangeDetector>(p => p.GetService<IChangeDetector>())
+                .AddScoped<IEntityStateListener, ILocalViewListener>(p => p.GetService<ILocalViewListener>()));
 
             serviceCollection.TryAdd(new ServiceCollection()
                 .AddSingleton<IDbSetFinder, DbSetFinder>()
@@ -93,6 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped<LoggingModelValidator>()
                 .AddScoped<IKeyPropagator, KeyPropagator>()
                 .AddScoped<INavigationFixer, NavigationFixer>()
+                .AddScoped<ILocalViewListener, LocalViewListener>()
                 .AddScoped<IStateManager, StateManager>()
                 .AddScoped<IConcurrencyDetector, ConcurrencyDetector>()
                 .AddScoped<IInternalEntityEntryFactory, InternalEntityEntryFactory>()

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -26,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     {
         private readonly DbContext _context;
         private readonly LazyRef<EntityQueryable<TEntity>> _entityQueryable;
+        private LocalView<TEntity> _localView;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -43,6 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 = new LazyRef<EntityQueryable<TEntity>>(
                     () => new EntityQueryable<TEntity>(_context.QueryProvider));
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override LocalView<TEntity> Local 
+            => _localView ?? (_localView = new LocalView<TEntity>(this));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ChangeTracking\Internal\IInternalEntityEntrySubscriber.cs" />
     <Compile Include="ChangeTracking\Internal\IKeyListener.cs" />
     <Compile Include="ChangeTracking\Internal\IKeyPropagator.cs" />
+    <Compile Include="ChangeTracking\Internal\ILocalViewListener.cs" />
     <Compile Include="ChangeTracking\Internal\INavigationFixer.cs" />
     <Compile Include="ChangeTracking\Internal\INavigationListener.cs" />
     <Compile Include="ChangeTracking\Internal\InternalClrEntityEntry.cs" />
@@ -111,9 +112,11 @@
     <Compile Include="ChangeTracking\Internal\IValueGenerationManager.cs" />
     <Compile Include="ChangeTracking\Internal\KeyPropagator.cs" />
     <Compile Include="ChangeTracking\Internal\KeyValueFactoryFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\LocalViewListener.cs" />
     <Compile Include="ChangeTracking\Internal\MultiSnapshot.cs" />
     <Compile Include="ChangeTracking\Internal\NavigationFixer.cs" />
     <Compile Include="ChangeTracking\Internal\NullableKeyIdentityMap.cs" />
+    <Compile Include="ChangeTracking\Internal\ObservableBackedBindingList.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalPropertyValues.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValuesFactoryFactory.cs" />
@@ -128,14 +131,18 @@
     <Compile Include="ChangeTracking\Internal\Snapshot.cs" />
     <Compile Include="ChangeTracking\Internal\SnapshotFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\SnapshotFactoryFactory`.cs" />
+    <Compile Include="ChangeTracking\Internal\SortableBindingList.cs" />
     <Compile Include="ChangeTracking\Internal\StateData.cs" />
     <Compile Include="ChangeTracking\Internal\StateManager.cs" />
     <Compile Include="ChangeTracking\Internal\StoreGeneratedValues.cs" />
     <Compile Include="ChangeTracking\Internal\TrackingQueryMode.cs" />
     <Compile Include="ChangeTracking\Internal\ValueGenerationManager.cs" />
+    <Compile Include="ChangeTracking\LocalView.cs" />
     <Compile Include="ChangeTracking\MemberEntry.cs" />
     <Compile Include="ChangeTracking\NavigationEntry.cs" />
     <Compile Include="ChangeTracking\ObservableHashSet.cs" />
+    <Compile Include="ChangeTracking\ObservableCollectionListSource.cs" />
+    <Compile Include="ChangeTracking\ObservableHashSetListSource.cs" />
     <Compile Include="ChangeTracking\PropertyEntry.cs" />
     <Compile Include="ChangeTracking\PropertyEntry`.cs" />
     <Compile Include="ChangeTracking\PropertyValues.cs" />
@@ -168,6 +175,7 @@
     <Compile Include="Extensions\MutableNavigationExtensions.cs" />
     <Compile Include="Extensions\MutablePropertyExtensions.cs" />
     <Compile Include="Extensions\NavigationExtensions.cs" />
+    <Compile Include="Extensions\ObservableCollectionExtensions.cs" />
     <Compile Include="Extensions\PropertyBaseExtensions.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />
     <Compile Include="Infrastructure\AccessorExtensions.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1009,7 +1009,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Data binding directly to a store query is not supported. Instead materialize the results into a collection, by calling a method such as ToList() or ToArray(), and bind to the collection. This should be done to avoid sending a query to the database each time the databound control iterates the data.
+        /// Data binding directly to a store query is not supported. Instead populate a DbSet with data, for example by calling Load on the DbSet, and then bind to local data to avoid sending a query to the database each time the databound control iterates the data. For WPF bind to DbSet.Local. For WinForms bind to DbSet.Local.ToBindingList(). For ASP.NET WebForms bind to DbSet.ToList() or use Model Binding.
         /// </summary>
         public static string DataBindingWithIListSource
         {

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -490,7 +490,7 @@
     <value>A relationship cannot be established from property '{property}' on type '{entityType}' to property '{referencedProperty}' on type '{referencedEntityType}'. Check the values in the InversePropertyAttribute to ensure relationship definitions are unique and reference from one navigation property to its corresponding inverse navigation property.</value>
   </data>
   <data name="DataBindingWithIListSource" xml:space="preserve">
-    <value>Data binding directly to a store query is not supported. Instead materialize the results into a collection, by calling a method such as ToList() or ToArray(), and bind to the collection. This should be done to avoid sending a query to the database each time the databound control iterates the data.</value>
+    <value>Data binding directly to a store query is not supported. Instead populate a DbSet with data, for example by calling Load on the DbSet, and then bind to local data to avoid sending a query to the database each time the databound control iterates the data. For WPF bind to DbSet.Local. For WinForms bind to DbSet.Local.ToBindingList(). For ASP.NET WebForms bind to DbSet.ToList() or use Model Binding.</value>
   </data>
   <data name="KeyAttributeOnDerivedEntity" xml:space="preserve">
     <value>The derived type '{derivedType}' cannot have KeyAttribute on property '{property}' since primary key can only be declared on the root type.</value>

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DatabindingInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DatabindingInMemoryTest.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class DatabindingInMemoryTest : DatabindingTestBase<InMemoryTestStore, F1InMemoryFixture>
+    {
+        public DatabindingInMemoryTest(F1InMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ConcurrencyModel;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class F1InMemoryFixture : F1FixtureBase<InMemoryTestStore>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public F1InMemoryFixture()
+        {
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                .BuildServiceProvider();
+        }
+
+        public override InMemoryTestStore CreateTestStore()
+        {
+            var store = new InMemoryF1TestStore(_serviceProvider);
+
+            using (var context = CreateContext(store))
+            {
+                ConcurrencyModelInitializer.Seed(context);
+            }
+
+            return store;
+        }
+
+        public override F1Context CreateContext(InMemoryTestStore testStore)
+            => new F1Context(new DbContextOptionsBuilder()
+                .UseInMemoryDatabase()
+                .UseInternalServiceProvider(_serviceProvider).Options);
+
+        public class InMemoryF1TestStore : InMemoryTestStore
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public InMemoryF1TestStore(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public override void Dispose()
+            {
+                _serviceProvider.GetRequiredService<IInMemoryStoreSource>().GetGlobalStore().Clear();
+
+                base.Dispose();
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests.csproj
@@ -63,6 +63,8 @@
     <Compile Include="DataAnnotationInMemoryFixture.cs" />
     <Compile Include="DataAnnotationInMemoryTest.cs" />
     <Compile Include="DatabaseInMemoryTest.cs" />
+    <Compile Include="DatabindingInMemoryTest.cs" />
+    <Compile Include="F1InMemoryFixture.cs" />
     <Compile Include="FieldMappingInMemoryTest.cs" />
     <Compile Include="FindInMemoryTest.cs" />
     <Compile Include="LoadInMemoryTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DatabindingSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DatabindingSqlServerTest.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class DatabindingSqlServerTest : DatabindingTestBase<SqlServerTestStore, F1SqlServerFixture>
+    {
+        public DatabindingSqlServerTest(F1SqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ConnectionSpecificationTest.cs" />
     <Compile Include="DataAnnotationSqlServerFixture.cs" />
     <Compile Include="DataAnnotationSqlServerTest.cs" />
+    <Compile Include="DatabindingSqlServerTest.cs" />
     <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />
     <Compile Include="F1SqlServerFixture.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DatabindingSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DatabindingSqliteTest.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class DatabindingSqliteTest : DatabindingTestBase<SqliteTestStore, F1SqliteFixture>
+    {
+        public DatabindingSqliteTest(F1SqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="DataAnnotationSqliteFixture.cs" />
     <Compile Include="DataAnnotationSqliteTest.cs" />
+    <Compile Include="DatabindingSqliteTest.cs" />
     <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="F1SqliteFixture.cs" />
     <Compile Include="FieldMappingSqliteTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -1230,9 +1230,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             return builder.Model;
         }
 
-        private static INavigationFixer CreateNavigationFixer(IServiceProvider contextServices)
-        {
-            return (INavigationFixer)contextServices.GetRequiredService<IEntityStateListener>();
-        }
+        private static INavigationFixer CreateNavigationFixer(IServiceProvider contextServices) 
+            => contextServices.GetRequiredService<INavigationFixer>();
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
@@ -1,0 +1,448 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class ObservableBackedBindingListTest
+    {
+        [Fact]
+        public void Items_added_to_ObservableCollection_are_added_to_binding_list()
+        {
+            var oc = new ObservableCollection<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(1);
+            oc.Add(item);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_from_ObservableCollection_are_removed_from_binding_list()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Remove(item);
+
+            Assert.False(obbl.Contains(item));
+            Assert.Equal(5, obbl.Count);
+        }
+
+        [Fact]
+        public void Items_replaced_in_the_ObservableCollection_are_replaced_in_the_binding_list()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var newItem = new ListElement(-4);
+            oc[2] = newItem;
+
+            Assert.False(obbl.Contains(item));
+            Assert.True(obbl.Contains(newItem));
+            Assert.Equal(6, obbl.Count);
+        }
+
+        [Fact]
+        public void Items_cleared_in_the_ObservableCollection_are_cleared_in_the_binding_list()
+        {
+            var oc = new ObservableCollection<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Clear();
+
+            Assert.Equal(0, obbl.Count);
+        }
+
+        [Fact]
+        public void Adding_duplicate_item_to_the_ObservableCollection_adds_duplicate_to_the_binding_list()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Add(item);
+
+            Assert.Equal(7, obbl.Count);
+            Assert.Equal(2, obbl.Count(i => ReferenceEquals(i, item)));
+        }
+
+        [Fact]
+        public void Items_added_to_the_binding_list_are_added_to_the_ObservableCollection()
+        {
+            var oc = new ObservableCollection<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(7);
+            obbl.Add(item);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_added_to_the_binding_list_with_AddNew_are_added_to_the_ObservableCollection()
+        {
+            var oc = new ObservableCollection<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_canceled_during_AddNew_are_not_added_to_the_ObservableCollection()
+        {
+            var oc = new ObservableCollection<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = obbl.AddNew();
+            obbl.CancelNew(0);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_inserted_into_the_binding_list_are_added_to_the_ObservableCollection()
+        {
+            var oc = new ObservableCollection<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(7);
+            obbl.Insert(0, item);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_set_in_the_binding_list_are_replaced_in_the_ObservableCollection()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var newItem = new ListElement(7);
+            obbl[2] = newItem;
+
+            Assert.True(oc.Contains(newItem));
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_from_the_binding_list_are_removed_from_the_ObservableCollection()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Remove(item);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_by_index_from_the_binding_list_are_removed_from_the_ObservableCollection()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.RemoveAt(2);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_cleared_from_the_binding_list_are_cleared_from_the_ObservableCollection()
+        {
+            var oc = new ObservableCollection<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Clear();
+
+            Assert.Equal(0, oc.Count);
+        }
+
+        [Fact]
+        public void Adding_duplicate_item_to_the_binding_list_adds_duplicate_to_the_ObservableCollection()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableCollection<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Add(item);
+
+            Assert.Equal(7, oc.Count);
+            Assert.Equal(2, oc.Count(i => ReferenceEquals(i, item)));
+        }
+
+        [Fact]
+        public void Attempt_to_AddNew_for_abstract_type_works_if_AddingNew_event_is_used_to_create_new_object()
+        {
+            var obbl = new ObservableBackedBindingList<NotXNode>(new ObservableCollection<NotXNode>());
+            var item = new NotXText("Some Value");
+
+            obbl.AddingNew += (s, e) => e.NewObject = item;
+            obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        [Fact]
+        public void Attempt_to_AddNew_for_type_without_parameterless_constructor_works_if_AddingNew_event_is_used_to_create_new_object()
+        {
+            var obbl = new ObservableBackedBindingList<NotXText>(new ObservableCollection<NotXText>());
+            var item = new NotXText("Some Value");
+
+            obbl.AddingNew += (s, e) => e.NewObject = item;
+            obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        [Fact]
+        public void Items_added_to_ObservableHashSet_are_added_to_binding_list()
+        {
+            var oc = new ObservableHashSet<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(1);
+            oc.Add(item);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_from_ObservableHashSet_are_removed_from_binding_list()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Remove(item);
+
+            Assert.False(obbl.Contains(item));
+            Assert.Equal(5, obbl.Count);
+        }
+
+        [Fact]
+        public void Items_cleared_in_the_ObservableHashSet_are_cleared_in_the_binding_list()
+        {
+            var oc = new ObservableHashSet<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Clear();
+
+            Assert.Equal(0, obbl.Count);
+        }
+
+        [Fact]
+        public void Adding_duplicate_item_to_the_ObservableHashSet_is_ignored()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            oc.Add(item);
+
+            Assert.Equal(6, obbl.Count);
+            Assert.Equal(1, obbl.Count(i => ReferenceEquals(i, item)));
+        }
+
+        [Fact]
+        public void Items_added_to_the_binding_list_are_added_to_the_ObservableHashSet()
+        {
+            var oc = new ObservableHashSet<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(7);
+            obbl.Add(item);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_added_to_the_binding_list_with_AddNew_are_added_to_the_ObservableHashSet()
+        {
+            var oc = new ObservableHashSet<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_canceled_during_AddNew_are_not_added_to_the_ObservableHashSet()
+        {
+            var oc = new ObservableHashSet<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = obbl.AddNew();
+            obbl.CancelNew(0);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_inserted_into_the_binding_list_are_added_to_the_ObservableHashSet()
+        {
+            var oc = new ObservableHashSet<ListElement>();
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var item = new ListElement(7);
+            obbl.Insert(0, item);
+
+            Assert.True(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_set_in_the_binding_list_are_replaced_in_the_ObservableHashSet()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            var newItem = new ListElement(7);
+            obbl[2] = newItem;
+
+            Assert.True(oc.Contains(newItem));
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_from_the_binding_list_are_removed_from_the_ObservableHashSet()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Remove(item);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_removed_by_index_from_the_binding_list_are_removed_from_the_ObservableHashSet()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.RemoveAt(2);
+
+            Assert.False(oc.Contains(item));
+        }
+
+        [Fact]
+        public void Items_cleared_from_the_binding_list_are_cleared_from_the_ObservableHashSet()
+        {
+            var oc = new ObservableHashSet<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Clear();
+
+            Assert.Equal(0, oc.Count);
+        }
+
+        [Fact]
+        public void Adding_duplicate_item_to_the_binding_list_is_ignored()
+        {
+            var item = new ListElement(4);
+            var oc = new ObservableHashSet<ListElement> { 3, 1, item, 1, 5, 9 };
+            var obbl = new ObservableBackedBindingList<ListElement>(oc);
+
+            obbl.Add(item);
+
+            Assert.Equal(6, oc.Count);
+            Assert.Equal(1, oc.Count(i => ReferenceEquals(i, item)));
+        }
+
+        [Fact]
+        public void Attempt_to_AddNew_on_set_for_abstract_type_works_if_AddingNew_event_is_used_to_create_new_object()
+        {
+            var obbl = new ObservableBackedBindingList<NotXNode>(new ObservableHashSet<NotXNode>());
+            var item = new NotXText("Some Value");
+
+            obbl.AddingNew += (s, e) => e.NewObject = item;
+            obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        [Fact]
+        public void Attempt_to_AddNew_on_set_for_type_without_parameterless_constructor_works_if_AddingNew_event_is_used_to_create_new_object()
+        {
+            var obbl = new ObservableBackedBindingList<NotXText>(new ObservableHashSet<NotXText>());
+            var item = new NotXText("Some Value");
+
+            obbl.AddingNew += (s, e) => e.NewObject = item;
+            obbl.AddNew();
+            obbl.EndNew(0);
+
+            Assert.True(obbl.Contains(item));
+        }
+
+        private class ListElement
+        {
+            public ListElement()
+            {
+            }
+
+            public ListElement(int i)
+            {
+                Int = i;
+                NullableInt = i;
+                String = i.ToString();
+                XNode = new NotXText(i.ToString());
+                Random = new Random();
+                ByteArray = new[] { (byte)i, (byte)i, (byte)i, (byte)i };
+            }
+
+            public static implicit operator ListElement(int i) => new ListElement(i);
+
+            public int Int { get; }
+            public int? NullableInt { get; set; }
+            public string String { get; set; }
+            public NotXNode XNode { get; set; }
+            public Random Random { get; set; }
+            public byte[] ByteArray { get; set; }
+
+            public static PropertyDescriptor Property(string name)
+                => TypeDescriptor.GetProperties(typeof(ListElement))[name];
+        }
+
+        private abstract class NotXNode
+        {
+        }
+
+        private class NotXText : NotXNode
+        {
+            private readonly string _value;
+
+            public NotXText(string value)
+            {
+                _value = value;
+            }
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableCollectionListSourceTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableCollectionListSourceTest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class ObservableCollectionListSourceTest
+    {
+        [Fact]
+        public void ObservableCollectionListSource_exposes_ObervableCollection_parameterless_constructor()
+        {
+            var ols = new ObservableCollectionListSource<FakeEntity>();
+            Assert.Equal(0, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableCollectionListSource_exposes_ObervableCollection_IEnumerable_constructor()
+        {
+            IEnumerable<FakeEntity> entities = new[] { new FakeEntity(), new FakeEntity() };
+            var ols = new ObservableCollectionListSource<FakeEntity>(entities);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableCollectionListSource_exposes_ObervableCollection_List_constructor()
+        {
+            var entities = new List<FakeEntity>
+            {
+                new FakeEntity(),
+                new FakeEntity()
+            };
+            var ols = new ObservableCollectionListSource<FakeEntity>(entities);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableCollectionListSource_ContainsListCollection_returns_false()
+        {
+            Assert.False(((IListSource)new ObservableCollectionListSource<FakeEntity>()).ContainsListCollection);
+        }
+
+        [Fact]
+        public void ObservableCollectionListSource_GetList_returns_BindingList_attached_to_the_ObservableCollection()
+        {
+            var ols = new ObservableCollectionListSource<FakeEntity>
+            {
+                new FakeEntity(),
+                new FakeEntity()
+            };
+            var bindingList = ((IListSource)ols).GetList();
+
+            Assert.Equal(2, bindingList.Count);
+
+            ols.Add(new FakeEntity());
+            Assert.Equal(3, bindingList.Count);
+
+            ols.Remove(ols[0]);
+            Assert.Equal(2, bindingList.Count);
+
+            bindingList.Add(new FakeEntity());
+            Assert.Equal(3, ols.Count);
+
+            bindingList.RemoveAt(0);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void The_BindingList_returned_from_ObservableCollectionListSource_GetList_is_cached()
+        {
+            var ols = new ObservableCollectionListSource<FakeEntity>();
+            var bindingList = ((IListSource)ols).GetList();
+
+            Assert.Same(bindingList, ((IListSource)ols).GetList());
+        }
+
+        private class FakeEntity
+        {
+            public int Id { get; set; }
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableHashSetListSourceTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ObservableHashSetListSourceTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class ObservableHashSetListSourceTest
+    {
+        [Fact]
+        public void ObservableHashSetListSource_exposes_ObervableCollection_parameterless_constructor()
+        {
+            var ols = new ObservableHashSetListSource<FakeEntity>();
+            Assert.Equal(0, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableHashSetListSource_exposes_ObervableCollection_IEnumerable_constructor()
+        {
+            IEnumerable<FakeEntity> entities = new[] { new FakeEntity(), new FakeEntity() };
+            var ols = new ObservableHashSetListSource<FakeEntity>(entities);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableHashSetListSource_exposes_ObervableCollection_List_constructor()
+        {
+            var entities = new List<FakeEntity>
+            {
+                new FakeEntity(),
+                new FakeEntity()
+            };
+            var ols = new ObservableHashSetListSource<FakeEntity>(entities);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void ObservableHashSetListSource_ContainsListCollection_returns_false()
+        {
+            Assert.False(((IListSource)new ObservableHashSetListSource<FakeEntity>()).ContainsListCollection);
+        }
+
+        [Fact]
+        public void ObservableHashSetListSource_GetList_returns_BindingList_attached_to_the_ObservableCollection()
+        {
+            var toRemove = new FakeEntity();
+
+            var ols = new ObservableHashSetListSource<FakeEntity>
+            {
+                toRemove,
+                new FakeEntity()
+            };
+            var bindingList = ((IListSource)ols).GetList();
+
+            Assert.Equal(2, bindingList.Count);
+
+            ols.Add(new FakeEntity());
+            Assert.Equal(3, bindingList.Count);
+
+            ols.Remove(toRemove);
+            Assert.Equal(2, bindingList.Count);
+
+            bindingList.Add(new FakeEntity());
+            Assert.Equal(3, ols.Count);
+
+            bindingList.RemoveAt(0);
+            Assert.Equal(2, ols.Count);
+        }
+
+        [Fact]
+        public void The_BindingList_returned_from_ObservableHashSetListSource_GetList_is_cached()
+        {
+            var ols = new ObservableHashSetListSource<FakeEntity>();
+            var bindingList = ((IListSource)ols).GetList();
+
+            Assert.Same(bindingList, ((IListSource)ols).GetList());
+        }
+
+        private class FakeEntity
+        {
+            public int Id { get; set; }
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
@@ -1,0 +1,184 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET451
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class SortableBindingListTest
+    {
+        private void SortTest(string property, ListSortDirection direction)
+        {
+            var list = new List<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var sortedList = direction == ListSortDirection.Ascending
+                ? new List<ListElement> { 1, 1, 3, 4, 5, 9 }
+                : new List<ListElement> { 9, 5, 4, 3, 1, 1 };
+
+            var bindingList = new SortableBindingList<ListElement>(list);
+
+            ((IBindingList)bindingList).ApplySort(ListElement.Property(property), direction);
+
+            Assert.True(list.SequenceEqual(sortedList, new ListElementComparer()));
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_ascending_using_IComparable_on_value_type()
+        {
+            SortTest("Int", ListSortDirection.Ascending);
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_ascending_using_IComparable_on_nullable_value_type()
+        {
+            SortTest("NullableInt", ListSortDirection.Ascending);
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_ascending_using_IComparable_on_reference_type()
+        {
+            SortTest("String", ListSortDirection.Ascending);
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_descending_using_IComparable_on_value_type()
+        {
+            SortTest("Int", ListSortDirection.Descending);
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_descending_using_IComparable_on_nullable_value_type()
+        {
+            SortTest("NullableInt", ListSortDirection.Descending);
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_descending_using_IComparable_on_reference_type()
+        {
+            SortTest("String", ListSortDirection.Descending);
+        }
+
+        [Fact]
+        public void SortableBindingList_does_not_sort_for_non_XNode_that_does_not_implement_IComparable()
+        {
+            var list = new List<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var unsortedList = new List<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var bindingList = new SortableBindingList<ListElement>(list);
+
+            ((IBindingList)bindingList).ApplySort(ListElement.Property("Random"), ListSortDirection.Ascending);
+
+            Assert.True(list.SequenceEqual(unsortedList, new ListElementComparer()));
+        }
+
+        [Fact]
+        public void SortableBindingList_does_not_sort_for_byte_arrays()
+        {
+            var list = new List<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var unsortedList = new List<ListElement> { 3, 1, 4, 1, 5, 9 };
+            var bindingList = new SortableBindingList<ListElement>(list);
+
+            ((IBindingList)bindingList).ApplySort(ListElement.Property("ByteArray"), ListSortDirection.Descending);
+
+            Assert.True(list.SequenceEqual(unsortedList, new ListElementComparer()));
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_when_list_contains_derived_objects()
+        {
+            var list = new List<ListElement>
+            {
+                new DerivedListElement(3),
+                new DerivedListElement(1),
+                new DerivedListElement(4)
+            };
+            var sortedList = new List<ListElement>
+            {
+                new DerivedListElement(1),
+                new DerivedListElement(3),
+                new DerivedListElement(4)
+            };
+
+            var bindingList = new SortableBindingList<ListElement>(list);
+
+            ((IBindingList)bindingList).ApplySort(ListElement.Property("Int"), ListSortDirection.Ascending);
+
+            Assert.True(list.SequenceEqual(sortedList, new ListElementComparer()));
+        }
+
+        [Fact]
+        public void SortableBindingList_can_sort_when_list_is_of_derived_type()
+        {
+            var list = new List<DerivedListElement>
+            {
+                new DerivedListElement(3),
+                new DerivedListElement(1),
+                new DerivedListElement(4)
+            };
+            var sortedList = new List<DerivedListElement>
+            {
+                new DerivedListElement(1),
+                new DerivedListElement(3),
+                new DerivedListElement(4)
+            };
+
+            var bindingList = new SortableBindingList<DerivedListElement>(list);
+
+            ((IBindingList)bindingList).ApplySort(ListElement.Property("Int"), ListSortDirection.Ascending);
+
+            Assert.True(list.SequenceEqual(sortedList, new ListElementComparer()));
+        }
+
+        private class ListElement
+        {
+            public ListElement()
+            {
+            }
+
+            public ListElement(int i)
+            {
+                Int = i;
+                NullableInt = i;
+                String = i.ToString();
+                Random = new Random();
+                ByteArray = new[] { (byte)i, (byte)i, (byte)i, (byte)i };
+            }
+
+            public static implicit operator ListElement(int i) => new ListElement(i);
+
+            public int Int { get; }
+            public int? NullableInt { get; set; }
+            public string String { get; set; }
+            public Random Random { get; set; }
+            public byte[] ByteArray { get; set; }
+
+            public static PropertyDescriptor Property(string name)
+                => TypeDescriptor.GetProperties(typeof(ListElement))[name];
+        }
+
+        private class DerivedListElement : ListElement
+        {
+            public DerivedListElement()
+            {
+            }
+
+            public DerivedListElement(int i)
+                : base(i)
+            {
+            }
+        }
+
+        private class ListElementComparer : IEqualityComparer<ListElement>
+        {
+            public bool Equals(ListElement x, ListElement y) => x.Int == y.Int;
+            public int GetHashCode(ListElement obj) => obj.Int;
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ObservableHashSetTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ObservableHashSetTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
@@ -483,6 +484,32 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             Assert.Equal(1, collectionChanged);
             Assert.Equal(new[] { "Brendan", "Nate" }, hashSet.OrderBy(i => i));
         }
+        
+#if NET451
+
+        [Fact]
+        public void The_BindingList_returned_from_ObservableHasSet_is_cached()
+        {
+            var ols = new ObservableHashSet<string>();
+            var bindingList = ols.ToBindingList();
+
+            Assert.Same(bindingList, ols.ToBindingList());
+        }
+
+        [Fact]
+        public void ToBindingList_returns_a_new_binding_list_each_time_when_called_on_non_DbLocalView_ObervableCollections()
+        {
+            var oc = new ObservableCollection<string>();
+
+            var bindingList = oc.ToBindingList();
+            Assert.NotNull(bindingList);
+
+            var bindingListAgain = oc.ToBindingList();
+            Assert.NotNull(bindingListAgain);
+            Assert.NotSame(bindingList, bindingListAgain);
+        }
+
+#endif
 
         private static void AssertCountChanging<T>(
             ObservableHashSet<T> hashSet,

--- a/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
         public virtual void Services_wire_up_correctly()
         {
             // Listeners
-            VerifyScoped<IEntityStateListener>(isExistingReplaced: true);
+            VerifyScoped<IEntityStateListener>(2, isExistingReplaced: true);
             VerifyScoped<INavigationListener>(isExistingReplaced: true);
             VerifyScoped<IKeyListener>(isExistingReplaced: true);
             VerifyScoped<IPropertyListener>(isExistingReplaced: true);
@@ -138,10 +138,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
             return VerifyService<TService>(isExistingReplaced, isSingleton: true, isRequired: true);
         }
 
-        protected TService VerifyScoped<TService>(bool isExistingReplaced = false)
+        protected TService VerifyScoped<TService>(int count = 1, bool isExistingReplaced = false)
             where TService : class
         {
-            return VerifyService<TService>(isExistingReplaced, isSingleton: false, isRequired: true);
+            return VerifyService<TService>(isExistingReplaced, isSingleton: false, isRequired: true, count: count);
         }
 
         protected TService VerifyOptionalSingleton<TService>()
@@ -159,7 +159,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
         private TService VerifyService<TService>(
             bool isExistingReplaced,
             bool isSingleton,
-            bool isRequired)
+            bool isRequired,
+            int count = 1)
             where TService : class
         {
             var provider = ((IInfrastructure<IServiceProvider>)_firstContext).Instance;
@@ -177,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 Assert.Same(service, otherScopeService);
             }
-            Assert.Equal(1, ((IInfrastructure<IServiceProvider>)_firstContext).Instance.GetServices<TService>().Count());
+            Assert.Equal(count, ((IInfrastructure<IServiceProvider>)_firstContext).Instance.GetServices<TService>().Count());
 
             if (typeof(TService) != typeof(IDbContextServices))
             {
@@ -189,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     if (isExistingReplaced)
                     {
                         Assert.NotSame(service, serviceProviderWithCustomService.GetService<TService>());
-                        Assert.Equal(2, serviceProviderWithCustomService.GetServices<TService>().Count());
+                        Assert.Equal(count + 1, serviceProviderWithCustomService.GetServices<TService>().Count());
                     }
                     else
                     {

--- a/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Microsoft.EntityFrameworkCore.Tests.csproj
@@ -71,8 +71,12 @@
     <Compile Include="ChangeTracking\Internal\InternalShadowEntityEntryTest.cs" />
     <Compile Include="ChangeTracking\Internal\KeyPropagatorTest.cs" />
     <Compile Include="ChangeTracking\Internal\NavigationFixerTest.cs" />
+    <Compile Include="ChangeTracking\Internal\ObservableBackedBindingListTest.cs" />
+    <Compile Include="ChangeTracking\Internal\ObservableCollectionListSourceTest.cs" />
+    <Compile Include="ChangeTracking\Internal\ObservableHashSetListSourceTest.cs" />
     <Compile Include="ChangeTracking\Internal\QueryFixupTest.cs" />
     <Compile Include="ChangeTracking\Internal\ShadowFkFixupTest.cs" />
+    <Compile Include="ChangeTracking\Internal\SortableBindingListTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateDataTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateManagerTest.cs" />
     <Compile Include="ChangeTracking\MemberEntryTest.cs" />


### PR DESCRIPTION
Issue #3915

Much of the implementation is the same as for EF6 and most of the tests have been ported directly. Key differences are:
- Calling .Local does not automatically call DetectChanges.
- .Local now returns a custom observable collection type rather than a type derived from ObservableCollection.

Both of these changes were driven by reported perf issues associated with the EF6 .Local. For the first point, DetectChanges can always be slow, and almost always .Local will return the same data regardless of whether DetectChanges is called.

For the second point, creating a new List containing a copy of all the tracked entities could be both slow and use a lot of memory. Also, the use of a list would mean inserts and removes from the list, which could be common, was slow. Therefore, the new type provides a view over the already tracked data without duplicating it.