### PR TITLE
[TINY] Fix to #6691 - Provider specific ExpressionFragmentTranslators should override default ones

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeExpressionFragmentTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/RelationalCompositeExpressionFragmentTranslator.cs
@@ -48,6 +48,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// </summary>
         /// <param name="translators"> The translators. </param>
         protected virtual void AddTranslators([NotNull] IEnumerable<IExpressionFragmentTranslator> translators)
-            => _translators.AddRange(translators);
+            => _translators.InsertRange(0, translators);
     }
 }


### PR DESCRIPTION
This is a fix to https://github.com/aspnet/EntityFramework/issues/6691

We did similar change for the MethodCallTranslators.