### PR TITLE
Fix #6091 - Left Outer Join Results Difference Between EF Core 1.0 an…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             SelectExpression selectExpression;
             return QueriesBySource.TryGetValue(querySource, out selectExpression)
                 ? selectExpression
-                : QueriesBySource.Values.SingleOrDefault(se => se.HandlesQuerySource(querySource));
+                : QueriesBySource.Values.LastOrDefault(se => se.HandlesQuerySource(querySource));
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4818,6 +4818,51 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 from o in orders
                 select new { c, o });
         }
+        
+        [ConditionalFact]
+        public virtual void GroupJoin_outer_projection()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                cs.GroupJoin(os, c => c.CustomerID, o => o.CustomerID, (c, o) => new { c.City, o }),
+                asserter: (l2oResults, efResults) => { Assert.Equal(l2oResults.Count, efResults.Count); });
+        }
+        
+        [ConditionalFact]
+        public virtual void GroupJoin_outer_projection2()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                cs.GroupJoin(os, c => c.CustomerID, o => o.CustomerID, (c, g) => new { c.City, g = g.Select(o => o.CustomerID) }),
+                asserter: (l2oResults, efResults) => { Assert.Equal(l2oResults.Count, efResults.Count); });
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_outer_projection_reverse()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                os.GroupJoin(cs, o => o.CustomerID, c => c.CustomerID, (o, c) => new { o.CustomerID, c }),
+                asserter: (l2oResults, efResults) => { Assert.Equal(l2oResults.Count, efResults.Count); });
+        }
+        
+        [ConditionalFact]
+        public virtual void GroupJoin_outer_projection_reverse2()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                os.GroupJoin(cs, o => o.CustomerID, c => c.CustomerID, (o, g) => new { o.CustomerID, g = g.Select(c => c.City) }),
+                asserter: (l2oResults, efResults) => { Assert.Equal(l2oResults.Count, efResults.Count); });
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_subquery_projection_outer_mixed()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                from o0 in os.Take(1)
+                join o1 in os on c.CustomerID equals o1.CustomerID into orders
+                from o2 in orders
+                select new { A = c.CustomerID, B = o0.CustomerID, C = o2.CustomerID },
+                asserter:
+                    (l2oResults, efResults) => { Assert.Equal(l2oResults.Count, efResults.Count); });
+        }
 
         [ConditionalFact]
         public virtual void GroupJoin_DefaultIfEmpty()


### PR DESCRIPTION
…d EF 6.x

Turns out that we have fixed this indirectly (albeit inefficiently) via e514b497355440c8c834fd166eea468d55dc64bb and 5953d96f1bfcdd529f958de6bfb2305f09e34e08.

This PR contains tests for #6091 and a small bug fix uncovered by one of the new tests.

I have prototyped an efficient solution that uses ROW_NUMBER for group delineation. Created #6441 to
track the improvement.