### PR TITLE
Fix to #6429 - NRE protection is not applied to manually created GroupJoin when trying to extract keys from collections potentially containing nulls

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -362,6 +362,41 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Include_where_list_contains_navigation2()
+        {
+            using (var context = CreateContext())
+            {
+                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+
+                var tags = context.Tags.Select(t => (Guid?)t.Id).ToList();
+
+                var gears = context.Gears
+                    .Include(g => g.Tag)
+                    .Where(g => g.CityOfBirth.Location != null && tags.Contains(g.Tag.Id))
+                    .ToList();
+
+                Assert.Equal(5, gears.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Navigation_accessed_twice_outside_and_inside_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+
+                var tags = context.Tags.Select(t => (Guid?)t.Id).ToList();
+
+                var gears = context.Gears
+                    .Where(g => g.Tag != null && tags.Contains(g.Tag.Id))
+                    .ToList();
+
+                Assert.Equal(5, gears.Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Include_with_join_multi_level()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             queryModel.TransformExpressions(_subQueryMemberPushDownExpressionVisitor.Visit);
 
-            _navigationRewritingExpressionVisitorFactory.Create(this).Rewrite(queryModel);
+            _navigationRewritingExpressionVisitorFactory.Create(this).Rewrite(queryModel, parentQueryModel: null);
 
             QueryCompilationContext.Logger
                 .LogDebug(

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ExpressionTransformingQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ExpressionTransformingQueryModelVisitor.cs
@@ -13,19 +13,20 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ExpressionTransformingQueryModelVisitor : QueryModelVisitorBase
+    public class ExpressionTransformingQueryModelVisitor<TVisitor> : QueryModelVisitorBase 
+        where TVisitor : RelinqExpressionVisitor
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual RelinqExpressionVisitor TransformingVisitor { get; }
+        protected virtual TVisitor TransformingVisitor { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ExpressionTransformingQueryModelVisitor([NotNull] RelinqExpressionVisitor transformingVisitor)
+        public ExpressionTransformingQueryModelVisitor([NotNull] TVisitor transformingVisitor)
         {
             Check.NotNull(transformingVisitor, nameof(transformingVisitor));
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -618,6 +618,23 @@ FROM [Level4] AS [e4]",
                 Sql);
         }
 
+        public override void Join_navigation_translated_to_subquery_deeply_nested_required()
+        {
+            base.Join_navigation_translated_to_subquery_deeply_nested_required();
+
+            Assert.Equal(
+                @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
+FROM [Level1] AS [e1]
+INNER JOIN [Level4] AS [e4] ON [e1].[Name] = (
+    SELECT TOP(1) [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0].[Name]
+    FROM [Level3] AS [subQuery0]
+    INNER JOIN [Level2] AS [subQuery.OneToOne_Required_FK_Inverse0] ON [subQuery0].[Level2_Required_Id] = [subQuery.OneToOne_Required_FK_Inverse0].[Id]
+    INNER JOIN [Level1] AS [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0] ON [subQuery.OneToOne_Required_FK_Inverse0].[Id] = [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0].[Id]
+    WHERE [subQuery0].[Id] = [e4].[Level3_Required_Id]
+)",
+                Sql);
+        }
+
         public override void Multiple_complex_includes()
         {
             base.Multiple_complex_includes();
@@ -1829,22 +1846,47 @@ FROM [Level1] AS [l1]",
                 Sql);
         }
 
-        public override void Null_protection_logic_work_for_key_access_of_manually_created_GroupJoin1()
+        public override void Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin1()
         {
-            base.Null_protection_logic_work_for_key_access_of_manually_created_GroupJoin1();
+            base.Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin1();
 
-            Assert.Equal(
-                @"",
+            Assert.Contains(
+                @"SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
+ORDER BY [l10].[Id]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]",
                 Sql);
         }
 
-        public override void Null_protection_logic_work_for_key_access_of_manually_created_GroupJoin2()
+        public override void Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin2()
         {
-            base.Null_protection_logic_work_for_key_access_of_manually_created_GroupJoin2();
+            base.Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin2();
 
             Assert.Contains(
-                @"SELECT [l2].[Id], [l2].[Date], [l2].[Name], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_SelfId]
-FROM [Level1] AS [l2]",
+                @"SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
+ORDER BY [l10].[Id]",
+                Sql);
+
+            Assert.Contains(
+            @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]",
+                Sql);
+        }
+
+        public override void Null_protection_logic_work_for_outer_key_access_of_manually_created_GroupJoin()
+        {
+            base.Null_protection_logic_work_for_outer_key_access_of_manually_created_GroupJoin();
+
+            Assert.Contains(
+                @"SELECT [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]",
                 Sql);
 
             Assert.Contains(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -378,6 +378,23 @@ ORDER BY [w].[OwnerFullName]",
         {
             base.Include_where_list_contains_navigation();
 
+            Assert.Equal(
+                @"SELECT [t].[Id]
+FROM [CogTag] AS [t]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM [Gear] AS [g]
+LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [g].[Nickname]) AND ([c].[GearSquadId] = [g].[SquadId])
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g.Tag].[Id] IS NOT NULL
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                Sql);
+        }
+
+        public override void Include_where_list_contains_navigation2()
+        {
+            base.Include_where_list_contains_navigation2();
+
             // Separate asserts to account for ordering differences on .NETCore
 
             Assert.Contains(
@@ -386,8 +403,8 @@ FROM [CogTag] AS [t]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT [g.Tag1].[Id], [g.Tag1].[GearNickName], [g.Tag1].[GearSquadId], [g.Tag1].[Note]
-FROM [CogTag] AS [g.Tag1]",
+                @"SELECT [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+FROM [City] AS [g.CityOfBirth]",
                 Sql);
 
             Assert.Contains(
@@ -395,6 +412,22 @@ FROM [CogTag] AS [g.Tag1]",
 FROM [Gear] AS [g]
 LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
 LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [g].[Nickname]) AND ([c].[GearSquadId] = [g].[SquadId])
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                Sql);
+        }
+
+        public override void Navigation_accessed_twice_outside_and_inside_subquery()
+        {
+            base.Navigation_accessed_twice_outside_and_inside_subquery();
+
+            Assert.Equal(
+                @"SELECT [t].[Id]
+FROM [CogTag] AS [t]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
+FROM [Gear] AS [g]
+LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g.Tag].[Id] IS NOT NULL
 ORDER BY [g].[Nickname], [g].[SquadId]",
                 Sql);


### PR DESCRIPTION
Problem was that for some groupjoin queries, e.g.:
```c#
var query = context.LevelOne
    .GroupJoin(
        context.LevelOne.Select(l1 => l1.OneToOne_Required_FK),
        l1 => l1.Id,
        l2 => EF.Property<int?>(l2, "Level1_Optional_Id"),
        (l1, l2s) => new { l1, l2s })
    .Select(r => r.l1)
```
In this case inner collection selector can potentially return null and therefore when translating inner key selector we should apply null protection logic. We were not doing that however, because those two operations were done in separate places, by two different instances of NavigationRewritingExpressionVisitor. Fix is to introduce additional state to the visitor, when visiting inner key selector, and then using that information when processing inner key selector.

Moreover now we are reusing the NavigationRewritingExpressionVisitor simplifying the code somewhat and allowing us to easily share state between different nav rewrite operations.

This also fixes #6609 - Query :: we are adding redundant navigation joins to query in some cases, resulting in correct but unnecessarily complex queries

Since now we are better at recognizing the same navigation joins (as they are processed by the same visitor)