### PR TITLE
Fix SQL Server value generation from model issue

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
             Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
             Assert.IsType<TemporaryCharValueGenerator>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
+            Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("Decimal"), entityType));
             Assert.IsType<StringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
             Assert.IsType<BinaryValueGenerator>(selector.Select(entityType.FindProperty("Binary"), entityType));
@@ -79,6 +80,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<short>>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<byte>>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<char>>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
+            Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("Decimal"), entityType));
             Assert.IsType<StringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
             Assert.IsType<BinaryValueGenerator>(selector.Select(entityType.FindProperty("Binary"), entityType));
@@ -157,6 +159,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             public Guid Guid { get; set; }
             public byte[] Binary { get; set; }
             public float Float { get; set; }
+            public decimal Decimal { get; set; }
             public int AlwaysIdentity { get; set; }
             public int AlwaysSequence { get; set; }
             public Random Random { get; set; }


### PR DESCRIPTION
When deciding which value generation to use, the SQL Server provider falls back to the model annotation. However, it did not properly check that the property's CLR type is compatible with the model-determined strategy. As a result, defining a ValueGeneratedOnAdd decimal on a model with strategy HiLo triggered a failure.