### PR TITLE
Adding printer class for QueryModel for easier debugging.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
@@ -19,16 +19,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override List<IConstantPrinter> GetConstantPrinters()
-        {
-            var relationalPrinters = new List<IConstantPrinter>
+        public RelationalExpressionPrinter()
+            : base(new List<IConstantPrinter>
             {
                 new CommandBuilderPrinter(),
                 new EntityTrackingInfoListPrinter(),
                 new MetadataPropertyCollectionPrinter()
-            };
-
-            return relationalPrinters.Concat(base.GetConstantPrinters()).ToList();
+            })
+        {
         }
 
         private class CommandBuilderPrinter : IConstantPrinter

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -487,6 +487,7 @@
     <Compile Include="Query\Internal\IQueryAnnotationExtractor.cs" />
     <Compile Include="Query\Internal\IQueryBuffer.cs" />
     <Compile Include="Query\Internal\IQueryCompiler.cs" />
+    <Compile Include="Query\Internal\IQueryModelPrinter.cs" />
     <Compile Include="Query\Internal\IQueryOptimizer.cs" />
     <Compile Include="Query\Internal\IRelatedEntitiesLoader.cs" />
     <Compile Include="Query\Internal\IWeakReferenceIdentityMap.cs" />
@@ -497,6 +498,7 @@
     <Compile Include="Query\Internal\QueryBuffer.cs" />
     <Compile Include="Query\Internal\QueryCompilationContextFactory.cs" />
     <Compile Include="Query\Internal\QueryCompiler.cs" />
+    <Compile Include="Query\Internal\QueryModelPrinter.cs" />
     <Compile Include="Query\Internal\QueryOptimizer.cs" />
     <Compile Include="Query\Internal\TaskResultAsyncEnumerable.cs" />
     <Compile Include="Query\Internal\WeakReferenceIdentityMap.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -681,19 +681,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Compiling query model: '{queryModel}'
+        /// Compiling query model: {newline}'{queryModel}'
         /// </summary>
-        public static string LogCompilingQueryModel([CanBeNull] object queryModel)
+        public static string LogCompilingQueryModel([CanBeNull] string newline, [CanBeNull] object queryModel)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("LogCompilingQueryModel", "queryModel"), queryModel);
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogCompilingQueryModel", "newline", "queryModel"), newline, queryModel);
         }
 
         /// <summary>
-        /// Optimized query model: '{queryModel}'
+        /// Optimized query model: {newline}'{queryModel}'
         /// </summary>
-        public static string LogOptimizedQueryModel([CanBeNull] object queryModel)
+        public static string LogOptimizedQueryModel([CanBeNull] string newline, [CanBeNull] object queryModel)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("LogOptimizedQueryModel", "queryModel"), queryModel);
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogOptimizedQueryModel", "newline", "queryModel"), newline, queryModel);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -367,10 +367,10 @@
     <value>The property '{property}' is not a navigation property of entity type '{entityType}'. The 'Include(string)' method can only be used with a '.' separated list of navigation property names.</value>
   </data>
   <data name="LogCompilingQueryModel" xml:space="preserve">
-    <value>Compiling query model: '{queryModel}'</value>
+    <value>Compiling query model: {newline}'{queryModel}'</value>
   </data>
   <data name="LogOptimizedQueryModel" xml:space="preserve">
-    <value>Optimized query model: '{queryModel}'</value>
+    <value>Optimized query model: {newline}'{queryModel}'</value>
   </data>
   <data name="LogIncludingNavigation" xml:space="preserve">
     <value>Including navigation: '{navigation}'</value>

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryCompilationContext.Logger
                     .LogDebug(
                         CoreEventId.CompilingQueryModel,
-                        () => CoreStrings.LogCompilingQueryModel(queryModel));
+                        () => CoreStrings.LogCompilingQueryModel(Environment.NewLine, queryModel.Print()));
 
                 _blockTaskExpressions = false;
 
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryCompilationContext.Logger
                     .LogDebug(
                         CoreEventId.CompilingQueryModel,
-                        () => CoreStrings.LogCompilingQueryModel(queryModel));
+                        () => CoreStrings.LogCompilingQueryModel(Environment.NewLine, queryModel.Print()));
 
                 _blockTaskExpressions = false;
 
@@ -359,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryCompilationContext.Logger
                 .LogDebug(
                     CoreEventId.OptimizedQueryModel,
-                    () => CoreStrings.LogOptimizedQueryModel(queryModel));
+                    () => CoreStrings.LogOptimizedQueryModel(Environment.NewLine, queryModel.Print()));
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -149,8 +149,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
         ///     A textual representation of the <see cref="T:System.Linq.Expressions.Expression" />.
         /// </returns>
         public override string ToString()
-            => AccessOperation.ToString()
-                .Replace("?.", ".")
-                .Replace(".", "?.");
+            => Caller.ToString() + "?" + AccessOperation.ToString().Substring(Caller.ToString().Length);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/IQueryModelPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/IQueryModelPrinter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Remotion.Linq;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IQueryModelPrinter
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        string Print([NotNull] QueryModel queryModel);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelExtensions.cs
@@ -20,6 +20,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static string Print([NotNull] this QueryModel queryModel)
+            => new QueryModelPrinter().Print(queryModel);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static int CountQuerySourceReferences(
             [NotNull] this QueryModel queryModel, [NotNull] IQuerySource querySource)
         {

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelPrinter.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class QueryModelPrinter : IQueryModelPrinter
+    {
+        private IndentedStringBuilder _stringBuilder;
+        private QueryModelExpressionPrinter _expressionPrinter;
+        private QueryModelPrintingVisitor _queryModelPrintingVisitor;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public QueryModelPrinter()
+        {
+            _expressionPrinter = new QueryModelExpressionPrinter();
+            _stringBuilder = _expressionPrinter.StringBuilder;
+            _queryModelPrintingVisitor = new QueryModelPrintingVisitor(_expressionPrinter);
+            _expressionPrinter.SetQueryModelPrintingVisitor(_queryModelPrintingVisitor);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Print([NotNull] QueryModel queryModel)
+        {
+            _stringBuilder.Clear();
+
+            _queryModelPrintingVisitor.VisitQueryModel(queryModel);
+
+            return _stringBuilder.ToString();
+        }
+
+        private class QueryModelExpressionPrinter : ExpressionPrinter
+        {
+            private QueryModelPrintingVisitor _queryModelPrintingVisitor;
+
+            public void SetQueryModelPrintingVisitor(QueryModelPrintingVisitor queryModelPrintingVisitor)
+            {
+                _queryModelPrintingVisitor = queryModelPrintingVisitor;
+            }
+
+            protected override Expression VisitExtension(Expression node)
+            {
+                var subquery = node as SubQueryExpression;
+                if (subquery != null)
+                {
+                    using (StringBuilder.Indent())
+                    {
+                        var isSubquery = _queryModelPrintingVisitor.IsSubquery;
+                        _queryModelPrintingVisitor.IsSubquery = true;
+                        _queryModelPrintingVisitor.VisitQueryModel(subquery.QueryModel);
+                        _queryModelPrintingVisitor.IsSubquery = isSubquery;
+                    }
+
+                    return node;
+                }
+
+                return base.VisitExtension(node);
+            }
+        }
+
+        private class QueryModelPrintingVisitor : ExpressionTransformingQueryModelVisitor<ExpressionPrinter>
+        {
+            public QueryModelPrintingVisitor([NotNull] ExpressionPrinter expressionPrinter) 
+                : base(expressionPrinter)
+            {
+            }
+
+            public bool IsSubquery { get; set; }
+
+            public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
+            {
+                if (IsSubquery)
+                {
+                    TransformingVisitor.StringBuilder.AppendLine();
+                }
+
+                if (queryModel.ResultOperators.Count > 0)
+                {
+                    TransformingVisitor.StringBuilder.Append("(");
+                }
+
+                TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+                base.VisitMainFromClause(fromClause, queryModel);
+            }
+
+            public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+                base.VisitAdditionalFromClause(fromClause, queryModel, index);
+            }
+
+            public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
+            {
+                base.VisitJoinClause(joinClause, queryModel, index);
+            }
+
+            public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, GroupJoinClause groupJoinClause)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append("on ");
+                TransformingVisitor.Visit(joinClause.OuterKeySelector);
+                TransformingVisitor.StringBuilder.Append(" equals ");
+                TransformingVisitor.Visit(joinClause.InnerKeySelector);
+            }
+
+            public override void VisitGroupJoinClause(GroupJoinClause groupJoinClause, QueryModel queryModel, int index)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append($"join {groupJoinClause.ItemType.ShortDisplayName()} {groupJoinClause.ItemName}");
+                base.VisitGroupJoinClause(groupJoinClause, queryModel, index);
+                TransformingVisitor.StringBuilder.Append($" into {groupJoinClause.ItemName}");
+            }
+
+            public override void VisitWhereClause(WhereClause whereClause, QueryModel queryModel, int index)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append($"where ");
+                base.VisitWhereClause(whereClause, queryModel, index);
+            }
+
+            public override void VisitOrderByClause(OrderByClause orderByClause, QueryModel queryModel, int index)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append("order by ");
+
+                var first = true;
+                foreach (var ordering in orderByClause.Orderings)
+                {
+                    VisitOrdering(ordering, queryModel, orderByClause, index);
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        TransformingVisitor.StringBuilder.Append(", ");
+                    }
+                }
+            }
+
+            public override void VisitOrdering(Ordering ordering, QueryModel queryModel, OrderByClause orderByClause, int index)
+            {
+                base.VisitOrdering(ordering, queryModel, orderByClause, index);
+
+                TransformingVisitor.StringBuilder.Append($" {ordering.OrderingDirection.ToString().ToLower()}");
+            }
+
+            protected override void VisitResultOperators(ObservableCollection<ResultOperatorBase> resultOperators, QueryModel queryModel)
+            {
+                if (resultOperators.Count > 0)
+                {
+                    TransformingVisitor.StringBuilder.Append(")");
+                }
+
+                base.VisitResultOperators(resultOperators, queryModel);
+            }
+
+            public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append($".{resultOperator.ToString()}");
+            }
+
+            public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
+            {
+                TransformingVisitor.StringBuilder.AppendLine();
+                TransformingVisitor.StringBuilder.Append("select ");
+                base.VisitSelectClause(selectClause, queryModel);
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -29,8 +29,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                 Assert.NotNull(customers);
                 Assert.StartsWith(
-                    @"    Compiling query model: 'value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind.Customer])'
-    Optimized query model: 'value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind.Customer])'
+                    @"    Compiling query model: 
+'from Customer <generated>_0 in DbSet<Customer>
+select <generated>_0'
+    Optimized query model: 
+'from Customer <generated>_0 in DbSet<Customer>
+select <generated>_0'
     TRACKED: True
 (QueryContext queryContext) => IEnumerable<Customer> _ShapedQuery(
     queryContext: queryContext, 
@@ -89,8 +93,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                         .ToList();
 
                 Assert.NotNull(customers);
-                Assert.StartsWith(@"    Compiling query model: 'value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind.Customer]) => Include([c].Orders)'
-    Optimized query model: 'value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind.Customer])'
+                Assert.StartsWith(@"    Compiling query model: 
+'(from Customer c in DbSet<Customer>
+select c)
+.Include([c].Orders)'
+    Optimized query model: 
+'from Customer c in DbSet<Customer>
+select c'
     Including navigation: 'c.Orders'
     TRACKED: True
 (QueryContext queryContext) => IEnumerable<Customer> _Include(
@@ -132,9 +141,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
          }
     , 
     querySourceRequiresTracking: True
-)
-Opening connection to database 'Northwind' on server '(localdb)\MSSQLLocalDB'.
-Closing connection to database 'Northwind' on server '(localdb)\MSSQLLocalDB'.",
+)",
                     TestSqlLoggerFactory.Log.Replace(Environment.NewLine, FileLineEnding));
             }
         }


### PR DESCRIPTION
Example of the output:

```
from Customer c in [EntityQueryable<Customer>]
where ([c].City == "London")
orderby [c].CustomerID asc
select
    from Order o1 in [EntityQueryable<Order>]
    where (([o1].CustomerID == [c].CustomerID) AndAlso (Convert([o1].OrderDate).Year == 1997))
    orderby [o1].OrderID asc
    select
        from Order o2 in [EntityQueryable<Order>]
        where ([o1].CustomerID == [c].CustomerID)
        orderby [o2].OrderID asc
        select [o1].OrderID
```

- Made ExpressionPrinter to work from Visit() method rather than from Print() entry method.
- Fixed minor issue with NullConditionalExpression.ToString()