### PR TITLE
Correct navigation index calculation

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1031,7 +1031,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     CoreStrings.ReferenceMustBeLoaded(navigation.Name, navigation.DeclaringEntityType.DisplayName()));
             }
 
-            _stateData.FlagProperty(GetNavigationStateDataIndex(navigation), PropertyFlag.IsLoaded, isFlagged: loaded);
+            _stateData.FlagProperty(navigation.GetIndex(), PropertyFlag.IsLoaded, isFlagged: loaded);
         }
 
         /// <summary>
@@ -1042,9 +1042,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             => (!navigation.IsCollection()
                 && EntityState != EntityState.Detached
                 && this[navigation] != null)
-               || _stateData.IsPropertyFlagged(GetNavigationStateDataIndex(navigation), PropertyFlag.IsLoaded);
-
-        private int GetNavigationStateDataIndex(INavigation navigation)
-            => navigation.GetIndex() - EntityType.PropertyCount();
+               || _stateData.IsPropertyFlagged(navigation.GetIndex(), PropertyFlag.IsLoaded);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -50,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static PropertyIndexes CalculateIndexes([NotNull] this IEntityType entityType, [NotNull] IPropertyBase propertyBase)
         {
             var index = 0;
+            var navigationIndex = 0;
             var shadowIndex = 0;
             var originalValueIndex = 0;
             var relationshipIndex = 0;
@@ -59,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (baseCounts != null)
             {
                 index = baseCounts.PropertyCount;
+                navigationIndex = baseCounts.NavigationCount;
                 shadowIndex = baseCounts.ShadowCount;
                 originalValueIndex = baseCounts.OriginalValueCount;
                 relationshipIndex = baseCounts.RelationshipCount;
@@ -89,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var navigation in entityType.GetDeclaredNavigations())
             {
                 var indexes = new PropertyIndexes(
-                    index: index++,
+                    index: navigationIndex++,
                     originalValueIndex: -1,
                     shadowIndex: -1,
                     relationshipIndex: navigation.IsCollection() && isNotifying ? -1 : relationshipIndex++,

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -404,6 +404,128 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         }
 
         [Fact]
+        public void Can_track_an_entity_with_more_than_10_properties()
+        {
+            using (var context = new GameDbContext())
+            {
+                context.Database.EnsureClean();
+
+                context.Characters.Add(new PlayerCharacter(new Level { Game = new Game() }));
+
+                context.SaveChanges();
+            }
+
+            using (var context = new GameDbContext())
+            {
+                var character = context.Characters
+                    .Include(c => c.Level.Game)
+                    .First();
+
+                Assert.NotNull(character.Game);
+                Assert.NotNull(character.Level);
+                Assert.NotNull(character.Level.Game);
+            }
+        }
+
+        public abstract class Actor
+        {
+            protected Actor()
+            {
+            }
+
+            protected Actor(Level level)
+            {
+                Level = level;
+                Game = level.Game;
+            }
+
+            public virtual int Id { get; private set; }
+            public virtual Level Level { get; set; }
+            public virtual int GameId { get; private set; }
+            public virtual Game Game { get; set; }
+        }
+
+        public class PlayerCharacter : Actor
+        {
+            public PlayerCharacter()
+            {
+            }
+
+            public PlayerCharacter(Level level)
+                : base(level)
+            {
+            }
+
+            public virtual string Name { get; set; }
+
+            public virtual int Strength { get; set; }
+            public virtual int Dexterity { get; set; }
+            public virtual int Speed { get; set; }
+            public virtual int Constitution { get; set; }
+            public virtual int Intelligence { get; set; }
+            public virtual int Willpower { get; set; }
+
+            public virtual int MaxHP { get; set; }
+            public virtual int HP { get; set; }
+
+            public virtual int MaxMP { get; set; }
+            public virtual int MP { get; set; }
+        }
+
+        public class Level
+        {
+            public virtual int Id { get; set; }
+            public virtual int GameId { get; set; }
+            public virtual Game Game { get; set; }
+        }
+
+        public class Game
+        {
+            public virtual int Id { get; set; }
+            public virtual ICollection<Actor> Actors { get; set; } = new HashSet<Actor>();
+            public virtual ICollection<Level> Levels { get; set; } = new HashSet<Level>();
+        }
+
+        public class GameDbContext : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("GameDbContext"));
+
+            public DbSet<Game> Games { get; set; }
+            public DbSet<Level> Levels { get; set; }
+            public DbSet<PlayerCharacter> Characters { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Level>(eb => { eb.HasKey(l => new { l.GameId, l.Id }); });
+
+                modelBuilder.Entity<Actor>(eb =>
+                {
+                    eb.HasKey(a => new { a.GameId, a.Id });
+                    eb.HasOne(a => a.Level)
+                        .WithMany()
+                        .HasForeignKey(nameof(Actor.GameId), "LevelId")
+                        .IsRequired();
+                });
+
+                modelBuilder.Entity<PlayerCharacter>();
+
+                modelBuilder.Entity<Game>(eb =>
+                {
+                    eb.Property(g => g.Id)
+                        .ValueGeneratedOnAdd();
+                    eb.HasMany(g => g.Levels)
+                        .WithOne(l => l.Game)
+                        .HasForeignKey(l => l.GameId);
+                    eb.HasMany(g => g.Actors)
+                        .WithOne(a => a.Game)
+                        .HasForeignKey(a => a.GameId)
+                        .OnDelete(DeleteBehavior.Restrict);
+                });
+            }
+        }
+
+        [Fact]
         public async Task Tracking_entities_asynchronously_returns_tracked_entities_back()
         {
             using (SqlServerNorthwindContext.GetSharedStore())

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2649,8 +2649,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetIndex());
             Assert.Equal(2, entityType.FindProperty("Name").GetIndex());
             Assert.Equal(3, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(4, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(5, entityType.FindNavigation("ReferenceNav").GetIndex());
+            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
+            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
 
             Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
@@ -2693,8 +2693,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(3, entityType.FindProperty("Mane").GetIndex());
             Assert.Equal(4, entityType.FindProperty("Name").GetIndex());
             Assert.Equal(5, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(6, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(7, entityType.FindNavigation("ReferenceNav").GetIndex());
+            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
+            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
 
             Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
@@ -2742,8 +2742,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(3, entityType.FindProperty("Mane").GetIndex());
             Assert.Equal(4, entityType.FindProperty("Name").GetIndex());
             Assert.Equal(5, entityType.FindProperty("Token").GetIndex());
-            Assert.Equal(6, entityType.FindNavigation("CollectionNav").GetIndex());
-            Assert.Equal(7, entityType.FindNavigation("ReferenceNav").GetIndex());
+            Assert.Equal(0, entityType.FindNavigation("CollectionNav").GetIndex());
+            Assert.Equal(1, entityType.FindNavigation("ReferenceNav").GetIndex());
 
             Assert.Equal(-1, entityType.FindProperty("Id").GetShadowIndex());
             Assert.Equal(-1, entityType.FindProperty("AnotherEntityId").GetShadowIndex());
@@ -2781,6 +2781,201 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(5, entityType.OriginalValueCount());
             Assert.Equal(3, entityType.RelationshipPropertyCount());
             Assert.Equal(2, entityType.StoreGeneratedCount());
+        }
+
+        [Fact]
+        public void Indexes_for_derived_types_are_calculated_correctly()
+        {
+            using (var context = new Levels())
+            {
+                var type = context.Model.FindEntityType(typeof(Level1));
+
+                Assert.Equal(0, type.FindProperty("Id").GetIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
+                Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
+                Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
+
+                Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
+                Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
+                Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
+                Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
+
+                Assert.Equal(3, type.PropertyCount());
+                Assert.Equal(2, type.NavigationCount());
+                Assert.Equal(1, type.ShadowPropertyCount());
+                Assert.Equal(3, type.OriginalValueCount());
+                Assert.Equal(4, type.RelationshipPropertyCount());
+                Assert.Equal(2, type.StoreGeneratedCount());
+
+                type = context.Model.FindEntityType(typeof(Level2));
+
+                Assert.Equal(0, type.FindProperty("Id").GetIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
+                Assert.Equal(3, type.FindProperty("Level2ReferenceId").GetIndex());
+                Assert.Equal(4, type.FindProperty("Prop2").GetIndex());
+                Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
+                Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
+                Assert.Equal(2, type.FindNavigation("Level2Collection").GetIndex());
+                Assert.Equal(3, type.FindNavigation("Level2Reference").GetIndex());
+
+                Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
+                Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
+                Assert.Equal(1, type.FindProperty("Level2ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetShadowIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
+                Assert.Equal(3, type.FindProperty("Level2ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(4, type.FindProperty("Prop2").GetOriginalValueIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
+                Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
+                Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
+                Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetRelationshipIndex());
+                Assert.Equal(5, type.FindNavigation("Level2Collection").GetRelationshipIndex());
+                Assert.Equal(6, type.FindNavigation("Level2Reference").GetRelationshipIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
+                Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level2Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level2Reference").GetStoreGeneratedIndex());
+
+                Assert.Equal(5, type.PropertyCount());
+                Assert.Equal(4, type.NavigationCount());
+                Assert.Equal(2, type.ShadowPropertyCount());
+                Assert.Equal(5, type.OriginalValueCount());
+                Assert.Equal(7, type.RelationshipPropertyCount());
+                Assert.Equal(3, type.StoreGeneratedCount());
+
+                type = context.Model.FindEntityType(typeof(Level3));
+
+                Assert.Equal(0, type.FindProperty("Id").GetIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
+                Assert.Equal(3, type.FindProperty("Level2ReferenceId").GetIndex());
+                Assert.Equal(4, type.FindProperty("Prop2").GetIndex());
+                Assert.Equal(5, type.FindProperty("Level3ReferenceId").GetIndex());
+                Assert.Equal(6, type.FindProperty("Prop3").GetIndex());
+                Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
+                Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
+                Assert.Equal(2, type.FindNavigation("Level2Collection").GetIndex());
+                Assert.Equal(3, type.FindNavigation("Level2Reference").GetIndex());
+                Assert.Equal(4, type.FindNavigation("Level3Collection").GetIndex());
+                Assert.Equal(5, type.FindNavigation("Level3Reference").GetIndex());
+
+                Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
+                Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
+                Assert.Equal(1, type.FindProperty("Level2ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetShadowIndex());
+                Assert.Equal(2, type.FindProperty("Level3ReferenceId").GetShadowIndex());
+                Assert.Equal(-1, type.FindProperty("Prop3").GetShadowIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
+                Assert.Equal(3, type.FindProperty("Level2ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(4, type.FindProperty("Prop2").GetOriginalValueIndex());
+                Assert.Equal(5, type.FindProperty("Level3ReferenceId").GetOriginalValueIndex());
+                Assert.Equal(6, type.FindProperty("Prop3").GetOriginalValueIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
+                Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
+                Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
+                Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetRelationshipIndex());
+                Assert.Equal(5, type.FindNavigation("Level2Collection").GetRelationshipIndex());
+                Assert.Equal(6, type.FindNavigation("Level2Reference").GetRelationshipIndex());
+                Assert.Equal(7, type.FindProperty("Level3ReferenceId").GetRelationshipIndex());
+                Assert.Equal(-1, type.FindProperty("Prop3").GetRelationshipIndex());
+                Assert.Equal(8, type.FindNavigation("Level3Collection").GetRelationshipIndex());
+                Assert.Equal(9, type.FindNavigation("Level3Reference").GetRelationshipIndex());
+
+                Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
+                Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
+                Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop2").GetStoreGeneratedIndex());
+                Assert.Equal(3, type.FindProperty("Level3ReferenceId").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindProperty("Prop3").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level2Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level2Reference").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level3Collection").GetStoreGeneratedIndex());
+                Assert.Equal(-1, type.FindNavigation("Level3Reference").GetStoreGeneratedIndex());
+
+                Assert.Equal(7, type.PropertyCount());
+                Assert.Equal(6, type.NavigationCount());
+                Assert.Equal(3, type.ShadowPropertyCount());
+                Assert.Equal(7, type.OriginalValueCount());
+                Assert.Equal(10, type.RelationshipPropertyCount());
+                Assert.Equal(4, type.StoreGeneratedCount());
+            }
+        }
+
+        private class Levels : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) 
+                => optionsBuilder.UseInMemoryDatabase();
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Level1>().HasOne(e => e.Level1Reference).WithMany(e => e.Level1Collection);
+                modelBuilder.Entity<Level2>().HasOne(e => e.Level2Reference).WithMany(e => e.Level2Collection);
+                modelBuilder.Entity<Level3>().HasOne(e => e.Level3Reference).WithMany(e => e.Level3Collection);
+            }
+        }
+
+        private class Level1
+        {
+            public int Id { get; set; }
+            public int Prop1 { get; set; }
+            public Level1 Level1Reference { get; set; }
+            public ICollection<Level1> Level1Collection { get; set; }
+        }
+
+        private class Level2 : Level1
+        {
+            public int Prop2 { get; set; }
+            public Level2 Level2Reference { get; set; }
+            public ICollection<Level2> Level2Collection { get; set; }
+        }
+
+        private class Level3 : Level2
+        {
+            public int Prop3 { get; set; }
+            public Level3 Level3Reference { get; set; }
+            public ICollection<Level3> Level3Collection { get; set; }
         }
 
         [Fact]


### PR DESCRIPTION
Issue #6570

This issue is caused by incorrectly calculating the indexes for navigations. Navigations started counting at the end of the properties, but I'm not sure why that was since all uses appear to be independent. This lack of overlap was then "corrected for" when using the index for the IsLoaded flag, but this correction was done incorrectly when derived types were involved. The fix is to just make navigation indexes count independently from property indexes. Note, however, that relationship indexes are still combined.