### PR TITLE
Fix to #5613 - Query :: optional navigations null-ref protection logic doesn't work for some cases involving multiple optional navs and method calls

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -981,6 +982,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return newOperand != explicitCast.Operand
                     ? new ExplicitCastExpression(newOperand, explicitCast.Type)
                     : expression;
+            }
+
+            var nullConditional = expression as NullConditionalExpression;
+            if (nullConditional != null)
+            {
+                return Visit(nullConditional.AccessOperation);
             }
 
             return base.VisitExtension(expression);

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Metadata\Internal\AnnotatableExtensions.cs" />
     <Compile Include="Metadata\Internal\DebugView.cs" />
     <Compile Include="Metadata\PropertyAccessMode.cs" />
+    <Compile Include="Query\Expressions\Internal\NullConditionalExpression.cs" />
     <Compile Include="Storage\DatabaseProvider.cs" />
     <Compile Include="WarningBehavior.cs" />
     <Compile Include="Internal\WarningsConfiguration.cs" />
@@ -549,6 +550,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.EntityFrameworkCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Logic in this file is based on https://github.com/bartdesmet/ExpressionFutures/
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    /// <summary>
+    ///     Expression representing null-conditional access.
+    /// </summary>
+    public class NullConditionalExpression : Expression
+    {
+        private Type _type;
+
+        /// <summary>
+        ///     Creates a new instance of NullConditionalExpression.
+        /// </summary>
+        /// <param name="nullableCaller"> Expression representing potentially nullable caller that needs to be tested for it's nullability. </param>
+        /// <param name="caller"> Expression representig actual caller for the access operation. </param>
+        /// <param name="accessOperation"> Expression representing access operation. </param>
+        public NullConditionalExpression(
+            [NotNull] Expression nullableCaller,
+            [NotNull] Expression caller,
+            [NotNull] Expression accessOperation)
+        {
+            Check.NotNull(nullableCaller, nameof(nullableCaller));
+            Check.NotNull(caller, nameof(caller));
+            Check.NotNull(accessOperation, nameof(accessOperation));
+
+            NullableCaller = nullableCaller;
+            Caller = caller;
+            AccessOperation = accessOperation;
+
+            _type = AccessOperation.Type.IsNullableType() ? AccessOperation.Type : AccessOperation.Type.MakeNullable();
+        }
+
+        /// <summary>
+        ///     Expression representing potentially nullable caller that needs to be tested for it's nullability.
+        /// </summary>
+        public virtual Expression NullableCaller { get; [param: NotNull] private set; }
+
+        /// <summary>
+        ///     Expression representig actual caller for the access operation.
+        /// </summary>
+        public virtual Expression Caller { get; [param: NotNull] private set; }
+
+        /// <summary>
+        ///     Expression representing access operation.
+        /// </summary>
+        public virtual Expression AccessOperation { get; [param: NotNull] private set; }
+
+        /// <summary>
+        ///     Indicates that the node can be reduced to a simpler node. If this returns true,
+        ///     Reduce() can be called to produce the reduced form. 
+        /// </summary>
+        public override bool CanReduce => true;
+
+        /// <summary>
+        ///     Gets the static type of the expression that this expression represents.
+        /// </summary>
+        public override Type Type => _type;
+
+        /// <summary>
+        ///     Gets the node type of this expression.
+        /// </summary>
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     Reduces this node to a simpler expression. If CanReduce returns true, this should
+        ///     return a valid expression. This method can return another node which itself must
+        ///     be reduced.
+        /// </summary>
+        public override Expression Reduce()
+        {
+            var nullableCallerType = NullableCaller.Type;
+            var nullableCaller = Parameter(nullableCallerType, "__caller");
+            var result = Parameter(_type, "__result");
+
+            var caller = Caller.Type != nullableCaller.Type
+                ? (Expression)Convert(nullableCaller, Caller.Type)
+                : nullableCaller;
+
+            var operation = new CallerReplacingExpressionVisitor(Caller, caller).Visit(AccessOperation);
+            if (operation.Type != _type)
+            {
+                operation = Convert(operation, _type);
+            }
+
+            var resultExpression =
+                Block(
+                    new[] { nullableCaller, result },
+                    Assign(nullableCaller, NullableCaller),
+                    Assign(result, Default(_type)),
+                    IfThen(
+                        NotEqual(nullableCaller, Default(nullableCallerType)),
+                        Assign(result, operation)),
+                    result
+                );
+
+            return resultExpression;
+        }
+
+        private class CallerReplacingExpressionVisitor : ExpressionVisitorBase
+        {
+            private readonly Expression _originalCaller;
+            private readonly Expression _newCaller;
+
+            public CallerReplacingExpressionVisitor(Expression originalCaller, Expression newCaller)
+            {
+                _originalCaller = originalCaller;
+                _newCaller = newCaller;
+            }
+
+            public override Expression Visit([CanBeNull] Expression node) => node == _originalCaller ? _newCaller : base.Visit(node);
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
@@ -254,19 +254,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     variableName = "var" + _parametersInScope.Count;
                     _parametersInScope.Add(variable, variableName);
                 }
-
-                _stringBuilder.Append("var " + variableName);
             }
 
-            if (node.Variables.Count > 0)
-            {
-                _stringBuilder.AppendLine();
-            }
+            var expressions = node.Result != null
+                ? node.Expressions.Except(new[] { node.Result })
+                : node.Expressions;
 
-            foreach (var expression in node.Expressions)
+            foreach (var expression in expressions)
             {
                 Visit(expression);
                 _stringBuilder.AppendLine();
+            }
+
+            if (node.Result != null)
+            {
+                _stringBuilder.AppendLine("return " + node.Result);
             }
 
             _stringBuilder.DecrementIndent();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -292,18 +292,6 @@ WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e1
                 Sql);
         }
 
-        public override void Nested_null_ref_protection_translates_properly()
-        {
-            base.Nested_null_ref_protection_translates_properly();
-
-            Assert.Equal(
-                @"SELECT [e2].[Id], [e2].[Date], [e2].[Level1_Optional_Id], [e2].[Level1_Required_Id], [e2].[Name], [e2].[OneToMany_Optional_InverseId], [e2].[OneToMany_Optional_Self_InverseId], [e2].[OneToMany_Required_InverseId], [e2].[OneToMany_Required_Self_InverseId], [e2].[OneToOne_Optional_PK_InverseId], [e2].[OneToOne_Optional_SelfId]
-FROM [Level2] AS [e2]
-INNER JOIN [Level1] AS [e2.OneToOne_Required_FK_Inverse] ON [e2].[Level1_Required_Id] = [e2.OneToOne_Required_FK_Inverse].[Id]
-WHERE [e2.OneToOne_Required_FK_Inverse].[Name] LIKE N'L' + N'%'",
-                Sql);
-        }
-
         public override void Optional_navigation_inside_method_call_translated_to_join()
         {
             base.Optional_navigation_inside_method_call_translated_to_join();
@@ -316,9 +304,33 @@ ORDER BY [e1].[Id]",
                 Sql);
         }
 
+        public override void Optional_navigation_inside_property_method_translated_to_join()
+        {
+            base.Optional_navigation_inside_property_method_translated_to_join();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId], [e1.OneToOne_Optional_FK].[Id], [e1.OneToOne_Optional_FK].[Date], [e1.OneToOne_Optional_FK].[Level1_Optional_Id], [e1.OneToOne_Optional_FK].[Level1_Required_Id], [e1.OneToOne_Optional_FK].[Name], [e1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e1]
+LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [e1].[Id]",
+                Sql);
+        }
+
         public override void Optional_navigation_inside_nested_method_call_translated_to_join()
         {
             base.Optional_navigation_inside_nested_method_call_translated_to_join();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId], [e1.OneToOne_Optional_FK].[Id], [e1.OneToOne_Optional_FK].[Date], [e1.OneToOne_Optional_FK].[Level1_Optional_Id], [e1.OneToOne_Optional_FK].[Level1_Required_Id], [e1.OneToOne_Optional_FK].[Name], [e1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e1]
+LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [e1].[Id]",
+                Sql);
+        }
+
+        public override void Method_call_on_optional_navigation_translates_to_null_conditional_properly_for_arguments()
+        {
+            base.Method_call_on_optional_navigation_translates_to_null_conditional_properly_for_arguments();
 
             Assert.Equal(
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId], [e1.OneToOne_Optional_FK].[Id], [e1.OneToOne_Optional_FK].[Date], [e1.OneToOne_Optional_FK].[Level1_Optional_Id], [e1.OneToOne_Optional_FK].[Level1_Required_Id], [e1.OneToOne_Optional_FK].[Name], [e1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]


### PR DESCRIPTION
Problem was that we were providing null protection in case of optional navigation access, but that did not include further calling methods on top of them.
If the navigation was null, the member access would return null and we would try to call a method on it, which results in NRE.

Fix is to introduce a new reducible expression that represents conditional access to a method or a member. In memory this gets rewritten to a Block expression that recursively evaluates it's caller, assigns it to a variable and depending on the value, either returns null or performs the required access operation. This is superior to using Conditional expression that we did before, because the caller only gets evaluated once, rather than N times.

Also fixes related issue #6261 - DateTime converted to Nullable<DateTime> inside optional navigation property, throws exception on AddDays.