### PR TITLE
Introduce ITypeBase and related changes

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     stringBuilder.IncrementIndent();
                     foreach (var property in propertiesList)
                     {
-                        appendAction(stringBuilder, property.DeclaringEntityType.ClrType.Name + "." + property.Name + ", ");
+                        appendAction(stringBuilder, property.DeclaringType.ClrType.Name + "." + property.Name + ", ");
                     }
 
                     stringBuilder.DecrementIndent();

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1429,7 +1429,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var querySourceReference = new QuerySourceReferenceExpression(querySource);
             var propertyExpression = isMemberExpression
-                ? Expression.Property(querySourceReference, property.GetPropertyInfo())
+                ? Expression.Property(querySourceReference, property.PropertyInfo)
                 : CreatePropertyExpression(querySourceReference, property);
 
             if (propertyExpression.Type.GetTypeInfo().IsValueType)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
@@ -141,11 +141,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         p => targetPrincipalEntityType.FindProperty(p.Name)).ToList()),
                     targetPrincipalEntityType);
                 var clonedNavigation = navigation.IsDependentToPrincipal()
-                    ? (navigation.GetPropertyInfo() != null
-                        ? targetForeignKey.HasDependentToPrincipal(navigation.GetPropertyInfo())
+                    ? (navigation.PropertyInfo != null
+                        ? targetForeignKey.HasDependentToPrincipal(navigation.PropertyInfo)
                         : targetForeignKey.HasDependentToPrincipal(navigation.Name))
-                    : (navigation.GetPropertyInfo() != null
-                        ? targetForeignKey.HasPrincipalToDependent(navigation.GetPropertyInfo())
+                    : (navigation.PropertyInfo != null
+                        ? targetForeignKey.HasPrincipalToDependent(navigation.PropertyInfo)
                         : targetForeignKey.HasPrincipalToDependent(navigation.Name));
                 navigation.GetAnnotations().ForEach(annotation => clonedNavigation[annotation.Name] = annotation.Value);
             }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StoreGeneratedValues.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StoreGeneratedValues.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     && value == null)
                 {
                     throw new InvalidOperationException(
-                        CoreStrings.DatabaseGeneratedNull(propertyBase.Name, propertyBase.DeclaringEntityType.DisplayName()));
+                        CoreStrings.DatabaseGeneratedNull(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
                 }
 
                 _values[index] = value ?? _nullSentinel;

--- a/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -251,22 +251,5 @@ namespace Microsoft.EntityFrameworkCore
         public static ChangeTrackingStrategy GetChangeTrackingStrategy(
             [NotNull] this IEntityType entityType)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType().ChangeTrackingStrategy;
-
-        /// <summary>
-        ///     <para>
-        ///         Gets the <see cref="PropertyAccessMode" /> being used for properties of this entity type.
-        ///         Null indicates that the default property access mode is being used.
-        ///     </para>
-        ///     <para>
-        ///         Note that individual properties can override this access mode. The value returned here will
-        ///         be used for any property for which no override has been specified.
-        ///     </para>
-        /// </summary>
-        /// <param name="entityType"> The entity type for which to get the access mode. </param>
-        /// <returns> The access mode being used, or null if the default access mode is being used. </returns>
-        public static PropertyAccessMode? GetPropertyAccessMode(
-            [NotNull] this IEntityType entityType)
-            => (PropertyAccessMode?)Check.NotNull(entityType, nameof(entityType))[CoreAnnotationNames.PropertyAccessModeAnnotation]
-               ?? entityType.Model.GetPropertyAccessMode();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/PropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/PropertyBaseExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="propertyBase"> The property for which the backing field will be returned. </param>
         /// <returns> The name of the backing field, or null. </returns>
         public static string GetField([NotNull] this IPropertyBase propertyBase)
-            => propertyBase.GetFieldInfo()?.Name;
+            => propertyBase.FieldInfo?.Name;
 
         /// <summary>
         ///     <para>
@@ -33,6 +33,6 @@ namespace Microsoft.EntityFrameworkCore
         public static PropertyAccessMode? GetPropertyAccessMode(
             [NotNull] this IPropertyBase propertyBase)
             => (PropertyAccessMode?)Check.NotNull(propertyBase, nameof(propertyBase))[CoreAnnotationNames.PropertyAccessModeAnnotation]
-               ?? propertyBase.DeclaringEntityType.GetPropertyAccessMode();
+               ?? propertyBase.DeclaringType.GetPropertyAccessMode();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/TypeBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/TypeBaseExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Extension methods for <see cref="ITypeBase" />.
+    /// </summary>
+    public static class TypeBaseExtensions
+    {
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for properties of this type.
+        ///         Null indicates that the default property access mode is being used.
+        ///     </para>
+        ///     <para>
+        ///         Note that individual properties can override this access mode. The value returned here will
+        ///         be used for any property for which no override has been specified.
+        ///     </para>
+        /// </summary>
+        /// <param name="typeBase"> The type for which to get the access mode. </param>
+        /// <returns> The access mode being used, or null if the default access mode is being used. </returns>
+        public static PropertyAccessMode? GetPropertyAccessMode(
+            [NotNull] this ITypeBase typeBase)
+            => (PropertyAccessMode?)Check.NotNull(typeBase, nameof(typeBase))[CoreAnnotationNames.PropertyAccessModeAnnotation]
+               ?? typeBase.Model.GetPropertyAccessMode();
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             if (ConfigurationSource.Convention.Overrides(propertyBase.GetFieldInfoConfigurationSource()))
             {
-                foreach (var type in propertyBase.DeclaringEntityType.ClrType.GetTypesInHierarchy().ToList())
+                foreach (var type in propertyBase.DeclaringType.ClrType.GetTypesInHierarchy().ToList())
                 {
                     var fieldInfo = TryMatchFieldName(type, propertyBase.ClrType, propertyBase.Name);
                     if (fieldInfo != null)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IEntityType.cs
@@ -1,44 +1,20 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
-    ///     Represents an entity in an <see cref="IModel" />.
+    ///     Represents an entity type in an <see cref="IModel" />.
     /// </summary>
-    public interface IEntityType : IAnnotatable
+    public interface IEntityType : ITypeBase
     {
-        /// <summary>
-        ///     Gets the model this entity belongs to.
-        /// </summary>
-        IModel Model { get; }
-
-        /// <summary>
-        ///     Gets the name of the entity.
-        /// </summary>
-        string Name { get; }
-
         /// <summary>
         ///     Gets the base type of the entity. Returns null if this is not a derived type in an inheritance hierarchy.
         /// </summary>
         IEntityType BaseType { get; }
-
-        /// <summary>
-        ///     <para>
-        ///         Gets the CLR class that is used to represent instances of this entity. Returns null if the entity does not have a
-        ///         corresponding CLR class (known as a shadow entity).
-        ///     </para>
-        ///     <para>
-        ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
-        ///         Therefore, shadow entities will only exist in migration model snapshots, etc.
-        ///     </para>
-        /// </summary>
-        Type ClrType { get; }
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     ///         Once the model is built, <see cref="IEntityType" /> represents a ready-only view of the same metadata.
     ///     </para>
     /// </summary>
-    public interface IMutableEntityType : IEntityType, IMutableAnnotatable
+    public interface IMutableEntityType : IEntityType, IMutableTypeBase
     {
         /// <summary>
         ///     Gets the model this entity belongs to.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableProperty.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     ///         Once the model is built, <see cref="IProperty" /> represents a ready-only view of the same metadata.
     ///     </para>
     /// </summary>
-    public interface IMutableProperty : IProperty, IMutableAnnotatable
+    public interface IMutableProperty : IProperty, IMutablePropertyBase
     {
         /// <summary>
         ///     Gets the type that this property belongs to.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutablePropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutablePropertyBase.cs
@@ -5,23 +5,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
     ///     <para>
-    ///         Represents a navigation property which can be used to navigate a relationship.
+    ///         Base type for navigation and scalar properties.
     ///     </para>
     ///     <para>
     ///         This interface is used during model creation and allows the metadata to be modified.
-    ///         Once the model is built, <see cref="INavigation" /> represents a ready-only view of the same metadata.
+    ///         Once the model is built, <see cref="IMutablePropertyBase" /> represents a ready-only view of the same metadata.
     ///     </para>
     /// </summary>
-    public interface IMutableNavigation : INavigation, IMutablePropertyBase
+    public interface IMutablePropertyBase : IPropertyBase, IMutableAnnotatable
     {
         /// <summary>
         ///     Gets the type that this property belongs to.
         /// </summary>
-        new IMutableEntityType DeclaringEntityType { get; }
-
-        /// <summary>
-        ///     Gets the foreign key that defines the relationship this navigation property will navigate.
-        /// </summary>
-        new IMutableForeignKey ForeignKey { get; }
+        new IMutableTypeBase DeclaringType { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableTypeBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableTypeBase.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents a type in an <see cref="IMutableModel" />.
+    ///     </para>
+    ///     <para>
+    ///         This interface is used during model creation and allows the metadata to be modified.
+    ///         Once the model is built, <see cref="ITypeBase" /> represents a ready-only view of the same metadata.
+    ///     </para>
+    /// </summary>
+    public interface IMutableTypeBase : ITypeBase, IMutableAnnotatable
+    {
+        /// <summary>
+        ///     Gets the model that this type belongs to.
+        /// </summary>
+        new IMutableModel Model { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/INavigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/INavigation.cs
@@ -9,6 +9,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface INavigation : IPropertyBase
     {
         /// <summary>
+        ///     Gets the entity type that this property belongs to.
+        /// </summary>
+        IEntityType DeclaringEntityType { get; }
+
+        /// <summary>
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.
         /// </summary>
         IForeignKey ForeignKey { get; }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
@@ -13,9 +12,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IProperty : IPropertyBase
     {
         /// <summary>
-        ///     Gets the type of value that this property holds.
+        ///     Gets the entity type that this property belongs to.
         /// </summary>
-        Type ClrType { get; }
+        IEntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this property can contain null.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -18,6 +20,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the type that this property belongs to.
         /// </summary>
-        IEntityType DeclaringEntityType { get; }
+        ITypeBase DeclaringType { get; }
+
+        /// <summary>
+        ///     Gets the type of value that this property holds.
+        /// </summary>
+        Type ClrType { get; }
+
+        /// <summary>
+        ///     Gets the <see cref="PropertyInfo" /> for the underlying CLR property that this
+        ///     object represents. This may be null for shadow properties or properties mapped directly to fields.
+        /// </summary>
+        PropertyInfo PropertyInfo { get; }
+
+        /// <summary>
+        ///     Gets the <see cref="FieldInfo" /> for the underlying CLR field that this
+        ///     object represents. This may be null for shadow properties or if the backing field for the
+        ///     property is not known.
+        /// </summary>
+        FieldInfo FieldInfo { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/ITypeBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/ITypeBase.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     Represents a type in an <see cref="IModel" />.
+    /// </summary>
+    public interface ITypeBase : IAnnotatable
+    {
+        /// <summary>
+        ///     Gets the model that this type belongs to.
+        /// </summary>
+        IModel Model { get; }
+
+        /// <summary>
+        ///     Gets the name of this type.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the CLR class that is used to represent instances of this type. Returns null if the type does not have a
+        ///         corresponding CLR class (known as a shadow type).
+        ///     </para>
+        ///     <para>
+        ///         Shadow types are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
+        ///         Therefore, shadow types will only exist in migration model snapshots, etc.
+        ///     </para>
+        /// </summary>
+        Type ClrType { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrAccessorFactory.cs
@@ -36,9 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var boundMethod = propertyBase != null
                 ? _genericCreate.MakeGenericMethod(
-                    propertyBase.DeclaringEntityType.ClrType,
-                    propertyBase.GetClrType(),
-                    propertyBase.GetClrType().UnwrapNullableType())
+                    propertyBase.DeclaringType.ClrType,
+                    propertyBase.ClrType,
+                    propertyBase.ClrType.UnwrapNullableType())
                 : _genericCreate.MakeGenericMethod(
                     propertyInfo.DeclaringType,
                     propertyInfo.PropertyType,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return accessor;
             }
 
-            var property = navigation.GetPropertyInfo();
+            var property = navigation.PropertyInfo;
             var elementType = property.PropertyType.TryGetElementType(typeof(IEnumerable<>));
 
             // TODO: Only ICollections supported; add support for enumerables with add/remove methods

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 entityParameter,
                 valueParameter).Compile();
 
-            var propertyType = propertyBase?.GetClrType() ?? propertyInfo?.PropertyType;
+            var propertyType = propertyBase?.ClrType ?? propertyInfo?.PropertyType;
 
             return propertyType.IsNullableType()
                    && propertyType.UnwrapNullableType().GetTypeInfo().IsEnum

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (property != null)
             {
-                var entityType = property.DeclaringEntityType.DisplayName();
+                var entityType = property.DeclaringType.DisplayName();
                 var propertyName = property.Name;
 
                 message

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class EntityType : ConventionalAnnotatable, IMutableEntityType
+    public class EntityType : TypeBase, IMutableEntityType
     {
         private readonly SortedSet<ForeignKey> _foreignKeys
             = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance);
@@ -35,16 +35,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private readonly SortedDictionary<IReadOnlyList<IProperty>, Key> _keys
             = new SortedDictionary<IReadOnlyList<IProperty>, Key>(PropertyListComparer.Instance);
 
-        private readonly object _typeOrName;
         private Key _primaryKey;
         private EntityType _baseType;
 
         private ChangeTrackingStrategy? _changeTrackingStrategy;
 
-        private ConfigurationSource _configurationSource;
         private ConfigurationSource? _baseTypeConfigurationSource;
         private ConfigurationSource? _primaryKeyConfigurationSource;
-        private readonly Dictionary<string, ConfigurationSource> _ignoredMembers = new Dictionary<string, ConfigurationSource>();
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private PropertyCounts _counts;
@@ -58,12 +55,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public EntityType([NotNull] string name, [NotNull] Model model, ConfigurationSource configurationSource)
-            : this(model, configurationSource)
+            : base(name, model, configurationSource)
         {
-            Check.NotEmpty(name, nameof(name));
-            Check.NotNull(model, nameof(model));
-
-            _typeOrName = name;
+            _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
+            Builder = new InternalEntityTypeBuilder(this, model.Builder);
         }
 
         /// <summary>
@@ -71,18 +66,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public EntityType([NotNull] Type clrType, [NotNull] Model model, ConfigurationSource configurationSource)
-            : this(model, configurationSource)
+            : base(clrType, model, configurationSource)
         {
             Check.ValidEntityType(clrType, nameof(clrType));
-            Check.NotNull(model, nameof(model));
 
-            _typeOrName = clrType;
-        }
-
-        private EntityType([NotNull] Model model, ConfigurationSource configurationSource)
-        {
-            Model = model;
-            _configurationSource = configurationSource;
             _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
             Builder = new InternalEntityTypeBuilder(this, model.Builder);
         }
@@ -92,18 +79,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalEntityTypeBuilder Builder { [DebuggerStepThrough] get; [DebuggerStepThrough] [param: CanBeNull] set; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual Type ClrType => _typeOrName as Type;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual Model Model { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -271,36 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual string Name
-        {
-            get
-            {
-                if (ClrType != null)
-                {
-                    return ClrType.DisplayName() ?? (string)_typeOrName;
-                }
-                return (string)_typeOrName;
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public override string ToString() => this.ToDebugString();
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
-            => _configurationSource = _configurationSource.Max(configurationSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -1643,11 +1589,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void PropertyMetadataChanged()
+        public override void PropertyMetadataChanged()
         {
-            foreach (var indexedProperty in this.GetPropertiesAndNavigations().OfType<PropertyBase>())
+            foreach (var property in GetProperties())
             {
-                indexedProperty.PropertyIndexes = null;
+                property.PropertyIndexes = null;
+            }
+
+            foreach (var navigation in GetNavigations())
+            {
+                navigation.PropertyIndexes = null;
             }
 
             // This path should only kick in when the model is still mutable and therefore access does not need
@@ -1702,54 +1653,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Ignore([NotNull] string name, ConfigurationSource configurationSource = ConfigurationSource.Explicit,
-            bool runConventions = true)
-        {
-            Check.NotNull(name, nameof(name));
-
-            ConfigurationSource existingIgnoredConfigurationSource;
-            if (_ignoredMembers.TryGetValue(name, out existingIgnoredConfigurationSource))
-            {
-                configurationSource = configurationSource.Max(existingIgnoredConfigurationSource);
-            }
-
-            _ignoredMembers[name] = configurationSource;
-
-            if (runConventions)
-            {
-                Model.ConventionDispatcher.OnEntityTypeMemberIgnored(Builder, name);
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual IReadOnlyList<string> GetIgnoredMembers()
-            => _ignoredMembers.Keys.ToList();
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual ConfigurationSource? FindDeclaredIgnoredMemberConfigurationSource([NotNull] string name)
-        {
-            Check.NotEmpty(name, nameof(name));
-
-            ConfigurationSource ignoredConfigurationSource;
-            if (_ignoredMembers.TryGetValue(name, out ignoredConfigurationSource))
-            {
-                return ignoredConfigurationSource;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual ConfigurationSource? FindIgnoredMemberConfigurationSource([NotNull] string name)
+        public override ConfigurationSource? FindIgnoredMemberConfigurationSource(string name)
         {
             var ignoredSource = FindDeclaredIgnoredMemberConfigurationSource(name);
 
@@ -1757,22 +1661,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Unignore([NotNull] string name)
-        {
-            Check.NotNull(name, nameof(name));
-            _ignoredMembers.Remove(name);
-        }
+        public override void OnTypeMemberIgnored(string name)
+            => Model.ConventionDispatcher.OnEntityTypeMemberIgnored(Builder, name);
 
         #endregion
 
         #region Explicit interface implementations
 
-        IModel IEntityType.Model => Model;
+        IModel ITypeBase.Model => Model;
+        IMutableModel IMutableTypeBase.Model => Model;
         IMutableModel IMutableEntityType.Model => Model;
-        Type IEntityType.ClrType => ClrType;
         IEntityType IEntityType.BaseType => _baseType;
 
         IMutableEntityType IMutableEntityType.BaseType

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -27,15 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static string DisplayName([NotNull] this IEntityType entityType)
-            => entityType.ClrType != null
-                ? entityType.ClrType.ShortDisplayName()
-                : entityType.Name;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public static IEnumerable<IEntityType> GetAllBaseTypesInclusive([NotNull] this IEntityType entityType)
         {
             var baseTypes = new List<IEntityType>();
@@ -206,13 +197,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool HasClrType([NotNull] this IEntityType entityType)
-            => entityType.ClrType != null;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public static IEnumerable<IEntityType> GetConcreteTypesInHierarchy([NotNull] this IEntityType entityType)
             => entityType.GetDerivedTypesInclusive().Where(et => !et.IsAbstract());
 
@@ -230,13 +214,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static EntityType LeastDerivedType([NotNull] this EntityType entityType, [NotNull] EntityType otherEntityType)
             => (EntityType)((IEntityType)entityType).LeastDerivedType(otherEntityType);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static bool IsAbstract([NotNull] this IEntityType entityType)
-            => entityType.ClrType?.GetTypeInfo().IsAbstract ?? false;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            var ignoredConfigurationSource = Metadata.FindIgnoredEntityTypeConfigurationSource(name);
+            var ignoredConfigurationSource = Metadata.FindIgnoredTypeConfigurationSource(name);
             return ignoredConfigurationSource.HasValue
                    && ignoredConfigurationSource.Value.Overrides(configurationSource);
         }
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private bool Ignore([NotNull] string name, [CanBeNull] Type type, ConfigurationSource configurationSource)
         {
-            var ignoredConfigurationSource = Metadata.FindIgnoredEntityTypeConfigurationSource(name);
+            var ignoredConfigurationSource = Metadata.FindIgnoredTypeConfigurationSource(name);
             if (ignoredConfigurationSource.HasValue)
             {
                 if (configurationSource.Overrides(ignoredConfigurationSource)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
@@ -14,7 +14,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class Model : ConventionalAnnotatable, IMutableModel
@@ -25,11 +25,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private readonly IDictionary<Type, EntityType> _clrTypeMap
             = new Dictionary<Type, EntityType>();
 
-        private readonly Dictionary<string, ConfigurationSource> _ignoredEntityTypeNames
+        private readonly Dictionary<string, ConfigurationSource> _ignoredTypeNames
             = new Dictionary<string, ConfigurationSource>();
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public Model()
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public Model([NotNull] ConventionSet conventions)
@@ -49,32 +49,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ChangeTrackingStrategy ChangeTrackingStrategy { get; set; } 
+        public virtual ChangeTrackingStrategy ChangeTrackingStrategy { get; set; }
             = ChangeTrackingStrategy.Snapshot;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ConventionDispatcher ConventionDispatcher { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalModelBuilder Builder { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<EntityType> GetEntityTypes() => _entityTypes.Values;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType AddEntityType(
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType AddEntityType(
@@ -125,21 +125,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType GetOrAddEntityType([NotNull] Type type)
             => FindEntityType(type) ?? AddEntityType(type);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType GetOrAddEntityType([NotNull] string name)
             => FindEntityType(name) ?? AddEntityType(name);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType FindEntityType([NotNull] Type type)
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType FindEntityType([NotNull] string name)
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType RemoveEntityType([NotNull] Type type)
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType RemoveEntityType([NotNull] string name)
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Ignore([NotNull] Type type,
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => Ignore(Check.NotNull(type, nameof(type)).DisplayName(), type, configurationSource, runConventions);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Ignore([NotNull] string name,
@@ -249,13 +249,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool runConventions)
         {
             ConfigurationSource existingIgnoredConfigurationSource;
-            if (_ignoredEntityTypeNames.TryGetValue(name, out existingIgnoredConfigurationSource))
+            if (_ignoredTypeNames.TryGetValue(name, out existingIgnoredConfigurationSource))
             {
                 configurationSource = configurationSource.Max(existingIgnoredConfigurationSource);
                 runConventions = false;
             }
 
-            _ignoredEntityTypeNames[name] = configurationSource;
+            _ignoredTypeNames[name] = configurationSource;
 
             if (runConventions)
             {
@@ -264,35 +264,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ConfigurationSource? FindIgnoredEntityTypeConfigurationSource([NotNull] Type type)
+        public virtual ConfigurationSource? FindIgnoredTypeConfigurationSource([NotNull] Type type)
         {
             Check.NotNull(type, nameof(type));
 
-            return FindIgnoredEntityTypeConfigurationSource(type.DisplayName());
+            return FindIgnoredTypeConfigurationSource(type.DisplayName());
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ConfigurationSource? FindIgnoredEntityTypeConfigurationSource([NotNull] string name)
+        public virtual ConfigurationSource? FindIgnoredTypeConfigurationSource([NotNull] string name)
         {
             Check.NotEmpty(name, nameof(name));
 
             ConfigurationSource ignoredConfigurationSource;
-            if (_ignoredEntityTypeNames.TryGetValue(name, out ignoredConfigurationSource))
-            {
-                return ignoredConfigurationSource;
-            }
-
-            return null;
+            return _ignoredTypeNames.TryGetValue(name, out ignoredConfigurationSource)
+                ? (ConfigurationSource?)ignoredConfigurationSource
+                : null;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Unignore([NotNull] Type type)
@@ -302,17 +299,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void Unignore([NotNull] string name)
         {
             Check.NotNull(name, nameof(name));
-            _ignoredEntityTypeNames.Remove(name);
+            _ignoredTypeNames.Remove(name);
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalModelBuilder Validate() => ConventionDispatcher.OnModelBuilt(Builder);
@@ -327,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         IMutableEntityType IMutableModel.RemoveEntityType(string name) => RemoveEntityType(name);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual DebugView<Model> DebugView

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrCollectionAccessor _collectionAccessor;
+        private PropertyIndexes _indexes;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -59,10 +60,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override EntityType DeclaringEntityType
+        public virtual EntityType DeclaringEntityType
             => this.IsDependentToPrincipal()
                 ? ForeignKey.DeclaringEntityType
                 : ForeignKey.PrincipalEntityType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public new virtual EntityType DeclaringType => DeclaringEntityType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void PropertyMetadataChanged() => DeclaringType.PropertyMetadataChanged();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
@@ -176,6 +189,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual PropertyIndexes PropertyIndexes
+        {
+            get
+            {
+                return NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, this,
+                    property => property.DeclaringType.CalculateIndexes(property));
+            }
+
+            [param: CanBeNull]
+            set
+            {
+                if (value == null)
+                {
+                    // This path should only kick in when the model is still mutable and therefore access does not need
+                    // to be thread-safe.
+                    _indexes = null;
+                }
+                else
+                {
+                    NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, value);
+                }
+            }
+        }
+
+        /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
@@ -198,8 +239,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         IForeignKey INavigation.ForeignKey => ForeignKey;
         IMutableForeignKey IMutableNavigation.ForeignKey => ForeignKey;
-        IEntityType IPropertyBase.DeclaringEntityType => DeclaringEntityType;
+        IEntityType INavigation.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableNavigation.DeclaringEntityType => DeclaringEntityType;
+        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
+        IMutableTypeBase IMutablePropertyBase.DeclaringType => DeclaringType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/NavigationExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" (").Append(navigation.GetField()).Append(", ");
             }
 
-            builder.Append(navigation.GetClrType()?.ShortDisplayName()).Append(")");
+            builder.Append(navigation.ClrType?.ShortDisplayName()).Append(")");
 
             if (navigation.IsCollection())
             {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual PropertyAccessors Create([NotNull] IPropertyBase propertyBase)
             => (PropertyAccessors)_genericCreate
-                .MakeGenericMethod(propertyBase.GetClrType())
+                .MakeGenericMethod(propertyBase.ClrType)
                 .Invoke(null, new object[] { propertyBase });
 
         private static readonly MethodInfo _genericCreate
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private static Func<InternalEntityEntry, TProperty> CreateCurrentValueGetter<TProperty>(
             IPropertyBase propertyBase, bool useStoreGeneratedValues)
         {
-            var entityClrType = propertyBase.DeclaringEntityType.ClrType;
+            var entityClrType = propertyBase.DeclaringType.ClrType;
             var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
 
             var shadowIndex = (propertyBase as IProperty)?.GetShadowIndex() ?? -1;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public abstract class PropertyBase : ConventionalAnnotatable, IPropertyBase
+    public abstract class PropertyBase : ConventionalAnnotatable, IMutablePropertyBase
     {
         private FieldInfo _fieldInfo;
         private ConfigurationSource? _fieldInfoConfigurationSource;
@@ -23,7 +23,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private IClrPropertyGetter _getter;
         private IClrPropertySetter _setter;
         private PropertyAccessors _accessors;
-        private PropertyIndexes _indexes;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -49,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public abstract EntityType DeclaringEntityType { get; }
+        public virtual IMutableTypeBase DeclaringType => ((IMutablePropertyBase)this).DeclaringType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -79,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return;
             }
 
-            var typesInHierarchy = DeclaringEntityType.ClrType.GetTypesInHierarchy().ToList();
+            var typesInHierarchy = DeclaringType.ClrType.GetTypesInHierarchy().ToList();
 
             foreach (var type in typesInHierarchy)
             {
@@ -93,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             throw new InvalidOperationException(
-                CoreStrings.MissingBackingField(fieldName, Name, DeclaringEntityType.DisplayName()));
+                CoreStrings.MissingBackingField(fieldName, Name, DeclaringType.DisplayName()));
         }
 
         /// <summary>
@@ -104,15 +103,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource, bool runConventions = true)
         {
             if (fieldInfo != null
-                && !fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(this.GetClrType().GetTypeInfo()))
+                && !fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
             {
                 throw new InvalidOperationException(
                     CoreStrings.BadBackingFieldType(
                         fieldInfo.Name,
                         fieldInfo.FieldType.ShortDisplayName(),
-                        DeclaringEntityType.DisplayName(),
+                        DeclaringType.DisplayName(),
                         Name,
-                        this.GetClrType().ShortDisplayName()));
+                        ClrType.ShortDisplayName()));
             }
 
             UpdateFieldInfoConfigurationSource(configurationSource);
@@ -122,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var oldFieldInfo = FieldInfo;
                 _fieldInfo = fieldInfo;
 
-                DeclaringEntityType.PropertyMetadataChanged();
+                PropertyMetadataChanged();
 
                 if (runConventions)
                 {
@@ -130,6 +129,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected abstract void PropertyMetadataChanged();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -181,34 +186,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual PropertyAccessors Accessors
             => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, p => new PropertyAccessorsFactory().Create(p));
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual PropertyIndexes PropertyIndexes
-        {
-            get
-            {
-                return NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, this,
-                    property => property.DeclaringEntityType.CalculateIndexes(property));
-            }
-
-            [param: CanBeNull]
-            set
-            {
-                if (value == null)
-                {
-                    // This path should only kick in when the model is still mutable and therefore access does not need
-                    // to be thread-safe.
-                    _indexes = null;
-                }
-                else
-                {
-                    NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, value);
-                }
-            }
-        }
-
-        IEntityType IPropertyBase.DeclaringEntityType => DeclaringEntityType;
+        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBase.cs
@@ -1,0 +1,167 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class TypeBase : ConventionalAnnotatable, IMutableTypeBase
+    {
+        private readonly object _typeOrName;
+        private ConfigurationSource _configurationSource;
+        private readonly Dictionary<string, ConfigurationSource> _ignoredMembers = new Dictionary<string, ConfigurationSource>();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected TypeBase([NotNull] string name, [NotNull] Model model, ConfigurationSource configurationSource)
+            : this(model, configurationSource)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotNull(model, nameof(model));
+
+            _typeOrName = name;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected TypeBase([NotNull] Type clrType, [NotNull] Model model, ConfigurationSource configurationSource)
+            : this(model, configurationSource)
+        {
+            Check.ValidEntityType(clrType, nameof(clrType));
+            Check.NotNull(model, nameof(model));
+
+            _typeOrName = clrType;
+        }
+
+        private TypeBase([NotNull] Model model, ConfigurationSource configurationSource)
+        {
+            Model = model;
+            _configurationSource = configurationSource;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type ClrType => _typeOrName as Type;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Model Model { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Name
+            => ClrType != null ? ClrType.DisplayName() : (string)_typeOrName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+            => _configurationSource = _configurationSource.Max(configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract void PropertyMetadataChanged();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Ignore([NotNull] string name, ConfigurationSource configurationSource = ConfigurationSource.Explicit,
+            bool runConventions = true)
+        {
+            Check.NotNull(name, nameof(name));
+
+            ConfigurationSource existingIgnoredConfigurationSource;
+            if (_ignoredMembers.TryGetValue(name, out existingIgnoredConfigurationSource))
+            {
+                configurationSource = configurationSource.Max(existingIgnoredConfigurationSource);
+            }
+
+            _ignoredMembers[name] = configurationSource;
+
+            if (runConventions)
+            {
+                OnTypeMemberIgnored(name);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract void OnTypeMemberIgnored([NotNull] string name);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IReadOnlyList<string> GetIgnoredMembers()
+            => _ignoredMembers.Keys.ToList();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConfigurationSource? FindDeclaredIgnoredMemberConfigurationSource([NotNull] string name)
+        {
+            Check.NotEmpty(name, nameof(name));
+
+            ConfigurationSource ignoredConfigurationSource;
+            if (_ignoredMembers.TryGetValue(name, out ignoredConfigurationSource))
+            {
+                return ignoredConfigurationSource;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConfigurationSource? FindIgnoredMemberConfigurationSource([NotNull] string name)
+            => FindDeclaredIgnoredMemberConfigurationSource(name);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Unignore([NotNull] string name)
+        {
+            Check.NotNull(name, nameof(name));
+            _ignoredMembers.Remove(name);
+        }
+
+        IModel ITypeBase.Model => Model;
+        IMutableModel IMutableTypeBase.Model => Model;
+        Type ITypeBase.ClrType => ClrType;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class TypeBaseExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DisplayName([NotNull] this ITypeBase type)
+            => type.ClrType != null
+                ? type.ClrType.ShortDisplayName()
+                : type.Name;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool HasClrType([NotNull] this ITypeBase type)
+            => type.ClrType != null;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool IsAbstract([NotNull] this ITypeBase type)
+            => type.ClrType?.GetTypeInfo().IsAbstract ?? false;
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Extensions\ObservableCollectionExtensions.cs" />
     <Compile Include="Extensions\PropertyBaseExtensions.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />
+    <Compile Include="Extensions\TypeBaseExtensions.cs" />
     <Compile Include="Infrastructure\AccessorExtensions.cs" />
     <Compile Include="Infrastructure\Annotatable.cs" />
     <Compile Include="Infrastructure\AnnotatableExtensions.cs" />
@@ -255,8 +256,13 @@
     <Compile Include="Metadata\Conventions\Internal\IIndexRemovedConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IIndexUniquenessConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IPropertyFieldChangedConvention.cs" />
+    <Compile Include="Metadata\IMutablePropertyBase.cs" />
+    <Compile Include="Metadata\IMutableTypeBase.cs" />
     <Compile Include="Metadata\Internal\AnnotatableExtensions.cs" />
     <Compile Include="Metadata\Internal\DebugView.cs" />
+    <Compile Include="Metadata\Internal\TypeBase.cs" />
+    <Compile Include="Metadata\Internal\TypeBaseExtensions.cs" />
+    <Compile Include="Metadata\ITypeBase.cs" />
     <Compile Include="Metadata\PropertyAccessMode.cs" />
     <Compile Include="Query\Expressions\Internal\NullConditionalExpression.cs" />
     <Compile Include="Query\ResultOperators\Internal\StringIncludeExpressionNode.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -611,7 +611,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             try
             {
-                new TestModelValidator().Validate(propertyBase.DeclaringEntityType.Model);
+                new TestModelValidator().Validate(propertyBase.DeclaringType.Model);
                 Assert.Null(failMessage);
             }
             catch (InvalidOperationException ex)
@@ -687,20 +687,20 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public virtual void Properties_can_have_field_cleared(PropertyBase propertyBase, PropertyInfo propertyInfo, string fieldName)
         {
             Assert.Null(propertyBase.GetField());
-            Assert.Null(propertyBase.GetFieldInfo());
+            Assert.Null(propertyBase.FieldInfo);
             Assert.Same(propertyInfo, propertyBase.MemberInfo);
 
             propertyBase.SetField(fieldName, ConfigurationSource.Explicit);
 
             Assert.Equal(fieldName, propertyBase.GetField());
-            var fieldInfo = propertyBase.GetFieldInfo();
+            var fieldInfo = propertyBase.FieldInfo;
             Assert.Equal(fieldName, fieldInfo.Name);
             Assert.Same(propertyInfo ?? (MemberInfo)fieldInfo, propertyBase.MemberInfo);
 
             propertyBase.SetField(null, ConfigurationSource.Explicit);
 
             Assert.Null(propertyBase.GetField());
-            Assert.Null(propertyBase.GetFieldInfo());
+            Assert.Null(propertyBase.FieldInfo);
             Assert.Same(propertyInfo, propertyBase.MemberInfo);
 
             propertyBase.SetFieldInfo(fieldInfo, ConfigurationSource.Explicit);
@@ -711,7 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             propertyBase.SetFieldInfo(null, ConfigurationSource.Explicit);
 
             Assert.Null(propertyBase.GetField());
-            Assert.Null(propertyBase.GetFieldInfo());
+            Assert.Null(propertyBase.FieldInfo);
             Assert.Same(propertyInfo, propertyBase.MemberInfo);
         }
 


### PR DESCRIPTION
Issue #6542

This is a change that has come out of the design for complex types. The main change is that IPropertyBase now has DeclaringType rather than DeclaringEntityType. This makes it a suitable base interface for property definitions of complex types. This is a breaking change, but one that we think will have minimal impact, especially given that the two subtypes of IPropertyBase (IProperty and INavigation) now get DeclaringEntityType. Nonetheless, it seems prudent to do it in 1.1 even if complex types don't make it into 1.1. Also, there are other changes here in code that has not yet shipped, and hence it is good to make these changes before shipping.