### PR TITLE
Add IDesignTimeServices

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/ReverseEngineering/E2ETestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/ReverseEngineering/E2ETestBase.cs
@@ -28,10 +28,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.Re
         {
             _output = output;
 
-            var serviceProvider = ConfigureDesignTimeServices(
-                    new ServiceCollection()
-                        .AddScaffolding()
-                        .AddLogging())
+            var serviceBuilder = new ServiceCollection()
+                .AddScaffolding()
+                .AddLogging();
+            ConfigureDesignTimeServices(serviceBuilder);
+
+            var serviceProvider = serviceBuilder
                 .AddSingleton(typeof(IFileService), sp => InMemoryFiles = new InMemoryFileService()).BuildServiceProvider();
 
             _reporter = new InMemoryOperationReporter(_output);
@@ -44,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.Re
         protected abstract ICollection<BuildReference> References { get; }
         protected abstract string ProviderName { get; }
 
-        protected abstract IServiceCollection ConfigureDesignTimeServices(IServiceCollection services);
+        protected abstract void ConfigureDesignTimeServices(IServiceCollection services);
 
         protected virtual void AssertEqualFileContents(FileSet expected, FileSet actual)
         {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerDesignTimeServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerDesignTimeServices.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -13,13 +13,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerDesignTimeServices
+    public class SqlServerDesignTimeServices : IDesignTimeServices
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IServiceCollection ConfigureDesignTimeServices([NotNull] IServiceCollection serviceCollection)
+        public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
                 .AddSingleton<IScaffoldingModelFactory, SqlServerScaffoldingModelFactory>()
                 .AddSingleton<IRelationalAnnotationProvider, SqlServerAnnotationProvider>()

--- a/src/Microsoft.EntityFrameworkCore.Sqlite.Design/Internal/SqliteDesignTimeServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite.Design/Internal/SqliteDesignTimeServices.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -14,13 +14,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqliteDesignTimeServices
+    public class SqliteDesignTimeServices : IDesignTimeServices
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IServiceCollection ConfigureDesignTimeServices([NotNull] IServiceCollection serviceCollection)
+        public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
                 .AddSingleton<IScaffoldingModelFactory, SqliteScaffoldingModelFactory>()
                 .AddSingleton<IRelationalTypeMapper, SqliteTypeMapper>()

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/IDesignTimeServices.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/IDesignTimeServices.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     Enables configuring design-time services. Tools will automatically discover implementations of this
+    ///     interface that are in the startup assembly.
+    /// </summary>
+    public interface IDesignTimeServices
+    {
+        /// <summary>
+        ///     Configures design-time services. Use this method to override the default design-time services with your
+        ///     own implementations.
+        /// </summary>
+        /// <param name="serviceCollection"> The design-time service collection. </param>
+        void ConfigureDesignTimeServices([NotNull] IServiceCollection serviceCollection);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Infrastructure\IDbContextOptions.cs" />
     <Compile Include="Infrastructure\IDbContextOptionsBuilderInfrastructure.cs" />
     <Compile Include="Infrastructure\IDbContextOptionsExtension.cs" />
+    <Compile Include="Infrastructure\IDesignTimeServices.cs" />
     <Compile Include="Infrastructure\IModelCacheKeyFactory.cs" />
     <Compile Include="Infrastructure\IModelCustomizer.cs" />
     <Compile Include="Infrastructure\IModelSource.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Design.Tests/Design/Internal/StartupInvokerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Design.Tests/Design/Internal/StartupInvokerTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Design.TestUtilities;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Tests.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -159,6 +160,26 @@ namespace Microsoft.EntityFrameworkCore.Design.Tests.Design.Internal
         }
 
         [Fact]
+        public void ConfigureDesignTimeServices_works_on_IDesignTimeServices_implementations()
+        {
+            var services = new ServiceCollection();
+            var startup = CreateStartupInvoker(
+                MockAssembly.Create(typeof(DesignTimeServices)),
+                "Irrelevant");
+
+            startup.ConfigureDesignTimeServices(services);
+
+            var service = services.BuildServiceProvider().GetRequiredService<TestService>();
+            Assert.Equal("DesignTimeServices", service.Value);
+        }
+
+        private class DesignTimeServices : IDesignTimeServices
+        {
+            public void ConfigureDesignTimeServices(IServiceCollection services)
+                => services.AddSingleton(new TestService("DesignTimeServices"));
+        }
+
+        [Fact]
         public void ConfigureServices_injects_services()
         {
             var assembly = MockAssembly.Create(typeof(StartupInjected));
@@ -188,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Tests.Design.Internal
         }
 
         [Fact]
-        public void ConfigureDesignTimeServices_works_on_IStartup_implementations()
+        public void ConfigureServices_works_on_IStartup_implementations()
         {
             var startup = CreateStartupInvoker(
                 MockAssembly.Create(typeof(MyStartup)),

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests.Reverse
     {
         protected override string ProviderName => "Microsoft.EntityFrameworkCore.SqlServer.Design";
 
-        protected override IServiceCollection ConfigureDesignTimeServices(IServiceCollection services)
+        protected override void ConfigureDesignTimeServices(IServiceCollection services)
             => new SqlServerDesignTimeServices().ConfigureDesignTimeServices(services);
 
         public virtual string TestNamespace => "E2ETest.Namespace";

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
@@ -416,7 +416,7 @@ CREATE TABLE IF NOT EXISTS Comment (
         protected abstract string ExpectedResultsParentDir { get; }
         protected abstract bool UseFluentApiOnly { get; }
 
-        protected override IServiceCollection ConfigureDesignTimeServices(IServiceCollection services)
+        protected override void ConfigureDesignTimeServices(IServiceCollection services)
             => new SqliteDesignTimeServices().ConfigureDesignTimeServices(services);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
@@ -24,9 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests
         {
             _testStore = SqliteTestStore.CreateScratch();
 
-            var serviceProvider = new SqliteDesignTimeServices()
-                .ConfigureDesignTimeServices(new ServiceCollection().AddLogging())
-                .BuildServiceProvider();
+            var serviceCollection = new ServiceCollection().AddLogging();
+            new SqliteDesignTimeServices().ConfigureDesignTimeServices(serviceCollection);
+            var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var logger = new TestLogger();
             serviceProvider.GetService<ILoggerFactory>().AddProvider(new TestLoggerProvider(logger));

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
@@ -26,9 +26,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests
         {
             _testStore = SqliteTestStore.CreateScratch();
 
-            var serviceProvider = new SqliteDesignTimeServices()
-                .ConfigureDesignTimeServices(
-                    new ServiceCollection().AddScaffolding().AddLogging())
+            var serviceCollection = new ServiceCollection().AddScaffolding().AddLogging();
+            new SqliteDesignTimeServices().ConfigureDesignTimeServices(serviceCollection);
+
+            var serviceProvider = serviceCollection
                 .AddSingleton<IFileService, FileSystemFileService>()
                 .BuildServiceProvider();
 


### PR DESCRIPTION
`IDesignTimeServices` can be implemented in the startup assembly to override the default design-time services like `MigrationsCodeGenerator` or `EntityTypeWriter`.

Also stops looking for `ConfigureServices` on `App` and `Program` (use `IDbContextFactory` instead).

Providers beware: This has a minor breaking changes in `Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests`

Resolves #5617, fixes #5677