### PR TITLE
[SMALL] Fix to #5812 - 'must be reducible node' when aggregating over a join

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3368,5 +3368,33 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
             }
         }
+
+        [ConditionalFact]
+        public virtual void SelectMany_where_with_subquery()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne.Include(l1 => l1.OneToMany_Required).ThenInclude(l2 => l2.OneToMany_Required)
+                    .ToList()
+                    .SelectMany(l1 => l1.OneToMany_Required).Where(l2 => l2.OneToMany_Required.Any())
+                    .Select(l2 => l2.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToMany_Required).Where(l2 => l2.OneToMany_Required.Any());
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]?.Name));
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -862,6 +862,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 return base.VisitQuerySourceReference(expression);
             }
+
+            protected override Expression VisitSubQuery(SubQueryExpression expression)
+            {
+                expression.QueryModel.TransformExpressions(Visit);
+
+                return expression;
+            }
         }
 
         private JoinClause BuildJoinFromNavigation(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1838,6 +1838,21 @@ ORDER BY [l1].[Id]",
                 Sql);
         }
 
+        public override void SelectMany_where_with_subquery()
+        {
+            base.SelectMany_where_with_subquery();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToMany_Required].[Id], [l1.OneToMany_Required].[Date], [l1.OneToMany_Required].[Level1_Optional_Id], [l1.OneToMany_Required].[Level1_Required_Id], [l1.OneToMany_Required].[Name], [l1.OneToMany_Required].[OneToMany_Optional_InverseId], [l1.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Required].[OneToMany_Required_InverseId], [l1.OneToMany_Required].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToMany_Required] ON [l1].[Id] = [l1.OneToMany_Required].[OneToMany_Required_InverseId]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level3] AS [l]
+    WHERE [l1.OneToMany_Required].[Id] = [l].[OneToMany_Required_InverseId])",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Problem was that when we do SelectMany, we should later re-map all subsequent references to the original query source, to point to the new query source (added during SelectMany nav rewrite). However we were not doing that for query sources inside a subquery. This caused incorrect query sources to be embedded in the query, which could not be translated and hence the 'must be reducible node' exception was thrown.

Fix is to also replace query sources inside a subquery.