### PR TITLE
Don't attempt to null out PK parts of composite FK during fixup

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -667,7 +667,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (!Equals(currentValue, value)
                     || (propertyIndex.HasValue
-                        && _stateData.IsPropertyFlagged(propertyIndex.Value, PropertyFlag.Unknown)))
+                        && (_stateData.IsPropertyFlagged(propertyIndex.Value, PropertyFlag.Unknown)
+                            || _stateData.IsPropertyFlagged(propertyIndex.Value, PropertyFlag.Null))))
                 {
                     var writeValue = true;
 

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <example>
         ///     <code>
-        ///         public void ConfigureServices(IServiceCollection services) 
+        ///         public void ConfigureServices(IServiceCollection services)
         ///         {
         ///             var connectionString = "connection string to database";
-        /// 
-        ///             services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString)); 
+        ///
+        ///             services.AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString));
         ///         }
         ///     </code>
         /// </example>
@@ -69,11 +69,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <example>
         ///     <code>
-        ///         public void ConfigureServices(IServiceCollection services) 
+        ///         public void ConfigureServices(IServiceCollection services)
         ///         {
         ///             var connectionString = "connection string to database";
-        /// 
-        ///             services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped); 
+        ///
+        ///             services.AddDbContext&lt;MyContext&gt;(ServiceLifetime.Scoped);
         ///         }
         ///     </code>
         /// </example>
@@ -106,15 +106,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <example>
         ///     <code>
-        ///         public void ConfigureServices(IServiceCollection services) 
+        ///         public void ConfigureServices(IServiceCollection services)
         ///         {
         ///             var connectionString = "connection string to database";
-        /// 
+        ///
         ///             services
         ///                 .AddEntityFrameworkSqlServer()
-        ///                 .AddDbContext&lt;MyContext&gt;((serviceProvider, options) => 
+        ///                 .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>
         ///                     options.UseSqlServer(connectionString)
-        ///                            .UseInternalServiceProvider(serviceProvider)); 
+        ///                            .UseInternalServiceProvider(serviceProvider));
         ///         }
         ///     </code>
         /// </example>


### PR DESCRIPTION
Because this either throws because the PK property cannot be set to null, or marks the property as conceptually null which then causes issues later.

There were also two issues in the tests:
- Equals method of one of the entities was wrong
- Tests wouldn't run on SQLite because composite keys with store generated ints are not supported

Issue #6840