### PR TITLE
Preserve temporary flag for store generated values until AcceptChanges

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data.Common;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
@@ -22,8 +23,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             Test_commit_failure(false);
         }
 
-        // #6720
-        //[Fact]
+        [Fact]
         public void Retries_on_true_commit_failure()
         {
             Test_commit_failure(true);
@@ -31,26 +31,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         private void Test_commit_failure(bool realFailure)
         {
+            CleanContext();
+
             using (var context = CreateContext())
             {
-                var contextServices = context.GetService<IServiceProvider>();
-                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+                var connection = (TestSqlServerConnection)context.GetService<ISqlServerConnection>();
 
                 connection.CommitFailures.Enqueue(new bool?[] { realFailure });
 
                 context.Products.Add(new Product());
                 new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
                     c => c.SaveChanges(acceptAllChangesOnSuccess: false),
-                    c =>
-                        {
-                            var succeeded = c.Products.AsNoTracking().Any();
-                            if (!succeeded)
-                            {
-                                // TODO: call DiscardStoreGeneratedValues()
-                                // #6719
-                            }
-                            return succeeded;
-                        },
+                    c => c.Products.AsNoTracking().Any(),
                     context);
                 context.ChangeTracker.AcceptAllChanges();
 
@@ -63,15 +55,64 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        // #6720
-        //[Fact]
+        [Fact]
+        public void Does_not_throw_or_retry_on_false_commit_failure_multiple_SaveChanges()
+        {
+            Test_commit_failure_multiple_SaveChanges(false);
+        }
+
+        [Fact]
+        public void Retries_on_true_commit_failure_multiple_SaveChanges()
+        {
+            Test_commit_failure_multiple_SaveChanges(true);
+        }
+
+        private void Test_commit_failure_multiple_SaveChanges(bool realFailure)
+        {
+            CleanContext();
+
+            using (var context1 = CreateContext())
+            {
+                var connection = (TestSqlServerConnection)context1.GetService<ISqlServerConnection>();
+
+                using (var context2 = CreateContext(connection.DbConnection))
+                {
+                    connection.CommitFailures.Enqueue(new bool?[] { realFailure });
+
+                    context1.Products.Add(new Product());
+                    context2.Products.Add(new Product());
+
+                    new TestSqlServerRetryingExecutionStrategy(context1).ExecuteInTransaction(
+                        _ =>
+                            {
+                                context2.Database.UseTransaction(null);
+                                context2.Database.UseTransaction(context1.Database.CurrentTransaction.GetDbTransaction());
+
+                                context1.SaveChanges(acceptAllChangesOnSuccess: false);
+
+                                return context2.SaveChanges(acceptAllChangesOnSuccess: false);
+                            },
+                        c => c.Products.AsNoTracking().Any(),
+                        context1);
+
+                    context1.ChangeTracker.AcceptAllChanges();
+                    context2.ChangeTracker.AcceptAllChanges();
+                }
+
+                using (var context = CreateContext())
+                {
+                    Assert.Equal(2, context.Products.Count());
+                }
+            }
+        }
+
+        [Fact]
         public void Does_not_throw_or_retry_on_false_execution_failure()
         {
             Test_execution_failure(false);
         }
 
-        // #6720
-        //[Fact]
+        [Fact]
         public void Retries_on_true_execution_failure()
         {
             Test_execution_failure(true);
@@ -79,10 +120,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         private void Test_execution_failure(bool realFailure)
         {
+            CleanContext();
+
             using (var context = CreateContext())
             {
-                var contextServices = context.GetService<IServiceProvider>();
-                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+                var connection = (TestSqlServerConnection)context.GetService<ISqlServerConnection>();
 
                 connection.ExecutionFailures.Enqueue(new bool?[] { null, realFailure });
 
@@ -91,16 +133,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 new TestSqlServerRetryingExecutionStrategy(context).ExecuteInTransaction(
                     c => c.SaveChanges(acceptAllChangesOnSuccess: false),
                     c =>
-                    {
-                        // This shouldn't be called if SaveChanges failed
-                        Assert.True(false);
-                        return false;
-                    },
+                        {
+                            // This shouldn't be called if SaveChanges failed
+                            Assert.True(false);
+                            return false;
+                        },
                     context);
                 context.ChangeTracker.AcceptAllChanges();
 
                 Assert.Equal(2, connection.OpenCount);
-                Assert.Equal(2, connection.ExecutionCount);
+                Assert.Equal(4, connection.ExecutionCount);
             }
 
             using (var context = CreateContext())
@@ -109,14 +151,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
         }
 
-        // #6720
-        //[Fact]
+        [Fact]
         public void Verification_is_retried_using_same_retry_limit()
         {
+            CleanContext();
+
             using (var context = CreateContext())
             {
-                var contextServices = context.GetService<IServiceProvider>();
-                var connection = (TestSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+                var connection = (TestSqlServerConnection)context.GetService<ISqlServerConnection>();
 
                 connection.ExecutionFailures.Enqueue(new bool?[] { true, null, true, true });
                 connection.CommitFailures.Enqueue(new bool?[] { true, true, true });
@@ -124,10 +166,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 context.Products.Add(new Product());
                 Assert.Throws<RetryLimitExceededException>(() =>
                     new TestSqlServerRetryingExecutionStrategy(context, TimeSpan.FromMilliseconds(100))
-                    .ExecuteInTransaction(
-                        c => c.SaveChanges(acceptAllChangesOnSuccess: false),
-                        c => false,
-                        context));
+                        .ExecuteInTransaction(
+                            c => c.SaveChanges(acceptAllChangesOnSuccess: false),
+                            c => false,
+                            context));
                 context.ChangeTracker.AcceptAllChanges();
 
                 Assert.Equal(6, connection.OpenCount);
@@ -162,13 +204,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             Fixture = fixture;
             TestStore = SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
-            {
-                using (var context = CreateContext())
                 {
-                    context.Database.EnsureCreated();
-                    TestSqlLoggerFactory.Reset();
-                }
-            });
+                    using (var context = CreateContext())
+                    {
+                        context.Database.EnsureCreated();
+                        TestSqlLoggerFactory.Reset();
+                    }
+                });
         }
 
         protected ExecutionStrategyFixture Fixture { get; }
@@ -176,10 +218,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
         public virtual void Dispose() => TestStore.Dispose();
 
-        protected virtual ExecutionStrategyContext CreateContext() => (ExecutionStrategyContext)Fixture.CreateContext();
+        protected virtual ExecutionStrategyContext CreateContext()
+            => (ExecutionStrategyContext)Fixture.CreateContext();
+
+        protected virtual ExecutionStrategyContext CreateContext(DbConnection connection)
+            => (ExecutionStrategyContext)Fixture.CreateContext(connection);
 
         public class ExecutionStrategyFixture
         {
+            private readonly DbContextOptions _baseOptions;
             private readonly DbContextOptions _options;
 
             public ExecutionStrategyFixture()
@@ -191,19 +238,42 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     .AddScoped<IRelationalCommandBuilderFactory, TestRelationalCommandBuilderFactory>()
                     .BuildServiceProvider();
 
-                _options = new DbContextOptionsBuilder()
-                    .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), b =>
-                        {
-                            b.ApplyConfiguration();
-                            b.MaxBatchSize(1);
-                        })
+                _baseOptions = new DbContextOptionsBuilder()
                     .UseInternalServiceProvider(serviceProvider)
                     .EnableSensitiveDataLogging()
                     .Options;
+
+                _options = new DbContextOptionsBuilder(_baseOptions)
+                    .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), ApplySqlServerOptions)
+                    .Options;
+            }
+
+            private static void ApplySqlServerOptions(SqlServerDbContextOptionsBuilder b)
+            {
+                b.ApplyConfiguration();
+                b.MaxBatchSize(1);
             }
 
             public virtual DbContext CreateContext()
                 => new ExecutionStrategyContext(_options);
+
+            public virtual DbContext CreateContext(DbConnection connection)
+                => new ExecutionStrategyContext(
+                    new DbContextOptionsBuilder(_baseOptions)
+                        .UseSqlServer(connection, ApplySqlServerOptions)
+                        .Options);
+        }
+
+        private void CleanContext()
+        {
+            using (var context = CreateContext())
+            {
+                foreach (var product in context.Products.ToList())
+                {
+                    context.Remove(product);
+                    context.SaveChanges();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Issue #6720

The fix is to stop marking the value as permanent as soon as the store generated value is generated, but instead weight until AcceptChanges when it is pushed into the entity. Also, when DiscardStoreGeneratedValues is used, a temporary value is ensured to stay temporary.