### PR TITLE
Query: Generate proper aliases for DefaultIfEmpty result operator

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -352,14 +352,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var emptySelectExpression = handlerContext.SelectExpressionFactory.Create(handlerContext.QueryModelVisitor.QueryCompilationContext, "empty");
             emptySelectExpression.AddToProjection(new AliasExpression("empty", Expression.Constant(null)));
 
-            selectExpression.AddTable(emptySelectExpression);
+            selectExpression.AddTable(emptySelectExpression, createUniqueAlias: false);
 
             var leftOuterJoinExpression = new LeftOuterJoinExpression(subquery);
             var constant1 = Expression.Constant(1);
 
             leftOuterJoinExpression.Predicate = Expression.Equal(constant1, constant1);
 
-            selectExpression.AddTable(leftOuterJoinExpression);
+            selectExpression.AddTable(leftOuterJoinExpression, createUniqueAlias: false);
 
             handlerContext.QueryModelVisitor.Expression
                 = new DefaultIfEmptyExpressionVisitor(

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -6316,6 +6316,22 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .Where(x => x < nextYear));
         }
 
+        [ConditionalFact]
+        public virtual void DefaultIfEmpty_without_group_join()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers
+                    .Where(c => c.City == "London")
+                    .DefaultIfEmpty()
+                    .Where(d => d != null)
+                    .Select(d => d.CustomerID)
+                    .ToList();
+
+                Assert.Equal(6, query.Count);
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -96,6 +96,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Entity_equality_null()
+        {
+            AssertQuery<Customer>(cs =>
+                from c in cs
+                where c == null
+                select c.CustomerID);
+        }
+
+        [ConditionalFact]
+        public virtual void Entity_equality_not_null()
+        {
+            AssertQuery<Customer>(cs =>
+                from c in cs
+                where c != null
+                select c.CustomerID);
+        }
+
+        [ConditionalFact]
         public virtual void Null_conditional_simple()
         {
             var c = Expression.Parameter(typeof(Customer));
@@ -6330,6 +6348,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(6, query.Count);
             }
+        }
+
+        [ConditionalFact]
+        public virtual void DefaultIfEmpty_in_subquery()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 from o in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                 where o != null
+                 select new { c.CustomerID, o.OrderID }));
+        }
+
+        [ConditionalFact]
+        public virtual void DefaultIfEmpty_in_subquery_nested()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs.Where(c => c.City == "Seattle")
+                 from o1 in os.Where(o => o.OrderID > 11000).DefaultIfEmpty()
+                 from o2 in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                 where o1 != null && o2 != null
+                 select new { c.CustomerID, o1.OrderID, o2.OrderDate }));
         }
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1260,7 +1260,7 @@ FROM [Level1] AS [e1]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT TOP(1) [subQuery2].[Id], [subQuery2].[Date], [subQuery2].[Level1_Optional_Id], [subQuery2].[Level1_Required_Id], [subQuery2].[Name], [subQuery2].[OneToMany_Optional_InverseId], [subQuery2].[OneToMany_Optional_Self_InverseId], [subQuery2].[OneToMany_Required_InverseId], [subQuery2].[OneToMany_Required_Self_InverseId], [subQuery2].[OneToOne_Optional_PK_InverseId], [subQuery2].[OneToOne_Optional_SelfId], [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
+                @"SELECT TOP(1) [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery2]
 LEFT JOIN [Level3] AS [subQuery3] ON [subQuery2].[Id] = [subQuery3].[Level2_Optional_Id]
 ORDER BY [subQuery2].[Id]",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -102,6 +102,28 @@ WHERE [c].[CustomerID] = N'ANATR'",
                 Sql);
         }
 
+        public override void Entity_equality_null()
+        {
+            base.Entity_equality_null();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NULL",
+                Sql);
+        }
+
+        public override void Entity_equality_not_null()
+        {
+            base.Entity_equality_not_null();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NOT NULL",
+                Sql);
+        }
+
         public override void Queryable_reprojection()
         {
             base.Queryable_reprojection();
@@ -6245,7 +6267,63 @@ FROM (
         FROM [Customers] AS [c0]
         WHERE [c0].[City] = N'London'
     ) AS [t0] ON 1 = 1
-) AS [t1]",
+) AS [t1]
+WHERE [t1].[CustomerID] IS NOT NULL",
+                Sql);
+        }
+
+        public override void DefaultIfEmpty_in_subquery()
+        {
+            base.DefaultIfEmpty_in_subquery();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [t1].[OrderID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [t0].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty0]
+    LEFT JOIN (
+        SELECT [o0].*
+        FROM [Orders] AS [o0]
+        WHERE [o0].[CustomerID] = [c].[CustomerID]
+    ) AS [t0] ON 1 = 1
+) AS [t1]
+WHERE [t1].[OrderID] IS NOT NULL",
+                Sql);
+        }
+
+        public override void DefaultIfEmpty_in_subquery_nested()
+        {
+            base.DefaultIfEmpty_in_subquery_nested();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [t1].[OrderID], [t4].[OrderDate]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [t0].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty0]
+    LEFT JOIN (
+        SELECT [o0].*
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] > 11000
+    ) AS [t0] ON 1 = 1
+) AS [t1]
+CROSS APPLY (
+    SELECT [t3].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty2]
+    LEFT JOIN (
+        SELECT [o2].*
+        FROM [Orders] AS [o2]
+        WHERE [o2].[CustomerID] = [c].[CustomerID]
+    ) AS [t3] ON 1 = 1
+) AS [t4]
+WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND ([t1].[OrderID] IS NOT NULL AND [t4].[OrderID] IS NOT NULL)",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -120,7 +120,7 @@ FROM [Customers] AS [c]",
                 @"SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
     SELECT NULL AS [empty]
-) AS [empty0]
+) AS [empty]
 LEFT JOIN (
     SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
     FROM [Employees] AS [c]
@@ -137,7 +137,7 @@ LEFT JOIN (
                 @"SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
     SELECT NULL AS [empty]
-) AS [empty0]
+) AS [empty]
 LEFT JOIN (
     SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
     FROM [Employees] AS [c]
@@ -165,7 +165,7 @@ WHERE [c].[EmployeeID] = -1",
                 @"SELECT [t].[EmployeeID]
 FROM (
     SELECT NULL AS [empty]
-) AS [empty0]
+) AS [empty]
 LEFT JOIN (
     SELECT [e].[EmployeeID]
     FROM [Employees] AS [e]
@@ -3523,19 +3523,19 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
             base.SelectMany_Joined_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate], [c].[ContactName]
+                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty10]
+    ) AS [empty0]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t1] ON 1 = 1
-) AS [t2]",
+    ) AS [t0] ON 1 = 1
+) AS [t1]",
                 Sql);
         }
 
@@ -3544,19 +3544,19 @@ CROSS APPLY (
             base.SelectMany_Joined_DefaultIfEmpty2();
 
             Assert.Equal(
-                @"SELECT [t2].[OrderID], [t2].[CustomerID], [t2].[EmployeeID], [t2].[OrderDate]
+                @"SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate]
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
     FROM (
         SELECT NULL AS [empty]
-    ) AS [empty10]
+    ) AS [empty0]
     LEFT JOIN (
         SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t1] ON 1 = 1
-) AS [t2]",
+    ) AS [t0] ON 1 = 1
+) AS [t1]",
                 Sql);
         }
 
@@ -6226,6 +6226,26 @@ FROM (
     WHERE [o0].[OrderDate] IS NOT NULL
 ) AS [t]
 WHERE [t].[c0] < @__nextYear_0",
+                Sql);
+        }
+
+        public override void DefaultIfEmpty_without_group_join()
+        {
+            base.DefaultIfEmpty_without_group_join();
+
+            Assert.Equal(
+                @"SELECT [t1].[CustomerID]
+FROM (
+    SELECT [t0].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty0]
+    LEFT JOIN (
+        SELECT [c0].*
+        FROM [Customers] AS [c0]
+        WHERE [c0].[City] = N'London'
+    ) AS [t0] ON 1 = 1
+) AS [t1]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 #if NETCOREAPP1_0
 using System.Threading;
@@ -12,9 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
     public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
     {
-        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture)
+        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
         public override void Take_Skip()


### PR DESCRIPTION
Resolves #6207 
Issues here:
Additional unification in `DefaultIfEmpty` result operator processing which causes alias references to break.
Another side-effect, Since DefaultIfEmpty operator is in query model without group join, it doesn't materialize and keeps valuebuffer which doesn't work well when valuebuffer is being compared to null.
