### PR TITLE
Query: Convert complex expression to alias while lifting order by in collection include

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
         private bool Equals([NotNull] ColumnExpression other)
-            => ((_property == null && other._property == null)
+            => ((_property == null && other._property == null && Name == other.Name)
                 || (_property != null && _property.Equals(other._property)))
                && Type == other.Type
                && _tableExpression.Equals(other._tableExpression);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -1340,8 +1340,35 @@ ORDER BY [o1].[c0_0] DESC, [o1].[CustomerID], [o1].[OrderID]",
                 Sql);
         }
 
+        public override void Include_collection_with_conditional_order_by(bool useString)
+        {
+            base.Include_collection_with_conditional_order_by(useString);
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY CASE
+    WHEN [c].[CustomerID] LIKE N'S' + N'%' AND (CHARINDEX(N'S', [c].[CustomerID]) = 1)
+    THEN 1 ELSE 2
+END, [c].[CustomerID]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT CASE
+        WHEN [c].[CustomerID] LIKE N'S' + N'%' AND (CHARINDEX(N'S', [c].[CustomerID]) = 1)
+        THEN 1 ELSE 2
+    END AS [c0_0], [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[c0_0], [c0].[CustomerID]",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
+
+        protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }


### PR DESCRIPTION
Fixes #6591 
Issue here was, when we were lifting order by in collection include, we only made alias for `SelectExpression` so for a case block, we updated column expression to add it to outer query order by. Which generated incorrect SQL because the column is not project from inner subquery and the table reference is incorrect.
Fix is to make alias for any expression in inner subquery order by which is not column expression or aliased column expression.
Another minor fix - if ColumnExpression does not have underlying property then `Equals` should match names too.