### PR TITLE
Add back IPropertyBase.DeclaringEntityType for binary compat with 1.0 providers

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/INavigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/INavigation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the entity type that this property belongs to.
         /// </summary>
-        IEntityType DeclaringEntityType { get; }
+        new IEntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IProperty.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the entity type that this property belongs to.
         /// </summary>
-        IEntityType DeclaringEntityType { get; }
+        new IEntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this property can contain null.

--- a/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/IPropertyBase.cs
@@ -14,6 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IPropertyBase : IAnnotatable
     {
         /// <summary>
+        ///     Gets the entity type that this property belongs to.
+        /// </summary>
+        [Obsolete("Use DeclaringType, IProperty.DeclaringEntityType, or INavigation.DeclaringEntityType.")]
+        IEntityType DeclaringEntityType { get; }
+
+        /// <summary>
         ///     Gets the name of the property.
         /// </summary>
         string Name { get; }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -195,5 +195,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, p => new PropertyAccessorsFactory().Create(p));
 
         ITypeBase IPropertyBase.DeclaringType => DeclaringType;
+
+        [Obsolete("Use DeclaringType, IProperty.DeclaringEntityType, or INavigation.DeclaringEntityType.")]
+        IEntityType IPropertyBase.DeclaringEntityType => (IEntityType)DeclaringType;
     }
 }


### PR DESCRIPTION
Issue #6768

/cc @divega @rowanmiller 