### PR TITLE
[SMALL] Fix to #6597 - "Operation is not valid due to the current state of the object" in some queries with navigation and paging

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -667,8 +667,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (!RequiresClientSelectMany
                 && previousSelectExpression != null
-                && (!groupJoin 
-                    || CanFlattenGroupJoin()))
+                && CanFlattenJoin())
             {
                 var selectExpression = TryGetQuery(joinClause);
 
@@ -819,14 +818,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             return previousMapping;
         }
 
-        private bool CanFlattenGroupJoin()
+        private bool CanFlattenJoin()
         {
-            var groupJoinExpression = Expression as MethodCallExpression;
+            var joinExpression = Expression as MethodCallExpression;
 
-            return groupJoinExpression != null 
-                && groupJoinExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.GroupJoin) 
-                && IsShapedQueryExpression(groupJoinExpression.Arguments[0] as MethodCallExpression, innerShapedQuery: false) 
-                && IsShapedQueryExpression(groupJoinExpression.Arguments[1] as MethodCallExpression, innerShapedQuery: true);
+            return joinExpression != null
+                && (joinExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.Join)
+                    || joinExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.GroupJoin))
+                && IsShapedQueryExpression(joinExpression.Arguments[0] as MethodCallExpression, innerShapedQuery: false)
+                && IsShapedQueryExpression(joinExpression.Arguments[1] as MethodCallExpression, innerShapedQuery: true);
         }
 
         private class OuterJoinOrderingExtractor : ExpressionVisitor

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3474,5 +3474,76 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 }
             }
         }
+
+        [ConditionalFact]
+        public virtual void Required_navigation_take_required_navigation()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelThree.Include(l3 => l3.OneToOne_Required_FK_Inverse).ThenInclude(l2 => l2.OneToOne_Required_FK_Inverse)
+                    .ToList()
+                    .Select(l3 => l3.OneToOne_Required_FK_Inverse)
+                    .OrderBy(l2 => l2.Id)
+                    .Take(10)
+                    .Select(l2 => l2.OneToOne_Required_FK_Inverse.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelThree
+                    .Select(l3 => l3.OneToOne_Required_FK_Inverse)
+                    .OrderBy(l3 => l3.Id)
+                    .Take(10)
+                    .Select(l2 => l2.OneToOne_Required_FK_Inverse.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]));
+                }
+            }
+        }
+
+        // issue #6618
+        ////[ConditionalFact]
+        public virtual void Optional_navigation_take_optional_navigation()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne.Include(l1 => l1.OneToOne_Optional_FK).ThenInclude(l2 => l2.OneToOne_Optional_FK)
+                    .ToList()
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .OrderBy(l2 => l2?.Id)
+                    .Take(10)
+                    .Select(l2 => l2?.OneToOne_Optional_FK?.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .OrderBy(l2 => l2.Id)
+                    .Take(10)
+                    .Select(l2 => l2.OneToOne_Optional_FK.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]));
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1912,6 +1912,40 @@ WHERE EXISTS (
                 Sql);
         }
 
+        public override void Required_navigation_take_required_navigation()
+        {
+            base.Required_navigation_take_required_navigation();
+
+            // Separate asserts to account for ordering differences on .NETCore
+
+            Assert.Contains(
+                @"SELECT [l2.OneToOne_Required_FK_Inverse].[Id], [l2.OneToOne_Required_FK_Inverse].[Name]
+FROM [Level1] AS [l2.OneToOne_Required_FK_Inverse]",
+                Sql);
+
+            Assert.Contains(
+                @"@__p_0: ?
+
+SELECT [t].[Level1_Required_Id]
+FROM (
+    SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse0].*
+    FROM [Level3] AS [l30]
+    INNER JOIN [Level2] AS [l3.OneToOne_Required_FK_Inverse0] ON [l30].[Level2_Required_Id] = [l3.OneToOne_Required_FK_Inverse0].[Id]
+    ORDER BY [l30].[Level2_Required_Id]
+) AS [t]",
+                Sql);
+
+        }
+
+        public override void Optional_navigation_take_optional_navigation()
+        {
+            base.Optional_navigation_take_optional_navigation();
+
+            Assert.Equal(
+                @"",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Problem was during join flattening - we can't flatten joins whose input elements are not directly ShapedQueries (e.g. when shaped query is wrapped in select). For those cases we should delegate to client eval.
We already do that for GroupJoin, but it can also happen for regular joins.