### PR TITLE
Trivial refactor to make ORDER BY more extensible

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -359,46 +359,52 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             _relationalCommandBuilder.Append("ORDER BY ");
 
-            VisitJoin(orderings, t =>
+            VisitJoin(orderings, GenerateOrdering);
+        }
+
+        /// <summary>
+        ///     Generates a single ordering in an SQL ORDER BY clause.
+        /// </summary>
+        /// <param name="ordering"> The ordering. </param>
+        protected virtual void GenerateOrdering(Ordering ordering)
+        {
+            var orderingExpression = ordering.Expression;
+            var aliasExpression = orderingExpression as AliasExpression;
+
+            if (aliasExpression != null)
+            {
+                if (aliasExpression.Alias != null)
                 {
-                    var orderingExpression = t.Expression;
-                    var aliasExpression = orderingExpression as AliasExpression;
+                    var columnExpression = aliasExpression.TryGetColumnExpression();
 
-                    if (aliasExpression != null)
+                    if (columnExpression != null)
                     {
-                        if (aliasExpression.Alias != null)
-                        {
-                            var columnExpression = aliasExpression.TryGetColumnExpression();
-
-                            if (columnExpression != null)
-                            {
-                                _relationalCommandBuilder
-                                    .Append(_sqlGenerationHelper.DelimitIdentifier(columnExpression.TableAlias))
-                                    .Append(".");
-                            }
-
-                            _relationalCommandBuilder.Append(_sqlGenerationHelper.DelimitIdentifier(aliasExpression.Alias));
-                        }
-                        else
-                        {
-                            Visit(aliasExpression.Expression);
-                        }
-                    }
-                    else if (orderingExpression is ConstantExpression
-                             || orderingExpression is ParameterExpression)
-                    {
-                        _relationalCommandBuilder.Append("(SELECT 1)");
-                    }
-                    else
-                    {
-                        Visit(ApplyOptimizations(orderingExpression, searchCondition: false));
+                        _relationalCommandBuilder
+                            .Append(_sqlGenerationHelper.DelimitIdentifier(columnExpression.TableAlias))
+                            .Append(".");
                     }
 
-                    if (t.OrderingDirection == OrderingDirection.Desc)
-                    {
-                        _relationalCommandBuilder.Append(" DESC");
-                    }
-                });
+                    _relationalCommandBuilder.Append(_sqlGenerationHelper.DelimitIdentifier(aliasExpression.Alias));
+                }
+                else
+                {
+                    Visit(aliasExpression.Expression);
+                }
+            }
+            else if (orderingExpression is ConstantExpression
+                     || orderingExpression is ParameterExpression)
+            {
+                _relationalCommandBuilder.Append("(SELECT 1)");
+            }
+            else
+            {
+                Visit(ApplyOptimizations(orderingExpression, searchCondition: false));
+            }
+
+            if (ordering.OrderingDirection == OrderingDirection.Desc)
+            {
+                _relationalCommandBuilder.Append(" DESC");
+            }
         }
 
         private void VisitJoin(


### PR DESCRIPTION
DefaultQuerySqlGenerator's GenerateOrderBy is a single block that's difficult to extend. Moved the generation of the individual ordering clauses into a separate function to allow appending to them.

This is necessary to support PostgreSQL ORDER BY ... NULLS FIRST.

I hope this can make it into 1.1, it's really very trivial.