### PR TITLE
Query: Fix #6123 - Include on InMemory store with Single loads more t…

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -10,7 +10,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeBraces_005Flock/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeBraces_005Fusing/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeBraces_005Fwhile/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeMissingParentheses/@EntryIndexedValue">HINT</s:String>
+	
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeModifiersOrder/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">WARNING</s:String>

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/IncludeInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/IncludeInMemoryTest.cs
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
     public class IncludeInMemoryTest : IncludeTestBase<NorthwindQueryInMemoryFixture>
     {
-        public IncludeInMemoryTest(NorthwindQueryInMemoryFixture fixture)
+        public IncludeInMemoryTest(NorthwindQueryInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
@@ -15,22 +13,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             : base(fixture)
         {
         }
-
-        [Theory] // Skipped for in-memory. See #6123
-        public override Task Load_many_to_one_reference_to_principal_already_loaded_untyped(bool async)
-            => Task.FromResult(0);
-
-        [Theory] // Skipped for in-memory. See #6123
-        public override Task Load_many_to_one_reference_to_principal_using_Query_already_loaded(bool async)
-            => Task.FromResult(0);
-
-        [Theory] // Skipped for in-memory. See #6123
-        public override Task Load_many_to_one_reference_to_principal_using_Query_already_loaded_untyped(bool async)
-            => Task.FromResult(0);
-
-        [Theory] // Skipped for in-memory. See #6123
-        public override Task Load_many_to_one_reference_to_principal_already_loaded(bool async)
-            => Task.FromResult(0);
 
         public class LoadInMemoryFixture : LoadFixtureBase
         {
@@ -51,15 +33,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             }
 
             public override InMemoryTestStore CreateTestStore()
-            {
-                return InMemoryTestStore.GetOrCreateShared(DatabaseName, () =>
+                => InMemoryTestStore.GetOrCreateShared(DatabaseName, () =>
                     {
                         using (var context = new LoadContext(_options))
                         {
                             Seed(context);
                         }
                     });
-            }
 
             public override DbContext CreateContext(InMemoryTestStore testStore)
                 => new LoadContext(_options);


### PR DESCRIPTION
…han it should

- Moved injection of Include logic higher up the query tree so that it will run after filtering ops.