### PR TITLE
Add support for AttachDBFilename

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/Operations/SqlServerCreateDatabaseOperation.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/Operations/SqlServerCreateDatabaseOperation.cs
@@ -8,5 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
     public class SqlServerCreateDatabaseOperation : MigrationOperation
     {
         public virtual string Name { get; [param: NotNull] set; }
+
+        public virtual string FileName { get; [param: CanBeNull] set; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerConnection.cs
@@ -50,10 +50,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ISqlServerConnection CreateMasterConnection()
-            => new SqlServerConnection(new DbContextOptionsBuilder()
-                .UseSqlServer(
-                    new SqlConnectionStringBuilder { ConnectionString = ConnectionString, InitialCatalog = "master" }.ConnectionString,
-                    b => b.CommandTimeout(CommandTimeout ?? DefaultMasterConnectionCommandTimeout)).Options, Logger);
+        {
+            var builder = new SqlConnectionStringBuilder(ConnectionString) { InitialCatalog = "master" };
+            builder.Remove("AttachDBFilename");
+
+            return new SqlServerConnection(new DbContextOptionsBuilder()
+                .UseSqlServer(builder.ConnectionString, b => b.CommandTimeout(CommandTimeout ?? DefaultMasterConnectionCommandTimeout)).Options, Logger);
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,18 +19,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task Exists_returns_false_when_database_doesnt_exist()
         {
-            await Exists_returns_false_when_database_doesnt_exist_test(async: false);
+            await Exists_returns_false_when_database_doesnt_exist_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task Exists_returns_false_when_database_with_filename_doesnt_exist()
+        {
+            await Exists_returns_false_when_database_doesnt_exist_test(async: false, file: true);
         }
 
         [Fact]
         public async Task ExistsAsync_returns_false_when_database_doesnt_exist()
         {
-            await Exists_returns_false_when_database_doesnt_exist_test(async: true);
+            await Exists_returns_false_when_database_doesnt_exist_test(async: true, file: false);
         }
 
-        private static async Task Exists_returns_false_when_database_doesnt_exist_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task ExistsAsync_returns_false_when_database_with_filename_doesnt_exist()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            await Exists_returns_false_when_database_doesnt_exist_test(async: true, file: true);
+        }
+
+        private static async Task Exists_returns_false_when_database_doesnt_exist_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false, useFileName: file))
             {
                 using (var context = new BloggingContext(testDatabase))
                 {
@@ -45,18 +60,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task Exists_returns_true_when_database_exists()
         {
-            await Exists_returns_true_when_database_exists_test(async: false);
+            await Exists_returns_true_when_database_exists_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task Exists_returns_true_when_database_with_filename_exists()
+        {
+            await Exists_returns_true_when_database_exists_test(async: false, file: true);
         }
 
         [Fact]
         public async Task ExistsAsync_returns_true_when_database_exists()
         {
-            await Exists_returns_true_when_database_exists_test(async: true);
+            await Exists_returns_true_when_database_exists_test(async: true, file: false);
         }
 
-        private static async Task Exists_returns_true_when_database_exists_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task ExistsAsync_returns_true_when_database_with_filename_exists()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: true))
+            await Exists_returns_true_when_database_exists_test(async: true, file: true);
+        }
+
+        private static async Task Exists_returns_true_when_database_exists_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: true, useFileName: file))
             {
                 using (var context = new BloggingContext(testDatabase))
                 {
@@ -72,32 +101,60 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsureDeleted_will_delete_database()
         {
-            await EnsureDeleted_will_delete_database_test(async: false, openConnection: false);
+            await EnsureDeleted_will_delete_database_test(async: false, open: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureDeleted_will_delete_database_with_filename()
+        {
+            await EnsureDeleted_will_delete_database_test(async: false, open: false, file: true);
         }
 
         [Fact]
         public async Task EnsureDeletedAsync_will_delete_database()
         {
-            await EnsureDeleted_will_delete_database_test(async: true, openConnection: false);
+            await EnsureDeleted_will_delete_database_test(async: true, open: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureDeletedAsync_will_delete_database_with_filename()
+        {
+            await EnsureDeleted_will_delete_database_test(async: true, open: false, file: true);
         }
 
         [Fact]
         public async Task EnsureDeleted_will_delete_database_with_opened_connections()
         {
-            await EnsureDeleted_will_delete_database_test(async: false, openConnection: true);
+            await EnsureDeleted_will_delete_database_test(async: false, open: true, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureDeleted_will_delete_database_with_filename_with_opened_connections()
+        {
+            await EnsureDeleted_will_delete_database_test(async: false, open: true, file: true);
         }
 
         [Fact]
         public async Task EnsureDeletedAsync_will_delete_database_with_opened_connections()
         {
-            await EnsureDeleted_will_delete_database_test(async: true, openConnection: true);
+            await EnsureDeleted_will_delete_database_test(async: true, open: true, file: false);
         }
 
-        private static async Task EnsureDeleted_will_delete_database_test(bool async, bool openConnection)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureDeletedAsync_will_delete_database_with_filename_with_opened_connections()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: true))
+            await EnsureDeleted_will_delete_database_test(async: true, open: true, file: true);
+        }
+
+        private static async Task EnsureDeleted_will_delete_database_test(bool async, bool open, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: true, useFileName: file))
             {
-                if (!openConnection)
+                if (!open)
                 {
                     testDatabase.Connection.Close();
                 }
@@ -129,18 +186,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsuredDeleted_noop_when_database_doesnt_exist()
         {
-            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: false);
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsuredDeleted_noop_when_database_with_filename_doesnt_exist()
+        {
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: false, file: true);
         }
 
         [Fact]
         public async Task EnsuredDeletedAsync_noop_when_database_doesnt_exist()
         {
-            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: true);
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: true, file: false);
         }
 
-        private static async Task EnsuredDeleted_noop_when_database_doesnt_exist_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsuredDeletedAsync_noop_when_database_with_filename_doesnt_exist()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: true, file: true);
+        }
+
+        private static async Task EnsuredDeleted_noop_when_database_doesnt_exist_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false, useFileName: file))
             {
                 using (var context = new BloggingContext(testDatabase))
                 {
@@ -169,18 +240,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsureCreated_can_create_schema_in_existing_database()
         {
-            await EnsureCreated_can_create_schema_in_existing_database_test(async: false);
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureCreated_can_create_schema_in_existing_database_with_filename()
+        {
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: false, file: true);
         }
 
         [Fact]
         public async Task EnsureCreatedAsync_can_create_schema_in_existing_database()
         {
-            await EnsureCreated_can_create_schema_in_existing_database_test(async: true);
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: true, file: false);
         }
 
-        private static async Task EnsureCreated_can_create_schema_in_existing_database_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureCreatedAsync_can_create_schema_in_existing_database_with_filename()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync())
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: true, file: true);
+        }
+
+        private static async Task EnsureCreated_can_create_schema_in_existing_database_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(useFileName: file))
             {
                 await RunDatabaseCreationTest(testDatabase, async);
             }
@@ -189,18 +274,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsureCreated_can_create_physical_database_and_schema()
         {
-            await EnsureCreated_can_create_physical_database_and_schema_test(async: false);
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureCreated_can_create_physical_database_with_filename_and_schema()
+        {
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: false, file: true);
         }
 
         [Fact]
         public async Task EnsureCreatedAsync_can_create_physical_database_and_schema()
         {
-            await EnsureCreated_can_create_physical_database_and_schema_test(async: true);
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: true, file: false);
         }
 
-        private static async Task EnsureCreated_can_create_physical_database_and_schema_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsureCreatedAsync_can_create_physical_database_with_filename_and_schema()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: true, file: true);
+        }
+
+        private static async Task EnsureCreated_can_create_physical_database_and_schema_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false, useFileName: file))
             {
                 await RunDatabaseCreationTest(testDatabase, async);
             }
@@ -264,18 +363,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsuredCreated_is_noop_when_database_exists_and_has_schema()
         {
-            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: false);
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: false, file: false);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsuredCreated_is_noop_when_database_with_filename_exists_and_has_schema()
+        {
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: false, file: true);
         }
 
         [Fact]
         public async Task EnsuredCreatedAsync_is_noop_when_database_exists_and_has_schema()
         {
-            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: true);
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: true, file: false);
         }
 
-        private static async Task EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(bool async)
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.IsSqlLocalDb)]
+        public async Task EnsuredCreatedAsync_is_noop_when_database_with_filename_exists_and_has_schema()
         {
-            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: true, file: true);
+        }
+
+        private static async Task EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(bool async, bool file)
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false, useFileName: file))
             {
                 using (var context = new BloggingContext(testDatabase))
                 {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerConditionAttribute.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerConditionAttribute.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                 }
                 if (Conditions.HasFlag(SqlServerCondition.SupportsMemoryOptimized))
                 {
-                    isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsMemoryOptimized)) ?? true;
+                    isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsMemoryOptimized)) ?? false;
                 }
                 if (Conditions.HasFlag(SqlServerCondition.IsSqlAzure))
                 {
@@ -43,6 +43,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                 if (Conditions.HasFlag(SqlServerCondition.IsNotSqlAzure))
                 {
                     isMet &= !TestEnvironment.DefaultConnection.Contains("database.windows.net");
+                }
+                if (Conditions.HasFlag(SqlServerCondition.IsSqlLocalDb))
+                {
+                    isMet &= TestEnvironment.DefaultConnection.IndexOf("(localdb)", StringComparison.OrdinalIgnoreCase) != -1;
                 }
                 return isMet;
             }
@@ -64,6 +68,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
         SupportsOffset = 1 << 1,
         IsSqlAzure = 1 << 2,
         IsNotSqlAzure = 1 << 3,
-        SupportsMemoryOptimized = 1 << 4
+        SupportsMemoryOptimized = 1 << 4,
+        IsSqlLocalDb = 1 << 5
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -34,24 +34,40 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
         ///     A non-transactional, transient, isolated test database. Use this in the case
         ///     where transactions are not appropriate.
         /// </summary>
-        public static Task<SqlServerTestStore> CreateScratchAsync(bool createDatabase = true)
-            => new SqlServerTestStore(GetScratchDbName()).CreateTransientAsync(createDatabase);
+        public static Task<SqlServerTestStore> CreateScratchAsync(bool createDatabase = true, bool useFileName = false)
+            => new SqlServerTestStore(GetScratchDbName(), useFileName).CreateTransientAsync(createDatabase);
 
-        public static SqlServerTestStore CreateScratch(bool createDatabase = true)
-            => new SqlServerTestStore(GetScratchDbName()).CreateTransient(createDatabase);
+        public static SqlServerTestStore CreateScratch(bool createDatabase = true, bool useFileName = false)
+            => new SqlServerTestStore(GetScratchDbName(), useFileName).CreateTransient(createDatabase);
 
         private SqlConnection _connection;
         private SqlTransaction _transaction;
         private readonly string _name;
+        private readonly string _fileName;
         private string _connectionString;
         private bool _deleteDatabase;
 
         public override string ConnectionString => _connectionString;
 
         // Use async static factory method
-        private SqlServerTestStore(string name)
+        private SqlServerTestStore(string name, bool useFileName = false)
         {
             _name = name;
+
+            if (useFileName)
+            {
+                #if NET451
+
+                var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+                #else
+
+                var baseDirectory = AppContext.BaseDirectory;
+
+                #endif
+
+                _fileName = Path.Combine(baseDirectory, name + ".mdf");
+            }
         }
 
         private static string GetScratchDbName()
@@ -71,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
         {
             CreateShared(typeof(SqlServerTestStore).Name + _name, initializeDatabase);
 
-            _connectionString = CreateConnectionString(_name);
+            _connectionString = CreateConnectionString(_name, _fileName);
             _connection = new SqlConnection(_connectionString);
 
             if (useTransaction)
@@ -185,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                 catch (SqlException e)
                 {
                     if (++retryCount >= 30
-                        || (e.Number != 233 && e.Number != -2 && e.Number != 4060))
+                        || (e.Number != 233 && e.Number != -2 && e.Number != 4060 && e.Number != 1832 && e.Number != 5120))
                     {
                         throw;
                     }
@@ -213,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                 catch (SqlException e)
                 {
                     if (++retryCount >= 30
-                        || (e.Number != 233 && e.Number != -2 && e.Number != 4060))
+                        || (e.Number != 233 && e.Number != -2 && e.Number != 4060 && e.Number != 1832 && e.Number != 5120))
                     {
                         throw;
                     }
@@ -227,7 +243,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 
         private async Task<SqlServerTestStore> CreateTransientAsync(bool createDatabase)
         {
-            _connectionString = CreateConnectionString(_name);
+            _connectionString = CreateConnectionString(_name, _fileName);
             _connection = new SqlConnection(_connectionString);
 
             if (createDatabase)
@@ -239,6 +255,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                     {
                         command.CommandTimeout = CommandTimeout;
                         command.CommandText = $"{Environment.NewLine}CREATE DATABASE [{_name}]";
+
+                        if (!string.IsNullOrEmpty(_fileName))
+                        {
+                            var logFileName = Path.ChangeExtension(_fileName, ".ldf");
+
+                            command.CommandText += $" ON (NAME = '{_name}', FILENAME = '{_fileName}')";
+                            command.CommandText += $" LOG ON (NAME = '{_name}_log', FILENAME = '{logFileName}')";
+                        }
 
                         await command.ExecuteNonQueryAsync();
 
@@ -254,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 
         private SqlServerTestStore CreateTransient(bool createDatabase)
         {
-            _connectionString = CreateConnectionString(_name);
+            _connectionString = CreateConnectionString(_name, _fileName);
             _connection = new SqlConnection(_connectionString);
 
             if (createDatabase)
@@ -266,6 +290,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                     {
                         command.CommandTimeout = CommandTimeout;
                         command.CommandText = $"{Environment.NewLine}CREATE DATABASE [{_name}]";
+
+                        if (!string.IsNullOrEmpty(_fileName))
+                        {
+                            var logFileName = Path.ChangeExtension(_fileName, ".ldf");
+
+                            command.CommandText += $" ON (NAME = '{_name}', FILENAME = '{_fileName}')";
+                            command.CommandText += $" LOG ON (NAME = '{_name}_log', FILENAME = '{logFileName}')";
+                        }
 
                         command.ExecuteNonQuery();
 
@@ -429,13 +461,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
         }
 
         public static string CreateConnectionString(string name)
-            => CreateConnectionString(name, new Random().Next(0, 2) == 1);
+            => CreateConnectionString(name, null, new Random().Next(0, 2) == 1);
+
+        public static string CreateConnectionString(string name, string fileName)
+            => CreateConnectionString(name, fileName, new Random().Next(0, 2) == 1);
 
         private static string CreateConnectionString(string name, bool multipleActiveResultSets)
+            => CreateConnectionString(name, null, multipleActiveResultSets);
+
+        private static string CreateConnectionString(string name, string fileName, bool multipleActiveResultSets)
             => new SqlConnectionStringBuilder(TestEnvironment.DefaultConnection)
             {
                 MultipleActiveResultSets = multipleActiveResultSets,
-                InitialCatalog = name
+                AttachDBFilename = fileName ?? "",
+                InitialCatalog = name,
             }.ConnectionString;
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -34,6 +34,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
+        public void Master_connection_string_contains_filename()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\MSSQLLocalDB;Database=SqlServerConnectionTest;AttachDBFilename=C:\Narf.mdf");
+
+            using (var connection = new SqlServerConnection(optionsBuilder.Options, new Logger<SqlServerConnection>(new LoggerFactory())))
+            {
+                using (var master = connection.CreateMasterConnection())
+                {
+                    Assert.Equal(@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=master", master.ConnectionString);
+                }
+            }
+        }
+
+        [Fact]
         public void Master_connection_string_none_default_command_timeout()
         {
             var optionsBuilder = new DbContextOptionsBuilder();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -45,6 +45,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
+        public async Task Create_checks_for_existence_and_retries_if_cannot_attach_file_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(1832, async: false);
+        }
+
+        [Fact]
+        public async Task Create_checks_for_existence_and_retries_if_cannot_open_file_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(5120, async: false);
+        }
+
+        [Fact]
         public async Task CreateAsync_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(233, async: true);
@@ -60,6 +72,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         public async Task CreateAsync_checks_for_existence_and_retries_if_cannot_open_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(4060, async: true);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_retries_if_cannot_attach_file_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(1832, async: true);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_retries_if_cannot_open_file_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(5120, async: true);
         }
 
         private async Task Create_checks_for_existence_and_retries_until_it_passes(int errorNumber, bool async)


### PR DESCRIPTION
There isn't any handling for custom filenames within sql connection strings ('AttachDBFilename'), which leads to obscure error messages. Thus, we just add proper handling of filenames.

* AttachDBFilename gets a reset while building master connection strings
* Exists checks accept error 1832 **and 5120** too as a hint for a non existing database
* SqlServerCreateDatabaseOperation gets an additional FileName property

*NOTE:* I don't get the difference between "CreationTests" and "CreatorTests", so I just added my tests to the former ones (the other ones seem to test less related stuff).

~~*NOTE:* The changes broke a unit test, which I just changed accordingly. I'm not sure, if that's ok.~~

Fixes #2810