### PR TITLE
[1.0.2] Query: Generate Inner Join for collection include while Skip/Take

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -288,8 +288,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             : selectExpression.Tables.Last(t => t.QuerySource == querySource);
 
                     var canGenerateExists
-                        = (selectExpression.Predicate != null
-                          || selectExpression.Offset == null)
+                        = selectExpression.Offset == null
+                          && selectExpression.Limit == null
                           && !IsOrderingOnNonPrincipalKeyProperties(
                               selectExpression.OrderBy,
                               navigation.ForeignKey.PrincipalKey.Properties);

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/IncludeTestBase.cs
@@ -194,6 +194,22 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
+        public virtual void Include_collection_take_no_order_by()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                        = context.Set<Customer>()
+                            .Take(10)
+                            .Include(c => c.Orders)
+                            .ToList();
+
+                Assert.Equal(10, customers.Count);
+                Assert.True(customers.All(c => c.Orders != null));
+            }
+        }
+
+        [Fact]
         public virtual void Include_collection_skip_take_no_order_by()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1027,18 +1027,22 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
 SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [t0].*
+    FROM (
+        SELECT [e].[Id]
+        FROM [Level1] AS [e]
+        LEFT JOIN (
+            SELECT [e1].[Id], [e1].[Level1_Optional_Id], [e1].[Level1_Required_Id], [e1].[Name], [e1].[OneToMany_Optional_InverseId], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_PK_InverseId], [e1].[OneToOne_Optional_SelfId]
+            FROM [Level2] AS [e1]
+        ) AS [t] ON [e].[Id] = [t].[Level1_Optional_Id]
+        WHERE ([e].[Name] <> N'L1 03') OR [e].[Name] IS NULL
+        ORDER BY [e].[Id]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t0]
+) AS [e2] ON [l].[OneToMany_Optional_InverseId] = [e2].[Id]
 LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
-WHERE EXISTS (
-    SELECT 1
-    FROM [Level1] AS [e]
-    LEFT JOIN (
-        SELECT [e1].[Id], [e1].[Level1_Optional_Id], [e1].[Level1_Required_Id], [e1].[Name], [e1].[OneToMany_Optional_InverseId], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_PK_InverseId], [e1].[OneToOne_Optional_SelfId]
-        FROM [Level2] AS [e1]
-    ) AS [t] ON [e].[Id] = [t].[Level1_Optional_Id]
-    WHERE (([e].[Name] <> N'L1 03') OR [e].[Name] IS NULL) AND (([l].[OneToMany_Optional_InverseId] = [e].[Id]) AND [l].[OneToMany_Optional_InverseId] IS NOT NULL)
-    ORDER BY @@ROWCOUNT
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY)
-ORDER BY [l].[OneToMany_Optional_InverseId]",
+ORDER BY [e2].[Id]",
                     Sql);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -86,6 +86,33 @@ ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_collection_take_no_order_by()
+        {
+            base.Include_collection_take_no_order_by();
+
+            if (SupportsOffset)
+            {
+                Assert.Equal(
+                    @"@__p_0: 10
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+
+@__p_0: 10
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_0) [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
+                    Sql);
+            }
+        }
+
         public override void Include_collection_skip_take_no_order_by()
         {
             base.Include_collection_skip_take_no_order_by();
@@ -211,12 +238,14 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-    WHERE ([o].[OrderID] = 10248) AND ([o0].[CustomerID] = [c].[CustomerID]))
-ORDER BY [o0].[CustomerID]",
+    WHERE [o].[OrderID] = 10248
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -232,12 +261,14 @@ ORDER BY [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Order Details] AS [o0]
-INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [o].[OrderID]
     FROM [Orders] AS [o]
-    WHERE ([o].[OrderID] = 10248) AND ([o0].[OrderID] = [o].[OrderID]))
-ORDER BY [o0].[OrderID]",
+    WHERE [o].[OrderID] = 10248
+    ORDER BY [o].[OrderID]
+) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+ORDER BY [o1].[OrderID]",
                 Sql);
         }
 
@@ -474,11 +505,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
-ORDER BY [o].[CustomerID]",
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -498,11 +531,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
-ORDER BY [o].[CustomerID]",
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -759,8 +794,8 @@ ORDER BY [t].[CustomerID], [t0].[CustomerID]
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
-WHERE EXISTS (
-    SELECT TOP(@__p_1) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID], [t0].[CustomerID] AS [CustomerID0]
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -772,16 +807,17 @@ WHERE EXISTS (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    WHERE [o0].[CustomerID] = [t0].[CustomerID])
-ORDER BY [o0].[CustomerID]
+    ORDER BY [t].[CustomerID], [t0].[CustomerID]
+) AS [t00] ON [o0].[CustomerID] = [t00].[CustomerID0]
+ORDER BY [t00].[CustomerID], [t00].[CustomerID0]
 
 @__p_1: 1
 @__p_0: 2
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(@__p_1) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID]
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -793,8 +829,9 @@ WHERE EXISTS (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    WHERE [o].[CustomerID] = [t].[CustomerID])
-ORDER BY [o].[CustomerID]",
+    ORDER BY [t].[CustomerID]
+) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t1].[CustomerID]",
                     Sql);
             }
         }
@@ -911,8 +948,8 @@ ORDER BY [t].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(@__p_1) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_1) [t].[CustomerID]
     FROM (
         SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
         FROM [Customers] AS [c0]
@@ -924,8 +961,9 @@ WHERE EXISTS (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
-    WHERE [o].[CustomerID] = [t].[CustomerID])
-ORDER BY [o].[CustomerID]",
+    ORDER BY [t].[CustomerID]
+) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID]
+ORDER BY [t1].[CustomerID]",
                     Sql);
             }
         }
@@ -1093,11 +1131,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
-ORDER BY [o].[CustomerID]",
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -1117,11 +1157,13 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE ([c].[CustomerID] = N'ALFKI') AND ([o].[CustomerID] = [c].[CustomerID]))
-ORDER BY [o].[CustomerID]",
+    WHERE [c].[CustomerID] = N'ALFKI'
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -1166,11 +1208,12 @@ ORDER BY [c].[CustomerID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE EXISTS (
-    SELECT TOP(@__p_0) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE [o].[CustomerID] = [c].[CustomerID])
-ORDER BY [o].[CustomerID]",
+    ORDER BY [c].[CustomerID]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -277,11 +277,14 @@ ORDER BY [e].[Species]
 
 SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND EXISTS (
-    SELECT TOP(2) 1
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [e].[Species]
     FROM [Animal] AS [e]
-    WHERE ([e].[Discriminator] = N'Eagle') AND ([a].[EagleId] = [e].[Species]))
-ORDER BY [a].[EagleId]",
+    WHERE [e].[Discriminator] = N'Eagle'
+    ORDER BY [e].[Species]
+) AS [e0] ON [a].[EagleId] = [e0].[Species]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')
+ORDER BY [e0].[Species]",
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #6530 
Issue: During Include with skip/take, first query select only fixed amount of rows. Second query should join related data with only those rows. But using `WHERE EXISTS` will give matching rows for all related data. With use of Skip, if there are not sufficient matching rows then where exists can return false. With Take it will return true for any matching rows. This would give incorrect result (reported in #5901 & fixed in #6002) or fetch whole table (#6530)
Solution is to disable `Where Exists` while using skip/take.