### PR TITLE
RowNumberPaging works when joining the same entities twice

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -533,7 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
                             return (ce != null
                                     && columnExpression != null
-                                    && (ce.Property == columnExpression.Property || ce.Name == columnExpression.Name)
+                                    && ce.Name == columnExpression.Name
                                     && ce.TableAlias == columnExpression.TableAlias)
                                 || ae?.Expression == expression;
                         });
@@ -599,7 +599,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                             var ce = e.TryGetColumnExpression();
 
                             return ce != null
-                                && ce.Property == columnExpression.Property
                                 && ce.Name == columnExpression.Name
                                 && ce.TableAlias == columnExpression.TableAlias;
                         });

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -250,6 +250,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Join_Customers_Orders_Orders_Skip_Take_Same_Properties()
+        {
+            AssertQuery<Customer, Order>((cs, os) => (
+                from o in os
+                join ca in cs on o.CustomerID equals ca.CustomerID
+                join cb in cs on o.CustomerID equals cb.CustomerID
+                orderby o.OrderID
+                select new
+                {
+                    o.OrderID,
+                    CustomerIDA = ca.CustomerID,
+                    CustomerIDB = cb.CustomerID,
+                    ContactNameA = ca.ContactName,
+                    ContactNameB = cb.ContactName,
+                }).Skip(10).Take(5));
+        }
+
+        [ConditionalFact]
         public virtual void Distinct_Skip_Take()
         {
             AssertQuery<Customer>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1357,6 +1357,25 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
 
         [ConditionalFact]
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Join_Customers_Orders_Orders_Skip_Take_Same_Properties()
+        {
+            base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties();
+
+            Assert.Equal(
+                @"@__p_0: 10
+@__p_1: 5
+
+SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID], [ca].[ContactName], [cb].[ContactName]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
+INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
+ORDER BY [o].[OrderID]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
+                Sql);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Take_Skip()
         {
             base.Take_Skip();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -111,6 +111,25 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
                 Sql);
         }
 
+        public override void Join_Customers_Orders_Orders_Skip_Take_Same_Properties()
+        {
+            base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties();
+
+            Assert.Equal(
+                @"@__p_0: 10
+@__p_1: 5
+
+SELECT [t].[OrderID], [t].[CustomerID], [t].[c0] AS [c0], [t].[ContactName], [t].[c1] AS [c1]
+FROM (
+    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [c0], [ca].[ContactName], [cb].[ContactName] AS [c1], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    FROM [Orders] AS [o]
+    INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
+    INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
+) AS [t]
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))",
+                Sql);
+        }
+
         public override void Take_Skip()
         {
             base.Take_Skip();


### PR DESCRIPTION
_sorry, I have to resend this PR because my original PR can't be reopened as I force-updated my original branch_

RowNumberPaging works when joining the same entities twice.

Sometimes we need to join the same table multiple times. For instance, a Product table may have entered user and update user and both of them need to join User table.

Take Northwind database as an example, I didn't find out a proper relationship that can join the same table twice, so I use Order entity and join Customer entity twice:

```csharp 
AssertQuery<Customer, Order>((cs, os) => (
                from o in os
                join ca in cs on o.CustomerID equals ca.CustomerID
                join cb in cs on o.CustomerID equals cb.CustomerID
                orderby o.OrderID
                select new
                {
                    o.OrderID,
                    CustomerIDA = ca.CustomerID,
                    CustomerIDB = cb.CustomerID,
                    ContactNameA = ca.ContactName,
                    ContactNameB = cb.ContactName,
                }).Skip(10).Take(5));
```

This test works in InMemory database, SQL Server that supports offset keyword, but not SQL Server RowNumberPaging. My PR make it work too when using RowNumberPaging.

Basically, for the test above, RowNumberPaging generates the following incorrect SQL statement:

```sql
SELECT [t].[OrderID], [t].[CustomerID], [t].[ContactName]
FROM (
    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [c0], [ca].[ContactName], [cb].[ContactName] AS [c1], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
    FROM [Orders] AS [o]
    INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
    INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
) AS [t]
WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
```

my PR will generate correct SQL statement:

```sql
SELECT [t].[OrderID], [t].[CustomerID], [t].[c0] AS [c0], [t].[ContactName], [t].[c1] AS [c1]
FROM (
    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [c0], [ca].[ContactName], [cb].[ContactName] AS [c1], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
    FROM [Orders] AS [o]
    INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
    INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
) AS [t]
WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
```

We found out this bug during our production development, so if this bug is confirmed, I hope this fix could be included in 1.0.1. Otherwise, it would affect our development work a lot.

Thanks.