### PR TITLE
Query: Fix #6633 - [Test] CompiledQueryCacheKey generates InvalidCast…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -74,7 +74,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             public override bool Equals(object obj)
-                => !ReferenceEquals(null, obj) && obj is RelationalCompiledQueryCacheKey && Equals((RelationalCompiledQueryCacheKey)obj);
+                => !ReferenceEquals(null, obj)
+                   && obj is RelationalCompiledQueryCacheKey
+                   && Equals((RelationalCompiledQueryCacheKey)obj);
 
             private bool Equals(RelationalCompiledQueryCacheKey other)
                 => _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public override bool Equals(object obj)
-                => !ReferenceEquals(null, obj) && obj is SqlServerCompiledQueryCacheKey && Equals((SqlServerCompiledQueryCacheKey)obj);
+                => !ReferenceEquals(null, obj)
+                   && obj is SqlServerCompiledQueryCacheKey
+                   && Equals((SqlServerCompiledQueryCacheKey)obj);
 
             private bool Equals(SqlServerCompiledQueryCacheKey other)
                 => _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey)

--- a/src/Microsoft.EntityFrameworkCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -111,6 +111,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// </returns>
             public override bool Equals(object obj)
             {
+                if (ReferenceEquals(null, obj)
+                    || !(obj is CompiledQueryCacheKey))
+                {
+                    return false;
+                }
+
                 var other = (CompiledQueryCacheKey)obj;
 
                 return ReferenceEquals(_model, other._model)


### PR DESCRIPTION
…Exception intermittently.

- Fixed a broken assumption in CompiledQueryCacheKey.Equals(object)