### PR TITLE
Query: Keep track of projected querysource in subquery to apply proper select *

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -139,9 +139,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                 if (sqlExpression == null)
                 {
-                    if (!(node is QuerySourceReferenceExpression))
+                    var qsre = node as QuerySourceReferenceExpression;
+                    if (qsre == null)
                     {
                         QueryModelVisitor.RequiresClientProjection = true;
+                    }
+                    else
+                    {
+                        if (QueryModelVisitor.ParentQueryModelVisitor != null)
+                        {
+                            selectExpression.SetTableForProjectStar(qsre.ReferencedQuerySource);
+                        }
                     }
                 }
                 else

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -79,6 +79,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </value>
         public virtual Expression Predicate { get; [param: CanBeNull] set; }
 
+        public virtual string ProjectStarAlias { get; [param: CanBeNull] set; }
+
+        public virtual void SetTableForProjectStar([NotNull] IQuerySource querySource)
+            => ProjectStarAlias = GetTableForQuerySource(querySource)?.Alias;
+
         /// <summary>
         ///     Type of this expression.
         /// </summary>
@@ -412,11 +417,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             subquery._offset = _offset;
             subquery._isDistinct = _isDistinct;
             subquery._subqueryDepth = _subqueryDepth;
+            subquery.ProjectStarAlias = ProjectStarAlias;
             subquery.IsProjectStar = IsProjectStar || !subquery._projection.Any();
 
             _limit = null;
             _offset = null;
             _isDistinct = false;
+            ProjectStarAlias = null;
 
             Predicate = null;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -206,8 +206,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (selectExpression.IsProjectStar)
             {
+                var tableAlias = selectExpression.ProjectStarAlias ?? selectExpression.Tables.Last().Alias;
+
                 _relationalCommandBuilder
-                    .Append(_sqlGenerationHelper.DelimitIdentifier(selectExpression.Tables.Last().Alias))
+                    .Append(_sqlGenerationHelper.DelimitIdentifier(tableAlias))
                     .Append(".*");
 
                 projectionAdded = true;

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -1298,9 +1298,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1332,9 +1332,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1359,9 +1359,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1393,9 +1393,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1420,9 +1420,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1451,9 +1451,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1491,9 +1491,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1522,9 +1522,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1562,9 +1562,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1589,9 +1589,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1620,9 +1620,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1651,9 +1651,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1682,9 +1682,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1713,9 +1713,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1744,9 +1744,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1775,9 +1775,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1803,9 +1803,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1830,9 +1830,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1857,9 +1857,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1886,9 +1886,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -1917,9 +1917,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -1950,10 +1950,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var id1s = expected.Select(e => e.Key);
                 var id2s = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(id1s.Contains(result[i].Id1));
-                    Assert.True(id2s.Contains(result[i].Id2));
+                    Assert.True(id1s.Contains(resultItem.Id1));
+                    Assert.True(id2s.Contains(resultItem.Id2));
                 }
             }
         }
@@ -1985,10 +1985,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var id1s = expected.Select(e => e.Key);
                 var id2s = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(id1s.Contains(result[i].Id1));
-                    Assert.True(id2s.Contains(result[i].Id2));
+                    Assert.True(id1s.Contains(resultItem.Id1));
+                    Assert.True(id2s.Contains(resultItem.Id2));
                 }
             }
         }
@@ -2020,10 +2020,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var id1s = expected.Select(e => e.Key);
                 var id2s = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(id1s.Contains(result[i].Id1));
-                    Assert.True(id2s.Contains(result[i].Id2));
+                    Assert.True(id1s.Contains(resultItem.Id1));
+                    Assert.True(id2s.Contains(resultItem.Id2));
                 }
             }
         }
@@ -2055,10 +2055,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var id1s = expected.Select(e => e.Key);
                 var id2s = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(id1s.Contains(result[i].Id1));
-                    Assert.True(id2s.Contains(result[i].Id2));
+                    Assert.True(id1s.Contains(resultItem.Id1));
+                    Assert.True(id2s.Contains(resultItem.Id2));
                 }
             }
         }
@@ -2085,9 +2085,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2117,9 +2117,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2149,9 +2149,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2194,10 +2194,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var names = expected.Select(e => e.Key);
                 var ids = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(names.Contains(result[i].Name));
-                    Assert.True(ids.Contains(result[i].Id));
+                    Assert.True(names.Contains(resultItem.Name));
+                    Assert.True(ids.Contains(resultItem.Id));
                 }
             }
         }
@@ -2240,10 +2240,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(expected.Count, result.Count);
                 var names = expected.Select(e => e.Key);
                 var ids = expected.Select(e => e.Value);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(names.Contains(result[i].Name));
-                    Assert.True(ids.Contains(result[i].Id));
+                    Assert.True(names.Contains(resultItem.Name));
+                    Assert.True(ids.Contains(resultItem.Id));
                 }
             }
         }
@@ -2286,12 +2286,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    var expectedElement = expected.Where(e => e.Id == result[i].Id).Single();
-                    Assert.True(expectedElement.Name == result[i].Name);
-                    Assert.True(expectedElement.Inner?.Id == result[i].Inner?.Id);
-                    Assert.True(expectedElement.Inner?.Name == result[i].Inner?.Name);
+                    var expectedElement = expected.Where(e => e.Id == resultItem.Id).Single();
+                    Assert.True(expectedElement.Name == resultItem.Name);
+                    Assert.True(expectedElement.Inner?.Id == resultItem.Inner?.Id);
+                    Assert.True(expectedElement.Inner?.Name == resultItem.Inner?.Name);
                 }
             }
         }
@@ -2369,9 +2369,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2448,12 +2448,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    var expectedElement = expected.Where(e => e.Id == result[i].Id).Single();
+                    var expectedElement = expected.Where(e => e.Id == resultItem.Id).Single();
 
-                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Id, result[i].OneToOne_Optional_FK?.Id);
-                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Name, result[i].OneToOne_Optional_FK?.Name);
+                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Name, resultItem.OneToOne_Optional_FK?.Name);
                 }
             }
         }
@@ -2484,14 +2484,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    var expectedElement = expected.Where(e => e.Id == result[i].Id).Single();
+                    var expectedElement = expected.Where(e => e.Id == resultItem.Id).Single();
 
-                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Id, result[i].OneToOne_Optional_FK?.Id);
-                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Name, result[i].OneToOne_Optional_FK?.Name);
+                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedElement.OneToOne_Optional_FK?.Name, resultItem.OneToOne_Optional_FK?.Name);
 
-                    var resultCollection = result[i].OneToOne_Optional_FK?.OneToMany_Required;
+                    var resultCollection = resultItem.OneToOne_Optional_FK?.OneToMany_Required;
                     Assert.Equal(expectedElement.OneToOne_Optional_FK?.OneToMany_Required?.Count, resultCollection?.Count);
 
                     if (resultCollection != null)
@@ -2538,12 +2538,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(5, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    var expectedElement = expected.Where(e => e.Key.Id == result[i].l1.Id).Single();
+                    var expectedElement = expected.Where(e => e.Key.Id == resultItem.l1.Id).Single();
 
                     var expectedOneToManyOptional = expectedElement.Key.OneToMany_Optional?.ToList();
-                    var actualOneToManyOptional = result[i].l1.OneToMany_Optional?.ToList();
+                    var actualOneToManyOptional = resultItem.l1.OneToMany_Optional?.ToList();
 
                     Assert.Equal(expectedOneToManyOptional?.Count, actualOneToManyOptional?.Count);
                     if (expectedOneToManyOptional != null)
@@ -2555,8 +2555,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     }
 
                     var expectedGrouping = expectedElement.Value?.ToList();
-                    var actualGrouping = result[i].grouping?.ToList();
-                    Assert.Equal(expectedGrouping?.Count(), result[i].grouping?.Count());
+                    var actualGrouping = resultItem.grouping?.ToList();
+                    Assert.Equal(expectedGrouping?.Count(), resultItem.grouping?.Count());
                     if (expectedGrouping != null)
                     {
                         for (var j = 0; j < expectedGrouping.Count(); j++)
@@ -2592,23 +2592,23 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 expected = (from e3 in context.LevelThree.ToList()
-                               join e1 in context.LevelOne.ToList()
-                               on
-                               (int?)e3.Id
-                               equals
-                               (
-                                   from subQuery2 in context.LevelTwo.ToList()
-                                   join subQuery3 in context.LevelThree.ToList()
-                                   on
-                                   subQuery2 != null ? (int?)subQuery2.Id : null
-                                   equals
-                                   subQuery3.Level2_Optional_Id
-                                   into
-                                   grouping
-                                   from subQuery3 in grouping.DefaultIfEmpty()
-                                   select subQuery3 != null ? (int?)subQuery3.Id : null
-                               ).FirstOrDefault()
-                               select e1.Id).ToList();
+                            join e1 in context.LevelOne.ToList()
+                            on
+                            (int?)e3.Id
+                            equals
+                            (
+                                from subQuery2 in context.LevelTwo.ToList()
+                                join subQuery3 in context.LevelThree.ToList()
+                                on
+                                subQuery2 != null ? (int?)subQuery2.Id : null
+                                equals
+                                subQuery3.Level2_Optional_Id
+                                into
+                                grouping
+                                from subQuery3 in grouping.DefaultIfEmpty()
+                                select subQuery3 != null ? (int?)subQuery3.Id : null
+                            ).FirstOrDefault()
+                            select e1.Id).ToList();
 
             }
 
@@ -2663,9 +2663,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -2692,9 +2692,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2724,9 +2724,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -2756,9 +2756,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -2785,9 +2785,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Id));
+                    Assert.True(expected.Contains(resultItem.Id));
                 }
             }
         }
@@ -2815,9 +2815,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -2845,9 +2845,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Name));
+                    Assert.True(expected.Contains(resultItem.Name));
                 }
             }
         }
@@ -2874,9 +2874,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -2905,9 +2905,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -2936,9 +2936,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -2967,9 +2967,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3004,9 +3004,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3041,9 +3041,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3076,9 +3076,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3148,9 +3148,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -3213,9 +3213,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -3243,9 +3243,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }
@@ -3284,9 +3284,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Name));
+                    Assert.True(expected.Contains(resultItem.Name));
                 }
             }
         }
@@ -3332,9 +3332,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Name));
+                    Assert.True(expected.Contains(resultItem.Name));
                 }
             }
         }
@@ -3378,9 +3378,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Name));
+                    Assert.True(expected.Contains(resultItem.Name));
                 }
             }
         }
@@ -3423,9 +3423,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i].Name));
+                    Assert.True(expected.Contains(resultItem.Name));
                 }
             }
         }
@@ -3465,9 +3465,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3493,9 +3493,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var resultItem in result)
                 {
-                    Assert.True(expected.Contains(result[i]?.Name));
+                    Assert.True(expected.Contains(resultItem?.Name));
                 }
             }
         }
@@ -3528,9 +3528,9 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var row in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(row));
                 }
             }
         }
@@ -3564,9 +3564,161 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(expected.Count, result.Count);
-                for (var i = 0; i < result.Count; i++)
+                foreach (var row in result)
                 {
-                    Assert.True(expected.Contains(result[i]));
+                    Assert.True(expected.Contains(row));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Projection_select_correct_table_from_subquery_when_materialization_is_not_required()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelTwo.Include(l2 => l2.OneToOne_Required_FK_Inverse).ToList()
+                    .Where(l2 => l2.OneToOne_Required_FK_Inverse.Name == "L1 03")
+                    .Take(3)
+                    .Select(l2 => l2.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelTwo
+                    .Where(l2 => l2.OneToOne_Required_FK_Inverse.Name == "L1 03")
+                    .Take(3)
+                    .Select(l2 => l2.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                foreach (var row in result)
+                {
+                    Assert.True(expected.Contains(row));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Projection_select_correct_table_with_anonymous_projection_in_subquery()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = (from l2 in context.LevelTwo.ToList()
+                            join l1 in context.LevelOne.ToList()
+                               on l2.Level1_Required_Id equals l1.Id
+                            join l3 in context.LevelThree.ToList()
+                               on l1.Id equals l3.Level2_Required_Id
+                            where l1.Name == "L1 03"
+                            where l3.Name == "L3 08"
+                            select new { l2, l1 })
+                    .Take(3)
+                    .Select(l => l.l2.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = (from l2 in context.LevelTwo
+                             join l1 in context.LevelOne
+                                on l2.Level1_Required_Id equals l1.Id
+                             join l3 in context.LevelThree
+                                on l1.Id equals l3.Level2_Required_Id
+                             where l1.Name == "L1 03"
+                             where l3.Name == "L3 08"
+                             select new { l2, l1 })
+                    .Take(3)
+                    .Select(l => l.l2.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                foreach (var row in result)
+                {
+                    Assert.True(expected.Contains(row));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Projection_select_correct_table_in_subquery_when_materialization_is_not_required_in_multiple_joins()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = (from l2 in context.LevelTwo.ToList()
+                            join l1 in context.LevelOne.ToList()
+                               on l2.Level1_Required_Id equals l1.Id
+                            join l3 in context.LevelThree.ToList()
+                               on l1.Id equals l3.Level2_Required_Id
+                            where l1.Name == "L1 03"
+                            where l3.Name == "L3 08"
+                            select l1)
+                    .Take(3)
+                    .Select(l1 => l1.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = (from l2 in context.LevelTwo
+                             join l1 in context.LevelOne
+                                on l2.Level1_Required_Id equals l1.Id
+                             join l3 in context.LevelThree
+                                on l1.Id equals l3.Level2_Required_Id
+                             where l1.Name == "L1 03"
+                             where l3.Name == "L3 08"
+                             select l1)
+                    .Take(3)
+                    .Select(l1 => l1.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                foreach (var row in result)
+                {
+                    Assert.True(expected.Contains(row));
+                }
+            }
+        }
+
+        //[ConditionalFact] TODO: See issue#6782
+        public virtual void Where_predicate_on_optional_reference_navigation()
+        {
+            List<string> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne.Include(l1 => l1.OneToOne_Required_FK).ToList()
+                    .Where(l1 => l1.OneToOne_Required_FK?.Name == "L2 03")
+                    .Take(3)
+                    .Select(l1 => l1.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Where(l1 => l1.OneToOne_Required_FK.Name == "L2 03")
+                    .Take(3)
+                    .Select(l1 => l1.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                foreach (var resultItem in result)
+                {
+                    Assert.True(expected.Contains(resultItem));
                 }
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
@@ -17,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         private readonly IServiceProvider _serviceProvider;
 
+        private readonly DbContextOptions _options;
+
         private readonly string _connectionString
             = SqlServerTestStore.CreateConnectionString(DatabaseName);
 
@@ -27,17 +29,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
                 .BuildServiceProvider();
+
+            _options = new DbContextOptionsBuilder()
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(_connectionString, b => b.ApplyConfiguration())
+                .UseInternalServiceProvider(_serviceProvider).Options;
         }
 
         public override SqlServerTestStore CreateTestStore()
         {
             return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
                 {
-                    var optionsBuilder = new DbContextOptionsBuilder()
-                        .UseSqlServer(_connectionString, b => b.ApplyConfiguration())
-                        .UseInternalServiceProvider(_serviceProvider);
-
-                    using (var context = new ComplexNavigationsContext(optionsBuilder.Options))
+                    using (var context = new ComplexNavigationsContext(_options))
                     {
                         context.Database.EnsureCreated();
                         ComplexNavigationsModelInitializer.Seed(context);
@@ -49,11 +52,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         public override ComplexNavigationsContext CreateContext(SqlServerTestStore testStore)
         {
-            var optionsBuilder = new DbContextOptionsBuilder()
-                .UseSqlServer(testStore.Connection, b => b.ApplyConfiguration())
-                .UseInternalServiceProvider(_serviceProvider);
-
-            var context = new ComplexNavigationsContext(optionsBuilder.Options);
+            var context = new ComplexNavigationsContext(_options);
 
             context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -564,7 +564,7 @@ FROM [Level1] AS [e1]",
                 Sql);
 
             Assert.Contains(
-                @"@_outer_Id: ?
+                @"@_outer_Id: 11
 
 SELECT TOP(1) [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
@@ -583,7 +583,7 @@ ORDER BY [subQuery].[Id]",
 FROM [Level1] AS [e1]",
                 Sql);
 
-            Assert.Contains(@"@_outer_Id: ?
+            Assert.Contains(@"@_outer_Id: 13
 
 SELECT TOP(1) [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Level3_Optional_Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Level3_Required_Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Name], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [subQuery]
@@ -1197,8 +1197,8 @@ ORDER BY [l1].[Id], [l1].[Id0]",
             if (SupportsOffset)
             {
                 Assert.Equal(
-                    @"@__p_0: ?
-@__p_1: ?
+                    @"@__p_0: 1
+@__p_1: 5
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_InverseId], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_PK_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1208,8 +1208,8 @@ WHERE ([e].[Name] <> N'L1 03') OR [e].[Name] IS NULL
 ORDER BY [e].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 1
+@__p_1: 5
 
 SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
@@ -1466,8 +1466,8 @@ WHERE (
             if (SupportsOffset)
             {
                 Assert.Equal(
-                    @"@__p_0: ?
-@__p_1: ?
+                    @"@__p_0: 0
+@__p_1: 10
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1476,8 +1476,8 @@ LEFT JOIN [Level2] AS [l2] ON [l2].[Level1_Required_Id] = [e].[Id]
 ORDER BY [e].[Name], [l].[Id], [l2].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 0
+@__p_1: 10
 
 SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_InverseId], [l3].[OneToMany_Optional_Self_InverseId], [l3].[OneToMany_Required_InverseId], [l3].[OneToMany_Required_Self_InverseId], [l3].[OneToOne_Optional_PK_InverseId], [l3].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l3]
@@ -1494,8 +1494,8 @@ INNER JOIN (
 ) AS [l20] ON [l3].[OneToMany_Required_InverseId] = [l20].[Id0]
 ORDER BY [l20].[Name], [l20].[Id], [l20].[Id0]
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 0
+@__p_1: 10
 
 SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l0]
@@ -1521,8 +1521,8 @@ ORDER BY [l1].[Name], [l1].[Id]",
             if (SupportsOffset)
             {
                 Assert.Equal(
-                    @"@__p_0: ?
-@__p_1: ?
+                    @"@__p_0: 0
+@__p_1: 10
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1531,8 +1531,8 @@ LEFT JOIN [Level2] AS [l2] ON [l2].[Level1_Required_Id] = [e].[Id]
 ORDER BY [e].[Name], [l].[Id], [l2].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 0
+@__p_1: 10
 
 SELECT [l3].[Id], [l3].[Level2_Optional_Id], [l3].[Level2_Required_Id], [l3].[Name], [l3].[OneToMany_Optional_InverseId], [l3].[OneToMany_Optional_Self_InverseId], [l3].[OneToMany_Required_InverseId], [l3].[OneToMany_Required_Self_InverseId], [l3].[OneToOne_Optional_PK_InverseId], [l3].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l3]
@@ -1549,8 +1549,8 @@ INNER JOIN (
 ) AS [l20] ON [l3].[OneToMany_Required_InverseId] = [l20].[Id0]
 ORDER BY [l20].[Name], [l20].[Id], [l20].[Id0]
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 0
+@__p_1: 10
 
 SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l0]
@@ -1576,8 +1576,8 @@ ORDER BY [l1].[Name], [l1].[Id]",
             if (SupportsOffset)
             {
                 Assert.Equal(
-                    @"@__p_0: ?
-@__p_1: ?
+                    @"@__p_0: 0
+@__p_1: 10
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1586,8 +1586,8 @@ LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Required_Id] = [l].[Id]
 ORDER BY [e].[Name], [l0].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 
-@__p_0: ?
-@__p_1: ?
+@__p_0: 0
+@__p_1: 10
 
 SELECT [l1].[Id], [l1].[Level3_Optional_Id], [l1].[Level3_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_InverseId], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_PK_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level4] AS [l1]
@@ -1825,7 +1825,7 @@ FROM [Level1] AS [l2.OneToOne_Required_FK_Inverse]",
                 Sql);
 
             Assert.Contains(
-                @"@__p_0: ?
+                @"@__p_0: 10
 
 SELECT [t].[Level1_Required_Id]
 FROM (
@@ -1843,6 +1843,56 @@ FROM (
 
             Assert.Equal(
                 @"",
+                Sql);
+        }
+
+        public override void Projection_select_correct_table_from_subquery_when_materialization_is_not_required()
+        {
+            base.Projection_select_correct_table_from_subquery_when_materialization_is_not_required();
+
+            Assert.Equal(
+                @"@__p_0: 3
+
+SELECT [t].[Name]
+FROM (
+    SELECT TOP(@__p_0) [l20].*
+    FROM [Level2] AS [l20]
+    INNER JOIN [Level1] AS [l2.OneToOne_Required_FK_Inverse0] ON [l20].[Level1_Required_Id] = [l2.OneToOne_Required_FK_Inverse0].[Id]
+    WHERE [l2.OneToOne_Required_FK_Inverse0].[Name] = N'L1 03'
+) AS [t]",
+                Sql);
+        }
+
+        public override void Projection_select_correct_table_with_anonymous_projection_in_subquery()
+        {
+            base.Projection_select_correct_table_with_anonymous_projection_in_subquery();
+
+            Assert.Equal(
+                @"@__p_0: 3
+
+SELECT TOP(@__p_0) [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId], [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+INNER JOIN [Level1] AS [l1] ON [l2].[Level1_Required_Id] = [l1].[Id]
+INNER JOIN [Level3] AS [l3] ON [l1].[Id] = [l3].[Level2_Required_Id]
+WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')",
+                Sql);
+        }
+
+        public override void Projection_select_correct_table_in_subquery_when_materialization_is_not_required_in_multiple_joins()
+        {
+            base.Projection_select_correct_table_in_subquery_when_materialization_is_not_required_in_multiple_joins();
+
+            Assert.Equal(
+                @"@__p_0: 3
+
+SELECT [t].[Name]
+FROM (
+    SELECT TOP(@__p_0) [l10].*
+    FROM [Level2] AS [l20]
+    INNER JOIN [Level1] AS [l10] ON [l20].[Level1_Required_Id] = [l10].[Id]
+    INNER JOIN [Level3] AS [l30] ON [l10].[Id] = [l30].[Level2_Required_Id]
+    WHERE ([l10].[Name] = N'L1 03') AND ([l30].[Name] = N'L3 08')
+) AS [t]",
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #6657 
Issue: The problem here is the querysource does not need materialization so while visiting subquery the select expression we generate has no projections. Since lift subquery, the inner select expression converts from `SELECT 1` to `SELECT *`. At present we have a arbitrary logic to pick last table from select expression when there is project star. This breaks down if the projection is coming from any other table.
Solution: While visiting subquerymodel we know that which qsre is being projected out but we don't add anything to projection due to materialization is not required. Based on this qsre, we can store table alias in SelectExpression as a reference that this is the table from which we may need columns later. When we push down the subquery which converts it to project star, the subquery needs to use the table alias stored before so that we have required columns from subquery.