### PR TITLE
Query: Convert Entity comparison with null to comparison on key properties

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -96,6 +96,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Entity_equality_null()
+        {
+            AssertQuery<Customer>(cs =>
+                from c in cs
+                where c == null
+                select c.CustomerID);
+        }
+
+        [ConditionalFact]
+        public virtual void Entity_equality_not_null()
+        {
+            AssertQuery<Customer>(cs =>
+                from c in cs
+                where c != null
+                select c.CustomerID);
+        }
+
+        [ConditionalFact]
         public virtual void Null_conditional_simple()
         {
             var c = Expression.Parameter(typeof(Customer));
@@ -6330,6 +6348,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(6, query.Count);
             }
+        }
+
+        [ConditionalFact]
+        public virtual void DefaultIfEmpty_in_subquery()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 from o in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                 where o != null
+                 select new { c.CustomerID, o.OrderID }));
+        }
+
+        [ConditionalFact]
+        public virtual void DefaultIfEmpty_in_subquery_nested()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs.Where(c => c.City == "Seattle")
+                 from o1 in os.Where(o => o.OrderID > 11000).DefaultIfEmpty()
+                 from o2 in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                 where o1 != null && o2 != null
+                 select new { c.CustomerID, o1.OrderID, o2.OrderDate }));
         }
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1260,7 +1260,7 @@ FROM [Level1] AS [e1]",
                 Sql);
 
             Assert.Contains(
-                @"SELECT TOP(1) [subQuery2].[Id], [subQuery2].[Date], [subQuery2].[Level1_Optional_Id], [subQuery2].[Level1_Required_Id], [subQuery2].[Name], [subQuery2].[OneToMany_Optional_InverseId], [subQuery2].[OneToMany_Optional_Self_InverseId], [subQuery2].[OneToMany_Required_InverseId], [subQuery2].[OneToMany_Required_Self_InverseId], [subQuery2].[OneToOne_Optional_PK_InverseId], [subQuery2].[OneToOne_Optional_SelfId], [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
+                @"SELECT TOP(1) [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery2]
 LEFT JOIN [Level3] AS [subQuery3] ON [subQuery2].[Id] = [subQuery3].[Level2_Optional_Id]
 ORDER BY [subQuery2].[Id]",

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -102,6 +102,28 @@ WHERE [c].[CustomerID] = N'ANATR'",
                 Sql);
         }
 
+        public override void Entity_equality_null()
+        {
+            base.Entity_equality_null();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NULL",
+                Sql);
+        }
+
+        public override void Entity_equality_not_null()
+        {
+            base.Entity_equality_not_null();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NOT NULL",
+                Sql);
+        }
+
         public override void Queryable_reprojection()
         {
             base.Queryable_reprojection();
@@ -6245,7 +6267,63 @@ FROM (
         FROM [Customers] AS [c0]
         WHERE [c0].[City] = N'London'
     ) AS [t0] ON 1 = 1
-) AS [t1]",
+) AS [t1]
+WHERE [t1].[CustomerID] IS NOT NULL",
+                Sql);
+        }
+
+        public override void DefaultIfEmpty_in_subquery()
+        {
+            base.DefaultIfEmpty_in_subquery();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [t1].[OrderID]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [t0].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty0]
+    LEFT JOIN (
+        SELECT [o0].*
+        FROM [Orders] AS [o0]
+        WHERE [o0].[CustomerID] = [c].[CustomerID]
+    ) AS [t0] ON 1 = 1
+) AS [t1]
+WHERE [t1].[OrderID] IS NOT NULL",
+                Sql);
+        }
+
+        public override void DefaultIfEmpty_in_subquery_nested()
+        {
+            base.DefaultIfEmpty_in_subquery_nested();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [t1].[OrderID], [t4].[OrderDate]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [t0].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty0]
+    LEFT JOIN (
+        SELECT [o0].*
+        FROM [Orders] AS [o0]
+        WHERE [o0].[OrderID] > 11000
+    ) AS [t0] ON 1 = 1
+) AS [t1]
+CROSS APPLY (
+    SELECT [t3].*
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty2]
+    LEFT JOIN (
+        SELECT [o2].*
+        FROM [Orders] AS [o2]
+        WHERE [o2].[CustomerID] = [c].[CustomerID]
+    ) AS [t3] ON 1 = 1
+) AS [t4]
+WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND ([t1].[OrderID] IS NOT NULL AND [t4].[OrderID] IS NOT NULL)",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 #if NETCOREAPP1_0
 using System.Threading;
@@ -12,9 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
     public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
     {
-        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture)
+        public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
         public override void Take_Skip()


### PR DESCRIPTION
Issue here:
We need to filter on qsre not null. But since it is not being materialized the value comes from the valuebuffer. `ValueBuffer` is tricky object here. When we use a composite shaper, the value buffer has values but we don't know corresponding value of particular qsre to compare it to null. And when it is valuebuffer for particular qsre only then `_values` becomes null instead of null value inside value buffer.

For SqlServer, which flattens query, we use composite shaper, we can translate such filters to Sql via entity equality rewriting.

For SQLite & InMemory where we generate different queries we need to guard against, `_values` in value buffer being null instead of actual value.

built on top of #6706 

Resolves #6636 