### PR TITLE
Fix breaking change to RelationalDatabaseCreator constructor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/RelationalServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/RelationalServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -73,23 +74,23 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     .AddScoped<IMigrationsModelDiffer, MigrationsModelDiffer>()
                     .AddScoped<MigrationsSqlGenerator>()
                     .AddScoped<RelationalExecutionStrategyFactory>()
-                    .AddScoped(p => GetProviderServices(p).ParameterNameGeneratorFactory)
-                    .AddScoped(p => GetProviderServices(p).SqlGenerationHelper)
-                    .AddScoped(p => GetProviderServices(p).CompositeMethodCallTranslator)
-                    .AddScoped(p => GetProviderServices(p).CompositeMemberTranslator)
-                    .AddScoped(p => GetProviderServices(p).CompositeExpressionFragmentTranslator)
-                    .AddScoped(p => GetProviderServices(p).MigrationsAnnotationProvider)
-                    .AddScoped(p => GetProviderServices(p).HistoryRepository)
-                    .AddScoped(p => GetProviderServices(p).MigrationsSqlGenerator)
-                    .AddScoped(p => GetProviderServices(p).RelationalConnection)
-                    .AddScoped(p => GetProviderServices(p).TypeMapper)
-                    .AddScoped(p => GetProviderServices(p).ModificationCommandBatchFactory)
-                    .AddScoped(p => GetProviderServices(p).CommandBatchPreparer)
-                    .AddScoped(p => GetProviderServices(p).BatchExecutor)
-                    .AddScoped(p => GetProviderServices(p).ValueBufferFactoryFactory)
-                    .AddScoped(p => GetProviderServices(p).RelationalDatabaseCreator)
-                    .AddScoped(p => GetProviderServices(p).UpdateSqlGenerator)
-                    .AddScoped(p => GetProviderServices(p).AnnotationProvider)
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ParameterNameGeneratorFactory))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).SqlGenerationHelper))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).CompositeMethodCallTranslator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).CompositeMemberTranslator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).CompositeExpressionFragmentTranslator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).MigrationsAnnotationProvider))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).HistoryRepository))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).MigrationsSqlGenerator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).RelationalConnection))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).TypeMapper))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ModificationCommandBatchFactory))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).CommandBatchPreparer))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).BatchExecutor))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ValueBufferFactoryFactory))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).RelationalDatabaseCreator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).UpdateSqlGenerator))
+                    .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).AnnotationProvider))
                     .AddQuery());
 
             return services;
@@ -114,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped<RelationalProjectionExpressionVisitorFactory>()
                 .AddScoped<RelationalCompiledQueryCacheKeyGenerator>()
                 .AddScoped<RelationalCompositeExpressionFragmentTranslator>()
-                .AddScoped(p => GetProviderServices(p).QuerySqlGeneratorFactory);
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).QuerySqlGeneratorFactory));
 
         private static IRelationalDatabaseProviderServices GetProviderServices(IServiceProvider serviceProvider)
         {

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -1,13 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -20,10 +23,39 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator
+    public abstract class RelationalDatabaseCreator : IRelationalDatabaseCreator, IServiceInjectionSite
     {
         private readonly IMigrationsModelDiffer _modelDiffer;
         private readonly IMigrationsSqlGenerator _migrationsSqlGenerator;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalDatabaseCreator" /> class.
+        /// </summary>
+        /// <param name="model"> The <see cref="IModel" /> for the context this creator is being used with. </param>
+        /// <param name="connection"> The <see cref="IRelationalConnection" /> to be used. </param>
+        /// <param name="modelDiffer"> The <see cref="IMigrationsModelDiffer" /> to be used. </param>
+        /// <param name="migrationsSqlGenerator"> The <see cref="IMigrationsSqlGenerator" /> to be used. </param>
+        /// <param name="migrationCommandExecutor"> The <see cref="IMigrationCommandExecutor" /> to be used. </param>
+        [Obsolete("Derived classes must be updated to call the new constructor with additional parameters.")]
+        protected RelationalDatabaseCreator(
+            [NotNull] IModel model,
+            [NotNull] IRelationalConnection connection,
+            [NotNull] IMigrationsModelDiffer modelDiffer,
+            [NotNull] IMigrationsSqlGenerator migrationsSqlGenerator,
+            [NotNull] IMigrationCommandExecutor migrationCommandExecutor)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(modelDiffer, nameof(modelDiffer));
+            Check.NotNull(migrationsSqlGenerator, nameof(migrationsSqlGenerator));
+            Check.NotNull(migrationCommandExecutor, nameof(migrationCommandExecutor));
+
+            Model = model;
+            Connection = connection;
+            _modelDiffer = modelDiffer;
+            _migrationsSqlGenerator = migrationsSqlGenerator;
+            MigrationCommandExecutor = migrationCommandExecutor;
+        }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RelationalDatabaseCreator" /> class.
@@ -75,7 +107,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the <see cref="IExecutionStrategyFactory" /> to be used.
         /// </summary>
-        protected virtual IExecutionStrategyFactory ExecutionStrategyFactory { get; }
+        protected virtual IExecutionStrategyFactory ExecutionStrategyFactory { get; private set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void IServiceInjectionSite.InjectServices(IServiceProvider serviceProvider)
+            => ExecutionStrategyFactory = ExecutionStrategyFactory ?? serviceProvider.GetService<IExecutionStrategyFactory>();
 
         /// <summary>
         ///     Determines whether the physical database exists. No attempt is made to determine if the database

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalDatabaseProviderServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalDatabaseProviderServices.cs
@@ -139,6 +139,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual IExpressionFragmentTranslator CompositeExpressionFragmentTranslator => GetService<RelationalCompositeExpressionFragmentTranslator>();
 
         /// <summary>
+        ///     Gets the <see cref="IDatabaseCreator" /> for the database provider.
+        /// </summary>
+        public override IDatabaseCreator Creator => RelationalDatabaseCreator;
+
+        /// <summary>
         ///     Gets the <see cref="IMethodCallTranslator" /> for the database provider.
         /// </summary>
         public abstract IMethodCallTranslator CompositeMethodCallTranslator { get; }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerDatabaseProviderServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerDatabaseProviderServices.cs
@@ -49,12 +49,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override IDatabaseCreator Creator => GetService<SqlServerDatabaseCreator>();
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public override IRelationalConnection RelationalConnection => GetService<ISqlServerConnection>();
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteDatabaseProviderServices.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteDatabaseProviderServices.cs
@@ -31,7 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         }
 
         public override string InvariantName => GetType().GetTypeInfo().Assembly.GetName().Name;
-        public override IDatabaseCreator Creator => GetService<SqliteDatabaseCreator>();
         public override IHistoryRepository HistoryRepository => GetService<SqliteHistoryRepository>();
         public override ISqlGenerationHelper SqlGenerationHelper => GetService<SqliteSqlGenerationHelper>();
         public override IMigrationsSqlGenerator MigrationsSqlGenerator => GetService<SqliteMigrationsSqlGenerator>();

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -114,15 +114,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped(p => GetContextServices(p).CurrentContext)
                 .AddScoped(p => GetContextServices(p).ContextOptions)
                 .AddScoped(p => GetContextServices(p).DatabaseProviderServices)
-                .AddScoped(p => GetProviderServices(p).Database)
-                .AddScoped(p => GetProviderServices(p).TransactionManager)
-                .AddScoped(p => GetProviderServices(p).ValueGeneratorSelector)
-                .AddScoped(p => GetProviderServices(p).Creator)
-                .AddScoped(p => GetProviderServices(p).ConventionSetBuilder)
-                .AddScoped(p => GetProviderServices(p).ValueGeneratorCache)
-                .AddScoped(p => GetProviderServices(p).ModelSource)
-                .AddScoped(p => GetProviderServices(p).ModelValidator)
-                .AddScoped(p => GetProviderServices(p).ExecutionStrategyFactory)
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).Database))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).TransactionManager))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ValueGeneratorSelector))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).Creator))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ConventionSetBuilder))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ValueGeneratorCache))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ModelSource))
+                .AddScoped(p => ServiceProviderExtensions.InjectAdditionalServices(p, GetProviderServices(p).ModelValidator))
+                .AddScoped(p => ServiceProviderExtensions.InjectAdditionalServices(p, GetProviderServices(p).ExecutionStrategyFactory))
                 .AddQuery());
 
             return serviceCollection;
@@ -151,19 +151,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped<ResultOperatorHandler>()
                 .AddScoped<QueryCompilationContextFactory>()
                 .AddScoped<ProjectionExpressionVisitorFactory>()
-                .AddScoped(p => GetProviderServices(p).QueryContextFactory)
-                .AddScoped(p => GetProviderServices(p).QueryCompilationContextFactory)
-                .AddScoped(p => GetProviderServices(p).CompiledQueryCacheKeyGenerator)
-                .AddScoped(p => GetProviderServices(p).EntityQueryModelVisitorFactory)
-                .AddScoped(p => GetProviderServices(p).EntityQueryableExpressionVisitorFactory)
-                .AddScoped(p => GetProviderServices(p).ExpressionPrinter)
-                .AddScoped(p => GetProviderServices(p).ResultOperatorHandler)
-                .AddScoped(p => GetProviderServices(p).ProjectionExpressionVisitorFactory);
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).QueryContextFactory))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).QueryCompilationContextFactory))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).CompiledQueryCacheKeyGenerator))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).EntityQueryModelVisitorFactory))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).EntityQueryableExpressionVisitorFactory))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ExpressionPrinter))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ResultOperatorHandler))
+                .AddScoped(p => p.InjectAdditionalServices(GetProviderServices(p).ProjectionExpressionVisitorFactory));
 
         private static IDbContextServices GetContextServices(IServiceProvider serviceProvider)
             => serviceProvider.GetRequiredService<IDbContextServices>();
 
         private static IDatabaseProviderServices GetProviderServices(IServiceProvider serviceProvider)
             => GetContextServices(serviceProvider).DatabaseProviderServices;
+        
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Internal/IServiceInjectionSite.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IServiceInjectionSite.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IServiceInjectionSite
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void InjectServices([NotNull] IServiceProvider serviceProvider);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/ServiceProviderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/ServiceProviderExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class ServiceProviderExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static TService InjectAdditionalServices<TService>(
+            [NotNull] this IServiceProvider serviceProvider, [NotNull] TService service)
+        {
+            (service as IServiceInjectionSite)?.InjectServices(serviceProvider);
+
+            return service;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -241,12 +241,14 @@
     <Compile Include="Internal\IModelValidator.cs" />
     <Compile Include="Internal\IndentedStringBuilder.cs" />
     <Compile Include="Internal\InternalDbSet.cs" />
+    <Compile Include="Internal\IServiceInjectionSite.cs" />
     <Compile Include="Internal\LazyRef.cs" />
     <Compile Include="Internal\LoggingModelValidator.cs" />
     <Compile Include="Internal\ModelValidator.cs" />
     <Compile Include="Internal\Multigraph.cs" />
     <Compile Include="Internal\NonCapturingLazyInitializer.cs" />
     <Compile Include="Internal\ReportedLogData.cs" />
+    <Compile Include="Internal\ServiceProviderExtensions.cs" />
     <Compile Include="Storage\Internal\ExecutionStrategyFactory.cs" />
     <Compile Include="Storage\Internal\NoopExecutionStrategy.cs" />
     <Compile Include="Internal\ProductInfo.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
@@ -29,7 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             StateManager = new LazyRef<IStateManager>(() => currentContext.Context.GetService<IStateManager>());
             ConcurrencyDetector = concurrencyDetector;
             ChangeDetector = new LazyRef<IChangeDetector>(() => currentContext.Context.GetService<IChangeDetector>());
-            ;
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #6622

The approach we discussed didn't pan out exactly because IRelationalDatabaseCreator can also be obtained as the non-relational service IDatabaseCreator. The delegate for this is defined in the core package and so cannot directly reference relational types. Therefore, I created an abstract interface that any provider service can implement which then allows the service itself to request the additional services it needs.

Tested by making SQLite and SQL Server providers use the obsolete constructor and running all tests.

RelationalQueryContextFactory was not changed--see issue #6713.

We should review other constructors for changes--see issue #6714