### PR TITLE
[1.0.2] Query: Close the connection properly while loading related data

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/AsyncFromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/AsyncFromSqlQueryTestBase.cs
@@ -361,6 +361,25 @@ FROM ""Customers""")
             }
         }
 
+        [Fact]
+        public virtual async Task Include_closed_connection_opened_by_it_when_buffering()
+        {
+            using (var context = CreateContext())
+            {
+                var connection = context.Database.GetDbConnection();
+
+                Assert.Equal(ConnectionState.Closed, connection.State);
+
+                var query = await context.Customers
+                        .Include(v => v.Orders)
+                        .Where(v => v.CustomerID == "ALFKI")
+                        .ToListAsync();
+
+                Assert.NotEmpty(query);
+                Assert.Equal(ConnectionState.Closed, connection.State);
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected AsyncFromSqlQueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
@@ -453,17 +453,36 @@ AND ((UnitsInStock + UnitsOnOrder) < ReorderLevel)")
         [Fact]
         public virtual void Include_does_not_close_user_opened_connection_for_empty_result()
         {
-            using (var ctx = CreateContext())
+            using (var context = CreateContext())
             {
-                ctx.Database.OpenConnection();
+                context.Database.OpenConnection();
 
-                var query = ctx.Customers
+                var query = context.Customers
                         .Include(v => v.Orders)
                         .Where(v => v.CustomerID == "MAMRFC")
                         .ToList();
 
                 Assert.Empty(query);
-                Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
+                Assert.Equal(ConnectionState.Open, context.Database.GetDbConnection().State);
+            }
+        }
+
+        [Fact]
+        public virtual void Include_closed_connection_opened_by_it_when_buffering()
+        {
+            using (var context = CreateContext())
+            {
+                var connection = context.Database.GetDbConnection();
+
+                Assert.Equal(ConnectionState.Closed, connection.State);
+
+                var query = context.Customers
+                        .Include(v => v.Orders)
+                        .Where(v => v.CustomerID == "ALFKI")
+                        .ToList();
+
+                Assert.NotEmpty(query);
+                Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -139,6 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
+                    _queryingEnumerable._relationalQueryContext.Connection?.Close();
                     _dataReader = null;
                     _dbDataReader = null;
                 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -126,6 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
+                    _queryingEnumerable._relationalQueryContext.Connection?.Close();
                     _dataReader = null;
                 }
             }


### PR DESCRIPTION
Resolves #6581 
Issue: When MARS is disabled, we buffer all the data. Which was setting datareader to null. Our dispose method was based on assumption that if datareader is non-null then only we opened connection & we should try to close it.
Fix: We should close the connection once we are done buffering all the data.

