### PR TITLE
Remove parameters with default values from IRelationalCommand

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalCommandExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalCommandExtensions.cs
@@ -1,104 +1,91 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Storage
 {
-    /// <summary>
-    ///     <para>
-    ///         A command to be executed against a relational database.
-    ///     </para>
-    ///     <para>
-    ///         This type is typically used by database providers (and other extensions). It is generally
-    ///         not used in application code.
-    ///     </para>
-    /// </summary>
-    public interface IRelationalCommand
+    public static class RelationalCommandExtensions
     {
-        /// <summary>
-        ///     Gets the command text to be executed.
-        /// </summary>
-        string CommandText { get; }
-
-        /// <summary>
-        ///     Gets the parameters for the command.
-        /// </summary>
-        IReadOnlyList<IRelationalParameter> Parameters { get; }
-
         /// <summary>
         ///     Executes the command with no results.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <returns> The number of rows affected. </returns>
-        int ExecuteNonQuery(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
+        public static int ExecuteNonQuery(
+            [NotNull] this IRelationalCommand command,
+            [NotNull] IRelationalConnection connection)
+            => command.ExecuteNonQuery(connection, parameterValues: null);
 
         /// <summary>
         ///     Asynchronously executes the command with no results.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the number of rows affected.
         /// </returns>
-        Task<int> ExecuteNonQueryAsync(
+        public static Task<int> ExecuteNonQueryAsync(
+            [NotNull] this IRelationalCommand command,
             [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken))
+            => command.ExecuteNonQueryAsync(connection, parameterValues: null, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Executes the command with a single scalar result.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <returns> The result of the command. </returns>
-        object ExecuteScalar(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
+        public static object ExecuteScalar(
+            [NotNull] this IRelationalCommand command,
+            [NotNull] IRelationalConnection connection)
+            => command.ExecuteScalar(connection, parameterValues: null);
 
         /// <summary>
         ///     Asynchronously executes the command with a single scalar result.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the result of the command.
         /// </returns>
-        Task<object> ExecuteScalarAsync(
+        public static Task<object> ExecuteScalarAsync(
+            [NotNull] this IRelationalCommand command,
             [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken))
+            => command.ExecuteScalarAsync(connection, parameterValues: null, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Executes the command with a <see cref="RelationalDataReader" /> result.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <returns> The result of the command. </returns>
-        RelationalDataReader ExecuteReader(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
+        public static RelationalDataReader ExecuteReader(
+            [NotNull] this IRelationalCommand command,
+            [NotNull] IRelationalConnection connection)
+            => command.ExecuteReader(connection, parameterValues: null);
 
         /// <summary>
         ///     Asynchronously executes the command with a <see cref="RelationalDataReader" /> result.
         /// </summary>
+        /// <param name="command"> The command to be executed. </param>
         /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation. The task result contains the result of the command.
         /// </returns>
-        Task<RelationalDataReader> ExecuteReaderAsync(
+        public static Task<RelationalDataReader> ExecuteReaderAsync(
+            [NotNull] this IRelationalCommand command,
             [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default(CancellationToken))
+            => command.ExecuteReaderAsync(connection, parameterValues: null, cancellationToken: cancellationToken);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -63,6 +63,7 @@
     </Compile>
     <Compile Include="Extensions\DbCommandLogData.cs" />
     <Compile Include="Extensions\DbParameterLogData.cs" />
+    <Compile Include="Extensions\RelationalCommandExtensions.cs" />
     <Compile Include="Extensions\RelationalExpressionExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Infrastructure\Internal\RelationalModelSource.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationCommand.cs
@@ -30,22 +30,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
         public virtual int ExecuteNonQuery(
                 [NotNull] IRelationalConnection connection,
-                [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
-                bool manageConnection = true)
+                [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null)
             => _relationalCommand.ExecuteNonQuery(
                 Check.NotNull(connection, nameof(connection)),
-                parameterValues,
-                manageConnection);
+                parameterValues);
 
         public virtual async Task<int> ExecuteNonQueryAsync(
                 [NotNull] IRelationalConnection connection,
                 [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
-                bool manageConnection = true,
                 CancellationToken cancellationToken = default(CancellationToken))
             => await _relationalCommand.ExecuteNonQueryAsync(
                 Check.NotNull(connection, nameof(connection)),
                 parameterValues,
-                manageConnection,
                 cancellationToken);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -110,8 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             = await relationalCommand.ExecuteReaderAsync(
                                 _queryingEnumerable._relationalQueryContext.Connection,
                                 _queryingEnumerable._relationalQueryContext.ParameterValues,
-                                manageConnection: false,
-                                cancellationToken: cancellationToken);
+                                cancellationToken);
 
                         _dbDataReader = _dataReader.DbDataReader;
                         _queryingEnumerable._shaperCommandContext.NotifyReaderCreated(_dbDataReader);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -99,8 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _dataReader
                             = relationalCommand.ExecuteReader(
                                 _queryingEnumerable._relationalQueryContext.Connection,
-                                _queryingEnumerable._relationalQueryContext.ParameterValues,
-                                manageConnection: false);
+                                _queryingEnumerable._relationalQueryContext.ParameterValues);
 
                         _dbDataReader = _dataReader.DbDataReader;
                         _queryingEnumerable._shaperCommandContext.NotifyReaderCreated(_dbDataReader);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilderFactory(
-            [NotNull] ISensitiveDataLogger<RelationalCommandBuilderFactory> logger,
+            [NotNull] ISensitiveDataLogger<IRelationalCommandBuilderFactory> logger,
             [NotNull] DiagnosticSource diagnosticSource,
             [NotNull] IRelationalTypeMapper typeMapper)
         {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvider;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Tests.TestUtilities;
@@ -23,13 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
     using CommandAction = Action<
         IRelationalConnection,
         IRelationalCommand,
-        IReadOnlyDictionary<string, object>,
-        bool>;
+        IReadOnlyDictionary<string, object>>;
     using CommandFunc = Func<
         IRelationalConnection,
         IRelationalCommand,
         IReadOnlyDictionary<string, object>,
-        bool,
         Task>;
 
     public class RelationalCommandTest
@@ -98,10 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(42, command.CommandTimeout);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Can_ExecuteNonQuery(bool manageConnection)
+        [Fact]
+        public void Can_ExecuteNonQuery()
         {
             var executeNonQueryCount = 0;
             var disposeCount = -1;
@@ -123,12 +118,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = relationalCommand.ExecuteNonQuery(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Equal(1, result);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
 
@@ -140,10 +134,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public virtual async Task Can_ExecuteNonQueryAsync(bool manageConnection)
+        [Fact]
+        public virtual async Task Can_ExecuteNonQueryAsync()
         {
             var executeNonQueryCount = 0;
             var disposeCount = -1;
@@ -165,12 +157,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = await relationalCommand.ExecuteNonQueryAsync(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Equal(1, result);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
 
@@ -182,10 +173,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Can_ExecuteScalar(bool manageConnection)
+        [Fact]
+        public void Can_ExecuteScalar()
         {
             var executeScalarCount = 0;
             var disposeCount = -1;
@@ -207,12 +196,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = (string)relationalCommand.ExecuteScalar(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Equal("ExecuteScalar Result", result);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
 
@@ -224,10 +212,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task Can_ExecuteScalarAsync(bool manageConnection)
+        [Fact]
+        public async Task Can_ExecuteScalarAsync()
         {
             var executeScalarCount = 0;
             var disposeCount = -1;
@@ -249,12 +235,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = (string)await relationalCommand.ExecuteScalarAsync(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Equal("ExecuteScalar Result", result);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
 
@@ -266,10 +251,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Can_ExecuteReader(bool manageConnection)
+        [Fact]
+        public void Can_ExecuteReader()
         {
             var executeReaderCount = 0;
             var disposeCount = -1;
@@ -293,13 +276,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = relationalCommand.ExecuteReader(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
 
             // Durring command execution
@@ -317,10 +299,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task Can_ExecuteReaderAsync(bool manageConnection)
+        [Fact]
+        public async Task Can_ExecuteReaderAsync()
         {
             var executeReaderCount = 0;
             var disposeCount = -1;
@@ -344,13 +324,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var relationalCommand = CreateRelationalCommand();
 
             var result = await relationalCommand.ExecuteReaderAsync(
-                new FakeRelationalConnection(options),
-                manageConnection: manageConnection);
+                new FakeRelationalConnection(options));
 
             Assert.Same(dbDataReader, result.DbDataReader);
             Assert.Equal(0, fakeDbConnection.CloseCount);
 
-            var expectedCount = manageConnection ? 1 : 0;
+            var expectedCount = 1;
             Assert.Equal(expectedCount, fakeDbConnection.OpenCount);
 
             // Durring command execution
@@ -372,38 +351,38 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             => new TheoryData<Delegate, string, bool>
             {
                 {
-                    new CommandAction((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteNonQuery(connection, parameterValues, manageConnection)),
+                    new CommandAction((connection, command, parameterValues)
+                        => command.ExecuteNonQuery(connection, parameterValues)),
                     "ExecuteNonQuery",
                     false
                 },
                 {
-                    new CommandAction((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteScalar(connection, parameterValues, manageConnection)),
+                    new CommandAction((connection, command, parameterValues)
+                        => command.ExecuteScalar(connection, parameterValues)),
                     "ExecuteScalar",
                     false
                 },
                 {
-                    new CommandAction((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteReader(connection, parameterValues, manageConnection)),
+                    new CommandAction((connection, command, parameterValues)
+                        => command.ExecuteReader(connection, parameterValues)),
                     "ExecuteReader",
                     false
                 },
                 {
-                    new CommandFunc((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteNonQueryAsync(connection, parameterValues, manageConnection)),
+                    new CommandFunc((connection, command, parameterValues)
+                        => command.ExecuteNonQueryAsync(connection, parameterValues)),
                     "ExecuteNonQuery",
                     true
                 },
                 {
-                    new CommandFunc((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteScalarAsync(connection, parameterValues, manageConnection)),
+                    new CommandFunc((connection, command, parameterValues)
+                        => command.ExecuteScalarAsync(connection, parameterValues)),
                     "ExecuteScalar",
                     true
                 },
                 {
-                    new CommandFunc((connection, command, parameterValues, manageConnection)
-                        => command.ExecuteReaderAsync(connection, parameterValues, manageConnection)),
+                    new CommandFunc((connection, command, parameterValues)
+                        => command.ExecuteReaderAsync(connection, parameterValues)),
                     "ExecuteReader",
                     true
                 }
@@ -431,14 +410,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("FirstInvariant"),
                     (await Assert.ThrowsAsync<InvalidOperationException>(async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null, true))).Message);
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("FirstInvariant"),
                     Assert.Throws<InvalidOperationException>(()
-                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null, true)).Message);
+                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null)).Message);
             }
         }
 
@@ -470,14 +449,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("ThirdInvariant"),
                     (await Assert.ThrowsAsync<InvalidOperationException>(async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true))).Message);
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("ThirdInvariant"),
                     Assert.Throws<InvalidOperationException>(()
-                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true)).Message);
+                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues)).Message);
             }
         }
 
@@ -507,11 +486,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
@@ -573,11 +552,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
@@ -635,11 +614,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(1, fakeConnection.DbConnections.Count);
@@ -703,14 +682,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("ThirdInvariant"),
                     (await Assert.ThrowsAsync<InvalidOperationException>(async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true))).Message);
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.MissingParameterValue("ThirdInvariant"),
                     Assert.Throws<InvalidOperationException>(()
-                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true)).Message);
+                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues)).Message);
             }
         }
 
@@ -744,14 +723,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
                 Assert.Equal(
                     RelationalStrings.ParameterNotObjectArray("CompositeInvariant"),
                     (await Assert.ThrowsAsync<InvalidOperationException>(async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true))).Message);
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues))).Message);
             }
             else
             {
                 Assert.Equal(
                     RelationalStrings.ParameterNotObjectArray("CompositeInvariant"),
                     Assert.Throws<InvalidOperationException>(()
-                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true)).Message);
+                        => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues)).Message);
             }
         }
 
@@ -786,12 +765,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             {
                 await Assert.ThrowsAsync<InvalidOperationException>(
                     async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null, true));
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null));
             }
             else
             {
                 Assert.Throws<InvalidOperationException>(()
-                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null, true));
+                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null));
             }
 
             Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
@@ -828,14 +807,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             {
                 await Assert.ThrowsAsync<InvalidOperationException>(
                     async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null, true));
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null));
 
                 Assert.Equal(1, fakeDbConnection.OpenAsyncCount);
             }
             else
             {
                 Assert.Throws<InvalidOperationException>(()
-                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null, true));
+                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null));
 
                 Assert.Equal(1, fakeDbConnection.OpenCount);
             }
@@ -874,19 +853,19 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             {
                 await Assert.ThrowsAsync<InvalidOperationException>(
                     async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null, false));
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, null));
 
-                Assert.Equal(0, fakeDbConnection.OpenAsyncCount);
+                Assert.Equal(1, fakeDbConnection.OpenAsyncCount);
             }
             else
             {
                 Assert.Throws<InvalidOperationException>(()
-                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null, false));
+                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, null));
 
-                Assert.Equal(0, fakeDbConnection.OpenCount);
+                Assert.Equal(1, fakeDbConnection.OpenCount);
             }
 
-            Assert.Equal(0, fakeDbConnection.CloseCount);
+            Assert.Equal(1, fakeDbConnection.CloseCount);
         }
 
         [Theory]
@@ -919,11 +898,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(1, log.Count);
@@ -966,11 +945,11 @@ Logged Command",
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(2, log.Count);
@@ -1011,11 +990,11 @@ Logged Command",
 
             if (async)
             {
-                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
             else
             {
-                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true);
+                ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues);
             }
 
             Assert.Equal(2, diagnostic.Count);
@@ -1078,12 +1057,12 @@ Logged Command",
             {
                 await Assert.ThrowsAsync<InvalidOperationException>(
                     async ()
-                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true));
+                        => await ((CommandFunc)commandDelegate)(fakeConnection, relationalCommand, parameterValues));
             }
             else
             {
                 Assert.Throws<InvalidOperationException>(()
-                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues, true));
+                    => ((CommandAction)commandDelegate)(fakeConnection, relationalCommand, parameterValues));
             }
 
             Assert.Equal(2, diagnostic.Count);
@@ -1127,10 +1106,10 @@ Logged Command",
         }
 
         private IRelationalCommand CreateRelationalCommand(
-                ISensitiveDataLogger logger = null,
-                DiagnosticSource diagnosticSource = null,
-                string commandText = "Command Text",
-                IReadOnlyList<IRelationalParameter> parameters = null)
+            ISensitiveDataLogger logger = null,
+            DiagnosticSource diagnosticSource = null,
+            string commandText = "Command Text",
+            IReadOnlyList<IRelationalParameter> parameters = null)
             => new RelationalCommand(
                 logger ?? new FakeSensitiveDataLogger<RelationalCommand>(),
                 diagnosticSource ?? new DiagnosticListener("Fake"),

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -220,30 +220,30 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
                 get { throw new NotImplementedException(); }
             }
 
-            public int ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+            public int ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
             {
                 return 0;
             }
 
-            public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                 => Task.FromResult(0);
 
-            public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+            public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues , CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+            public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<object> ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<object> ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -216,28 +216,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
                     get { throw new NotImplementedException(); }
                 }
 
-                public int ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+                public int ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
                 {
                     throw new NotImplementedException();
                 }
 
-                public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     throw new NotImplementedException();
                 }
 
-                public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+                public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
                     => Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize);
 
-                public Task<object> ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<object> ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                     => Task.FromResult<object>(Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize));
 
-                public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true)
+                public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
                 {
                     throw new NotImplementedException();
                 }
 
-                public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues = null, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     throw new NotImplementedException();
                 }


### PR DESCRIPTION
Make RelationalCommandBuilderFactory use a public type for the ISensitiveDataLogger category

Fixes #6700