### PR TITLE
Query: Fix #6458 - CompiledQueryCache use a static lock that will mak…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/CompiledQueryCache.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/CompiledQueryCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -10,23 +11,24 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class CompiledQueryCache : ICompiledQueryCache
     {
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string CompiledQueryParameterPrefix = "__";
 
-        private static readonly object _compiledQueryLockObject = new object();
+        private static readonly ConcurrentDictionary<object, object> _querySyncObjects 
+            = new ConcurrentDictionary<object, object>();
 
         private readonly IMemoryCache _memoryCache;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public CompiledQueryCache([NotNull] IDbContextServices contextServices)
@@ -35,40 +37,47 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Func<QueryContext, TResult> GetOrAddQuery<TResult>(
             object cacheKey, Func<Func<QueryContext, TResult>> compiler)
         {
             Func<QueryContext, TResult> compiledQuery;
-            lock (_compiledQueryLockObject)
+
+            retry:
+            if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
             {
-                if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
+                if (!_querySyncObjects.TryAdd(cacheKey, null))
                 {
-                    compiledQuery = compiler();
-                    _memoryCache.Set(cacheKey, compiledQuery);
+                    goto retry;
                 }
+
+                compiledQuery = compiler();
+
+                _memoryCache.Set(cacheKey, compiledQuery);
+
+                object _;
+                _querySyncObjects.TryRemove(cacheKey, out _);
             }
 
             return compiledQuery;
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Func<QueryContext, IAsyncEnumerable<TResult>> GetOrAddAsyncQuery<TResult>(
             object cacheKey, Func<Func<QueryContext, IAsyncEnumerable<TResult>>> compiler)
         {
             Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery;
-            lock (_compiledQueryLockObject)
+
+            if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
             {
-                if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
-                {
-                    compiledQuery = compiler();
-                    _memoryCache.Set(cacheKey, compiledQuery);
-                }
+                compiledQuery = compiler();
+
+                _memoryCache.Set(cacheKey, compiledQuery);
             }
 
             return compiledQuery;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -10,16 +10,56 @@ using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+// ReSharper disable AccessToDisposedClosure
+
 #pragma warning disable 1998
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class AsyncQuerySqlServerTest : AsyncQueryTestBase<NorthwindQuerySqlServerFixture>
     {
+        public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        [ConditionalFact]
+        public async Task Query_compiler_concurrency()
+        {
+            const int threadCount = 50;
+
+            var tasks = new Task[threadCount];
+
+            for (var i = 0; i < threadCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                    {
+                        using (var context = CreateContext())
+                        {
+                            (from c in context.Customers
+                             where c.City == "London"
+                             orderby c.CustomerID
+                             select (from o1 in context.Orders
+                                     where o1.CustomerID == c.CustomerID
+                                           && o1.OrderDate.Value.Year == 1997
+                                     orderby o1.OrderID
+                                     select (from o2 in context.Orders
+                                             where o1.CustomerID == c.CustomerID
+                                             orderby o2.OrderID
+                                             select o1.OrderID)))
+                                .Load();
+                        }
+                    });
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
         [ConditionalFact]
         public async Task Race_when_context_disposed_before_query_termination()
         {
             Task<Customer> task;
-           
+
             using (var context = CreateContext())
             {
                 task = context.Customers.SingleAsync(c => c.CustomerID == "ALFKI");
@@ -58,7 +98,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1().ToLower()) || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
+                cs => cs.Where(c =>
+                    c.ContactName.Contains(LocalMethod1().ToLower())
+                    || c.ContactName.Contains(LocalMethod1().ToUpper())), // case-sensitive
                 entryCount: 34);
         }
 
@@ -71,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public async Task Single_Predicate_Cancellation()
         {
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                await Single_Predicate_Cancellation(Fixture.CancelQuery()));
+                    await Single_Predicate_Cancellation(Fixture.CancelQuery()));
         }
 
         [Fact]
@@ -89,12 +131,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 Assert.Equal(6, tasks[1].Count);
                 Assert.Equal(4, tasks[2].Count);
             }
-        }
-
-        public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
-            : base(fixture)
-        {
-            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1256,7 +1256,7 @@ FROM (
                 Sql);
         }
 
-        [Fact]
+        [ConditionalFact]
         public override void Select_Distinct_Count()
         {
             base.Select_Distinct_Count();


### PR DESCRIPTION
- Removed static lock and added logic to ensure a single compilation per cache-key.