### PR TITLE
Remove assert for unknown migration ops

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -203,7 +203,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 }
                 else
                 {
-                    Debug.Assert(false, "Unexpected operation type: " + operation.GetType());
                     leftovers.Add(operation);
                 }
             }


### PR DESCRIPTION
The 1.0.1 MigrationsModelDiffer contains an assert which makes sure there are no unknown migration operations. This prevents providers (such as Npgsql) from adding their own custom migration operations and handling them in subclasses of MigrationsModelDiffer.