### PR TITLE
Adds overloads that use TimeSpan instead of Int32.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -211,6 +211,18 @@ namespace Microsoft.EntityFrameworkCore
 
         public static void SetCommandTimeout([NotNull] this DatabaseFacade databaseFacade, int? timeout)
             => GetRelationalConnection(databaseFacade).CommandTimeout = timeout;
+        public static void SetCommandTimeout([NotNull] this DatabaseFacade databaseFacade, TimeSpan timeout)
+        {
+            if (timeout < TimeSpan.Zero)
+            {
+                throw new ArgumentException($"Timeout must be greater than or equal to zero.  Provided: {timeout.TotalSeconds} seconds.");
+            }
+            if (timeout.TotalSeconds > Int32.MaxValue)
+            {
+                throw new ArgumentException($"Timeout must be less than or equal to Int32.MaxValue (2147483647) seconds.  Provided: {timeout.Seconds} seconds.");
+            }
+            SetCommandTimeout(databaseFacade, Convert.ToInt32(timeout.TotalSeconds));
+        }
 
         public static int? GetCommandTimeout([NotNull] this DatabaseFacade databaseFacade)
             => GetRelationalConnection(databaseFacade).CommandTimeout;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/CommandConfigurationTests.cs
@@ -24,6 +24,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
                     context.Database.SetCommandTimeout(null);
                     Assert.Null(context.Database.GetCommandTimeout());
+
+                    context.Database.SetCommandTimeout(TimeSpan.FromSeconds(66));
+                    Assert.Equal(66, context.Database.GetCommandTimeout());
                 }
             }
 
@@ -41,9 +44,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
                     Assert.Throws<ArgumentException>(
                         () => context.Database.SetCommandTimeout(-3));
+                    Assert.Throws<ArgumentException>(
+                        () => context.Database.SetCommandTimeout(TimeSpan.FromSeconds(-3)));
 
                     Assert.Throws<ArgumentException>(
                         () => context.Database.SetCommandTimeout(-99));
+                    Assert.Throws<ArgumentException>(
+                        () => context.Database.SetCommandTimeout(TimeSpan.FromSeconds(-99)));
+
+                    Assert.Throws<ArgumentException>(
+                        () => context.Database.SetCommandTimeout(TimeSpan.FromSeconds(UInt32.MaxValue)));
                 }
             }
 


### PR DESCRIPTION
I tried to follow the conventions elsewhere in the file, but feel free to let me know if I have not followed code style correctly.

The `ArgumentOutOfRangeException` seemed like the best way to handle the fact that `TimeSpan`s aren't really bounded, though with the new the API surface area the upper bound constraint seems arbitrary.  However, in most real world use cases it will probably not be hit and it is documented.  I decided to throw on negative number as well because that doesn't make sense.  The overload doesn't accept null because if you want to pass null explicitly you can simply call the other overload (transparent to the user) and if you have a `TimeSpan?` you are doing it wrong.  ;)

I added two tests, but I'll admit that they are pretty weak.  I didn't see any tests for the original overloads and I'm not sure how to author a test that will correctly spin up a `DatabaseFacade` where the `SetCommandTimeout` will actually succeed.  Feedback is welcome on how I can make a positive test for timeout setting.

The overload that returns a `TimeSpan` is likely a bit contentious, as is always the case when you have an "overload" that differs only by return type.  I can pull it out if desired, I added it mainly for consistency but I admit that it feels quite awkward.

Fixes #6614
