### PR TITLE
Query: Minor perf optimizations

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -148,9 +148,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         try
                         {
-                            // TODO remove this when/if bug is resolved in Ix-Async https://github.com/Reactive-Extensions/Rx.NET/issues/166
-                            cancellationToken.ThrowIfCancellationRequested();
-
                             return await _innerEnumerator.MoveNext(cancellationToken);
                         }
                         catch (Exception exception)

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Task<TResult> ExecuteAsync<TResult>(Expression query, CancellationToken cancellationToken)
+        public virtual async Task<TResult> ExecuteAsync<TResult>(Expression query, CancellationToken cancellationToken)
         {
             Check.NotNull(query, nameof(query));
 
@@ -129,7 +129,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             try
             {
-                return CompileAsyncQuery<TResult>(query)(queryContext).First(cancellationToken);
+                var asyncEnumerable = CompileAsyncQuery<TResult>(query)(queryContext);
+
+                using (var asyncEnumerator = asyncEnumerable.GetEnumerator())
+                {
+                    await asyncEnumerator.MoveNext(cancellationToken);
+
+                    return asyncEnumerator.Current;
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
- Removed an allocation from the query execution code path. 
- Reverted hack introduced in fixing #4317 because it looks like the IX-Async issue has been resolved.