### PR TITLE
[1.0.2] Query: Remove Sql-Server specific projection modifier for search conditions

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4972,6 +4972,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void IsNullOrEmpty_negated_in_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<Customer>()
+                    .Select(c => new { Id = c.CustomerID, Value = !string.IsNullOrEmpty(c.Region) })
+                    .ToList();
+
+                Assert.Equal(91, query.Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void IsNullOrWhiteSpace_in_predicate()
         {
             AssertQuery<Customer>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -736,8 +736,8 @@ WHERE [w].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
 
             Assert.Equal(
                 @"SELECT [w].[Id], CASE
-    WHEN [w].[IsAutomatic] = 0
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    WHEN [w].[IsAutomatic] = 1
+    THEN CAST(0 AS BIT) ELSE CAST(1 AS BIT)
 END
 FROM [Weapon] AS [w]
 WHERE [w].[IsAutomatic] = 1",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5157,6 +5157,19 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
+        public override void IsNullOrEmpty_negated_in_projection()
+        {
+            base.IsNullOrEmpty_negated_in_projection();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], CASE
+    WHEN [c].[Region] IS NOT NULL AND NOT (([c].[Region] = N'') AND [c].[Region] IS NOT NULL)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void IsNullOrWhiteSpace_in_predicate()
         {
             base.IsNullOrWhiteSpace_in_predicate();


### PR DESCRIPTION
Resolves #6598 
We have `ProjectionComparisonTransformingVisitor` class in Sql-Server specific code.
https://github.com/aspnet/EntityFramework/blob/dev/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs#L153
Which somewhat does the same thing as `SearchConditionTranslatingVisitor`. In combination, both tried to make a case block hence we got into state of incorrect nested case blocks.
Sql-Server specific code should be removed and relational one should be used. The most of the changes needed in `SearchConditionTranslatingVisitor` are already done in 1.1.0 codebase.