### PR TITLE
Query: Convert Order By constant & @@rowcount to (SELECT 1)

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -382,6 +382,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                             Visit(aliasExpression.Expression);
                         }
                     }
+                    else if (orderingExpression is ConstantExpression
+                        || orderingExpression is ParameterExpression)
+                    {
+                        _relationalCommandBuilder.Append("(SELECT 1)");
+                    }
                     else
                     {
                         Visit(ApplyOptimizations(orderingExpression, searchCondition: false));

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -3140,7 +3140,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 91);
         }
 
-        //[ConditionalFact] TODO: See issue#6145
+        [ConditionalFact]
         public virtual void OrderBy_true()
         {
             AssertQuery<Customer>(
@@ -3149,11 +3149,21 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 91);
         }
 
-        //[ConditionalFact] TODO: See issue#6145
+        [ConditionalFact]
         public virtual void OrderBy_integer()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => 3),
+                assertOrder: true,
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_parameter()
+        {
+            var param = 5;
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => param),
                 assertOrder: true,
                 entryCount: 91);
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             if (selectExpression.Offset != null
                 && !selectExpression.OrderBy.Any())
             {
-                Sql.AppendLine().Append("ORDER BY @@ROWCOUNT");
+                Sql.AppendLine().Append("ORDER BY (SELECT 1)");
             }
 
             base.GenerateLimitOffset(selectExpression);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1986,7 +1986,6 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
                 Sql);
         }
 
-        // TODO: See issue#6145 - Incorrect query generated
         public override void Left_join_predicate_value_equals_condition()
         {
             base.Left_join_predicate_value_equals_condition();
@@ -1996,7 +1995,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
 FROM [Gear] AS [g]
 LEFT JOIN [Weapon] AS [w] ON [w].[SynergyWithId] IS NOT NULL
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY 1",
+ORDER BY (SELECT 1)",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1296,7 +1296,7 @@ OFFSET @__p_0 ROWS",
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY @@ROWCOUNT
+ORDER BY (SELECT 1)
 OFFSET @__p_0 ROWS",
                 Sql);
         }
@@ -3603,7 +3603,7 @@ ORDER BY [c].[CustomerID]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY 1",
+ORDER BY (SELECT 1)",
                 Sql);
         }
 
@@ -3614,7 +3614,18 @@ ORDER BY 1",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY 3",
+ORDER BY (SELECT 1)",
+                Sql);
+        }
+
+        public override void OrderBy_parameter()
+        {
+            base.OrderBy_parameter();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)",
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #6145 , #6580 
Converted OrderBy with Constant/Parameter to `(SELECT 1)`
Converted dummy `@@rowcount` to `(SELECT 1)`