### PR TITLE
[SMALL] Fix to #5544 - Query :: force client evaluation on First() inside a query

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -436,7 +436,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             handlerContext.SelectExpression.Limit = Expression.Constant(1);
 
-            return handlerContext.EvalOnClient(requiresClientResultOperator: false);
+            var requiresClientResultOperator = !((FirstResultOperator)handlerContext.ResultOperator).ReturnDefaultWhenEmpty
+                && handlerContext.QueryModelVisitor.ParentQueryModelVisitor != null;
+
+            return handlerContext.EvalOnClient(requiresClientResultOperator);
         }
 
         private static Expression HandleGroup(HandlerContext handlerContext)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4277,6 +4277,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void FirstOrDefault_inside_subquery_gets_server_evaluated()
+        {
+            AssertQuery<Customer>(
+                // ReSharper disable once ReplaceWithSingleCallToFirstOrDefault
+                cs => cs.Where(c => c.CustomerID == "ALFKI" && c.Orders.Where(o => o.CustomerID == "ALFKI").FirstOrDefault().CustomerID == "ALFKI"),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void First_inside_subquery_gets_client_evaluated()
+        {
+            AssertQuery<Customer>(
+                // ReSharper disable once ReplaceWithSingleCallToFirstOrDefault
+                cs => cs.Where(c => c.CustomerID == "ALFKI" && c.Orders.Where(o => o.CustomerID == "ALFKI").First().CustomerID == "ALFKI"),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
         public virtual void Last()
         {
             AssertQuery<Customer>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2044,6 +2044,38 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
+        public override void FirstOrDefault_inside_subquery_gets_server_evaluated()
+        {
+            base.FirstOrDefault_inside_subquery_gets_server_evaluated();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] = N'ALFKI') AND ((
+    SELECT TOP(1) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE ([o].[CustomerID] = N'ALFKI') AND ([c].[CustomerID] = [o].[CustomerID])
+) = N'ALFKI')",
+                Sql);
+        }
+
+        public override void First_inside_subquery_gets_client_evaluated()
+        {
+            base.First_inside_subquery_gets_client_evaluated();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o0].[CustomerID]
+FROM [Orders] AS [o0]
+WHERE ([o0].[CustomerID] = N'ALFKI') AND (@_outer_CustomerID = [o0].[CustomerID])",
+                Sql);
+        }
+
         public override void Last()
         {
             base.Last();


### PR DESCRIPTION
We used to try server-evaluate calls to First() in a subquery, however we are unable to properly mimic the exception that could potentially be thrown from First() method. Fix is to always force client evaluation when First() is used in a subquery.
If one wants to avoid client evaluation, FirstOrDefault() should be used.