### PR TITLE
Query: Set table alias for star projection properly for all cases

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -470,6 +470,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             // Don't create new alias when adding tables to subquery
             subquery.AddTable(joinExpression.TableExpression, createUniqueAlias: false);
+            subquery.ProjectStarAlias = joinExpression.Alias;
             subquery.IsProjectStar = true;
             subquery.Predicate = selectExpression.Predicate;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     {
                         if (QueryModelVisitor.ParentQueryModelVisitor != null)
                         {
-                            selectExpression.SetTableForProjectStar(qsre.ReferencedQuerySource);
+                            selectExpression.ProjectStarAlias = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource).Alias;
                         }
                     }
                 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -88,13 +88,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public virtual string ProjectStarAlias { get; [param: CanBeNull] set; }
 
         /// <summary>
-        ///     Sets the table alias for the star projection.
-        /// </summary>
-        /// <param name="querySource"> The query source.</param>
-        public virtual void SetTableForProjectStar([NotNull] IQuerySource querySource)
-            => ProjectStarAlias = GetTableForQuerySource(querySource)?.Alias;
-
-        /// <summary>
         ///     Type of this expression.
         /// </summary>
         public override Type Type => _projection.Count == 1
@@ -442,6 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             ClearOrderBy();
 
             AddTable(subquery, createUniqueAlias: false);
+            ProjectStarAlias = subquery.Alias;
 
             return subquery;
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -361,6 +361,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             selectExpression.AddTable(leftOuterJoinExpression, createUniqueAlias: false);
 
+            selectExpression.ProjectStarAlias = subquery.Alias;
+
             handlerContext.QueryModelVisitor.Expression
                 = new DefaultIfEmptyExpressionVisitor(
                         handlerContext.QueryModelVisitor.QueryCompilationContext)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (selectExpression.IsProjectStar)
             {
-                var tableAlias = selectExpression.ProjectStarAlias ?? selectExpression.Tables.Last().Alias;
+                var tableAlias = selectExpression.ProjectStarAlias;
 
                 _relationalCommandBuilder
                     .Append(_sqlGenerationHelper.DelimitIdentifier(tableAlias))


### PR DESCRIPTION
Resolves #6785 

Set table for project star wherever we generate subquery which needs project star.
~~Slight change in API for `SetTableForProjectStar` since we don't have query source perfectly matched with table alias.~~
Nuked the function to set project star. Direct setter on the property since we need to store string alias only.