### PR TITLE
Add support for triggers that modify values in the inserted/updated row to SQL Server

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Update/UpdateSqlGenerator.cs
@@ -155,7 +155,8 @@ namespace Microsoft.EntityFrameworkCore.Update
             AppendFromClause(commandStringBuilder, name, schema);
             // TODO: there is no notion of operator - currently all the where conditions check equality
             AppendWhereAffectedClause(commandStringBuilder, conditionOperations);
-            commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator).AppendLine();
+            commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator).AppendLine()
+                .AppendLine();
 
             return ResultSetMapping.LastInResultSet;
         }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_set_both_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_not_set_both_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_set_both_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_not_set_both_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -217,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -252,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -298,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -332,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -350,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -368,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -386,7 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -431,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -448,7 +448,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -482,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -499,7 +499,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -516,7 +516,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -560,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_many_no_navs_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_many_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -577,7 +577,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_many_no_navs_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_many_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -619,7 +619,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_set_both_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -637,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_not_set_both_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -655,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -672,7 +672,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -690,7 +690,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -707,7 +707,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -725,7 +725,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -742,7 +742,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_set_both_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -760,7 +760,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_not_set_both_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -778,7 +778,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -795,7 +795,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -813,7 +813,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -830,7 +830,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -848,7 +848,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -894,7 +894,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -911,7 +911,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -928,7 +928,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -946,7 +946,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -964,7 +964,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -982,7 +982,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1027,7 +1027,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1044,7 +1044,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1061,7 +1061,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_then_principal_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1078,7 +1078,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1095,7 +1095,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1112,7 +1112,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_then_dependent_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1156,7 +1156,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_then_principal_one_to_one_no_navs_FK_set_no_navs_set()
+        public virtual void Add_dependent_then_principal_one_to_one_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1173,7 +1173,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_then_dependent_one_to_one_no_navs_FK_set_no_navs_set()
+        public virtual void Add_principal_then_dependent_one_to_one_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1215,7 +1215,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_set_both_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1262,7 +1262,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_not_set_both_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1307,7 +1307,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1359,7 +1359,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1412,7 +1412,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1458,7 +1458,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1507,7 +1507,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1551,7 +1551,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_set_both_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1598,7 +1598,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_not_set_both_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1643,7 +1643,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1686,7 +1686,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1732,7 +1732,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1776,7 +1776,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1822,7 +1822,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1864,7 +1864,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1914,7 +1914,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -1955,7 +1955,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2006,7 +2006,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2053,7 +2053,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2097,7 +2097,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2139,7 +2139,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2189,7 +2189,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2233,7 +2233,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2275,7 +2275,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2316,7 +2316,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2358,7 +2358,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2398,7 +2398,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_many_no_navs_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_many_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2446,7 +2446,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_many_no_navs_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_many_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2485,7 +2485,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_set_both_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2532,7 +2532,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_not_set_both_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2577,7 +2577,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2629,7 +2629,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2682,7 +2682,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2728,7 +2728,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2777,7 +2777,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2821,7 +2821,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_set_both_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2868,7 +2868,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_not_set_both_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_not_set_both_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2913,7 +2913,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -2956,7 +2956,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3002,7 +3002,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3046,7 +3046,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3090,7 +3090,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3132,7 +3132,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3182,7 +3182,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3223,7 +3223,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3274,7 +3274,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3321,7 +3321,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3365,7 +3365,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_not_set_principal_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_prin_uni_FK_not_set_principal_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3407,7 +3407,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3457,7 +3457,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3501,7 +3501,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3543,7 +3543,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3584,7 +3584,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3626,7 +3626,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_dep_uni_FK_not_set_dependent_nav_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3666,7 +3666,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_dependent_but_not_principal_one_to_one_no_navs_FK_set_no_navs_set()
+        public virtual void Add_dependent_but_not_principal_one_to_one_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3714,7 +3714,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_principal_but_not_dependent_one_to_one_no_navs_FK_set_no_navs_set()
+        public virtual void Add_principal_but_not_dependent_one_to_one_no_navs_FK_set_no_navs_set()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3753,7 +3753,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_overlapping_graph_from_level()
+        public virtual void Add_overlapping_graph_from_level()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3771,7 +3771,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_overlapping_graph_from_game()
+        public virtual void Add_overlapping_graph_from_game()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -3790,7 +3790,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [Fact]
-        public void Add_overlapping_graph_from_item()
+        public virtual void Add_overlapping_graph_from_item()
         {
             ExecuteWithStrategyInTransaction(context =>
                 {
@@ -4071,7 +4071,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         protected StoreGeneratedFixupContext CreateContext()
             => (StoreGeneratedFixupContext)Fixture.CreateContext(TestStore);
 
-        public void Dispose() => TestStore.Dispose();
+        public virtual void Dispose() => TestStore.Dispose();
 
         protected TFixture Fixture { get; }
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
 
             var stringBuilder = new StringBuilder();
-            var resultSetMapping = UpdateSqlGenerator.AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands, lastIndex - 1);
+            var resultSetMapping = UpdateSqlGenerator.AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands, lastIndex - _bulkInsertCommands.Count);
             for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
             {
                 CommandResultSet[i] = resultSetMapping;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -57,12 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             var readOperations = modificationCommands[0].ColumnModifications.Where(o => o.IsRead).ToList();
             var writeOperations = modificationCommands[0].ColumnModifications.Where(o => o.IsWrite).ToList();
+            var keyOperations = modificationCommands[0].ColumnModifications.Where(o => o.IsKey).ToList();
+
             var defaultValuesOnly = writeOperations.Count == 0;
-            var nonIdentityOperations = defaultValuesOnly
-                ? modificationCommands[0].ColumnModifications
+            var nonIdentityOperations = modificationCommands[0].ColumnModifications
                     .Where(o => o.Property.SqlServer().ValueGenerationStrategy != SqlServerValueGenerationStrategy.IdentityColumn)
-                    .ToList()
-                : new List<ColumnModification>();
+                    .ToList();
 
             if (defaultValuesOnly)
             {
@@ -92,21 +92,31 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             if (defaultValuesOnly)
             {
-                return AppendBulkInsertWithServerValuesOnly(commandStringBuilder, modificationCommands, commandPosition, nonIdentityOperations, readOperations);
+                return AppendBulkInsertWithServerValuesOnly(commandStringBuilder, modificationCommands, commandPosition, nonIdentityOperations, keyOperations, readOperations);
             }
 
             if (modificationCommands[0].Entries.SelectMany(e => e.EntityType.GetAllBaseTypesInclusive())
-                .Any(e => e.SqlServer().IsMemoryOptimized))
+                    .Any(e => e.SqlServer().IsMemoryOptimized))
             {
-                foreach (var modification in modificationCommands)
+                if (!nonIdentityOperations.Any(o => o.IsRead && o.IsKey))
                 {
-                    AppendInsertOperation(commandStringBuilder, modification, commandPosition);
+                    foreach (var modification in modificationCommands)
+                    {
+                        AppendInsertOperation(commandStringBuilder, modification, commandPosition++);
+                    }
+                }
+                else
+                {
+                    foreach (var modification in modificationCommands)
+                    {
+                        AppendInsertOperationWithServerKeys(commandStringBuilder, modification, keyOperations, readOperations, commandPosition++);
+                    }
                 }
 
                 return ResultSetMapping.LastInResultSet;
             }
 
-            return AppendBulkInsertWithServerValues(commandStringBuilder, modificationCommands, commandPosition, writeOperations, readOperations);
+            return AppendBulkInsertWithServerValues(commandStringBuilder, modificationCommands, commandPosition, writeOperations, keyOperations, readOperations);
         }
 
         private ResultSetMapping AppendBulkInsertWithoutServerValues(
@@ -144,6 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             IReadOnlyList<ModificationCommand> modificationCommands,
             int commandPosition,
             List<ColumnModification> writeOperations,
+            List<ColumnModification> keyOperations,
             List<ColumnModification> readOperations)
         {
             AppendDeclareTable(
@@ -172,26 +183,29 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 commandStringBuilder,
                 InsertedTableBaseName,
                 commandPosition,
-                modificationCommands[0].ColumnModifications,
+                keyOperations,
                 PositionColumnDeclaration);
+
+            var name = modificationCommands[0].TableName;
+            var schema = modificationCommands[0].Schema;
 
             AppendMergeCommandHeader(
                 commandStringBuilder,
-                modificationCommands[0].TableName,
-                modificationCommands[0].Schema,
+                name,
+                schema,
                 ToInsertTableBaseName,
                 commandPosition,
                 ToInsertTableAlias,
                 writeOperations);
             AppendOutputClause(
                 commandStringBuilder,
-                modificationCommands[0].ColumnModifications,
+                keyOperations,
                 InsertedTableBaseName,
                 commandPosition,
                 FullPositionColumnName);
             commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
 
-            AppendSelectCommand(commandStringBuilder, readOperations, InsertedTableBaseName, commandPosition, PositionColumnName);
+            AppendSelectCommand(commandStringBuilder, readOperations, keyOperations, InsertedTableBaseName, commandPosition, name, schema, orderColumn: PositionColumnName);
 
             return ResultSetMapping.NotLastInResultSet;
         }
@@ -201,12 +215,15 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             IReadOnlyList<ModificationCommand> modificationCommands,
             int commandPosition,
             List<ColumnModification> nonIdentityOperations,
+            List<ColumnModification> keyOperations,
             List<ColumnModification> readOperations)
         {
-            AppendDeclareTable(commandStringBuilder, InsertedTableBaseName, commandPosition, readOperations);
+            AppendDeclareTable(commandStringBuilder, InsertedTableBaseName, commandPosition, keyOperations);
 
-            AppendInsertCommandHeader(commandStringBuilder, modificationCommands[0].TableName, modificationCommands[0].Schema, nonIdentityOperations);
-            AppendOutputClause(commandStringBuilder, readOperations, InsertedTableBaseName, commandPosition);
+            var name = modificationCommands[0].TableName;
+            var schema = modificationCommands[0].Schema;
+            AppendInsertCommandHeader(commandStringBuilder, name, schema, nonIdentityOperations);
+            AppendOutputClause(commandStringBuilder, keyOperations, InsertedTableBaseName, commandPosition);
             AppendValuesHeader(commandStringBuilder, nonIdentityOperations);
             AppendValues(commandStringBuilder, nonIdentityOperations);
             for (var i = 1; i < modificationCommands.Count; i++)
@@ -216,47 +233,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
             commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator);
 
-            AppendSelectCommand(commandStringBuilder, readOperations, InsertedTableBaseName, commandPosition);
+            AppendSelectCommand(commandStringBuilder, readOperations, keyOperations, InsertedTableBaseName, commandPosition, name, schema);
 
             return ResultSetMapping.NotLastInResultSet;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override ResultSetMapping AppendUpdateOperation(StringBuilder commandStringBuilder, ModificationCommand command, int commandPosition)
-        {
-            Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
-            Check.NotNull(command, nameof(command));
-
-            var name = command.TableName;
-            var schema = command.Schema;
-            var operations = command.ColumnModifications;
-
-            var writeOperations = operations.Where(o => o.IsWrite).ToList();
-            var conditionOperations = operations.Where(o => o.IsCondition).ToList();
-            var readOperations = operations.Where(o => o.IsRead).ToList();
-
-            if (readOperations.Count > 0)
-            {
-                AppendDeclareTable(commandStringBuilder, InsertedTableBaseName, commandPosition, readOperations);
-            }
-            AppendUpdateCommandHeader(commandStringBuilder, name, schema, writeOperations);
-            if (readOperations.Count > 0)
-            {
-                AppendOutputClause(commandStringBuilder, readOperations, InsertedTableBaseName, commandPosition);
-            }
-            AppendWhereClause(commandStringBuilder, conditionOperations);
-            commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator);
-
-            if (readOperations.Count > 0)
-            {
-                return AppendSelectCommand(commandStringBuilder, readOperations, InsertedTableBaseName, commandPosition);
-            }
-            commandStringBuilder.AppendLine();
-
-            return AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
         }
 
         private void AppendMergeCommandHeader(
@@ -342,7 +321,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             StringBuilder commandStringBuilder,
             string name,
             int index,
-            IReadOnlyList<ColumnModification> readOperations,
+            IReadOnlyList<ColumnModification> operations,
             string additionalColumns = null)
         {
             commandStringBuilder
@@ -351,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 .Append(index)
                 .Append(" TABLE (")
                 .AppendJoin(
-                    readOperations,
+                    operations,
                     this,
                     (sb, o, generator) =>
                         {
@@ -412,11 +391,41 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 .Append("INTO ").Append(tableName).Append(tableIndex);
         }
 
+        private ResultSetMapping AppendInsertOperationWithServerKeys(
+            StringBuilder commandStringBuilder,
+            ModificationCommand command,
+            IReadOnlyList<ColumnModification> keyOperations,
+            IReadOnlyList<ColumnModification> readOperations,
+            int commandPosition)
+        {
+            Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+            Check.NotNull(command, nameof(command));
+
+            var name = command.TableName;
+            var schema = command.Schema;
+            var operations = command.ColumnModifications;
+
+            var writeOperations = operations.Where(o => o.IsWrite).ToList();
+
+            AppendDeclareTable(commandStringBuilder, InsertedTableBaseName, commandPosition, keyOperations);
+
+            AppendInsertCommandHeader(commandStringBuilder, name, schema, writeOperations);
+            AppendOutputClause(commandStringBuilder, keyOperations, InsertedTableBaseName, commandPosition);
+            AppendValuesHeader(commandStringBuilder, writeOperations);
+            AppendValues(commandStringBuilder, writeOperations);
+            commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator);
+
+            return AppendSelectCommand(commandStringBuilder, readOperations, keyOperations, InsertedTableBaseName, commandPosition, name, schema);
+        }
+
         private ResultSetMapping AppendSelectCommand(
             StringBuilder commandStringBuilder,
             IReadOnlyList<ColumnModification> readOperations,
+            IReadOnlyList<ColumnModification> keyOperations,
+            string insertedTableName,
+            int insertedTableIndex,
             string tableName,
-            int tableIndex,
+            string schema,
             string orderColumn = null)
         {
             commandStringBuilder
@@ -425,19 +434,35 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 .AppendJoin(
                     readOperations,
                     SqlGenerationHelper,
-                    (sb, o, helper) => { helper.DelimitIdentifier(sb, o.ColumnName); })
-                .Append(" FROM ").Append(tableName).Append(tableIndex);
+                    (sb, o, helper) => { helper.DelimitIdentifier(sb, o.ColumnName, "t"); })
+                .Append(" FROM ");
+            SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, tableName, schema);
+            commandStringBuilder
+                .Append(" t")
+                .AppendLine()
+                .Append("INNER JOIN ")
+                .Append(insertedTableName).Append(insertedTableIndex)
+                .Append(" i")
+                .Append(" ON ")
+                .AppendJoin(keyOperations, (sb, c) =>
+                    {
+                        sb.Append("(");
+                        SqlGenerationHelper.DelimitIdentifier(sb, c.ColumnName, "t");
+                        sb.Append(" = ");
+                        SqlGenerationHelper.DelimitIdentifier(sb, c.ColumnName, "i");
+                        sb.Append(")");
+                    }, " AND ");
 
             if (orderColumn != null)
             {
                 commandStringBuilder
                     .AppendLine()
-                    .Append("ORDER BY ")
-                    .Append(orderColumn);
+                    .Append("ORDER BY ");
+                SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, orderColumn, "i");
             }
 
             commandStringBuilder
-                .Append(SqlGenerationHelper.StatementTerminator)
+                .Append(SqlGenerationHelper.StatementTerminator).AppendLine()
                 .AppendLine();
 
             return ResultSetMapping.LastInResultSet;
@@ -451,7 +476,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder))
                 .Append("SELECT @@ROWCOUNT")
-                .Append(SqlGenerationHelper.StatementTerminator).AppendLine();
+                .Append(SqlGenerationHelper.StatementTerminator).AppendLine()
+                .AppendLine();
 
             return ResultSetMapping.LastInResultSet;
         }
@@ -475,7 +501,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             Check.NotNull(columnModification, nameof(columnModification));
 
             SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, columnModification.ColumnName);
-            commandStringBuilder.Append(" = ").Append("scope_identity()");
+            commandStringBuilder.Append(" = ");
+
+            commandStringBuilder.Append("scope_identity()");
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             commandStringBuilder
                 .Append("SELECT changes()")
-                .Append(SqlGenerationHelper.StatementTerminator)
+                .Append(SqlGenerationHelper.StatementTerminator).AppendLine()
                 .AppendLine();
 
             return ResultSetMapping.LastInResultSet;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             protected override ResultSetMapping AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema, int commandPosition)
             {
                 commandStringBuilder
-                    .Append("SELECT provider_specific_rowcount();" + Environment.NewLine);
+                    .Append("SELECT provider_specific_rowcount();" + Environment.NewLine + Environment.NewLine);
 
                 return ResultSetMapping.LastInResultSet;
             }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             Assert.Equal(
                 "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
-                "SELECT " + RowsAffected + ";" + Environment.NewLine,
+                "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             Assert.Equal(
                 "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
-                "SELECT " + RowsAffected + ";" + Environment.NewLine,
+                "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "VALUES (@p0, @p1, @p2);" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + ", " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "VALUES (@p0, @p1, @p2, @p3);" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "VALUES (@p0, @p1, @p2);" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "DEFAULT VALUES;" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + ", " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "DEFAULT VALUES;" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Id" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " = " + Identity + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 OpenDelimeter + "Name" + CloseDelimeter + " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " +
                 OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " = @p2" + Environment.NewLine +
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
-                "SELECT " + RowsAffected + ";" + Environment.NewLine,
+                "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 OpenDelimeter + "Name" + CloseDelimeter + " = @p0, " + OpenDelimeter + "Quacks" + CloseDelimeter + " = @p1, " +
                 OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " = @p2" + Environment.NewLine +
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL AND " + OpenDelimeter + "ConcurrencyToken" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
-                "SELECT " + RowsAffected + ";" + Environment.NewLine,
+                "SELECT " + RowsAffected + ";" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 "WHERE " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine +
                 "SELECT " + OpenDelimeter + "Computed" + CloseDelimeter + "" + Environment.NewLine +
                 "FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
-                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine,
+                "WHERE " + RowsAffected + " = 1 AND " + OpenDelimeter + "Id" + CloseDelimeter + " IS NULL;" + Environment.NewLine + Environment.NewLine,
                 stringBuilder.ToString());
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -249,7 +249,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();",
         {
             base.TimestampAttribute_throws_if_value_in_database_changed();
 
-            // Not vallidating SQL because not significantly different from other tests and
+            // Not validating SQL because not significantly different from other tests and
             // row version value is not stable.
         }
 


### PR DESCRIPTION
For inserts inner join the INSERTED table instead of reading values directly from it.
For updates use the relational implementation that doesn't use INSERTED table.

Fixes #6044
Fixes #6474