### PR TITLE
Metadata cleanup following hierarchy/base class changes

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IProperty property)
+        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IPropertyBase property)
             => Expression.Default(property.ClrType);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -464,7 +464,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(!(propertyBase is IProperty) || !((IProperty)propertyBase).IsShadowProperty);
+            Debug.Assert(!propertyBase.IsShadowProperty);
 
             return propertyBase.GetGetter().GetClrValue(Entity);
         }
@@ -475,7 +475,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual void WritePropertyValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value)
         {
-            Debug.Assert(!(propertyBase is IProperty) || !((IProperty)propertyBase).IsShadowProperty);
+            Debug.Assert(!propertyBase.IsShadowProperty);
 
             propertyBase.GetSetter().SetClrValue(Entity, value);
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class InternalMixedEntityEntry : InternalEntityEntry
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly ISnapshot _shadowValues;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InternalMixedEntityEntry(
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InternalMixedEntityEntry(
@@ -49,47 +49,40 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override object Entity { get; }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override T ReadShadowValue<T>(int shadowIndex)
             => _shadowValues.GetValue<T>(shadowIndex);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
-        {
-            var property = propertyBase as IProperty;
-
-            return (property == null) || !property.IsShadowProperty
+            => !propertyBase.IsShadowProperty
                 ? base.ReadPropertyValue(propertyBase)
-                : _shadowValues[property.GetShadowIndex()];
-        }
+                : _shadowValues[propertyBase.GetShadowIndex()];
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override void WritePropertyValue(IPropertyBase propertyBase, object value)
         {
-            var property = propertyBase as IProperty;
-
-            if ((property == null)
-                || !property.IsShadowProperty)
+            if (!propertyBase.IsShadowProperty)
             {
                 base.WritePropertyValue(propertyBase, value);
             }
             else
             {
-                _shadowValues[property.GetShadowIndex()] = value;
+                _shadowValues[propertyBase.GetShadowIndex()] = value;
             }
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalShadowEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalShadowEntityEntry.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -10,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
-    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class InternalShadowEntityEntry : InternalEntityEntry
@@ -18,13 +17,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly ISnapshot _propertyValues;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override object Entity => null;
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InternalShadowEntityEntry(
@@ -39,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public InternalShadowEntityEntry(
@@ -52,34 +51,24 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         }
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override T ReadShadowValue<T>(int shadowIndex)
             => _propertyValues.GetValue<T>(shadowIndex);
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
-        {
-            var property = propertyBase as IProperty;
-            Debug.Assert((property != null) && property.IsShadowProperty);
-
-            return _propertyValues[property.GetShadowIndex()];
-        }
+            => _propertyValues[propertyBase.GetShadowIndex()];
 
         /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override void WritePropertyValue(IPropertyBase propertyBase, object value)
-        {
-            var property = propertyBase as IProperty;
-            Debug.Assert((property != null) && property.IsShadowProperty);
-
-            _propertyValues[property.GetShadowIndex()] = value;
-        }
+            => _propertyValues[propertyBase.GetShadowIndex()] = value;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IProperty property)
+        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IPropertyBase property)
             => Expression.Convert(
                 Expression.Call(
                     parameter,

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -107,7 +107,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 var propertyBase = propertyBases[i];
 
                 var navigation = propertyBase as INavigation;
-                var property = propertyBase as IProperty;
 
                 arguments[i] =
                     navigation != null
@@ -118,9 +117,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             Expression.MakeMemberAccess(
                                 entityVariable,
                                 propertyBase.GetMemberInfo(forConstruction: false, forSet: false)))
-                        : property != null
-                          && property.IsShadowProperty
-                            ? CreateReadShadowValueExpression(parameter, property)
+                        : propertyBase.IsShadowProperty
+                            ? CreateReadShadowValueExpression(parameter, propertyBase)
                             : Expression.MakeMemberAccess(
                                 entityVariable,
                                 propertyBase.GetMemberInfo(forConstruction: false, forSet: false));
@@ -153,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual Expression CreateReadShadowValueExpression(
-            [CanBeNull] ParameterExpression parameter, [NotNull] IProperty property)
+            [CanBeNull] ParameterExpression parameter, [NotNull] IPropertyBase property)
             => Expression.Call(
                 parameter,
                 InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod(property.ClrType),

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableNavigationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableNavigationExtensions.cs
@@ -3,8 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -33,40 +31,5 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The target entity type. </returns>
         public static IMutableEntityType GetTargetType([NotNull] this IMutableNavigation navigation)
             => (IMutableEntityType)((INavigation)navigation).GetTargetType();
-
-        /// <summary>
-        ///     <para>
-        ///         Sets the backing field to use for this navigation property.
-        ///     </para>
-        ///     <para>
-        ///         Backing fields are normally found by convention as described
-        ///         here: http://go.microsoft.com/fwlink/?LinkId=723277.
-        ///         This method is useful for setting backing fields explicitly in cases where the
-        ///         correct field is not found by convention.
-        ///     </para>
-        ///     <para>
-        ///         By default, the backing field is only used for navigation properties when the property
-        ///         must be read and there is no getter, or the property must be set and there is not setter.
-        ///         This can be changed by calling <see cref="SetPropertyAccessMode" /> for the property.
-        ///     </para>
-        /// </summary>
-        /// <param name="navigation"> The navigation property for which the field should be set. </param>
-        /// <param name="fieldName"> The name of the field to use. </param>
-        public static void SetField([NotNull] this IMutableNavigation navigation, [CanBeNull] string fieldName)
-            => Check.NotNull(navigation, nameof(navigation)).AsPropertyBase()
-                .SetField(fieldName, ConfigurationSource.Explicit);
-
-        /// <summary>
-        ///     Sets the <see cref="PropertyAccessMode" /> to use for this navigation property.
-        /// </summary>
-        /// <param name="navigation"> The navigation property for which to set the access mode. </param>
-        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" />, or null to clear the mode set.</param>
-        public static void SetPropertyAccessMode(
-            [NotNull] this IMutableNavigation navigation, PropertyAccessMode? propertyAccessMode)
-        {
-            Check.NotNull(navigation, nameof(navigation));
-
-            navigation[CoreAnnotationNames.PropertyAccessModeAnnotation] = propertyAccessMode;
-        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyBaseExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Extension methods for <see cref="IMutablePropertyBase" />.
+    /// </summary>
+    public static class MutablePropertyBaseExtensions
+    {
+        /// <summary>
+        ///     <para>
+        ///         Sets the backing field to use for this property.
+        ///     </para>
+        ///     <para>
+        ///         Backing fields are normally found by convention as described
+        ///         here: http://go.microsoft.com/fwlink/?LinkId=723277.
+        ///         This method is useful for setting backing fields explicitly in cases where the
+        ///         correct field is not found by convention.
+        ///     </para>
+        ///     <para>
+        ///         By default, the backing field, if one is found or has been specified, is used when
+        ///         new objects are constructed, typically when entities are queried from the database.
+        ///         Properties are used for all other accesses. This can be changed by calling
+        ///         <see cref="SetPropertyAccessMode" />.
+        ///     </para>
+        /// </summary>
+        /// <param name="property"> The property for which the backing field should be set. </param>
+        /// <param name="fieldName"> The name of the field to use. </param>
+        public static void SetField([NotNull] this IMutablePropertyBase property, [CanBeNull] string fieldName)
+            => Check.NotNull(property, nameof(property)).AsPropertyBase()
+                .SetField(fieldName, ConfigurationSource.Explicit);
+
+        /// <summary>
+        ///     Sets the <see cref="PropertyAccessMode" /> to use for this property.
+        /// </summary>
+        /// <param name="property"> The property for which to set the access mode. </param>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" />, or null to clear the mode set.</param>
+        public static void SetPropertyAccessMode(
+            [NotNull] this IMutablePropertyBase property, PropertyAccessMode? propertyAccessMode)
+        {
+            Check.NotNull(property, nameof(property));
+
+            property[CoreAnnotationNames.PropertyAccessModeAnnotation] = propertyAccessMode;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
@@ -62,19 +62,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Sets the <see cref="PropertyAccessMode" /> to use for this property.
-        /// </summary>
-        /// <param name="property"> The property for which to set the access mode. </param>
-        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" />, or null to clear the mode set.</param>
-        public static void SetPropertyAccessMode(
-            [NotNull] this IMutableProperty property, PropertyAccessMode? propertyAccessMode)
-        {
-            Check.NotNull(property, nameof(property));
-
-            property[CoreAnnotationNames.PropertyAccessModeAnnotation] = propertyAccessMode;
-        }
-
-        /// <summary>
         ///     Sets a value indicating whether or not this property can persist unicode characters.
         /// </summary>
         /// <param name="property"> The property to set the value for. </param>
@@ -118,28 +105,5 @@ namespace Microsoft.EntityFrameworkCore
         /// </returns>
         public static IEnumerable<IMutableKey> GetContainingKeys([NotNull] this IMutableProperty property)
             => ((IProperty)property).GetContainingKeys().Cast<IMutableKey>();
-
-        /// <summary>
-        ///     <para>
-        ///         Sets the backing field to use for this property.
-        ///     </para>
-        ///     <para>
-        ///         Backing fields are normally found by convention as described
-        ///         here: http://go.microsoft.com/fwlink/?LinkId=723277.
-        ///         This method is useful for setting backing fields explicitly in cases where the
-        ///         correct field is not found by convention.
-        ///     </para>
-        ///     <para>
-        ///         By default, the backing field, if one is found or has been specified, is used when
-        ///         new objects are constructed, typically when entities are queried from the database.
-        ///         Properties are used for all other accesses. This can be changed by calling
-        ///         <see cref="SetPropertyAccessMode" />.
-        ///     </para>
-        /// </summary>
-        /// <param name="property"> The property for which the backing field should be set. </param>
-        /// <param name="fieldName"> The name of the field to use. </param>
-        public static void SetField([NotNull] this IMutableProperty property, [CanBeNull] string fieldName)
-            => Check.NotNull(property, nameof(property)).AsPropertyBase()
-                .SetField(fieldName, ConfigurationSource.Explicit);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -57,13 +56,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     values when new entities are added to the context.
         /// </summary>
         bool RequiresValueGenerator { get; }
-
-        /// <summary>
-        ///     Gets a value indicating whether this is a shadow property. A shadow property is one that does not have a
-        ///     corresponding property in the entity class. The current value for the property is stored in
-        ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
-        /// </summary>
-        bool IsShadowProperty { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this property is used as a concurrency token. When a property is configured

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -39,5 +40,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     property is not known.
         /// </summary>
         FieldInfo FieldInfo { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether this is a shadow property. A shadow property is one that does not have a
+        ///     corresponding property in the entity class. The current value for the property is stored in
+        ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
+        /// </summary>
+        bool IsShadowProperty { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -334,12 +334,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool IsShadowProperty => MemberInfo == null;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public virtual bool IsConcurrencyToken
         {
             get

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -56,6 +56,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool IsShadowProperty => MemberInfo == null;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual PropertyInfo PropertyInfo { get; }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -19,6 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static int GetShadowIndex([NotNull] this IPropertyBase property)
+            => property.GetPropertyIndexes().ShadowIndex;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static int GetStoreGeneratedIndex([NotNull] this IPropertyBase propertyBase)
             => propertyBase.GetPropertyIndexes().StoreGenerationIndex;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -67,13 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
             return null;
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static int GetShadowIndex([NotNull] this IProperty property)
-            => property.GetPropertyIndexes().ShadowIndex;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/TypeBase.cs
@@ -40,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected TypeBase([NotNull] Type clrType, [NotNull] Model model, ConfigurationSource configurationSource)
             : this(model, configurationSource)
         {
-            Check.ValidEntityType(clrType, nameof(clrType));
             Check.NotNull(model, nameof(model));
 
             _typeOrName = clrType;

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Extensions\MutableKeyExtensions.cs" />
     <Compile Include="Extensions\MutableModelExtensions.cs" />
     <Compile Include="Extensions\MutableNavigationExtensions.cs" />
+    <Compile Include="Extensions\MutablePropertyBaseExtensions.cs" />
     <Compile Include="Extensions\MutablePropertyExtensions.cs" />
     <Compile Include="Extensions\NavigationExtensions.cs" />
     <Compile Include="Extensions\ObservableCollectionExtensions.cs" />


### PR DESCRIPTION
These are changes that have been made on the ComplexTypes branch for things that I found following the change to the metadata types hierarchy and the move of some members to IPropertyBase. Making these changes to dev since they aren't strictly related to complex type support and it is better to change them sooner rather than later.