### PR TITLE
Query: Bug 6478: Do not mutate original subquery model in SubqueryMemberPushDownExpressionVisitor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -6159,6 +6159,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Subquery_member_pushdown_does_not_change_original_subquery_model()
+        {
+            AssertQuery<Order, Customer>((os, cs) =>
+                 os.Select(o => new
+                 {
+                     OrderId = o.OrderID,
+                     City = cs.SingleOrDefault(c => c.CustomerID == o.CustomerID).City
+                 })
+                 .OrderBy(o => o.City)
+                 .Skip(0)
+                 .Take(10));
+        }
+
         protected NorthwindContext CreateContext()
         {
             return Fixture.CreateContext();

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
@@ -26,9 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (subSelector is QuerySourceReferenceExpression
                 || subSelector is SubQueryExpression)
             {
-                var subQueryModel = subQueryExpression.QueryModel;
+                var subQueryModel = subQueryExpression.QueryModel.Clone();
 
-                subQueryModel.SelectClause.Selector = VisitMember(memberExpression.Update(subSelector));
+                subQueryModel.SelectClause.Selector = VisitMember(memberExpression.Update(subQueryModel.SelectClause.Selector));
                 subQueryModel.ResultTypeOverride = subQueryModel.SelectClause.Selector.Type;
 
                 return new SubQueryExpression(subQueryModel);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3246,7 +3246,7 @@ LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
         }
-        
+
         public override void GroupJoin_DefaultIfEmpty_Project()
         {
             base.GroupJoin_DefaultIfEmpty_Project();
@@ -5983,7 +5983,7 @@ CROSS JOIN [Orders] AS [o]
 CROSS JOIN [Employees] AS [e]",
                 Sql);
         }
-        
+
         public override void Parameter_extraction_short_circuits_1()
         {
             base.Parameter_extraction_short_circuits_1();
@@ -6034,6 +6034,22 @@ WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(mon
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Subquery_member_pushdown_does_not_change_original_subquery_model()
+        {
+            base.Subquery_member_pushdown_does_not_change_original_subquery_model();
+
+            Assert.StartsWith(
+                @"SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(2) [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] = @_outer_CustomerID",
                 Sql);
         }
 


### PR DESCRIPTION
Fix #6478 
Issue: In certain queries where there is a subquery being used in multiple parts, the same subquerymodel is shared among all. If there is member access on subquery then our optimizer in `SubqueryMemberPushDownExpressionVisitor` modifies the selector for subquerymodel. Due to this, other places where subquerymodel is used now has invalid querymodel.
Fix: Since the subquerymodel could be shared, before modifying it, clone it to make a new copy in order to keep the original model intact.