### PR TITLE
Lift properties from the derived types in addition to the current type when setting base type.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -26,9 +27,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
 
             var directlyDerivedTypes = entityType.Model.GetEntityTypes().Where(t =>
-                    (t.BaseType == entityType.BaseType)
-                    && t.HasClrType()
-                    && (FindClosestBaseType(t) == entityType))
+                t != entityType
+                && t.HasClrType()
+                && ((t.BaseType == null && clrType.GetTypeInfo().IsAssignableFrom(t.ClrType.GetTypeInfo()))
+                    || (t.BaseType == entityType.BaseType && FindClosestBaseType(t) == entityType)))
                 .ToList();
 
             foreach (var directlyDerivedType in directlyDerivedTypes)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
@@ -28,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var baseType = clrType.GetTypeInfo().BaseType;
             EntityType baseEntityType = null;
 
-            while ((baseType != null)
-                   && (baseEntityType == null))
+            while (baseType != null
+                   && baseEntityType == null)
             {
                 baseEntityType = entityType.Model.FindEntityType(baseType);
                 baseType = baseType.GetTypeInfo().BaseType;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -268,14 +268,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual InternalPropertyBuilder Attach(
             [NotNull] InternalEntityTypeBuilder entityTypeBuilder, ConfigurationSource configurationSource)
         {
-            var newProperty = Metadata.DeclaringEntityType.FindProperty(Metadata.Name);
-            InternalPropertyBuilder newPropertyBuilder = null;
+            var newProperty = entityTypeBuilder.Metadata.FindProperty(Metadata.Name);
+            InternalPropertyBuilder newPropertyBuilder;
             if (newProperty != null
-                && newProperty.GetConfigurationSource().Overrides(configurationSource)
-                && ((Metadata.ClrType != null
-                     && Metadata.ClrType != newProperty.ClrType)
-                    || (Metadata.PropertyInfo != null
-                        && newProperty.PropertyInfo == null)))
+                && (newProperty.GetConfigurationSource().Overrides(configurationSource)
+                    || (Metadata.ClrType == newProperty.ClrType
+                        && Metadata.PropertyInfo?.Name == newProperty.PropertyInfo?.Name)))
             {
                 newPropertyBuilder = newProperty.Builder;
             }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -881,11 +881,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The type '{entityType}' cannot have base type '{baseType}' because both types include the properties: {properties}.
+        /// The type '{entityType}' cannot have base type '{baseType}' because the properties '{derivedPropertyType}.{derivedProperty}' and '{basePropertyType}.{baseProperty}' are conflicting.
         /// </summary>
-        public static string DuplicatePropertiesOnBase([CanBeNull] object entityType, [CanBeNull] object baseType, [CanBeNull] object properties)
+        public static string DuplicatePropertiesOnBase([CanBeNull] object entityType, [CanBeNull] object baseType, [CanBeNull] object derivedPropertyType, [CanBeNull] object derivedProperty, [CanBeNull] object basePropertyType, [CanBeNull] object baseProperty)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicatePropertiesOnBase", "entityType", "baseType", "properties"), entityType, baseType, properties);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicatePropertiesOnBase", "entityType", "baseType", "derivedPropertyType", "derivedProperty", "basePropertyType", "baseProperty"), entityType, baseType, derivedPropertyType, derivedProperty, basePropertyType, baseProperty);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -442,7 +442,7 @@
     <value>Options extension of type '{optionsExtension}' not found.</value>
   </data>
   <data name="DuplicatePropertiesOnBase" xml:space="preserve">
-    <value>The type '{entityType}' cannot have base type '{baseType}' because both types include the properties: {properties}.</value>
+    <value>The type '{entityType}' cannot have base type '{baseType}' because the properties '{derivedPropertyType}.{derivedProperty}' and '{basePropertyType}.{baseProperty}' are conflicting.</value>
   </data>
   <data name="CannotBeNullablePK" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the property is a part of a key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of a key can be marked as nullable/optional.</value>

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/DerivedTypeDiscoveryConventionTest.cs
@@ -21,7 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             new DerivedTypeDiscoveryConvention().Apply(entityBuilderA);
 
             Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
-            Assert.Null(entityBuilderC.Metadata.BaseType);
+            Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
+
+            new DerivedTypeDiscoveryConvention().Apply(entityBuilderB);
+
+            Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
+            Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -323,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             b.AddProperty(A.GProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(B).Name, typeof(A).Name, "G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(B).Name, typeof(A).Name, typeof(B).Name, "G", typeof(A).Name, "G"),
                 Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
         }
 
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             d.AddProperty(A.GProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(D).Name, typeof(C).Name, "E, G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(D).Name, typeof(C).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
                 Assert.Throws<InvalidOperationException>(() => { d.HasBaseType(c); }).Message);
         }
 
@@ -365,7 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             d.HasBaseType(c);
 
             Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(C).Name, typeof(A).Name, "E, G"),
+                CoreStrings.DuplicatePropertiesOnBase(typeof(C).Name, typeof(A).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
                 Assert.Throws<InvalidOperationException>(() => { c.HasBaseType(a); }).Message);
         }
 


### PR DESCRIPTION
Properly discover base types when they are added to the model after the derived types.
Improve the exception message for conflicting properties in the new base type.
Don't duplicate unused inherited properties that are being removed when setting a new base type. They will be discovered by conventions if they should be on the entity type.

Fixes #6814