### PR TITLE
Increate .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+sudo: required
 dist: trusty
 os:
   - linux
@@ -16,8 +17,8 @@ addons:
     - zlib1g
 env:
   global:
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ mono:
   - 4.0.5
 os:
   - linux
-  - osx
+  # - osx CoreCLR tests time out too frequently on OSX to be useful.
 osx_image: xcode7.1
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: csharp
 sudo: required
 dist: trusty
-os:
-  - linux
-  # - osx CoreCLR does not support OS X 10.9 (yet)
-mono:
-  - beta
 addons:
   apt:
     packages:
@@ -19,12 +14,20 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+mono:
+  - 4.0.5
+os:
+  - linux
+  - osx
+osx_image: xcode7.1
 branches:
   only:
     - master
     - release
     - dev
     - /^(.*\/)?ci-.*$/
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - ./build.sh --quiet verify
 notifications:


### PR DESCRIPTION
- aspnet/Universe#349
- add `sudo: required` recommended for the Trusty image
- use same `env` syntax as in other repos

questions:
- why are OS X builds disabled for EF? most other repos use `osx_image: xcode7.1`
- why does EF use Mono "beta" instead of 4.0.5?