### PR TITLE
Support opting out of wrapping database operations in a transaction during SaveChanges()

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/RelationalTestStore.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/RelationalTestStore.cs
@@ -10,5 +10,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public abstract DbConnection Connection { get; }
         public abstract DbTransaction Transaction { get; }
         public abstract string ConnectionString { get; }
+        public virtual void OpenConnection() => Connection.Open();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TransactionFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TransactionFixtureBase.cs
@@ -15,6 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         public abstract DbContext CreateContext(DbConnection connection);
 
+        protected virtual string DatabaseName => "TransactionTest";
+
         public virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<TransactionCustomer>(ps =>
@@ -22,18 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     ps.Property(c => c.Id).ValueGeneratedNever();
                     ps.ToTable("Customers");
                 });
-        }
-
-        protected void Seed(DbContext context)
-        {
-            context.Database.EnsureCreated();
-
-            foreach (var customer in Customers)
-            {
-                context.Add(customer);
-            }
-
-            context.SaveChanges();
         }
 
         public readonly IReadOnlyList<TransactionCustomer> Customers = new List<TransactionCustomer>

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -18,11 +19,65 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         where TFixture : TransactionFixtureBase<TTestStore>, new()
     {
         [Fact]
-        public virtual void SaveChanges_implicitly_starts_transaction()
+        public virtual void SaveChanges_can_be_used_with_no_transaction()
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
-                context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                context.Database.AutoTransactionsEnabled = false;
+
+                context.Add(new TransactionCustomer { Id = 77, Name = "Bobble" });
+                context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    new List<int> { 1, 2, 77 }, 
+                    context.Set<TransactionCustomer>().OrderBy(c => c.Id).Select(e => e.Id).ToList());
+            }
+        }
+
+        [Fact]
+        public virtual async Task SaveChangesAsync_can_be_used_with_no_transaction()
+        {
+            EnsureInitialState();
+
+            using (var context = CreateContext())
+            {
+                context.Database.AutoTransactionsEnabled = false;
+
+                context.Add(new TransactionCustomer { Id = 77, Name = "Bobble" });
+                context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
+
+                try
+                {
+                    await context.SaveChangesAsync();
+                }
+                catch (DbUpdateException)
+                {
+                }
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    new List<int> { 1, 2, 77 },
+                    context.Set<TransactionCustomer>().OrderBy(c => c.Id).Select(e => e.Id).ToList());
+            }
+        }
+
+        [Fact]
+        public virtual void SaveChanges_implicitly_starts_transaction()
+        {
+            EnsureInitialState();
+
+            using (var context = CreateContext())
+            {
+                context.Add(new TransactionCustomer { Id = 77, Name = "Bobble" });
                 context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                 Assert.Throws<DbUpdateException>(() => context.SaveChanges());
@@ -34,9 +89,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [Fact]
         public virtual async Task SaveChangesAsync_implicitly_starts_transaction()
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
-                context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                context.Add(new TransactionCustomer { Id = 77, Name = "Bobble" });
                 context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                 try
@@ -51,11 +108,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual void SaveChanges_uses_explicit_transaction_without_committing()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void SaveChanges_uses_explicit_transaction_without_committing(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
                 firstEntry.State = EntityState.Deleted;
 
@@ -70,11 +133,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual void SaveChanges_false_uses_explicit_transaction_without_committing_or_accepting_changes()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void SaveChanges_false_uses_explicit_transaction_without_committing_or_accepting_changes(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
                 firstEntry.State = EntityState.Deleted;
 
@@ -93,11 +162,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual async Task SaveChangesAsync_uses_explicit_transaction_without_committing()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task SaveChangesAsync_uses_explicit_transaction_without_committing(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
                 firstEntry.State = EntityState.Deleted;
 
@@ -112,11 +187,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual async Task SaveChangesAsync_false_uses_explicit_transaction_without_committing_or_accepting_changes()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task SaveChangesAsync_false_uses_explicit_transaction_without_committing_or_accepting_changes(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
                 firstEntry.State = EntityState.Deleted;
 
@@ -135,11 +216,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual void SaveChanges_uses_explicit_transaction_and_does_not_rollback_on_failure()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void SaveChanges_uses_explicit_transaction_and_does_not_rollback_on_failure(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = context.Database.BeginTransaction())
                 {
                     var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
@@ -162,11 +249,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task SaveChangesAsync_uses_explicit_transaction_and_does_not_rollback_on_failure()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task SaveChangesAsync_uses_explicit_transaction_and_does_not_rollback_on_failure(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = await context.Database.BeginTransactionAsync())
                 {
                     var firstEntry = context.Entry(context.Set<TransactionCustomer>().First());
@@ -189,11 +282,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task RelationalTransaction_can_be_commited()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task RelationalTransaction_can_be_commited(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = await context.Database.BeginTransactionAsync())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -208,11 +307,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task RelationalTransaction_can_be_commited_from_context()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task RelationalTransaction_can_be_commited_from_context(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (await context.Database.BeginTransactionAsync())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -227,11 +332,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task RelationalTransaction_can_be_rolled_back()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task RelationalTransaction_can_be_rolled_back(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = await context.Database.BeginTransactionAsync())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -243,11 +354,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task RelationalTransaction_can_be_rolled_back_from_context()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task RelationalTransaction_can_be_rolled_back_from_context(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (await context.Database.BeginTransactionAsync())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -259,11 +376,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual void Query_uses_explicit_transaction()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void Query_uses_explicit_transaction(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = context.Database.BeginTransaction())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -271,6 +394,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                     using (var innerContext = CreateContext())
                     {
+                        innerContext.Database.AutoTransactionsEnabled = autoTransaction;
+
                         if (DirtyReadsOccur)
                         {
                             using (innerContext.Database.BeginTransaction(IsolationLevel.ReadUncommitted))
@@ -290,6 +415,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
+                        innerContext.Database.AutoTransactionsEnabled = autoTransaction;
+
                         innerContext.Database.UseTransaction(transaction.GetDbTransaction());
                         Assert.Equal(Fixture.Customers.Count - 1, innerContext.Set<TransactionCustomer>().Count());
                     }
@@ -297,11 +424,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task QueryAsync_uses_explicit_transaction()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task QueryAsync_uses_explicit_transaction(bool autoTransaction)
         {
+            EnsureInitialState();
+
             using (var context = CreateContext())
             {
+                context.Database.AutoTransactionsEnabled = autoTransaction;
+
                 using (var transaction = await context.Database.BeginTransactionAsync())
                 {
                     context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
@@ -309,6 +442,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                     using (var innerContext = CreateContext())
                     {
+                        innerContext.Database.AutoTransactionsEnabled = autoTransaction;
+
                         if (DirtyReadsOccur)
                         {
                             using (await innerContext.Database.BeginTransactionAsync(IsolationLevel.ReadUncommitted))
@@ -328,6 +463,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
+                        innerContext.Database.AutoTransactionsEnabled = autoTransaction;
+
                         innerContext.Database.UseTransaction(transaction.GetDbTransaction());
                         Assert.Equal(Fixture.Customers.Count - 1, await innerContext.Set<TransactionCustomer>().CountAsync());
                     }
@@ -335,67 +472,139 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [Fact]
-        public virtual async Task Can_use_open_connection_with_started_transaction()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Can_use_open_connection_with_started_transaction(bool autoTransaction)
         {
-            using (var transaction = TestDatabase.Connection.BeginTransaction())
-            {
-                using (var context = CreateContext(TestDatabase.Connection))
-                {
-                    context.Database.UseTransaction(transaction);
+            EnsureInitialState();
 
-                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
-                    await context.SaveChangesAsync();
+            try
+            {
+                TestDatabase.OpenConnection();
+
+                using (var transaction = TestDatabase.Connection.BeginTransaction())
+                {
+                    using (var context = CreateContext(TestDatabase.Connection))
+                    {
+                        context.Database.AutoTransactionsEnabled = autoTransaction;
+
+                        context.Database.UseTransaction(transaction);
+
+                        context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                        await context.SaveChangesAsync();
+                    }
                 }
+            }
+            finally
+            {
+                TestDatabase.Connection.Close();
             }
 
             AssertStoreInitialState();
         }
 
-        [Fact]
-        public virtual void UseTransaction_throws_if_mismatched_connection()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void UseTransaction_throws_if_mismatched_connection(bool autoTransaction)
         {
-            using (var transaction = TestDatabase.Connection.BeginTransaction())
-            {
-                using (var context = CreateContext())
-                {
-                    var ex = Assert.Throws<InvalidOperationException>(() =>
-                        context.Database.UseTransaction(transaction));
-                    Assert.Equal(RelationalStrings.TransactionAssociatedWithDifferentConnection, ex.Message);
-                }
-            }
-        }
+            EnsureInitialState();
 
-        [Fact]
-        public virtual void UseTransaction_throws_if_another_transaction_started()
-        {
-            using (var transaction = TestDatabase.Connection.BeginTransaction())
+            try
             {
-                using (var context = CreateContext())
+                TestDatabase.OpenConnection();
+
+                using (var transaction = TestDatabase.Connection.BeginTransaction())
                 {
-                    using (context.Database.BeginTransaction())
+                    using (var context = CreateContext())
                     {
+                        context.Database.AutoTransactionsEnabled = autoTransaction;
+
                         var ex = Assert.Throws<InvalidOperationException>(() =>
                             context.Database.UseTransaction(transaction));
-                        Assert.Equal(RelationalStrings.TransactionAlreadyStarted, ex.Message);
+                        Assert.Equal(RelationalStrings.TransactionAssociatedWithDifferentConnection, ex.Message);
                     }
                 }
             }
+            finally
+            {
+                TestDatabase.Connection.Close();
+            }
         }
 
-        [Fact]
-        public virtual void UseTransaction_will_not_dispose_external_transaction()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void UseTransaction_throws_if_another_transaction_started(bool autoTransaction)
         {
-            using (var transaction = TestDatabase.Connection.BeginTransaction())
+            EnsureInitialState();
+
+            try
             {
-                using (var context = CreateContext(TestDatabase.Connection))
+                TestDatabase.OpenConnection();
+
+                using (var transaction = TestDatabase.Connection.BeginTransaction())
                 {
-                    context.Database.UseTransaction(transaction);
+                    using (var context = CreateContext())
+                    {
+                        context.Database.AutoTransactionsEnabled = autoTransaction;
 
-                    context.Database.GetService<IRelationalConnection>().Dispose();
-
-                    Assert.NotNull(transaction.Connection);
+                        using (context.Database.BeginTransaction())
+                        {
+                            var ex = Assert.Throws<InvalidOperationException>(() =>
+                                context.Database.UseTransaction(transaction));
+                            Assert.Equal(RelationalStrings.TransactionAlreadyStarted, ex.Message);
+                        }
+                    }
                 }
+            }
+            finally
+            {
+                TestDatabase.Connection.Close();
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual void UseTransaction_will_not_dispose_external_transaction(bool autoTransaction)
+        {
+            EnsureInitialState();
+
+            try
+            {
+                TestDatabase.OpenConnection();
+
+                using (var transaction = TestDatabase.Connection.BeginTransaction())
+                {
+                    using (var context = CreateContext(TestDatabase.Connection))
+                    {
+                        context.Database.AutoTransactionsEnabled = autoTransaction;
+
+                        context.Database.UseTransaction(transaction);
+
+                        context.Database.GetService<IRelationalConnection>().Dispose();
+
+                        Assert.NotNull(transaction.Connection);
+                    }
+                }
+            }
+            finally
+            {
+                TestDatabase.Connection.Close();
+            }
+        }
+
+        protected virtual void EnsureInitialState()
+        {
+            using (var context = CreateContext())
+            {
+                context.RemoveRange(context.Set<TransactionCustomer>().ToList());
+                context.SaveChanges();
+
+                context.AddRange(Fixture.Customers);
+                context.SaveChanges();
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore
         private IDbSetInitializer _setInitializer;
         private IEntityFinderSource _entityFinderSource;
         private ChangeTracker _changeTracker;
+        private DatabaseFacade _database;
         private IStateManager _stateManager;
         private IChangeDetector _changeDetector;
         private IEntityGraphAttacher _graphAttacher;
@@ -897,7 +898,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Provides access to database related information and operations for this context.
         /// </summary>
-        public virtual DatabaseFacade Database => new DatabaseFacade(this);
+        public virtual DatabaseFacade Database => _database ?? (_database = new DatabaseFacade(this));
 
         /// <summary>
         ///     Provides access to information and operations for entity instances this context is tracking.

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/DatabaseFacade.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/DatabaseFacade.cs
@@ -155,6 +155,23 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <summary>
         ///     <para>
+        ///         Gets or sets a value indicating whether or not a transaction will be created
+        ///         automatically by <see cref="DbContext.SaveChanges()" /> if none of the
+        ///         'BeginTransaction' or 'UseTransaction' methods have been called.
+        ///     </para>
+        ///     <para>
+        ///         The default value is true, meaning that SaveChanges will always use a transaction
+        ///         when saving changes.
+        ///     </para>
+        ///     <para>
+        ///         Setting this value to false should only be done with caution since the database
+        ///         could be left in a corrupted state if SaveChanges fails.
+        ///     </para>
+        /// </summary>
+        public virtual bool AutoTransactionsEnabled { get; set; } = true;
+
+        /// <summary>
+        ///     <para>
         ///         Gets the scoped <see cref="IServiceProvider" /> being used to resolve services.
         ///     </para>
         ///     <para>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/BatchExecutorTest.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
@@ -29,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
 
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var batchExecutor = new BatchExecutor();
+            var batchExecutor = new BatchExecutor(new CurrentDbContext(new DbContext(new DbContextOptionsBuilder().Options)));
 
             await batchExecutor.ExecuteAsync(new[] { mockModificationCommandBatch.Object }, mockRelationalConnection.Object, cancellationToken);
 
@@ -54,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
 
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var batchExecutor = new BatchExecutor();
+            var batchExecutor = new BatchExecutor(new CurrentDbContext(new DbContext(new DbContextOptionsBuilder().Options)));
 
             await batchExecutor.ExecuteAsync(new[] { mockModificationCommandBatch.Object }, mockRelationalConnection.Object, cancellationToken);
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
@@ -23,36 +23,45 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         public override SqlServerTestStore CreateTestStore()
         {
-            var db = SqlServerTestStore.CreateScratch();
-
-            using (var command = db.Connection.CreateCommand())
+            return SqlServerTestStore.GetOrCreateShared(DatabaseName, false, () =>
             {
-                command.CommandText = "ALTER DATABASE [" + db.Connection.Database + "] SET ALLOW_SNAPSHOT_ISOLATION ON";
-                command.ExecuteNonQuery();
-            }
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), b => b.MaxBatchSize(1))
+                    .UseInternalServiceProvider(_serviceProvider);
 
-            using (var command = db.Connection.CreateCommand())
-            {
-                command.CommandText = "ALTER DATABASE [" + db.Connection.Database + "] SET READ_COMMITTED_SNAPSHOT ON";
-                command.ExecuteNonQuery();
-            }
+                using (var context = new DbContext(optionsBuilder.Options))
+                {
+                    context.Database.EnsureClean();
 
-            using (var context = CreateContext(db))
-            {
-                Seed(context);
-            }
+                    var connection = context.Database.GetDbConnection();
 
-            return db;
+                    connection.Open();
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = "ALTER DATABASE [" + connection.Database + "] SET ALLOW_SNAPSHOT_ISOLATION ON";
+                        command.ExecuteNonQuery();
+                    }
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = "ALTER DATABASE [" + connection.Database + "] SET READ_COMMITTED_SNAPSHOT ON";
+                        command.ExecuteNonQuery();
+                    }
+
+                    connection.Close();
+                }
+            });
         }
 
         public override DbContext CreateContext(SqlServerTestStore testStore)
             => new DbContext(new DbContextOptionsBuilder()
-                .UseSqlServer(testStore.ConnectionString)
+                .UseSqlServer(testStore.ConnectionString, b => b.MaxBatchSize(1))
                 .UseInternalServiceProvider(_serviceProvider).Options);
 
         public override DbContext CreateContext(DbConnection connection)
             => new DbContext(new DbContextOptionsBuilder()
-                .UseSqlServer(connection)
+                .UseSqlServer(connection, b => b.MaxBatchSize(1))
                 .UseInternalServiceProvider(_serviceProvider).Options);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/TransactionSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/TransactionSqliteFixture.cs
@@ -22,14 +22,17 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
         public override SqliteTestStore CreateTestStore()
         {
-            var db = SqliteTestStore.CreateScratch(sharedCache: true);
-
-            using (var context = CreateContext(db))
+            return SqliteTestStore.GetOrCreateShared(DatabaseName, false, true, () =>
             {
-                Seed(context);
-            }
+                var optionsBuilder = new DbContextOptionsBuilder()
+                    .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))
+                    .UseInternalServiceProvider(_serviceProvider);
 
-            return db;
+                using (var context = new DbContext(optionsBuilder.Options))
+                {
+                    context.Database.EnsureClean();
+                }
+            });
         }
 
         public override DbContext CreateContext(SqliteTestStore testStore)


### PR DESCRIPTION
Issue #6339

```C#
context.Database.AutoTransactionsEnabled = false;
```

Doesn't affect anything done with UseTransaction or BeginTransaction--only prevents EF from creating a transaction automatically.

Also some perf improvements for running the transaction tests--previously when running on my machine they would take about 70 seconds. Now they take about 3. But note that most of this is masked when running many tests in parallel.