### PR TITLE
Query: Skip/Take with Any/All should preserve skip/take

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -301,9 +301,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             [param: CanBeNull]
             set
             {
-                Check.NotNull(value, nameof(value));
-
-                PushDownIfLimit();
+                if (value != null)
+                {
+                    PushDownIfLimit();
+                }
 
                 _limit = value;
             }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -357,6 +357,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Skip_Take_Any()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10).Any());
+        }
+
+        [ConditionalFact]
+        public virtual void Skip_Take_All()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10).All(p => p.CustomerID.Length == 5));
+        }
+
+        [ConditionalFact]
         public virtual void Take_Skip_Distinct()
         {
             AssertQuery<Customer>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3657,6 +3657,47 @@ FROM [Customers] AS [c]",
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Skip_Take_Distinct() => base.Skip_Take_Distinct();
 
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Skip_Take_Any()
+        {
+            base.Skip_Take_Any();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 10
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        ORDER BY [c].[ContactName]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Skip_Take_All()
+        {
+            base.Skip_Take_All();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 10
+
+SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        WHERE LEN([c].[CustomerID]) <> 5
+        ORDER BY [c].[ContactName]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
         public override void OrderBy()
         {
             base.OrderBy();


### PR DESCRIPTION
Fore `Any()` or `All()` we created new `SelectExpression` for inner subquery but we should clone it so that we preserve all limit, offset & orderby from it.

Fixes #6710 

Should this go to 1.2.0 or dev?