### PR TITLE
[1.0.1] Remove trailing whitespace from a resource name

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Properties/DesignCoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Properties/DesignCoreStrings.Designer.cs
@@ -381,9 +381,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         /// Could not serialize {obj} [{name}]
         /// </summary>
-        public static string CouldNotSerialize ([CanBeNull] object obj, [CanBeNull] object name)
+        public static string CouldNotSerialize([CanBeNull] object obj, [CanBeNull] object name)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CouldNotSerialize ", "obj", "name"), obj, name);
+            return string.Format(CultureInfo.CurrentCulture, GetString("CouldNotSerialize", "obj", "name"), obj, name);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.EntityFrameworkCore.Design.Core/Properties/DesignCoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Design.Core/Properties/DesignCoreStrings.resx
@@ -255,7 +255,7 @@ Change your target project to the migrations project by using the Package Manage
   <data name="InvokeStartupMethodFailed" xml:space="preserve">
     <value>An error occurred while calling method '{method}' on startup class '{startupClass}'. Consider using IDbContextFactory to override the initialization of the DbContext at design-time. Error: {error}</value>
   </data>
-  <data name="CouldNotSerialize " xml:space="preserve">
+  <data name="CouldNotSerialize" xml:space="preserve">
     <value>Could not serialize {obj} [{name}]</value>
   </data>
 </root>


### PR DESCRIPTION
This was introduced in 0bae43dd1e5f46271cba354f002d62f42f1b6dff when fixing #5765

@Eilon @divega 
