### PR TITLE
[1.0.2] Fix to #6620 - GroupBy multiple keys throws exception in 1.0.1

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -3758,6 +3758,69 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void GroupBy_with_orderby()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => o.CustomerID).OrderBy(g => g.Key),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var efGroupings = efResults.Cast<IGrouping<string, Order>>().ToList();
+
+                        foreach (IGrouping<string, Order> l2oGrouping in l2oResults)
+                        {
+                            var efGrouping = efGroupings.Single(efg => efg.Key == l2oGrouping.Key);
+
+                            Assert.Equal(l2oGrouping.OrderBy(p => p.OrderID), efGrouping.OrderBy(p => p.OrderID));
+                        }
+                    }, 
+                entryCount: 830);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_with_orderby_and_anonymous_projection()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Select(g => new { Foo = "Foo", Group = g }),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        Assert.Equal(l2oResults.Count, efResults.Count);
+                        for (int i = 0; i < l2oResults.Count; i++)
+                        {
+                            dynamic l2oResult = l2oResults[i];
+                            dynamic efResult = efResults[i];
+
+                            Assert.Equal(l2oResult.Foo, l2oResult.Foo);
+                            IGrouping<string, Order> l2oGrouping = l2oResult.Group;
+                            IGrouping<string, Order> efGrouping = efResult.Group;
+                            Assert.Equal(l2oGrouping.OrderBy(p => p.OrderID), efGrouping.OrderBy(p => p.OrderID));
+                        }
+                    },
+                entryCount: 830);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_with_orderby_take_skip_distinct()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Take(5).Skip(3).Distinct(),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var efGroupings = efResults.Cast<IGrouping<string, Order>>().ToList();
+
+                        foreach (IGrouping<string, Order> l2oGrouping in l2oResults)
+                        {
+                            var efGrouping = efGroupings.Single(efg => efg.Key == l2oGrouping.Key);
+
+                            Assert.Equal(l2oGrouping.OrderBy(p => p.OrderID), efGrouping.OrderBy(p => p.OrderID));
+                        }
+                    },
+                entryCount: 31);
+        }
+
+        [ConditionalFact]
         public virtual void Select_All()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -569,11 +569,34 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return;
             }
 
-            var groupResultOperator 
-                = queryModel.ResultOperators.OfType<GroupResultOperator>().LastOrDefault();
+            var outputExpression = queryModel.SelectClause.Selector;
 
-            var outputExpression
-                = groupResultOperator?.ElementSelector ?? queryModel.SelectClause.Selector;
+            var resultItemType = _expression.Type.GetSequenceType();
+            var isGrouping = resultItemType.IsGrouping();
+
+            if (isGrouping)
+            {
+                var groupResultOperator
+                    = queryModel.ResultOperators.OfType<GroupResultOperator>().LastOrDefault();
+
+                if (groupResultOperator != null)
+                {
+                    outputExpression = groupResultOperator.ElementSelector;
+                }
+                else
+                {
+                    var subqueryExpression = ((queryModel.SelectClause.Selector as QuerySourceReferenceExpression)
+                        ?.ReferencedQuerySource as MainFromClause)?.FromExpression as SubQueryExpression;
+
+                    var nestedGroupResultOperator
+                        = subqueryExpression?.QueryModel?.ResultOperators?.OfType<GroupResultOperator>()?.LastOrDefault();
+
+                    if (nestedGroupResultOperator != null)
+                    {
+                        outputExpression = nestedGroupResultOperator.ElementSelector;
+                    }
+                }
+            }
 
             var entityTrackingInfos
                 = _entityResultFindingExpressionVisitorFactory.Create(QueryCompilationContext)
@@ -581,15 +604,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (entityTrackingInfos.Any())
             {
-                var resultItemType = _expression.Type.GetSequenceType();
-                var resultItemTypeInfo = resultItemType.GetTypeInfo();
-
                 MethodInfo trackingMethod;
 
-                if (resultItemTypeInfo.IsGenericType
-                    && (resultItemTypeInfo.GetGenericTypeDefinition() == typeof(IGrouping<,>)
-                        || resultItemTypeInfo.GetGenericTypeDefinition() == typeof(IAsyncGrouping<,>)))
- 
+                if (isGrouping)
+
                 {
                     trackingMethod
                         = LinqOperatorProvider.TrackGroupedEntities

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -81,6 +81,13 @@ namespace System
                && !type.IsInterface
                && (!type.IsGenericType || !type.IsGenericTypeDefinition);
 
+        public static bool IsGrouping(this Type type) => IsGrouping(type.GetTypeInfo());
+
+        private static bool IsGrouping(TypeInfo type)
+            => type.IsGenericType
+                    && (type.GetGenericTypeDefinition() == typeof(IGrouping<,>)
+                        || type.GetGenericTypeDefinition() == typeof(IAsyncGrouping<,>));
+
         public static Type UnwrapEnumType(this Type type)
         {
             var isNullable = type.IsNullableType();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3156,6 +3156,39 @@ ORDER BY [o].[OrderID]",
                 Sql);
         }
 
+        public override void GroupBy_with_orderby()
+        {
+            base.GroupBy_with_orderby();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupBy_with_orderby_and_anonymous_projection()
+        {
+            base.GroupBy_with_orderby_and_anonymous_projection();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupBy_with_orderby_take_skip_distinct()
+        {
+            base.GroupBy_with_orderby_take_skip_distinct();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
+                Sql);
+        }
+
         public override void SelectMany_cartesian_product_with_ordering()
         {
             base.SelectMany_cartesian_product_with_ordering();


### PR DESCRIPTION
Problem was with Tracking queries involving GroupBy and OrderBy/Skip/Take/Distinct. When tracking results of group by we were trying to extract Grouping element from the result however we always assumed that the Grouping result operator would be on the main QueryModel. When Orderby/Take/Skip etc are used in conjunction with GroupBy, the GroupBy result operator is actually in the subquery. Fix is to properly extract Group Element information from the subquery when needed.