### PR TITLE
Query: Properly modify column references while from clause is subquery

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -326,12 +326,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
                         if (aliasExpression != null)
                         {
-                            var expression = UpdateColumnExpression(aliasExpression.Expression, subquery);
+                            if (aliasExpression.Alias != null)
+                            {
+                                _orderBy.Add(
+                                    new Ordering(
+                                        new ColumnExpression(aliasExpression.Alias, aliasExpression.Type, subquery),
+                                        ordering.OrderingDirection));
+                            }
+                            else
+                            {
+                                var expression = UpdateColumnExpression(aliasExpression.Expression, subquery);
 
-                            _orderBy.Add(
-                                new Ordering(
-                                    new AliasExpression(aliasExpression.Alias, expression),
-                                    ordering.OrderingDirection));
+                                _orderBy.Add(
+                                    new Ordering(
+                                        new AliasExpression(expression), ordering.OrderingDirection));
+                            }
                         }
                     }
                 }
@@ -884,13 +893,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
                 foreach (var aliasExpression in subquery._projection.Cast<AliasExpression>())
                 {
-                    var expression = UpdateColumnExpression(aliasExpression.Expression, subquery);
+                    if (aliasExpression.Alias != null)
+                    {
+                        _projection.Add(
+                            new ColumnExpression(
+                                aliasExpression.Alias,
+                                aliasExpression.Type,
+                                subquery));
+                    }
+                    else
+                    {
+                        var expression = UpdateColumnExpression(aliasExpression.Expression, subquery);
 
-                    _projection.Add(
-                        new AliasExpression(aliasExpression.Alias, expression)
-                        {
-                            SourceMember = aliasExpression.SourceMember
-                        });
+                        _projection.Add(
+                            new AliasExpression(expression)
+                            {
+                                SourceMember = aliasExpression.SourceMember
+                            });
+                    }
                 }
 
                 IsProjectStar = false;

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -6270,14 +6270,25 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Subquery_member_pushdown_does_not_change_original_subquery_model()
         {
             AssertQuery<Order, Customer>((os, cs) =>
-                 os.Select(o => new
-                 {
-                     OrderId = o.OrderID,
-                     City = cs.SingleOrDefault(c => c.CustomerID == o.CustomerID).City
-                 })
-                 .OrderBy(o => o.City)
-                 .Skip(0)
-                 .Take(10));
+                os.Select(o => new
+                {
+                    OrderId = o.OrderID,
+                    City = cs.SingleOrDefault(c => c.CustomerID == o.CustomerID).City
+                })
+                .OrderBy(o => o.City)
+                .Skip(0)
+                .Take(10));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_expression_references_are_updated_correctly_with_subquery()
+        {
+            var nextYear = DateTime.UtcNow.AddYears(1).Year;
+            AssertQuery<Order>(
+                os => os.Where(o => o.OrderDate != null)
+                    .Select(o => o.OrderDate.Value.Year)
+                    .Distinct()
+                    .Where(x => x < nextYear));
         }
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5760,7 +5760,7 @@ FROM (
     FROM [Customers] AS [c]
     ORDER BY [Coalesce]
 ) AS [t]
-ORDER BY [Coalesce]
+ORDER BY [t].[Coalesce]
 OFFSET @__p_1 ROWS",
                 Sql);
         }
@@ -6143,6 +6143,23 @@ FROM [Orders] AS [o]
 SELECT TOP(2) [c0].[City]
 FROM [Customers] AS [c0]
 WHERE [c0].[CustomerID] = @_outer_CustomerID",
+                Sql);
+        }
+
+        public override void Select_expression_references_are_updated_correctly_with_subquery()
+        {
+            base.Select_expression_references_are_updated_correctly_with_subquery();
+
+            Assert.Equal(
+                @"@__nextYear_0: 2017
+
+SELECT [t].[c0]
+FROM (
+    SELECT DISTINCT DATEPART(year, [o0].[OrderDate]) AS [c0]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderDate] IS NOT NULL
+) AS [t]
+WHERE [t].[c0] < @__nextYear_0",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -205,7 +205,7 @@ FROM (
 
 SELECT [t0].*
 FROM (
-    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [Coalesce]) AS [__RowNumber__]
+    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[Coalesce]) AS [__RowNumber__]
     FROM (
         SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Coalesce]
         FROM [Customers] AS [c]


### PR DESCRIPTION
Fixes #6270 
Issue: There are multiple issues here
1. In projection, we have function to update column references while from is subquery but if the inner projection is aliased then it does not use alias. And in the case of specific SQL function, it tries to use it on a column which is not projected in the subquery. Fix is to use the alias if the inner projection has alias, else update column reference.
2. In where clause, when we select whole querysourcerefence, we were trying to use the subquery selector. That works only if the single column is being projected out of the subquery. But in the case if the inner subquery projection is aliased due to Sql function then it will have Sql function with references which may not be projected in subquery. Fix is to use the alias expression if single column is projected out and using alias.
3. In the select expression distinct was applied for the case where the projection is on client therefore incorrect projection was being made distinct, giving wrong result. Fix is to check for client eval of projection before applying distinct.