### PR TITLE
Query: Fix issue in projections with multiple query sources involved …

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -5932,10 +5932,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 var query = context.Customers.OrderBy(c => c.CustomerID)
-                    .Select(c => new { c.CustomerID, Value = c.CustomerID == "ALFKI" & c.CustomerID == "ANATR" | c.CustomerID == "ANTON"}).ToList();
+                    .Select(c => new { c.CustomerID, Value = c.CustomerID == "ALFKI" & c.CustomerID == "ANATR" | c.CustomerID == "ANTON" }).ToList();
 
                 Assert.All(query.Where(c => c.CustomerID != "ANTON"), t => Assert.Equal(false, t.Value));
             }
+        }
+
+        [ConditionalFact]
+        public virtual void Handle_materialization_properly_when_more_than_two_query_sources_are_involved()
+        {
+            AssertQuery<Customer, Order, Employee>((cs, os, es) =>
+                      (from c in cs
+                       from o in os
+                       from e in es
+                       select new { c }).FirstOrDefault());
         }
 
         protected NorthwindContext CreateContext()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5917,6 +5917,18 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
+        public override void Handle_materialization_properly_when_more_than_two_query_sources_are_involved()
+        {
+            base.Handle_materialization_properly_when_more_than_two_query_sources_are_involved();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+CROSS JOIN [Employees] AS [e]",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Resolves #6390 
Issue: While translating cross join to server eval, we were removing projections added for client eval but we did that by clearing out all projections. Which works fine in case there are only 2 query sources, (while translating 2nd we need to clear first one). But if there are more than 2 from clauses then it removes required projections too.
Fix: Keep track of existing projections and remove only projections added for client eval join.