### PR TITLE
Add methods to ExecutionStrategy that allow suppressing exceptions that don't indicate a failure

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
@@ -210,8 +210,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 if (CurrentTransaction != null)
                 {
                     CurrentTransaction = null;
-
-                    Close();
                 }
             }
             else

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTransaction.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private readonly ILogger _logger;
         private readonly bool _transactionOwned;
 
+        private bool _connectionClosed;
         private bool _disposed;
 
         /// <summary>
@@ -113,6 +114,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Debug.Assert((_relationalConnection.CurrentTransaction == null) || (_relationalConnection.CurrentTransaction == this));
 
             _relationalConnection.UseTransaction(null);
+
+            if (!_connectionClosed)
+            {
+                _connectionClosed = true;
+
+                _relationalConnection.Close();
+            }
         }
 
         DbTransaction IInfrastructure<DbTransaction>.Instance => _dbTransaction;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
@@ -48,13 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure()
-            => ExecutionStrategy(c => new SqlAzureExecutionStrategy(c));
+            => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
         /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
-            => ExecutionStrategy(c => new SqlAzureExecutionStrategy(c, maxRetryCount));
+            => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount));
 
         /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
@@ -66,6 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             int maxRetryCount,
             TimeSpan maxRetryDelay,
             [NotNull] ICollection<int> errorNumbersToAdd)
-            => ExecutionStrategy(c => new SqlAzureExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
+            => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount, maxRetryDelay, errorNumbersToAdd));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerInMemoryTablesConvention : IEntityTypeAnnotationSetConvention, IKeyConvention, IIndexConvention
+    public class SqlServerMemoryOptimizedTablesConvention : IEntityTypeAnnotationSetConvention, IKeyConvention, IIndexConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             ReplaceConvention(conventionSet.PropertyAddedConventions, (DatabaseGeneratedAttributeConvention)valueGenerationStrategyConvention);
 
-            var sqlServerInMemoryTablesConvention = new SqlServerInMemoryTablesConvention();
+            var sqlServerInMemoryTablesConvention = new SqlServerMemoryOptimizedTablesConvention();
             conventionSet.EntityTypeAnnotationSetConventions.Add(sqlServerInMemoryTablesConvention);
 
             conventionSet.KeyAddedConventions.Add(sqlServerInMemoryTablesConvention);

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -71,7 +71,7 @@
     <Compile Include="Infrastructure\Internal\SqlServerModelSource.cs" />
     <Compile Include="Infrastructure\Internal\SqlServerOptionsExtension.cs" />
     <Compile Include="Infrastructure\SqlServerDbContextOptionsBuilder.cs" />
-    <Compile Include="Metadata\Conventions\Internal\SqlServerInMemoryTablesConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\SqlServerMemoryOptimizedTablesConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\SqlServerValueGenerationStrategyConvention.cs" />
     <Compile Include="Metadata\Conventions\SqlServerConventionSetBuilder.cs" />
     <Compile Include="Metadata\Internal\SqlServerAnnotationNames.cs" />
@@ -139,7 +139,7 @@
     <Compile Include="Query\Sql\Internal\SqlServerQuerySqlGenerator.cs" />
     <Compile Include="Query\Sql\Internal\SqlServerQuerySqlGeneratorFactory.cs" />
     <Compile Include="Query\Sql\Internal\ISqlServerExpressionVisitor.cs" />
-    <Compile Include="SqlAzureExecutionStrategy.cs" />
+    <Compile Include="SqlServerRetryingExecutionStrategy.cs" />
     <Compile Include="Storage\Internal\ISqlServerConnection.cs" />
     <Compile Include="Storage\Internal\SqlServerConnection.cs" />
     <Compile Include="Storage\Internal\SqlServerDatabaseCreator.cs" />
@@ -150,7 +150,7 @@
     <Compile Include="Storage\Internal\SqlServerSqlGenerationHelper.cs" />
     <Compile Include="Storage\Internal\SqlServerTypeMapper.cs" />
     <Compile Include="Storage\Internal\SqlServerExecutionStrategyFactory.cs" />
-    <Compile Include="Storage\Internal\SqlAzureRetriableExceptionDetector.cs" />
+    <Compile Include="Storage\Internal\SqlServerTransientExceptionDetector.cs" />
     <Compile Include="Update\Internal\ISqlServerUpdateSqlGenerator.cs" />
     <Compile Include="Update\Internal\SqlServerModificationCommandBatch.cs" />
     <Compile Include="Update\Internal\SqlServerModificationCommandBatchFactory.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
@@ -13,101 +13,65 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class SqlAzureExecutionStrategy : ExecutionStrategy
+    public class SqlServerRetryingExecutionStrategy : ExecutionStrategy
     {
         private readonly ICollection<int> _errorNumbersToAdd;
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" /> without a context.
-        /// </summary>
-        /// <remarks>
-        ///     The default retry limit is 5, which means that the total amount of time spent before failing is 26 seconds plus the random factor.
-        /// </remarks>
-        protected SqlAzureExecutionStrategy()
-            : base(null, DefaultMaxRetryCount, DefaultMaxDelay)
-        {
-        }
-
-        /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The context on which the operations will be invoked. </param>
         /// <remarks>
         ///     The default retry limit is 5, which means that the total amount of time spent before failing is 26 seconds plus the random factor.
         /// </remarks>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] DbContext context)
             : this(context, DefaultMaxRetryCount)
         {
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The required dependencies. </param>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] ExecutionStrategyContext context)
             : this(context, DefaultMaxRetryCount)
         {
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" /> without a context.
-        /// </summary>
-        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
-        protected SqlAzureExecutionStrategy(
-            int maxRetryCount)
-            : base(null, maxRetryCount, DefaultMaxDelay)
-        {
-        }
-
-        /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The context on which the operations will be invoked. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] DbContext context,
             int maxRetryCount)
-            : this(context, maxRetryCount, DefaultMaxDelay, null)
+            : this(context, maxRetryCount, DefaultMaxDelay, errorNumbersToAdd: null)
         {
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The required dependencies. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] ExecutionStrategyContext context,
             int maxRetryCount)
-            : this(context, maxRetryCount, DefaultMaxDelay, null)
+            : this(context, maxRetryCount, DefaultMaxDelay, errorNumbersToAdd: null)
         {
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" /> without a context.
-        /// </summary>
-        /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
-        /// <param name="maxRetryDelay"> The maximum delay in milliseconds between retries. </param>
-        /// <param name="errorNumbersToAdd"> Additional SQL error numbers that should be considered transient. </param>
-        protected SqlAzureExecutionStrategy(
-            int maxRetryCount,
-            TimeSpan maxRetryDelay,
-            [CanBeNull] ICollection<int> errorNumbersToAdd)
-            : base(null, maxRetryCount, maxRetryDelay)
-        {
-            _errorNumbersToAdd = errorNumbersToAdd;
-        }
-
-        /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The context on which the operations will be invoked. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
         /// <param name="maxRetryDelay"> The maximum delay in milliseconds between retries. </param>
         /// <param name="errorNumbersToAdd"> Additional SQL error numbers that should be considered transient. </param>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] DbContext context,
             int maxRetryCount,
             TimeSpan maxRetryDelay,
@@ -119,13 +83,13 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlAzureExecutionStrategy" />.
+        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
         /// </summary>
         /// <param name="context"> The required dependencies. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
         /// <param name="maxRetryDelay"> The maximum delay in milliseconds between retries. </param>
         /// <param name="errorNumbersToAdd"> Additional SQL error numbers that should be considered transient. </param>
-        public SqlAzureExecutionStrategy(
+        public SqlServerRetryingExecutionStrategy(
             [NotNull] ExecutionStrategyContext context,
             int maxRetryCount,
             TimeSpan maxRetryDelay,
@@ -152,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
-            return SqlAzureRetriableExceptionDetector.ShouldRetryOn(exception);
+            return SqlServerTransientExceptionDetector.ShouldRetryOn(exception);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerExecutionStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerExecutionStrategy.cs
@@ -18,7 +18,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public virtual bool RetriesOnFailure => false;
 
-        public virtual TResult Execute<TState, TResult>(Func<TState, TResult> operation, TState state)
+        public virtual TResult Execute<TState, TResult>(
+            Func<TState, TResult> operation, Func<TState, ExecutionResult<TResult>> verifySucceeded, TState state)
         {
             try
             {
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception ex)
             {
-                if (ExecutionStrategy.UnwrapAndHandleException(ex, SqlAzureRetriableExceptionDetector.ShouldRetryOn))
+                if (ExecutionStrategy.CallOnWrappedException(ex, SqlServerTransientExceptionDetector.ShouldRetryOn))
                 {
                     throw new InvalidOperationException(SqlServerStrings.TransientExceptionDetected, ex);
                 }
@@ -37,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public virtual async Task<TResult> ExecuteAsync<TState, TResult>(
             Func<TState, CancellationToken, Task<TResult>> operation,
+            Func<TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
             TState state,
             CancellationToken cancellationToken)
         {
@@ -46,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception ex)
             {
-                if (ExecutionStrategy.UnwrapAndHandleException(ex, SqlAzureRetriableExceptionDetector.ShouldRetryOn))
+                if (ExecutionStrategy.CallOnWrappedException(ex, SqlServerTransientExceptionDetector.ShouldRetryOn))
                 {
                     throw new InvalidOperationException(SqlServerStrings.TransientExceptionDetected, ex);
                 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
@@ -8,9 +8,9 @@ using JetBrains.Annotations;
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>
-    ///     Detects the exceptions caused by SQL Azure transient failures.
+    ///     Detects the exceptions caused by SQL Server transient failures.
     /// </summary>
-    public class SqlAzureRetriableExceptionDetector
+    public class SqlServerTransientExceptionDetector
     {
         public static bool ShouldRetryOn([NotNull] Exception ex)
         {
@@ -21,6 +21,23 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 {
                     switch (err.Number)
                     {
+                        // SQL Error Code: 49920
+                        // Cannot process request. Too many operations in progress for subscription "%ld".
+                        // The service is busy processing multiple requests for this subscription.
+                        // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for operation status.
+                        // Wait until pending requests are complete or delete one of your pending requests and retry your request later.
+                        case 49920:
+                        // SQL Error Code: 49919
+                        // Cannot process create or update request. Too many create or update operations in progress for subscription "%ld".
+                        // The service is busy processing multiple create or update requests for your subscription or server.
+                        // Requests are currently blocked for resource optimization. Query sys.dm_operation_status for pending operations.
+                        // Wait till pending create or update requests are complete or delete one of your pending requests and
+                        // retry your request later.
+                        case 49919:
+                        // SQL Error Code: 49918
+                        // Cannot process request. Not enough resources to process request.
+                        // The service is currently busy.Please retry the request later.
+                        case 49918:
                         // SQL Error Code: 41325
                         // The current transaction failed to commit due to a serializable validation failure.
                         case 41325:
@@ -30,10 +47,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         // SQL Error Code: 41302
                         // The current transaction attempted to update a record that has been updated since the transaction started.
                         case 41302:
-                        // SQL Error Code: 41301
-                        // A previous transaction that the current transaction took a dependency on has aborted,
-                        // and the current transaction can no longer commit
-                        case 41301:
                         // SQL Error Code: 40613
                         // Database XXXX on server YYYY is not currently available. Please retry the connection later.
                         // If the problem persists, contact customer support, and provide them the session tracing ID of ZZZZZ.
@@ -75,6 +88,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         // allowed connections) on the server. (provider: TCP Provider, error: 0 - An existing connection was forcibly closed by
                         // the remote host.)
                         case 233:
+                        // SQL Error Code: 121
+                        // The semaphore timeout period has expired
+                        case 121:
                         // SQL Error Code: 64
                         // A connection was successfully established with the server, but then an error occurred during the login process.
                         // (provider: TCP Provider, error: 0 - The specified network name is no longer available.)

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ExecutionStrategyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ExecutionStrategyExtensions.cs
@@ -106,13 +106,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Executes the specified asynchronous operation and returns the result.
         /// </summary>
-        /// <typeparam name="TResult">
-        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
-        /// </typeparam>
         /// <param name="strategy">The strategy that will be used for the execution.</param>
         /// <param name="operation">
         ///     A function that returns a started task of type <typeparamref name="TResult" />.
         /// </param>
+        /// <typeparam name="TResult">
+        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
+        /// </typeparam>
         /// <returns>
         ///     A task that will run to completion if the original task completes successfully (either the
         ///     first time or after retrying transient failures). If the task fails with a non-transient error or
@@ -126,9 +126,6 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Executes the specified asynchronous operation and returns the result.
         /// </summary>
-        /// <typeparam name="TResult">
-        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
-        /// </typeparam>
         /// <param name="strategy">The strategy that will be used for the execution.</param>
         /// <param name="operation">
         ///     A function that returns a started task of type <typeparamref name="TResult" />.
@@ -137,6 +134,9 @@ namespace Microsoft.EntityFrameworkCore
         ///     A cancellation token used to cancel the retry operation, but not operations that are already in flight
         ///     or that already completed successfully.
         /// </param>
+        /// <typeparam name="TResult">
+        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
+        /// </typeparam>
         /// <returns>
         ///     A task that will run to completion if the original task completes successfully (either the
         ///     first time or after retrying transient failures). If the task fails with a non-transient error or
@@ -201,14 +201,14 @@ namespace Microsoft.EntityFrameworkCore
         ///     Executes the specified asynchronous operation and returns the result.
         /// </summary>
         /// <param name="strategy">The strategy that will be used for the execution.</param>
-        /// <typeparam name="TResult">
-        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
-        /// </typeparam>
         /// <param name="operation">
         ///     A function that returns a started task of type <typeparamref name="TResult" />.
         /// </param>
         /// <param name="state">The state that will be passed to the operation.</param>
         /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <typeparam name="TResult">
+        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
+        /// </typeparam>
         /// <returns>
         ///     A task that will run to completion if the original task completes successfully (either the
         ///     first time or after retrying transient failures). If the task fails with a non-transient error or
@@ -219,5 +219,179 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] Func<TState, Task<TResult>> operation,
             [CanBeNull] TState state)
             => strategy.ExecuteAsync((t, ct) => t.operation(t.state), new { operation, state }, default(CancellationToken));
+
+        /// <summary>
+        ///     Executes the specified operation and returns the result.
+        /// </summary>
+        /// <param name="strategy">The strategy that will be used for the execution.</param>
+        /// <param name="operation">
+        ///     A delegate representing an executable operation that returns the result of type <typeparamref name="TResult" />.
+        /// </param>
+        /// <param name="state">The state that will be passed to the operation.</param>
+        /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <typeparam name="TResult">The return type of <paramref name="operation" />.</typeparam>
+        /// <returns>The result from the operation.</returns>
+        public static TResult Execute<TState, TResult>(
+            [NotNull] this IExecutionStrategy strategy, [NotNull] Func<TState, TResult> operation, [CanBeNull] TState state)
+            => strategy.Execute(operation, verifySucceeded: null, state: state);
+
+        /// <summary>
+        ///     Executes the specified asynchronous operation and returns the result.
+        /// </summary>
+        /// <param name="strategy">The strategy that will be used for the execution.</param>
+        /// <param name="operation">
+        ///     A function that returns a started task of type <typeparamref name="TResult" />.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token used to cancel the retry operation, but not operations that are already in flight
+        ///     or that already completed successfully.
+        /// </param>
+        /// <param name="state">The state that will be passed to the operation.</param>
+        /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <typeparam name="TResult">
+        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
+        /// </typeparam>
+        /// <returns>
+        ///     A task that will run to completion if the original task completes successfully (either the
+        ///     first time or after retrying transient failures). If the task fails with a non-transient error or
+        ///     the retry limit is reached, the returned task will become faulted and the exception must be observed.
+        /// </returns>
+        public static Task<TResult> ExecuteAsync<TState, TResult>(
+            [NotNull] this IExecutionStrategy strategy,
+            [NotNull] Func<TState, CancellationToken, Task<TResult>> operation,
+            [CanBeNull] TState state,
+            CancellationToken cancellationToken)
+            => strategy.ExecuteAsync(operation, verifySucceeded: null, state: state, cancellationToken: cancellationToken);
+
+        /// <summary>
+        ///     Executes the specified operation in a transaction and returns the result after commiting it.
+        /// </summary>
+        /// <param name="strategy">The strategy that will be used for the execution.</param>
+        /// <param name="operation">
+        ///     A delegate representing an executable operation that returns the result of type <typeparamref name="TResult" />.
+        /// </param>
+        /// <param name="verifySucceeded">
+        ///     A delegate that tests whether the operation succeeded even though an exception was thrown when the
+        ///     transaction was being committed.
+        /// </param>
+        /// <param name="state"> The state that will be passed to the operation. </param>
+        /// <param name="context"> The context that will be used to start the transaction. </param>
+        /// <typeparam name="TState"> The type of the state. </typeparam>
+        /// <typeparam name="TResult"> The return type of <paramref name="operation" />. </typeparam>
+        /// <returns> The result from the operation. </returns>
+        /// <exception cref="RetryLimitExceededException">
+        ///     Thrown if the operation has not succeeded after the configured number of retries.
+        /// </exception>
+        public static TResult ExecuteInTransaction<TState, TResult>(
+            [NotNull] this IExecutionStrategy strategy,
+            [NotNull] Func<TState, TResult> operation,
+            [CanBeNull] Func<TState, bool> verifySucceeded,
+            [CanBeNull] TState state,
+            [NotNull] DbContext context)
+            => strategy.Execute(s =>
+                {
+                    using (var transaction = s.Context.Database.BeginTransaction())
+                    {
+                        s.CommitFailed = false;
+                        s.Result = s.Operation(s.State);
+                        s.CommitFailed = true;
+                        transaction.Commit();
+                    }
+                    return s.Result;
+                },
+                s => new ExecutionResult<TResult>(s.CommitFailed && s.VerifySucceeded(s.State), s.Result),
+                new ExecutionState<TState, TResult>(operation, verifySucceeded, state, context));
+
+        /// <summary>
+        ///     Executes the specified asynchronous operation and returns the result.
+        /// </summary>
+        /// <param name="strategy">The strategy that will be used for the execution.</param>
+        /// <param name="operation">
+        ///     A function that returns a started task of type <typeparamref name="TResult" />.
+        /// </param>
+        /// <param name="verifySucceeded">
+        ///     A delegate that tests whether the operation succeeded even though an exception was thrown when the
+        ///     transaction was being committed.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token used to cancel the retry operation, but not operations that are already in flight
+        ///     or that already completed successfully.
+        /// </param>
+        /// <param name="state"> The state that will be passed to the operation. </param>
+        /// <param name="context"> The context that will be used to start the transaction. </param>
+        /// <typeparam name="TState"> The type of the state. </typeparam>
+        /// <typeparam name="TResult"> The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />. </typeparam>
+        /// <returns>
+        ///     A task that will run to completion if the original task completes successfully (either the
+        ///     first time or after retrying transient failures). If the task fails with a non-transient error or
+        ///     the retry limit is reached, the returned task will become faulted and the exception must be observed.
+        /// </returns>
+        /// <exception cref="RetryLimitExceededException">
+        ///     Thrown if the operation has not succeeded after the configured number of retries.
+        /// </exception>
+        public static Task<TResult> ExecuteInTransactionAsync<TState, TResult>(
+            [NotNull] this IExecutionStrategy strategy,
+            [NotNull] Func<TState, CancellationToken, Task<TResult>> operation,
+            [CanBeNull] Func<TState, CancellationToken, Task<bool>> verifySucceeded,
+            [CanBeNull] TState state,
+            [NotNull] DbContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => strategy.ExecuteAsync(async (s, c) =>
+                {
+                    using (var transaction = await s.Context.Database.BeginTransactionAsync(c))
+                    {
+                        s.CommitFailed = false;
+                        s.Result = await s.Operation(s.State, c);
+                        s.CommitFailed = true;
+                        transaction.Commit();
+                    }
+                    return s.Result;
+                },
+                async (s, c) => new ExecutionResult<TResult>(s.CommitFailed && await s.VerifySucceeded(s.State, c), s.Result),
+                new ExecutionStateAsync<TState, TResult>(operation, verifySucceeded, state, context));
+
+        private class ExecutionState<TState, TResult>
+        {
+            public ExecutionState(
+                Func<TState, TResult> operation,
+                Func<TState, bool> verifySucceeded,
+                TState state,
+                DbContext context)
+            {
+                Operation = operation;
+                VerifySucceeded = verifySucceeded;
+                State = state;
+                Context = context;
+            }
+
+            public Func<TState, TResult> Operation { get; }
+            public Func<TState, bool> VerifySucceeded { get; }
+            public TState State { get; }
+            public DbContext Context { get; }
+            public TResult Result { get; set; }
+            public bool CommitFailed { get; set; }
+        }
+
+        private class ExecutionStateAsync<TState, TResult>
+        {
+            public ExecutionStateAsync(
+                Func<TState, CancellationToken, Task<TResult>> operation,
+                Func<TState, CancellationToken, Task<bool>> verifySucceeded,
+                TState state,
+                DbContext context)
+            {
+                Operation = operation;
+                VerifySucceeded = verifySucceeded;
+                State = state;
+                Context = context;
+            }
+
+            public Func<TState, CancellationToken, Task<TResult>> Operation { get; }
+            public Func<TState, CancellationToken, Task<bool>> VerifySucceeded { get; }
+            public TState State { get; }
+            public DbContext Context { get; }
+            public TResult Result { get; set; }
+            public bool CommitFailed { get; set; }
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -246,13 +246,14 @@
     <Compile Include="Internal\Multigraph.cs" />
     <Compile Include="Internal\NonCapturingLazyInitializer.cs" />
     <Compile Include="Internal\ServiceProviderExtensions.cs" />
-    <Compile Include="Storage\Internal\ExecutionStrategyFactory.cs" />
-    <Compile Include="Storage\Internal\NoopExecutionStrategy.cs" />
     <Compile Include="Internal\ProductInfo.cs" />
     <Compile Include="Internal\ReferenceEnumerableEqualityComparer.cs" />
     <Compile Include="Internal\ReferenceEqualityComparer.cs" />
     <Compile Include="Internal\ServiceProviderCache.cs" />
     <Compile Include="Internal\TypeExtensions.cs" />
+    <Compile Include="Storage\ExecutionResult.cs" />
+    <Compile Include="Storage\Internal\ExecutionStrategyFactory.cs" />
+    <Compile Include="Storage\Internal\NoopExecutionStrategy.cs" />
     <Compile Include="Metadata\Conventions\Internal\BackingFieldConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\ForeignKeyIndexConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IEntityTypeAnnotationSetConvention.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Storage/ExecutionResult.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/ExecutionResult.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Represents the execution state of an operation.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    public class ExecutionResult<TResult>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="ExecutionResult{TResult}" />.
+        /// </summary>
+        /// <param name="successful"><c>true</c> if the operation succeeded.</param>
+        /// <param name="result">The result of the operation if successful.</param>
+        public ExecutionResult(bool successful, [CanBeNull] TResult result)
+        {
+            IsSuccessful = successful;
+            Result = result;
+        }
+
+        /// <summary>
+        ///     Indicates whether the operation succeeded.
+        /// </summary>
+        public virtual bool IsSuccessful { get; }
+
+        /// <summary>
+        ///     The result of the operation if successful.
+        /// </summary>
+        public virtual TResult Result { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Storage/IExecutionStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/IExecutionStrategy.cs
@@ -24,35 +24,45 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="operation">
         ///     A delegate representing an executable operation that returns the result of type <typeparamref name="TResult" />.
         /// </param>
-        /// <param name="state">The state that will be passed to the operation.</param>
-        /// <typeparam name="TState">The type of the state.</typeparam>
-        /// <typeparam name="TResult">The return type of <paramref name="operation" />.</typeparam>
-        /// <returns>The result from the operation.</returns>
-        TResult Execute<TState, TResult>([NotNull] Func<TState, TResult> operation, [CanBeNull] TState state);
+        /// <param name="verifySucceeded"> A delegate that tests whether the operation succeeded even though an exception was thrown. </param>
+        /// <param name="state"> The state that will be passed to the operation. </param>
+        /// <typeparam name="TState"> The type of the state. </typeparam>
+        /// <typeparam name="TResult"> The return type of <paramref name="operation" />. </typeparam>
+        /// <returns> The result from the operation. </returns>
+        /// <exception cref="RetryLimitExceededException">
+        ///     Thrown if the operation has not succeeded after the configured number of retries.
+        /// </exception>
+        TResult Execute<TState, TResult>(
+            [NotNull] Func<TState, TResult> operation,
+            [CanBeNull] Func<TState, ExecutionResult<TResult>> verifySucceeded,
+            [CanBeNull] TState state);
 
         /// <summary>
         ///     Executes the specified asynchronous operation and returns the result.
         /// </summary>
-        /// <typeparam name="TResult">
-        ///     The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />.
-        /// </typeparam>
         /// <param name="operation">
         ///     A function that returns a started task of type <typeparamref name="TResult" />.
         /// </param>
+        /// <param name="verifySucceeded"> A delegate that tests whether the operation succeeded even though an exception was thrown. </param>
         /// <param name="cancellationToken">
         ///     A cancellation token used to cancel the retry operation, but not operations that are already in flight
         ///     or that already completed successfully.
         /// </param>
-        /// <param name="state">The state that will be passed to the operation.</param>
-        /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <param name="state"> The state that will be passed to the operation. </param>
+        /// <typeparam name="TState"> The type of the state. </typeparam>
+        /// <typeparam name="TResult"> The result type of the <see cref="Task{T}" /> returned by <paramref name="operation" />. </typeparam>
         /// <returns>
         ///     A task that will run to completion if the original task completes successfully (either the
         ///     first time or after retrying transient failures). If the task fails with a non-transient error or
         ///     the retry limit is reached, the returned task will become faulted and the exception must be observed.
         /// </returns>
+        /// <exception cref="RetryLimitExceededException">
+        ///     Thrown if the operation has not succeeded after the configured number of retries.
+        /// </exception>
         Task<TResult> ExecuteAsync<TState, TResult>(
             [NotNull] Func<TState, CancellationToken, Task<TResult>> operation,
+            [CanBeNull] Func<TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
             [CanBeNull] TState state,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Storage/Internal/NoopExecutionStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/Internal/NoopExecutionStrategy.cs
@@ -33,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public TResult Execute<TState, TResult>(Func<TState, TResult> operation, TState state) => operation(state);
+        public TResult Execute<TState, TResult>(
+            Func<TState, TResult> operation, Func<TState, ExecutionResult<TResult>> verifySucceeded, TState state)
+            => operation(state);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -41,8 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public Task<TResult> ExecuteAsync<TState, TResult>(
             Func<TState, CancellationToken, Task<TResult>> operation,
+            Func<TState, CancellationToken, Task<ExecutionResult<TResult>>> verifySucceeded,
             TState state,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
             => operation(state, cancellationToken);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FieldMappingInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/FieldMappingInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,12 +25,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             {
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
-                    .AddScoped<InMemoryTransactionManager, TestInMemoryTransactionManager>()
                     .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
                     .BuildServiceProvider();
-
-                var optionsBuilder = new DbContextOptionsBuilder();
-                optionsBuilder.UseInMemoryDatabase();
             }
 
             public override InMemoryTestStore CreateTestStore()
@@ -47,7 +44,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             public override DbContext CreateContext(InMemoryTestStore testStore)
                 => new FieldMappingContext(new DbContextOptionsBuilder()
                     .UseInMemoryDatabase()
-                    .UseInternalServiceProvider(_serviceProvider).Options);
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+                    .Options);
 
             public class InMemoryGraphUpdatesTestStore : InMemoryTestStore
             {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedFixupInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,7 +48,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
-                    .AddScoped<InMemoryTransactionManager, TestInMemoryTransactionManager>()
                     .BuildServiceProvider();
             }
 
@@ -66,7 +66,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             public override DbContext CreateContext(InMemoryTestStore testStore)
                 => new StoreGeneratedFixupContext(new DbContextOptionsBuilder()
                     .UseInMemoryDatabase()
-                    .UseInternalServiceProvider(_serviceProvider).Options);
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+                    .Options);
 
             public class InMemoryStoreGeneratedFixupTestStore : InMemoryTestStore
             {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,151 +21,151 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         [Fact]
         public override void Identity_key_with_read_only_before_save_throws_if_explicit_values_set()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Identity_property_on_Added_entity_with_default_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Identity_property_on_Modified_entity_is_included_in_update_when_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Identity_property_on_Modified_entity_is_not_included_in_update_when_not_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Computed_property_on_Added_entity_with_default_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Computed_property_on_Modified_entity_is_included_in_update_when_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Added_entity_with_default_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Added_entity_cannot_have_value_set_explicitly()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Modified_entity_is_not_included_in_update_even_when_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Added_entity_with_default_value_gets_value_from_store()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Added_entity_gets_store_value_even_when_set_explicitly()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Modified_entity_is_not_included_in_update_when_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         [Fact]
         public override void Always_identity_property_on_Modified_entity_is_not_included_in_the_update_when_not_modified()
         {
-            // In-memory store does not support store generation 
+            // In-memory store does not support store generation
         }
 
         public class StoreGeneratedInMemoryFixture : StoreGeneratedFixtureBase
@@ -178,16 +179,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
-                    .AddScoped<InMemoryTransactionManager, TestInMemoryTransactionManager>()
                     .BuildServiceProvider();
             }
 
             public override InMemoryTestStore CreateTestStore()
-            {
-                return InMemoryTestStore.GetOrCreateShared(DatabaseName, () =>
+                => InMemoryTestStore.GetOrCreateShared(DatabaseName, () =>
                     {
                         var optionsBuilder = new DbContextOptionsBuilder()
                             .UseInMemoryDatabase()
+                            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                             .UseInternalServiceProvider(_serviceProvider);
 
                         using (var context = new StoreGeneratedContext(optionsBuilder.Options))
@@ -196,12 +196,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                             context.Database.EnsureCreated();
                         }
                     });
-            }
 
             public override DbContext CreateContext(InMemoryTestStore testStore)
             {
                 var optionsBuilder = new DbContextOptionsBuilder()
                     .UseInMemoryDatabase()
+                    .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                     .UseInternalServiceProvider(_serviceProvider);
 
                 var context = new StoreGeneratedContext(optionsBuilder.Options);
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 
                 modelBuilder.Entity<Gumball>(b =>
                     {
-                        // In-memory store does not support store generation of keys
+                        // In-memory store does not support store generationof keys
                         b.Property(e => e.Id).Metadata.IsReadOnlyBeforeSave = false;
                     });
             }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/UpdatesInMemoryFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/UpdatesInMemoryFixture.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.UpdatesModel;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
@@ -17,12 +17,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
         public UpdatesInMemoryFixture()
         {
             _serviceProvider = new ServiceCollection()
-                .AddScoped<InMemoryTransactionManager, TestInMemoryTransactionManager>()
                 .AddEntityFrameworkInMemoryDatabase()
                 .BuildServiceProvider();
 
             _optionsBuilder = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase()
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .UseInternalServiceProvider(_serviceProvider);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
@@ -1,0 +1,209 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class ExecutionStrategyTest : IClassFixture<ExecutionStrategyTest.ExecutionStrategyFixture>, IDisposable
+    {
+        [Fact]
+        public void Does_not_throw_or_retry_on_false_commit_failure()
+        {
+            Test_commit_failure(false);
+        }
+
+        // #6720
+        //[Fact]
+        public void Retries_on_true_commit_failure()
+        {
+            Test_commit_failure(true);
+        }
+
+        private void Test_commit_failure(bool realFailure)
+        {
+            using (var context = CreateContext())
+            {
+                var contextServices = context.GetService<IServiceProvider>();
+                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+
+                connection.CommitFailures.Enqueue(new bool?[] { realFailure });
+
+                context.Products.Add(new Product());
+                new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
+                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c =>
+                        {
+                            var succeeded = c.Products.AsNoTracking().Any();
+                            if (!succeeded)
+                            {
+                                // TODO: call DiscardStoreGeneratedValues()
+                                // #6719
+                            }
+                            return succeeded;
+                        },
+                    context);
+                context.ChangeTracker.AcceptAllChanges();
+
+                Assert.Equal(realFailure ? 3 : 2, connection.OpenCount);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(1, context.Products.Count());
+            }
+        }
+
+        // #6720
+        //[Fact]
+        public void Does_not_throw_or_retry_on_false_execution_failure()
+        {
+            Test_execution_failure(false);
+        }
+
+        // #6720
+        //[Fact]
+        public void Retries_on_true_execution_failure()
+        {
+            Test_execution_failure(true);
+        }
+
+        private void Test_execution_failure(bool realFailure)
+        {
+            using (var context = CreateContext())
+            {
+                var contextServices = context.GetService<IServiceProvider>();
+                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+
+                connection.ExecutionFailures.Enqueue(new bool?[] { null, realFailure });
+
+                context.Products.Add(new Product());
+                context.Products.Add(new Product());
+                new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
+                    c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                    c =>
+                    {
+                        // This shouldn't be called if SaveChanges failed
+                        Assert.True(false);
+                        return false;
+                    },
+                    context);
+                context.ChangeTracker.AcceptAllChanges();
+
+                Assert.Equal(2, connection.OpenCount);
+                Assert.Equal(2, connection.ExecutionCount);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(2, context.Products.Count());
+            }
+        }
+
+        // #6720
+        //[Fact]
+        public void Verification_is_retried_using_same_retry_limit()
+        {
+            using (var context = CreateContext())
+            {
+                var contextServices = context.GetService<IServiceProvider>();
+                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+
+                connection.ExecutionFailures.Enqueue(new bool?[] { true, null, true, true });
+                connection.CommitFailures.Enqueue(new bool?[] { true, true, true });
+
+                context.Products.Add(new Product());
+                Assert.Throws<RetryLimitExceededException>(() =>
+                    new TestSqlServerRetryingExecutionStrategy(context, TimeSpan.FromMilliseconds(100))
+                    .ExecuteInTransaction(
+                        c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                        c => false,
+                        context));
+                context.ChangeTracker.AcceptAllChanges();
+
+                Assert.Equal(6, connection.OpenCount);
+                Assert.Equal(6, connection.ExecutionCount);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(0, context.Products.Count());
+            }
+        }
+
+        protected class ExecutionStrategyContext : DbContext
+        {
+            public ExecutionStrategyContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Product> Products { get; set; }
+        }
+
+        protected class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private const string DatabaseName = nameof(ExecutionStrategyTest);
+
+        public ExecutionStrategyTest(ExecutionStrategyFixture fixture)
+        {
+            Fixture = fixture;
+            TestStore = SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+            {
+                using (var context = CreateContext())
+                {
+                    context.Database.EnsureCreated();
+                    TestSqlLoggerFactory.Reset();
+                }
+            });
+        }
+
+        protected ExecutionStrategyFixture Fixture { get; }
+        protected SqlServerTestStore TestStore { get; }
+
+        public virtual void Dispose() => TestStore.Dispose();
+
+        protected virtual ExecutionStrategyContext CreateContext() => (ExecutionStrategyContext)Fixture.CreateContext();
+
+        public class ExecutionStrategyFixture
+        {
+            private readonly DbContextOptions _options;
+
+            public ExecutionStrategyFixture()
+            {
+                var serviceProvider = new ServiceCollection()
+                    .AddEntityFrameworkSqlServer()
+                    .AddSingleton<ILoggerFactory, TestSqlLoggerFactory>()
+                    .AddScoped<ISqlServerConnection, TestSqlServerConnection>()
+                    .AddScoped<IRelationalCommandBuilderFactory, TestRelationalCommandBuilderFactory>()
+                    .BuildServiceProvider();
+
+                _options = new DbContextOptionsBuilder()
+                    .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), b =>
+                        {
+                            b.ApplyConfiguration();
+                            b.MaxBatchSize(1);
+                        })
+                    .UseInternalServiceProvider(serviceProvider)
+                    .EnableSensitiveDataLogging()
+                    .Options;
+            }
+
+            public virtual DbContext CreateContext()
+                => new ExecutionStrategyContext(_options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="BuiltInDataTypesSqlServerTest.cs" />
     <Compile Include="ChangeTrackingSqlServerTest.cs" />
     <Compile Include="CommandConfigurationTest.cs" />
+    <Compile Include="ExecutionStrategyTest.cs" />
     <Compile Include="CompiledQueryCacheKeyGeneratorTest.cs" />
     <Compile Include="ComplexNavigationsQuerySqlServerFixture.cs" />
     <Compile Include="ComplexNavigationsQuerySqlServerTest.cs" />
@@ -126,6 +127,8 @@
     <Compile Include="SqlAzure\SqlAzureFundamentalsTest.cs" />
     <Compile Include="SqlExecutorSqlServerTest.cs" />
     <Compile Include="SqlServerConfigPatternsTest.cs" />
+    <Compile Include="Utilities\CollectionExtensions.cs" />
+    <Compile Include="Utilities\SqlExceptionFactory.cs" />
     <Compile Include="Utilities\SqlServerDatabaseCleaner.cs" />
     <Compile Include="SqlServerDatabaseCreationTest.cs" />
     <Compile Include="SqlServerDatabaseCreatorTest.cs" />
@@ -149,7 +152,10 @@
     <Compile Include="Utilities\SqlServerConfiguredConditionAttribute.cs" />
     <Compile Include="Utilities\SqlServerTestStore.cs" />
     <Compile Include="Utilities\TestEnvironment.cs" />
-    <Compile Include="Utilities\TestSqlAzureExecutionStrategy.cs" />
+    <Compile Include="Utilities\TestRelationalCommandBuilderFactory.cs" />
+    <Compile Include="Utilities\TestRelationalTransaction.cs" />
+    <Compile Include="Utilities\TestSqlServerConnection.cs" />
+    <Compile Include="Utilities\TestSqlServerRetryingExecutionStrategy.cs" />
     <Compile Include="Utilities\TestSqlServerModelSource.cs" />
     <Compile Include="WarningsSqlServerFixture.cs" />
     <Compile Include="WarningsSqlServerTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public TransactionSqlServerTest(TransactionSqlServerFixture fixture)
             : base(fixture)
         {
-            TestSqlAzureExecutionStrategy.Suspended = true;
+            TestSqlServerRetryingExecutionStrategy.Suspended = true;
         }
 
         protected override bool SnapshotSupported => true;
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public override void Dispose()
         {
             base.Dispose();
-            TestSqlAzureExecutionStrategy.Suspended = false;
+            TestSqlServerRetryingExecutionStrategy.Suspended = false;
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/CollectionExtensions.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/CollectionExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
+{
+    public static class CollectionExtensions
+    {
+        public static Queue<T> Enqueue<T>(this Queue<T> queue, IEnumerable<T> items)
+        {
+            foreach (var item in items)
+            {
+                queue.Enqueue(item);
+            }
+
+            return queue;
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 
             if (TestEnvironment.IsSqlAzure)
             {
-                optionsBuilder.ExecutionStrategy(c => new TestSqlAzureExecutionStrategy(c));
+                optionsBuilder.ExecutionStrategy(c => new TestSqlServerRetryingExecutionStrategy(c));
             }
 
             return optionsBuilder;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlExceptionFactory.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlExceptionFactory.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
+{
+    public static class SqlExceptionFactory
+    {
+        public static SqlException CreateSqlException(int number)
+        {
+            var errorCtors = typeof(SqlError)
+                .GetTypeInfo()
+                .DeclaredConstructors;
+
+#if NET451
+            var error = (SqlError)errorCtors.First(c => c.GetParameters().Length == 7)
+                .Invoke(new object[] { number, (byte)0, (byte)0, "Server", "ErrorMessage", "Procedure", 0 });
+#else
+// CoreCLR internal constructor has an additional parameter
+            var error = (SqlError)errorCtors.First(c => c.GetParameters().Length == 8)
+                .Invoke(new object[] { number, (byte)0, (byte)0, "Server", "ErrorMessage", "Procedure", 0, null });
+#endif
+            var errors = (SqlErrorCollection)typeof(SqlErrorCollection)
+                .GetTypeInfo()
+                .DeclaredConstructors
+                .Single()
+                .Invoke(null);
+
+            typeof(SqlErrorCollection).GetRuntimeMethods().Single(m => m.Name == "Add").Invoke(errors, new object[] { error });
+
+            var exceptionCtors = typeof(SqlException)
+                .GetTypeInfo()
+                .DeclaredConstructors;
+
+            return (SqlException)exceptionCtors.First(c => c.GetParameters().Length == 4)
+                .Invoke(new object[] { "Bang!", errors, null, Guid.NewGuid() });
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -281,7 +281,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                                           END", name);
 
         public static IExecutionStrategy GetExecutionStrategy()
-            => TestEnvironment.IsSqlAzure ? new TestSqlAzureExecutionStrategy() : (IExecutionStrategy)NoopExecutionStrategy.Instance;
+            => TestEnvironment.IsSqlAzure ? new TestSqlServerRetryingExecutionStrategy() : (IExecutionStrategy)NoopExecutionStrategy.Instance;
 
         public override DbConnection Connection => _connection;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
@@ -1,0 +1,188 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
+{
+    public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
+    {
+        private readonly ISensitiveDataLogger _logger;
+        private readonly DiagnosticSource _diagnosticSource;
+        private readonly IRelationalTypeMapper _typeMapper;
+
+        public TestRelationalCommandBuilderFactory(
+            ISensitiveDataLogger<RelationalCommandBuilderFactory> logger,
+            DiagnosticSource diagnosticSource,
+            IRelationalTypeMapper typeMapper)
+        {
+            _logger = logger;
+            _diagnosticSource = diagnosticSource;
+            _typeMapper = typeMapper;
+        }
+
+        public virtual IRelationalCommandBuilder Create()
+            => new TestRelationalCommandBuilder(
+                _logger,
+                _diagnosticSource,
+                _typeMapper);
+
+        private class TestRelationalCommandBuilder : IRelationalCommandBuilder
+        {
+            private readonly ISensitiveDataLogger _logger;
+            private readonly DiagnosticSource _diagnosticSource;
+
+            public TestRelationalCommandBuilder(
+                ISensitiveDataLogger logger,
+                DiagnosticSource diagnosticSource,
+                IRelationalTypeMapper typeMapper)
+            {
+                _logger = logger;
+                _diagnosticSource = diagnosticSource;
+                ParameterBuilder = new RelationalParameterBuilder(typeMapper);
+            }
+
+            IndentedStringBuilder IInfrastructure<IndentedStringBuilder>.Instance { get; } = new IndentedStringBuilder();
+
+            public IRelationalParameterBuilder ParameterBuilder { get; }
+
+            public IRelationalCommand Build()
+                => new TestRelationalCommand(
+                    _logger,
+                    _diagnosticSource,
+                    ((IInfrastructure<IndentedStringBuilder>)this).Instance.ToString(),
+                    ParameterBuilder.Parameters);
+        }
+
+        private class TestRelationalCommand : IRelationalCommand
+        {
+            private readonly RelationalCommand _realRelationalCommand;
+
+            public TestRelationalCommand(
+                ISensitiveDataLogger logger,
+                DiagnosticSource diagnosticSource,
+                string commandText,
+                IReadOnlyList<IRelationalParameter> parameters)
+            {
+                _realRelationalCommand = new RelationalCommand(logger, diagnosticSource, commandText, parameters);
+            }
+
+            public string CommandText => _realRelationalCommand.CommandText;
+
+            public IReadOnlyList<IRelationalParameter> Parameters => _realRelationalCommand.Parameters;
+
+            public int ExecuteNonQuery(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = _realRelationalCommand.ExecuteNonQuery(connection, parameterValues);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            public Task<int> ExecuteNonQueryAsync(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = _realRelationalCommand.ExecuteNonQueryAsync(connection, parameterValues, cancellationToken);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            public object ExecuteScalar(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = _realRelationalCommand.ExecuteScalar(connection, parameterValues);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            public async Task<object> ExecuteScalarAsync(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = await _realRelationalCommand.ExecuteScalarAsync(connection, parameterValues, cancellationToken);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            public RelationalDataReader ExecuteReader(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = _realRelationalCommand.ExecuteReader(connection, parameterValues);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            public async Task<RelationalDataReader> ExecuteReaderAsync(
+                IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
+            {
+                var errorNumber = PreExecution(connection);
+
+                var result = await _realRelationalCommand.ExecuteReaderAsync(connection, parameterValues, cancellationToken);
+                if (errorNumber.HasValue)
+                {
+                    connection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
+                }
+                return result;
+            }
+
+            private int? PreExecution(IRelationalConnection connection)
+            {
+                int? errorNumber = null;
+                var testConnection = (TestSqlServerConnection)connection;
+
+                testConnection.ExecutionCount++;
+                if (testConnection.ExecutionFailures.Count > 0)
+                {
+                    var fail = testConnection.ExecutionFailures.Dequeue();
+                    if (fail.HasValue)
+                    {
+                        if (fail.Value)
+                        {
+                            testConnection.DbConnection.Close();
+                            throw SqlExceptionFactory.CreateSqlException(testConnection.ErrorNumber);
+                        }
+                        errorNumber = testConnection.ErrorNumber;
+                    }
+                }
+                return errorNumber;
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
+{
+    public class TestRelationalTransaction : IDbContextTransaction, IInfrastructure<DbTransaction>
+    {
+        private readonly IDbContextTransaction _realTransaction;
+        private readonly TestSqlServerConnection _testConnection;
+        private bool _connectionClosed;
+
+        public TestRelationalTransaction(
+            TestSqlServerConnection connection, DbTransaction transaction, ILogger logger, bool transactionOwned)
+            : this(connection, new RelationalTransaction(connection, transaction, logger, transactionOwned))
+        {
+        }
+
+        public TestRelationalTransaction(TestSqlServerConnection connection, IDbContextTransaction transaction)
+        {
+            _testConnection = connection;
+            _realTransaction = transaction;
+        }
+
+        public void Dispose()
+        {
+            _realTransaction.Dispose();
+
+            ClearTransaction();
+        }
+
+        public void Commit()
+        {
+            if (_testConnection.CommitFailures.Count > 0)
+            {
+                var fail = _testConnection.CommitFailures.Dequeue();
+                if (fail.HasValue)
+                {
+                    if (fail.Value)
+                    {
+                        _realTransaction.GetDbTransaction().Rollback();
+                    }
+                    else
+                    {
+                        _realTransaction.GetDbTransaction().Commit();
+                    }
+                    _testConnection.DbConnection.Close();
+                    throw SqlExceptionFactory.CreateSqlException(_testConnection.ErrorNumber);
+                }
+            }
+
+            _realTransaction.Commit();
+
+            ClearTransaction();
+        }
+
+        public void Rollback()
+        {
+            _realTransaction.Rollback();
+
+            ClearTransaction();
+        }
+
+        private void ClearTransaction()
+        {
+            _testConnection.UseTransaction(null);
+
+            if (!_connectionClosed)
+            {
+                _connectionClosed = true;
+
+                _testConnection.Close();
+            }
+        }
+
+        public DbTransaction Instance => _realTransaction.GetDbTransaction();
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
+{
+    public class TestSqlServerConnection : ISqlServerConnection
+    {
+        private readonly ISqlServerConnection _realConnection;
+
+        public TestSqlServerConnection(IDbContextOptions options, ILogger<SqlServerConnection> logger)
+            : this(new SqlServerConnection(options, logger))
+        {
+        }
+
+        protected TestSqlServerConnection(ISqlServerConnection connection)
+        {
+            _realConnection = connection;
+        }
+
+        public int ErrorNumber { get; set; } = -2;
+        public Queue<bool?> OpenFailures { get; } = new Queue<bool?>();
+        public int OpenCount { get; set; }
+        public Queue<bool?> CommitFailures { get; } = new Queue<bool?>();
+        public Queue<bool?> ExecutionFailures { get; } = new Queue<bool?>();
+        public int ExecutionCount { get; set; }
+
+        public virtual string ConnectionString => _realConnection.ConnectionString;
+        public virtual DbConnection DbConnection => _realConnection.DbConnection;
+
+        public virtual int? CommandTimeout
+        {
+            get { return _realConnection.CommandTimeout; }
+            set { _realConnection.CommandTimeout = value; }
+        }
+
+        public virtual IDbContextTransaction CurrentTransaction { get; private set; }
+
+        public virtual IValueBufferCursor ActiveCursor
+        {
+            get { return _realConnection.ActiveCursor; }
+            set { _realConnection.ActiveCursor = value; }
+        }
+
+        public virtual bool IsMultipleActiveResultSetsEnabled => _realConnection.IsMultipleActiveResultSetsEnabled;
+
+        public virtual void Open()
+        {
+            PreOpen();
+
+            _realConnection.Open();
+        }
+
+        public virtual Task OpenAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            PreOpen();
+
+            return _realConnection.OpenAsync(cancellationToken);
+        }
+
+        private void PreOpen()
+        {
+            if (_realConnection.DbConnection.State == ConnectionState.Open)
+            {
+                return;
+            }
+
+            OpenCount++;
+            if (OpenFailures.Count <= 0)
+            {
+                return;
+            }
+            var fail = OpenFailures.Dequeue();
+            if (fail.HasValue)
+            {
+                throw SqlExceptionFactory.CreateSqlException(ErrorNumber);
+            }
+        }
+
+        public virtual void Close() => _realConnection.Close();
+
+        public virtual IDbContextTransaction BeginTransaction()
+            => BeginTransaction(IsolationLevel.Unspecified);
+
+        public virtual Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = new CancellationToken())
+            => BeginTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
+
+        public virtual IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel)
+        {
+            Open();
+            CurrentTransaction = new TestRelationalTransaction(this, _realConnection.BeginTransaction(isolationLevel));
+            return CurrentTransaction;
+        }
+
+        public virtual async Task<IDbContextTransaction> BeginTransactionAsync(
+            IsolationLevel isolationLevel, CancellationToken cancellationToken = new CancellationToken())
+        {
+            await OpenAsync(cancellationToken);
+            CurrentTransaction = new TestRelationalTransaction(this, await _realConnection.BeginTransactionAsync(isolationLevel, cancellationToken));
+            return CurrentTransaction;
+        }
+
+        public IDbContextTransaction UseTransaction(DbTransaction transaction)
+        {
+            var realTransaction = _realConnection.UseTransaction(transaction);
+            if (realTransaction == null)
+            {
+                CurrentTransaction = null;
+                return null;
+            }
+
+            Open();
+            CurrentTransaction = new TestRelationalTransaction(this, realTransaction);
+            return CurrentTransaction;
+        }
+
+        public void CommitTransaction() => CurrentTransaction.Commit();
+
+        public void RollbackTransaction() => CurrentTransaction.Rollback();
+
+        public void Dispose()
+        {
+            CurrentTransaction?.Dispose();
+
+            _realConnection.Dispose();
+        }
+
+        public ISqlServerConnection CreateMasterConnection() => new TestSqlServerConnection(_realConnection.CreateMasterConnection());
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -7,28 +7,33 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
-    public class TestSqlAzureExecutionStrategy : SqlAzureExecutionStrategy
+    public class TestSqlServerRetryingExecutionStrategy : SqlServerRetryingExecutionStrategy
     {
         private static readonly int[] _additionalErrorNumbers =
         {
             -1, // Physical connection is not usable
             -2, // Timeout
             42008, // Mirroring (Only when a database is deleted and another one is crated in fast succession)
-            42019, // CREATE DATABASE operation failed
-            49918 // Not enough resources to process request
+            42019 // CREATE DATABASE operation failed
         };
 
-        public TestSqlAzureExecutionStrategy()
-            : base(DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers)
+        public TestSqlServerRetryingExecutionStrategy()
+            : base(new DbContext(new DbContextOptionsBuilder().UseSqlServer(TestEnvironment.DefaultConnection).Options),
+                  DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers)
         {
         }
 
-        public TestSqlAzureExecutionStrategy(DbContext context)
+        public TestSqlServerRetryingExecutionStrategy(DbContext context)
             : base(context, DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers)
         {
         }
 
-        public TestSqlAzureExecutionStrategy(ExecutionStrategyContext context)
+        public TestSqlServerRetryingExecutionStrategy(DbContext context, TimeSpan maxDelay)
+            : base(context, DefaultMaxRetryCount, maxDelay, _additionalErrorNumbers)
+        {
+        }
+
+        public TestSqlServerRetryingExecutionStrategy(ExecutionStrategyContext context)
             : base(context, DefaultMaxRetryCount, DefaultMaxDelay, _additionalErrorNumbers)
         {
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/Conventions/SqlServerMemoryOptimizedTablesConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/Conventions/SqlServerMemoryOptimizedTablesConventionTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata.Conventions
 {
-    public class SqlServerInMemoryTablesConventionTest
+    public class SqlServerMemoryOptimizedTablesConventionTest
     {
         [Fact]
         public void Keys_and_indexes_are_nonclustered_for_memory_optimized_tables()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -41,7 +41,7 @@
     <Compile Include="CommandConfigurationTests.cs" />
     <Compile Include="DbSetAsTableNameSqlServerTest.cs" />
     <Compile Include="Metadata\Conventions\SqlServerConventionSetBuilderTests.cs" />
-    <Compile Include="Metadata\Conventions\SqlServerInMemoryTablesConventionTest.cs" />
+    <Compile Include="Metadata\Conventions\SqlServerMemoryOptimizedTablesConventionTest.cs" />
     <Compile Include="Metadata\Conventions\SqlServerValueGenerationStrategyConventionTest.cs" />
     <Compile Include="Metadata\SqlServerBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\SqlServerInternalMetadataBuilderExtensionsTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Tests/Storage/ExecutionStrategyTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Storage/ExecutionStrategyTests.cs
@@ -19,11 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
     {
         public class TestExecutionStrategy : ExecutionStrategy
         {
-            public TestExecutionStrategy()
-                : base(null, DefaultMaxRetryCount, DefaultMaxDelay)
-            {
-            }
-
             public TestExecutionStrategy(DbContext context)
                 : base(new ExecutionStrategyContext(context, null), DefaultMaxRetryCount, DefaultMaxDelay)
             {
@@ -41,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void GetNextDelay_returns_the_expected_default_sequence()
         {
-            var strategy = new TestExecutionStrategy();
+            var strategy = new TestExecutionStrategy(CreateContext());
             var delays = new List<TimeSpan?>();
             for (var i = 0; i < 5; i++)
             {
@@ -70,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void RetriesOnFailure_returns_true()
         {
-            var mockExecutionStrategy = new TestExecutionStrategy();
+            var mockExecutionStrategy = new TestExecutionStrategy(CreateContext());
 
             Assert.True(mockExecutionStrategy.RetriesOnFailure);
         }
@@ -117,11 +112,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var executed = false;
 
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.ShouldRetryOn(It.IsAny<Exception>())).Returns<Exception>(
                 e => e is ArgumentOutOfRangeException);
@@ -158,11 +152,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void Execute_doesnt_retry_if_succesful(Action<ExecutionStrategy, Func<int>> execute)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e =>
@@ -197,11 +190,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void Execute_doesnt_retry_if_suspended(Action<ExecutionStrategy, Func<int>> execute)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e =>
@@ -243,11 +235,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void Execute_retries_until_succesful(Action<ExecutionStrategy, Func<int>> execute)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e => TimeSpan.FromTicks(0));
@@ -284,9 +275,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void Execute_retries_until_not_retrieable_exception_is_thrown(Action<ExecutionStrategy, Func<int>> execute)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
                     CallBase = true
                 };
 
@@ -328,9 +318,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var executionCount = 0;
 
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
                     CallBase = true
                 };
 
@@ -365,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public Task ExecuteAsync_Func_throws_for_an_existing_transaction()
         {
-            return ExecuteAsync_throws_for_an_existing_transaction(e => e.ExecuteAsync((s, ct) => Task.FromResult(1), CancellationToken.None));
+            return ExecuteAsync_throws_for_an_existing_transaction(e => e.ExecuteAsync((s, ct) => Task.FromResult(1), null, CancellationToken.None));
         }
 
         private async Task ExecuteAsync_throws_for_an_existing_transaction(Func<ExecutionStrategy, Task> executeAsync)
@@ -397,12 +386,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private async Task ExecuteAsync_does_not_throw_when_invoked_twice(Func<ExecutionStrategy, Func<CancellationToken, Task<int>>, Task> executeAsync)
         {
             var executed = false;
-
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.ShouldRetryOn(It.IsAny<Exception>())).Returns<Exception>(
                 e => e is ArgumentOutOfRangeException);
@@ -439,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task ExecuteAsync_doesnt_retry_if_succesful(Func<ExecutionStrategy, Func<CancellationToken, Task<int>>, Task> executeAsync)
         {
-            var executionStrategyMock = new Mock<TestExecutionStrategy>
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
             {
                 CallBase = true
             };
@@ -477,8 +464,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task ExecuteAsync_doesnt_retry_if_suspended(Func<ExecutionStrategy, Func<CancellationToken, Task<int>>, Task> executeAsync)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
                 {
                     CallBase = true
                 };
@@ -525,11 +511,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private async Task ExecuteAsync_retries_until_succesful(Func<ExecutionStrategy, Func<CancellationToken, Task<int>>, Task> executeAsync)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e => TimeSpan.FromTicks(0));
@@ -568,11 +553,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private async Task ExecuteAsync_retries_until_not_retrieable_exception_is_thrown(
             Func<ExecutionStrategy, Func<CancellationToken, Task<int>>, Task> executeAsync)
         {
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e => TimeSpan.FromTicks(0));
@@ -611,11 +595,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var executionCount = 0;
 
-            var executionStrategyMock =
-                new Mock<TestExecutionStrategy>
-                {
-                    CallBase = true
-                };
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            {
+                CallBase = true
+            };
 
             executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
                 e => executionCount < 3 ? (TimeSpan?)TimeSpan.FromTicks(0) : null);
@@ -630,41 +613,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
                                 {
                                     if (executionCount++ < 3)
                                     {
-                                        throw new ArgumentOutOfRangeException();
+                                        throw new DbUpdateException("", new ArgumentOutOfRangeException());
                                     }
                                     Assert.True(false);
                                     return Task.FromResult(0);
-                                }))).InnerException);
+                                }))).InnerException.InnerException);
 
             Assert.Equal(3, executionCount);
-        }
-
-        [Fact]
-        public void Unwraps_DbUpdateException()
-        {
-            var innerException = new TimeoutException();
-            Assert.True(
-                ExecutionStrategy.UnwrapAndHandleException(
-                    new DbUpdateException("", innerException),
-                    ex =>
-                        {
-                            Assert.Same(innerException, ex);
-                            return true;
-                        }));
-        }
-
-        [Fact]
-        public void Unwraps_wrapped_null_exception()
-        {
-            Exception innerException = null;
-            Assert.True(
-                ExecutionStrategy.UnwrapAndHandleException(
-                    new DbUpdateException("", innerException),
-                    ex =>
-                        {
-                            Assert.Same(innerException, ex);
-                            return true;
-                        }));
         }
 
         protected DbContext CreateContext()


### PR DESCRIPTION
Add more transient error numbers and remove one that is not transient
Rename SqlAzureExecutionStrategy to SqlServerTransientExecutionStrategy

Fixes #6680
Fixes #6665

@ajcvickers This contains tests for #6720