### PR TITLE
Remove ability to force shadowness in core metadata

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Extensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             foreach (var property in sourceEntityType.GetDeclaredProperties())
             {
-                var clonedProperty = targetEntityType.AddProperty(property.Name, property.ClrType, property.IsShadowProperty);
+                var clonedProperty = targetEntityType.AddProperty(property.Name, property.ClrType);
                 clonedProperty.IsNullable = property.IsNullable;
                 clonedProperty.IsConcurrencyToken = property.IsConcurrencyToken;
                 clonedProperty.RequiresValueGenerator = property.RequiresValueGenerator;

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableEntityTypeExtensions.cs
@@ -322,12 +322,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to get or add the property to. </param>
         /// <param name="name"> The name of the property. </param>
         /// <param name="propertyType"> The type of value the property will hold. </param>
-        /// <param name="shadow"> Whether the property is in shadow-state. </param>
         /// <returns> The existing or newly created property. </returns>
         /// <remarks> The returned property might not have the specified type and shadowness. </remarks>
         public static IMutableProperty GetOrAddProperty(
-            [NotNull] this IMutableEntityType entityType, [NotNull] string name, [NotNull] Type propertyType, bool shadow)
-            => entityType.FindProperty(name) ?? entityType.AddProperty(name, propertyType, shadow);
+            [NotNull] this IMutableEntityType entityType, [NotNull] string name, [CanBeNull] Type propertyType)
+            => entityType.FindProperty(name) ?? entityType.AddProperty(name, propertyType);
 
         /// <summary>
         ///     Gets the property with the given name, or creates a new one if one is not already defined.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IMutableEntityType.cs
@@ -162,9 +162,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="name"> The name of the property to add. </param>
         /// <param name="propertyType"> The type of value the property will hold. </param>
-        /// <param name="shadow"> Whether the property is in shadow-state. </param>
         /// <returns> The newly created property. </returns>
-        IMutableProperty AddProperty([NotNull] string name, [NotNull] Type propertyType, bool shadow);
+        IMutableProperty AddProperty([NotNull] string name, [CanBeNull] Type propertyType);
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -289,13 +289,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual InternalPropertyBuilder Property([NotNull] PropertyInfo clrProperty, ConfigurationSource configurationSource)
-            => Property(clrProperty.Name, clrProperty.PropertyType, clrProperty: clrProperty, configurationSource: configurationSource);
+        public virtual InternalPropertyBuilder Property([NotNull] MemberInfo clrProperty, ConfigurationSource configurationSource)
+            => Property(clrProperty.Name, clrProperty.GetMemberType(), clrProperty: clrProperty, configurationSource: configurationSource);
 
         private InternalPropertyBuilder Property(
             [NotNull] string propertyName,
             [CanBeNull] Type propertyType,
-            [CanBeNull] PropertyInfo clrProperty,
+            [CanBeNull] MemberInfo clrProperty,
             [CanBeNull] ConfigurationSource? configurationSource)
         {
             if (IsIgnored(propertyName, configurationSource))
@@ -337,7 +337,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] Property existingProperty,
             [NotNull] string propertyName,
             [CanBeNull] Type propertyType,
-            [CanBeNull] PropertyInfo clrProperty,
+            [CanBeNull] MemberInfo clrProperty,
             [CanBeNull] ConfigurationSource? configurationSource)
         {
             var property = existingProperty;
@@ -1765,7 +1765,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var property = Metadata.FindProperty(propertyName);
                 if (property == null)
                 {
-                    var clrProperty = Metadata.ClrType?.GetPropertiesInHierarchy(propertyName).FirstOrDefault();
+                    var clrProperty = Metadata.ClrType?.GetMembersInHierarchy(propertyName).FirstOrDefault();
                     var type = typesList?[i];
                     InternalPropertyBuilder propertyBuilder;
                     if (clrProperty != null)
@@ -1802,7 +1802,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<Property> GetOrCreateProperties([CanBeNull] IEnumerable<PropertyInfo> clrProperties, ConfigurationSource configurationSource)
+        public virtual IReadOnlyList<Property> GetOrCreateProperties([CanBeNull] IEnumerable<MemberInfo> clrProperties, ConfigurationSource configurationSource)
         {
             if (clrProperties == null)
             {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -1228,7 +1228,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
-            [NotNull] IReadOnlyList<PropertyInfo> properties, ConfigurationSource configurationSource)
+            [NotNull] IReadOnlyList<MemberInfo> properties, ConfigurationSource configurationSource)
             => HasForeignKey(properties, Metadata.DeclaringEntityType, configurationSource);
 
         /// <summary>
@@ -1252,7 +1252,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalRelationshipBuilder HasForeignKey(
-            [NotNull] IReadOnlyList<PropertyInfo> properties, [NotNull] EntityType dependentEntityType, ConfigurationSource configurationSource)
+            [NotNull] IReadOnlyList<MemberInfo> properties, [NotNull] EntityType dependentEntityType, ConfigurationSource configurationSource)
             => HasForeignKey(
                 dependentEntityType.Builder.GetOrCreateProperties(properties, configurationSource),
                 dependentEntityType,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -24,20 +24,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public Navigation([NotNull] PropertyInfo navigationProperty, [NotNull] ForeignKey foreignKey)
-            : base(Check.NotNull(navigationProperty, nameof(navigationProperty)).Name, navigationProperty)
-        {
-            Check.NotNull(foreignKey, nameof(foreignKey));
-
-            ForeignKey = foreignKey;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public Navigation([NotNull] string navigationName, [NotNull] ForeignKey foreignKey)
-            : base(navigationName, null)
+        public Navigation(
+            [NotNull] string name,
+            [CanBeNull] PropertyInfo propertyInfo,
+            [CanBeNull] FieldInfo fieldInfo,
+            [NotNull] ForeignKey foreignKey)
+            : base(name, propertyInfo, fieldInfo)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -38,37 +38,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public Property(
             [NotNull] string name,
             [NotNull] Type clrType,
+            [CanBeNull] PropertyInfo propertyInfo,
+            [CanBeNull] FieldInfo fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource)
-            : base(name, null)
+            : base(name, propertyInfo, fieldInfo)
         {
             Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
             ClrType = clrType;
-            Initialize(declaringEntityType, configurationSource);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public Property(
-            [NotNull] PropertyInfo propertyInfo,
-            [NotNull] EntityType declaringEntityType,
-            ConfigurationSource configurationSource)
-            : base(Check.NotNull(propertyInfo, nameof(propertyInfo)).Name, propertyInfo)
-        {
-            Check.NotNull(declaringEntityType, nameof(declaringEntityType));
-
-            DeclaringEntityType = declaringEntityType;
-            ClrType = propertyInfo.PropertyType;
-            Initialize(declaringEntityType, configurationSource);
-        }
-
-        private void Initialize(EntityType declaringEntityType, ConfigurationSource configurationSource)
-        {
             _configurationSource = configurationSource;
 
             Builder = new InternalPropertyBuilder(this, declaringEntityType.Model.Builder);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -30,12 +30,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         protected PropertyBase(
             [NotNull] string name,
-            [CanBeNull] PropertyInfo propertyInfo)
+            [CanBeNull] PropertyInfo propertyInfo,
+            [CanBeNull] FieldInfo fieldInfo)
         {
             Check.NotEmpty(name, nameof(name));
 
             Name = name;
             PropertyInfo = propertyInfo;
+            _fieldInfo = fieldInfo;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -53,6 +53,9 @@
     <Compile Include="..\Shared\PropertyInfoExtensions.cs">
       <Link>PropertyInfoExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\MemberInfoExtensions.cs">
+      <Link>MemberInfoExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\SharedTypeExtensions.cs">
       <Link>SharedTypeExtensions.cs</Link>
     </Compile>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -433,15 +433,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot be added to entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.
-        /// </summary>
-        public static string NoClrProperty([CanBeNull] object property, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NoClrProperty", "property", "entityType"), property, entityType);
-        }
-
-        /// <summary>
-        /// The property '{property}' cannot be added to entity type '{entityType}' because the property is not in shadow state and the type of the corresponding CLR property '{clrType}' does not match the specified type '{propertyType}'.
+        /// The property '{property}' cannot be added to type '{entityType}' because the type of the corresponding CLR property or field '{clrType}' does not match the specified type '{propertyType}'.
         /// </summary>
         public static string PropertyWrongClrType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object propertyType)
         {
@@ -449,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.
+        /// The property '{property}' cannot exist on type '{entityType}' because the type is marked as shadow state while the property is not. Shadow state types can only contain shadow state properties.
         /// </summary>
         public static string ClrPropertyOnShadowEntity([CanBeNull] object property, [CanBeNull] object entityType)
         {
@@ -1313,7 +1305,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot be added to the entity type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type needs to be specified.
+        /// The property '{property}' cannot be added to the type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type must be specified.
         /// </summary>
         public static string NoPropertyType([CanBeNull] object property, [CanBeNull] object entityType)
         {

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -273,14 +273,11 @@
   <data name="DuplicateProperty" xml:space="preserve">
     <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
-  <data name="NoClrProperty" xml:space="preserve">
-    <value>The property '{property}' cannot be added to entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.</value>
-  </data>
   <data name="PropertyWrongClrType" xml:space="preserve">
-    <value>The property '{property}' cannot be added to entity type '{entityType}' because the property is not in shadow state and the type of the corresponding CLR property '{clrType}' does not match the specified type '{propertyType}'.</value>
+    <value>The property '{property}' cannot be added to type '{entityType}' because the type of the corresponding CLR property or field '{clrType}' does not match the specified type '{propertyType}'.</value>
   </data>
   <data name="ClrPropertyOnShadowEntity" xml:space="preserve">
-    <value>The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.</value>
+    <value>The property '{property}' cannot exist on type '{entityType}' because the type is marked as shadow state while the property is not. Shadow state types can only contain shadow state properties.</value>
   </data>
   <data name="PropertyInUse" xml:space="preserve">
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.</value>
@@ -604,7 +601,7 @@
     <value>The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.</value>
   </data>
   <data name="NoPropertyType" xml:space="preserve">
-    <value>The property '{property}' cannot be added to the entity type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type needs to be specified.</value>
+    <value>The property '{property}' cannot be added to the type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type must be specified.</value>
   </data>
   <data name="TempValue" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has a temporary value. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.</value>

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Reflection
+{
+    internal static class MemberInfoExtensions
+    {
+        public static Type GetMemberType(this MemberInfo memberInfo)
+            => (memberInfo as PropertyInfo)?.PropertyType ?? ((FieldInfo)memberInfo)?.FieldType;
+    }
+}

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -185,6 +185,36 @@ namespace System
             while (type != null);
         }
 
+        public static IEnumerable<MemberInfo> GetMembersInHierarchy(this Type type, string name)
+        {
+            // Do the whole hierarchy for properties first since looking for fields is slower.
+            var currentType = type;
+            do
+            {
+                var typeInfo = currentType.GetTypeInfo();
+                var propertyInfo = typeInfo.GetDeclaredProperty(name);
+                if (propertyInfo != null
+                    && !(propertyInfo.GetMethod ?? propertyInfo.SetMethod).IsStatic)
+                {
+                    yield return propertyInfo;
+                }
+                currentType = typeInfo.BaseType;
+            }
+            while (currentType != null);
+
+            currentType = type;
+            do
+            {
+                var fieldInfo = currentType.GetRuntimeFields().FirstOrDefault(f => f.Name == name && !f.IsStatic);
+                if (fieldInfo != null)
+                {
+                    yield return fieldInfo;
+                }
+                currentType = currentType.GetTypeInfo().BaseType;
+            }
+            while (currentType != null);
+        }
+
         private static readonly Dictionary<Type, object> _commonTypeDictionary = new Dictionary<Type, object>
         {
             { typeof(int), default(int) },

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = model.AddEntityType(typeof(Customer));
-            var property1 = customerType.AddProperty("Id", typeof(int), shadow: false);
+            var property1 = customerType.AddProperty("Id", typeof(int));
             customerType.GetOrSetPrimaryKey(property1);
             customerType.AddProperty("Name", typeof(string));
 

--- a/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
             builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random), shadow: false);
+            entityType.AddProperty("Random", typeof(Random));
 
             foreach (var property in entityType.GetProperties())
             {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             Assert.Null(entityType.Relational().DiscriminatorProperty);
 
-            var property = entityType.AddProperty("D", typeof(string), shadow: true);
+            var property = entityType.AddProperty("D", typeof(string));
 
             entityType.Relational().DiscriminatorProperty = property;
 
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
             var entityType = modelBuilder
                 .Entity<Customer>()
                 .Metadata;
-            var property = entityType.AddProperty("D", typeof(string), shadow: true);
+            var property = entityType.AddProperty("D", typeof(string));
 
             var derivedType = modelBuilder
                 .Entity<SpecialCustomer>()
@@ -389,7 +389,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<SpecialCustomer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D", typeof(string), shadow: true);
+            var property = entityType.AddProperty("D", typeof(string));
 
             Assert.Equal(RelationalStrings.DiscriminatorPropertyNotFound("D", nameof(SpecialCustomer)),
                 Assert.Throws<InvalidOperationException>(() => otherType.Relational().DiscriminatorProperty = property).Message);
@@ -404,7 +404,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<Customer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D", typeof(string), shadow: true);
+            var property = entityType.AddProperty("D", typeof(string));
             entityType.Relational().DiscriminatorProperty = property;
 
             Assert.Null(entityType.Relational().DiscriminatorValue);
@@ -441,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Entity<Customer>()
                 .Metadata;
 
-            var property = entityType.AddProperty("D", typeof(int), true);
+            var property = entityType.AddProperty("D", typeof(int));
             entityType.Relational().DiscriminatorProperty = property;
 
             Assert.Equal(RelationalStrings.DiscriminatorValueIncompatible("V", "D", typeof(int)),

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             var entityA = model.AddEntityType(typeof(A));
             SetPrimaryKey(entityA);
 
-            var property = entityA.AddProperty("P0", typeof(int?), shadow: false);
+            var property = entityA.AddProperty("P0", typeof(int?));
             property.IsNullable = false;
             entityA.AddKey(new[] { property });
             property.Relational().DefaultValue = 1;
@@ -535,7 +535,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         {
             base.SetBaseType(entityType, baseEntityType);
 
-            var discriminatorProperty = baseEntityType.GetOrAddProperty("Discriminator", typeof(string), true);
+            var discriminatorProperty = baseEntityType.GetOrAddProperty("Discriminator", typeof(string));
             baseEntityType.Relational().DiscriminatorProperty = discriminatorProperty;
             baseEntityType.Relational().DiscriminatorValue = baseEntityType.Name;
             entityType.Relational().DiscriminatorValue = entityType.Name;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ModificationCommandTest.cs
@@ -386,12 +386,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             var model = new Model();
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var key = entityType.AddProperty("Id", typeof(int));
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var nonKey = entityType.AddProperty("Name", typeof(string));
             nonKey.IsConcurrencyToken = computeNonKeyValue;
 
             nonKey.Relational().ColumnName = "Col2";

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -533,12 +533,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
 
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var key = entityType.AddProperty("Id", typeof(int));
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var nonKey = entityType.AddProperty("Name", typeof(string));
             nonKey.Relational().ColumnName = "Col2";
             nonKey.ValueGenerated = computeNonKeyValue ? ValueGenerated.OnAddOrUpdate : ValueGenerated.Never;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             model.SqlServer().GetOrAddSequence(SqlServerModelAnnotations.DefaultHiLoSequenceName);
 
             var entityType = model.FindEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random), shadow: false);
+            entityType.AddProperty("Random", typeof(Random));
 
             foreach (var property in entityType.GetProperties())
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -38,8 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            entityType.AddProperty("Long", typeof(int), shadow: false);
-            entityType.AddProperty("Hammer", typeof(string), shadow: false);
+            entityType.AddProperty("Long", typeof(int));
+            entityType.AddProperty("Hammer", typeof(string));
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -60,8 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            entityType.AddProperty("Long", typeof(int), shadow: false);
-            entityType.AddProperty("Hammer", typeof(string), shadow: true);
+            entityType.AddProperty("Long", typeof(int));
+            entityType.AddProperty("Spanner", typeof(string));
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -1299,46 +1299,46 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase));
-            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int), shadow: false);
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase));
-            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int), shadow: false);
-            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string), shadow: false);
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string));
             compositeKeyProperty2.IsNullable = false;
             someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             entityType1.HasBaseType(someSimpleEntityType);
-            var property3 = entityType1.AddProperty("Name", typeof(string), shadow: false);
+            var property3 = entityType1.AddProperty("Name", typeof(string));
             property3.IsConcurrencyToken = true;
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
             entityType2.HasBaseType(someCompositeEntityType);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadow: false);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.FindPrimaryKey(), entityType1);
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadow: false);
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
             justAProperty.RequiresValueGenerator = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            var property6 = entityType3.AddProperty("Id", typeof(int), shadow: false);
+            var property6 = entityType3.AddProperty("Id", typeof(int));
             entityType3.GetOrSetPrimaryKey(property6);
-            var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
+            var property7 = entityType3.AddProperty("Name", typeof(string));
             property7.IsConcurrencyToken = true;
             entityType3.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
+            var property8 = entityType4.AddProperty("Id", typeof(int));
             entityType4.GetOrSetPrimaryKey(property8);
-            var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
+            var property9 = entityType4.AddProperty("Name", typeof(string));
             property9.IsConcurrencyToken = true;
             entityType4.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.HasBaseType(someSimpleEntityType);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadow: false);
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadow: false);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
             entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.FindPrimaryKey(), entityType2);
 
             return model;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         {
             var model = BuildModel();
             var entityType = model.FindEntityType(typeof(SomeEntity).FullName);
-            var keyProperty = entityType.FindProperty("Id");
+            var keyProperty = entityType.AddProperty("Id_", typeof(int));
             var nonKeyProperty = entityType.FindProperty("Name");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
@@ -99,46 +99,46 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase));
-            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int), shadow: true);
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase));
-            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int), shadow: false);
-            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string), shadow: false);
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string));
             compositeKeyProperty2.IsNullable = false;
             someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             entityType1.HasBaseType(someSimpleEntityType);
-            var property3 = entityType1.AddProperty("Name", typeof(string), shadow: false);
+            var property3 = entityType1.AddProperty("Name", typeof(string));
             property3.IsConcurrencyToken = false;
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
             entityType2.HasBaseType(someCompositeEntityType);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadow: true);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.FindPrimaryKey(), entityType1);
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadow: false);
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
             justAProperty.RequiresValueGenerator = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            var property6 = entityType3.AddProperty("Id", typeof(int), shadow: false);
+            var property6 = entityType3.AddProperty("Id", typeof(int));
             entityType3.GetOrSetPrimaryKey(property6);
-            var property7 = entityType3.AddProperty("Name", typeof(string), shadow: false);
+            var property7 = entityType3.AddProperty("Name", typeof(string));
             property7.IsConcurrencyToken = true;
             entityType3.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            var property8 = entityType4.AddProperty("Id", typeof(int), shadow: false);
+            var property8 = entityType4.AddProperty("Id", typeof(int));
             entityType4.GetOrSetPrimaryKey(property8);
-            var property9 = entityType4.AddProperty("Name", typeof(string), shadow: false);
+            var property9 = entityType4.AddProperty("Name", typeof(string));
             property9.IsConcurrencyToken = true;
             entityType4.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.HasBaseType(someSimpleEntityType);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadow: false);
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadow: false);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
             entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.FindPrimaryKey(), entityType2);
 
             return model;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
             var keyProperties = new Property[propertyCount];
             for (var i = 0; i < propertyCount; i++)
             {
-                var property = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i), typeof(int?), shadow: false);
+                var property = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i), typeof(int?));
                 keyProperties[i] = property;
                 keyProperties[i].RequiresValueGenerator = true;
                 keyProperties[i].IsNullable = false;
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
 
         public void SetPrimaryKey(EntityType entityType)
         {
-            var property = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var property = entityType.AddProperty("Id", typeof(int));
             entityType.SetPrimaryKey(property);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/BackingFieldConventionTest.cs
@@ -20,10 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             => FieldMatchTest<TheDarkSideOfTheMoon>("IsThereAnybodyOutThere", "IsThereAnybodyOutThere");
 
         [Fact]
-        public void Property_name_matching_field_is_not_used_if_type_is_not_compatible()
-            => FieldMatchTest<TheDarkSideOfTheMoon>("EmptySpaces", "emptySpaces");
-
-        [Fact]
         public void Camel_case_matching_field_is_used_as_next_preference()
             => FieldMatchTest<TheDarkSideOfTheMoon>("Breathe", "breathe");
 
@@ -72,10 +68,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         [Fact]
         public void Property_name_matching_field_is_used_as_first_preference_for_field_only()
             => FieldMatchTest<TheDarkerSideOfTheMoon>("IsThereAnybodyOutThere", "IsThereAnybodyOutThere");
-
-        [Fact]
-        public void Property_name_matching_field_is_not_used_if_type_is_not_compatible_for_field_only()
-            => FieldMatchTest<TheDarkerSideOfTheMoon>("EmptySpaces", "emptySpaces");
 
         [Fact]
         public void Camel_case_matching_field_is_used_as_next_preference_for_field_only()
@@ -200,19 +192,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 
             public int ComfortablyNumb { get; set; }
 
-            private int? IsThereAnybodyOutThere;
-            private int? isThereAnybodyOutThere;
-            private int? _isThereAnybodyOutThere;
-            private int? _IsThereAnybodyOutThere;
-            private int? m_isThereAnybodyOutThere;
-            private int? m_IsThereAnybodyOutThere;
-
-            private string EmptySpaces;
-            private int? emptySpaces;
-            private int? _emptySpaces;
-            private int? _EmptySpaces;
-            private int? m_emptySpaces;
-            private int? m_EmptySpaces;
+            private int IsThereAnybodyOutThere;
+            private int isThereAnybodyOutThere;
+            private int _isThereAnybodyOutThere;
+            private int _IsThereAnybodyOutThere;
+            private int m_isThereAnybodyOutThere;
+            private int m_IsThereAnybodyOutThere;
 
             private int? breathe;
             private int? _breathe;
@@ -315,19 +300,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
 #pragma warning disable 169
             private string m_SpeakToMe;
 
-            private int? IsThereAnybodyOutThere;
-            private int? isThereAnybodyOutThere;
-            private int? _isThereAnybodyOutThere;
-            private int? _IsThereAnybodyOutThere;
-            private int? m_isThereAnybodyOutThere;
-            private int? m_IsThereAnybodyOutThere;
-
-            private string EmptySpaces;
-            private int? emptySpaces;
-            private int? _emptySpaces;
-            private int? _EmptySpaces;
-            private int? m_emptySpaces;
-            private int? m_EmptySpaces;
+            private int IsThereAnybodyOutThere;
+            private int isThereAnybodyOutThere;
+            private int _isThereAnybodyOutThere;
+            private int _IsThereAnybodyOutThere;
+            private int m_isThereAnybodyOutThere;
+            private int m_IsThereAnybodyOutThere;
 
             private int? breathe;
             private int? _breathe;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -327,7 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
-            entityTypeBuilder.Property<int>(nameof(F.IgnoredProperty));
+            entityTypeBuilder.Property<string>(nameof(F.IgnoredProperty));
 
             // Because brining the property in by the fluent API overrides the annotation it has no effect
             Assert.True(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/EntityTypeExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/EntityTypeExtensionsTest.cs
@@ -15,8 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
         public void Can_get_all_properties_and_navigations()
         {
             var entityType = new Model().AddEntityType(nameof(SelfRef));
-            var pk = entityType.GetOrSetPrimaryKey(entityType.AddProperty(nameof(SelfRef.Id), typeof(int), shadow: true));
-            var fkProp = entityType.AddProperty(nameof(SelfRef.SelfRefId), typeof(int?), shadow: true);
+            var pk = entityType.GetOrSetPrimaryKey(entityType.AddProperty(nameof(SelfRef.Id), typeof(int)));
+            var fkProp = entityType.AddProperty(nameof(SelfRef.SelfRefId), typeof(int?));
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, pk, entityType);
             fk.IsUnique = true;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Delegate_getter_is_returned_for_IProperty_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             Assert.Equal(7, new ClrPropertyGetterFactory().Create(idProperty).GetClrValue(new Customer { Id = 7 }));
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -1611,7 +1611,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Same(fk1, orderType.FindForeignKey(customerFkProperty, customerKey1, customerType));
             Assert.Same(fk1, orderType.GetForeignKeys().Single());
 
-            var altKeyProperty = customerType.AddProperty(nameof(Customer.AlternateId), typeof(int), shadow: false);
+            var altKeyProperty = customerType.AddProperty(nameof(Customer.AlternateId), typeof(int));
             var customerKey2 = customerType.AddKey(altKeyProperty);
             var fk2 = orderType.AddForeignKey(customerFkProperty, customerKey2, customerType);
 
@@ -1700,11 +1700,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var model = new Model();
             var baseType = model.AddEntityType(typeof(BaseType));
             var idProperty = baseType.GetOrAddProperty(Customer.IdProperty);
-            var idProperty2 = baseType.GetOrAddProperty("id2", typeof(int), shadow: true);
+            var idProperty2 = baseType.GetOrAddProperty("id2", typeof(int));
             var key = baseType.GetOrAddKey(new[] { idProperty, idProperty2 });
             IMutableEntityType entityType = model.AddEntityType(typeof(Customer));
             entityType.BaseType = baseType;
-            var fkProperty = entityType.AddProperty("fk", typeof(int), shadow: true);
+            var fkProperty = entityType.AddProperty("fk", typeof(int));
 
             Assert.Equal(
                 CoreStrings.ForeignKeyPropertyInKey(Customer.IdProperty.Name, typeof(Customer).Name),
@@ -1767,7 +1767,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var model = new Model();
 
             var principalType = model.AddEntityType(typeof(PrincipalEntity));
-            var property1 = principalType.AddProperty("PeeKay", typeof(int), shadow: false);
+            var property1 = principalType.AddProperty("PeeKay", typeof(int));
             principalType.GetOrSetPrimaryKey(property1);
 
             var dependentType = model.AddEntityType(typeof(DependentEntity));
@@ -2304,7 +2304,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityType = model.AddEntityType(typeof(Customer));
             Assert.Null(entityType.RemoveProperty("Id"));
 
-            var property1 = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var property1 = entityType.AddProperty("Id", typeof(int));
 
             Assert.False(property1.IsShadowProperty);
             Assert.Equal("Id", property1.Name);
@@ -2312,7 +2312,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.False(((IProperty)property1).IsConcurrencyToken);
             Assert.Same(entityType, property1.DeclaringEntityType);
 
-            var property2 = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property2 = entityType.AddProperty("Name", typeof(string));
 
             Assert.NotNull(property1.Builder);
             Assert.NotNull(property2.Builder);
@@ -2336,7 +2336,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
 
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadow: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             Assert.False(idProperty.IsShadowProperty);
             Assert.Equal("Id", idProperty.Name);
@@ -2368,17 +2368,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Equal(CoreStrings.ClrPropertyOnShadowEntity(nameof(Customer.Name), "Customer"),
                 Assert.Throws<InvalidOperationException>(() =>
-                    entityType.AddProperty(nameof(Customer.Name), typeof(int), shadow: false)).Message);
-        }
-
-        [Fact]
-        public void AddProperty_throws_if_no_clr_property()
-        {
-            var entityType = new Model().AddEntityType(typeof(Customer));
-
-            Assert.Equal(CoreStrings.NoClrProperty("Random", nameof(Customer)),
-                Assert.Throws<InvalidOperationException>(() =>
-                    entityType.AddProperty("Random", null, shadow: false)).Message);
+                    entityType.AddProperty(Customer.NameProperty)).Message);
         }
 
         [Fact]
@@ -2399,7 +2389,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(CoreStrings.PropertyWrongClrType(
                 nameof(Customer.Name), nameof(Customer), typeof(string).DisplayName(), typeof(int).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() =>
-                    entityType.AddProperty(nameof(Customer.Name), typeof(int), shadow: false)).Message);
+                    entityType.AddProperty(nameof(Customer.Name), typeof(int))).Message);
         }
 
         [Fact]
@@ -2559,11 +2549,11 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             entityType.GetOrAddProperty(Customer.NameProperty);
             entityType.AddProperty(Customer.IdProperty);
-            entityType.AddProperty("Mane", typeof(int), shadow: true);
+            entityType.AddProperty("Mane_", typeof(int));
 
             Assert.False(entityType.FindProperty("Name").IsShadowProperty);
             Assert.False(entityType.FindProperty("Id").IsShadowProperty);
-            Assert.True(entityType.FindProperty("Mane").IsShadowProperty);
+            Assert.True(entityType.FindProperty("Mane_").IsShadowProperty);
         }
 
         [Fact]
@@ -2625,15 +2615,15 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var entityType = model.AddEntityType(typeof(Customer));
 
             entityType.GetOrAddProperty(Customer.NameProperty);
-            entityType.AddProperty("Id", typeof(int), shadow: true);
-            entityType.AddProperty("Mane", typeof(int), shadow: true);
+            entityType.AddProperty("Id_", typeof(int));
+            entityType.AddProperty("Mane_", typeof(int));
 
-            Assert.Equal(0, entityType.FindProperty("Id").GetIndex());
-            Assert.Equal(1, entityType.FindProperty("Mane").GetIndex());
+            Assert.Equal(0, entityType.FindProperty("Id_").GetIndex());
+            Assert.Equal(1, entityType.FindProperty("Mane_").GetIndex());
             Assert.Equal(2, entityType.FindProperty("Name").GetIndex());
 
-            Assert.Equal(0, entityType.FindProperty("Id").GetShadowIndex());
-            Assert.Equal(1, entityType.FindProperty("Mane").GetShadowIndex());
+            Assert.Equal(0, entityType.FindProperty("Id_").GetShadowIndex());
+            Assert.Equal(1, entityType.FindProperty("Mane_").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
 
             Assert.Equal(2, entityType.ShadowPropertyCount());
@@ -2681,10 +2671,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(3, entityType.RelationshipPropertyCount());
             Assert.Equal(2, entityType.StoreGeneratedCount());
 
-            var gameProperty = entityType.AddProperty("Game", typeof(int), shadow: true);
+            var gameProperty = entityType.AddProperty("Game", typeof(int));
             gameProperty.IsConcurrencyToken = true;
 
-            var maneProperty = entityType.AddProperty("Mane", typeof(int), shadow: true);
+            var maneProperty = entityType.AddProperty("Mane", typeof(int));
             maneProperty.IsConcurrencyToken = true;
 
             Assert.Equal(0, entityType.FindProperty("Id").GetIndex());

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1442,7 +1442,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var entityType = entityBuilder.Metadata;
-            var property = entityType.AddProperty(Order.IdProperty.Name, typeof(int), shadow: false);
+            var property = entityType.AddProperty(Order.IdProperty.Name, typeof(int));
 
             Assert.Same(property, entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.Convention).Metadata);
 
@@ -1837,7 +1837,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int), shadow: false);
+            var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int));
             var property2 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid?));
             var foreignKey = dependentEntityBuilder.Metadata.AddForeignKey(
                 new[]

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void UnderlyingType_returns_correct_underlying_type()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property1 = entityType.AddProperty("Id", typeof(int?), shadow: false);
+            var property1 = entityType.AddProperty("Id", typeof(int?));
             Assert.Equal(typeof(int), property1.ClrType.UnwrapNullableType());
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void IsShadowProperty_is_set()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty(nameof(Entity.Name), typeof(string), shadow: false);
+            var property = entityType.AddProperty(nameof(Entity.Name), typeof(string));
 
             Assert.False(property.IsShadowProperty);
         }
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_does_not_use_ValueGenerated_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_as_using_ValueGenerated()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_is_not_concurrency_token_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.False(property.IsConcurrencyToken);
         }
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_as_concurrency_token()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             property.IsConcurrencyToken = true;
             Assert.True(property.IsConcurrencyToken);
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Can_mark_property_to_always_use_store_generated_values()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.False(property.IsStoreGeneratedAlways);
 
@@ -185,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Store_generated_concurrency_tokens_always_use_store_values_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.False(((IProperty)property).IsStoreGeneratedAlways);
 
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_is_read_write_by_default()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.False(property.IsReadOnlyAfterSave);
             Assert.False(property.IsReadOnlyBeforeSave);
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_before_save()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
             property.IsReadOnlyBeforeSave = true;
 
             Assert.True(property.IsReadOnlyBeforeSave);
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_after_save()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
             property.IsReadOnlyAfterSave = true;
 
             Assert.True(property.IsReadOnlyAfterSave);
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
         public void Property_can_be_marked_as_read_only_always()
         {
             var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string), shadow: false);
+            var property = entityType.AddProperty("Name", typeof(string));
 
             Assert.False(property.IsReadOnlyBeforeSave);
             Assert.False(property.IsReadOnlyAfterSave);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
             var model = builder.Model;
             var entityType = model.FindEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random), shadow: false);
+            entityType.AddProperty("Random", typeof(Random));
 
             foreach (var property in entityType.GetProperties())
             {


### PR DESCRIPTION
Issue #6548

This boils down to two public overloads of AddProperty--one is called when the MemberInfo is known, the other when it is not known. The latter looks up the MemberInfo and then they collapse together into one method calling one constructor.