### PR TITLE
Add back members to metadata interfaces

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/IEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IEntityType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -102,5 +103,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The properties defined on this entity. </returns>
         IEnumerable<IProperty> GetProperties();
+
+        /// <summary>
+        ///     Gets the model that this type belongs to.
+        /// </summary>
+        new IModel Model { get; } // Defined here to maintain binary compat with 1.0
+
+        /// <summary>
+        ///     Gets the name of this type.
+        /// </summary>
+        new string Name { get; } // Defined here to maintain binary compat with 1.0
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the CLR class that is used to represent instances of this type. Returns null if the type does not have a
+        ///         corresponding CLR class (known as a shadow type).
+        ///     </para>
+        ///     <para>
+        ///         Shadow types are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
+        ///         Therefore, shadow types will only exist in migration model snapshots, etc.
+        ///     </para>
+        /// </summary>
+        new Type ClrType { get; } // Defined here to maintain binary compat with 1.0
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -65,5 +67,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     changes will not be applied to the database.
         /// </summary>
         bool IsConcurrencyToken { get; }
+
+        /// <summary>
+        ///     Gets the type of value that this property holds.
+        /// </summary>
+        new Type ClrType { get; } // Defined here to maintain binary compat with 1.0
+
+        /// <summary>
+        ///     Gets a value indicating whether this is a shadow property. A shadow property is one that does not have a
+        ///     corresponding property in the entity class. The current value for the property is stored in
+        ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
+        /// </summary>
+        new bool IsShadowProperty { get; } // Defined here to maintain binary compat with 1.0
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -1639,6 +1639,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         #region Explicit interface implementations
 
         IModel ITypeBase.Model => Model;
+        IModel IEntityType.Model => Model;
         IMutableModel IMutableTypeBase.Model => Model;
         IMutableModel IMutableEntityType.Model => Model;
         IEntityType IEntityType.BaseType => _baseType;


### PR DESCRIPTION
Issue #6709

This should fix binary compat issues where 1.0 providers are bound to these members on the derived types.