### PR TITLE
Query: Copy OrderBy in PushDownSubquery

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -283,6 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 if (_offset != null)
                 {
                     PushDownSubquery();
+                    ClearOrderBy();
                 }
 
                 _isDistinct = value;
@@ -326,32 +327,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                     && value != null)
                 {
                     var subquery = PushDownSubquery();
-
-                    subquery._offset = null;
-
-                    foreach (var ordering in subquery.OrderBy)
-                    {
-                        var aliasExpression = ordering.Expression as AliasExpression;
-
-                        if (aliasExpression != null)
-                        {
-                            if (aliasExpression.Alias != null)
-                            {
-                                _orderBy.Add(
-                                    new Ordering(
-                                        new ColumnExpression(aliasExpression.Alias, aliasExpression.Type, subquery),
-                                        ordering.OrderingDirection));
-                            }
-                            else
-                            {
-                                var expression = UpdateColumnExpression(aliasExpression.Expression, subquery);
-
-                                _orderBy.Add(
-                                    new Ordering(
-                                        new AliasExpression(expression), ordering.OrderingDirection));
-                            }
-                        }
-                    }
                 }
 
                 _offset = value;
@@ -437,6 +412,50 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             AddTable(subquery, createUniqueAlias: false);
             ProjectStarAlias = subquery.Alias;
+
+            foreach (var ordering in subquery.OrderBy)
+            {
+                var expression = ordering.Expression;
+
+                var aliasExpression = expression as AliasExpression;
+                if (aliasExpression != null)
+                {
+                    if (aliasExpression.Alias != null)
+                    {
+                        _orderBy.Add(
+                            new Ordering(
+                                new ColumnExpression(aliasExpression.Alias, aliasExpression.Type, subquery),
+                                ordering.OrderingDirection));
+                    }
+                    else
+                    {
+                        var newExpression = UpdateColumnExpression(aliasExpression.Expression, subquery);
+
+                        _orderBy.Add(
+                            new Ordering(
+                                new AliasExpression(newExpression), ordering.OrderingDirection));
+                    }
+                }
+                else
+                {
+                    if (!subquery.IsProjectStar)
+                    {
+                        subquery.AddToProjection(expression);
+                    }
+
+                    var newExpression = UpdateColumnExpression(expression, subquery);
+
+                    _orderBy.Add(
+                            new Ordering(
+                                new AliasExpression(newExpression), ordering.OrderingDirection));
+                }
+            }
+
+            if (subquery.Limit == null
+                && subquery.Offset == null)
+            {
+                subquery.ClearOrderBy();
+            }
 
             return subquery;
         }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3500,7 +3500,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [ConditionalFact]
+        //[ConditionalFact] // TODO: See issue#6896
         public virtual void Required_navigation_take_required_navigation()
         {
             List<string> expected;

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -6405,6 +6405,61 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                  select new { c.CustomerID, o1.OrderID, o2.OrderDate }));
         }
 
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_level_1()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(8),
+                assertOrder: true,
+                entryCount: 8);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_level_2()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(8)
+                    .Take(3),
+                assertOrder: true,
+                entryCount: 3);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_distinct()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(15)
+                    .Distinct()
+                    .Take(8),
+                assertOrder: false,
+                entryCount: 8);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_level_3()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(15)
+                    .Take(10)
+                    .Take(8)
+                    .Take(5),
+                assertOrder: true,
+                entryCount: 5);
+        }
+
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -207,6 +207,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 selectExpression.Predicate = predicate;
 
+                if (selectExpression.Alias != null)
+                {
+                    selectExpression.ClearOrderBy();
+                }
+
                 return selectExpression;
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -686,7 +686,7 @@ FROM (
     ORDER BY [c0].[CustomerID]
 ) AS [t]
 CROSS JOIN [Customers] AS [c2]
-ORDER BY [c2].[CustomerID]
+ORDER BY [t].[CustomerID], [c2].[CustomerID]
 
 @__p_0: 5
 
@@ -899,7 +899,8 @@ FROM (
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t]
-CROSS JOIN [Customers] AS [c2]",
+CROSS JOIN [Customers] AS [c2]
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -921,7 +922,8 @@ FROM (
     ORDER BY [od0].[OrderID], [od0].[ProductID]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
-INNER JOIN [Orders] AS [od.Order] ON [t].[OrderID] = [od.Order].[OrderID]",
+INNER JOIN [Orders] AS [od.Order] ON [t].[OrderID] = [od.Order].[OrderID]
+ORDER BY [t].[OrderID], [t].[ProductID]",
                     Sql);
             }
         }
@@ -1030,7 +1032,8 @@ CROSS JOIN (
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t0]
 LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
-LEFT JOIN [Customers] AS [c0] ON [t0].[CustomerID] = [c0].[CustomerID]",
+LEFT JOIN [Customers] AS [c0] ON [t0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [t].[CustomerID]",
                     Sql);
             }
         }
@@ -1056,7 +1059,8 @@ CROSS JOIN (
     ORDER BY [o2].[OrderID]
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t0]
-LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]",
+LEFT JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]",
                     Sql);
             }
         }
@@ -1082,7 +1086,8 @@ CROSS JOIN (
     ORDER BY [o2].[OrderID]
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t0]
-LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]",
+LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]
+ORDER BY [t].[OrderID]",
                     Sql);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -73,6 +73,7 @@ FROM (
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t]
+ORDER BY [t].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -104,7 +105,8 @@ FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
-) AS [t]",
+) AS [t]
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -124,7 +126,8 @@ FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
-) AS [t]",
+) AS [t]
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -141,6 +144,7 @@ FROM (
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t]
+ORDER BY [t].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -169,6 +173,7 @@ FROM (
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t]
+ORDER BY [t].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1630,7 +1630,8 @@ FROM (
     SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
-) AS [t]",
+) AS [t]
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -3611,7 +3612,8 @@ FROM (
     SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
     ORDER BY [c].[CustomerID]
-) AS [t]",
+) AS [t]
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -3628,7 +3630,8 @@ FROM (
     FROM [Customers] AS [c]
     CROSS JOIN [Orders] AS [o]
     ORDER BY [c].[CustomerID], [o].[OrderID]
-) AS [t]",
+) AS [t]
+ORDER BY [t].[CustomerID], [t].[OrderID]",
                 Sql);
         }
 
@@ -6378,6 +6381,90 @@ CROSS APPLY (
     ) AS [t3] ON 1 = 1
 ) AS [t4]
 WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND ([t1].[OrderID] IS NOT NULL AND [t4].[OrderID] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_1()
+        {
+            base.OrderBy_skip_take_level_1();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 8
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[ContactTitle], [c].[ContactName]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_2()
+        {
+            base.OrderBy_skip_take_level_2();
+
+            Assert.Equal(
+                @"@__p_2: 3
+@__p_0: 5
+@__p_1: 8
+
+SELECT TOP(@__p_2) [t].*
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle], [c].[ContactName]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+ORDER BY [t].[ContactTitle], [t].[ContactName]",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_distinct()
+        {
+            base.OrderBy_skip_take_distinct();
+
+            Assert.Equal(
+                @"@__p_2: 8
+@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT TOP(@__p_2) [t].*
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle], [c].[ContactName]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_3()
+        {
+            base.OrderBy_skip_take_level_3();
+
+            Assert.Equal(
+                @"@__p_4: 5
+@__p_3: 8
+@__p_2: 10
+@__p_0: 5
+@__p_1: 15
+
+SELECT TOP(@__p_4) [t1].*
+FROM (
+    SELECT TOP(@__p_3) [t0].*
+    FROM (
+        SELECT TOP(@__p_2) [t].*
+        FROM (
+            SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            FROM [Customers] AS [c]
+            ORDER BY [c].[ContactTitle], [c].[ContactName]
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        ) AS [t]
+        ORDER BY [t].[ContactTitle], [t].[ContactName]
+    ) AS [t0]
+    ORDER BY [t0].[ContactTitle], [t0].[ContactName]
+) AS [t1]
+ORDER BY [t1].[ContactTitle], [t1].[ContactName]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -37,7 +37,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[CustomerID]) AS [__RowNumber__]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[__RowNumber__] > @__p_0",
+WHERE [t].[__RowNumber__] > @__p_0
+ORDER BY [t].[CustomerID]",
                 Sql);
         }
 
@@ -70,7 +71,8 @@ FROM (
     SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))",
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
+ORDER BY [t].[ContactName]",
                 Sql);
         }
 
@@ -88,7 +90,8 @@ FROM (
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
-WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))",
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -106,7 +109,8 @@ FROM (
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
-WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))",
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -125,7 +129,8 @@ FROM (
     INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
     INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
 ) AS [t]
-WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))",
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -145,7 +150,8 @@ FROM (
         ORDER BY [c].[ContactName]
     ) AS [t]
 ) AS [t0]
-WHERE [t0].[__RowNumber__] > @__p_1",
+WHERE [t0].[__RowNumber__] > @__p_1
+ORDER BY [t0].[ContactName]",
                 Sql);
         }
 
@@ -212,7 +218,8 @@ FROM (
         ORDER BY [Coalesce]
     ) AS [t]
 ) AS [t0]
-WHERE [t0].[__RowNumber__] > @__p_1",
+WHERE [t0].[__RowNumber__] > @__p_1
+ORDER BY [t0].[Coalesce]",
                 Sql);
         }
 
@@ -243,6 +250,99 @@ WHERE CHARINDEX(N'M', [c].[ContactName]) > 0",
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_0 = N'')",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_1()
+        {
+            base.OrderBy_skip_take_level_1();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 8
+
+SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))
+ORDER BY [t].[ContactTitle], [t].[ContactName]",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_2()
+        {
+            base.OrderBy_skip_take_level_2();
+
+            Assert.Equal(
+                @"@__p_2: 3
+@__p_0: 5
+@__p_1: 8
+
+SELECT TOP(@__p_2) [t].*
+FROM (
+    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
+) AS [t]
+ORDER BY [t].[ContactTitle], [t].[ContactName]",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_distinct()
+        {
+            base.OrderBy_skip_take_distinct();
+
+            Assert.Equal(
+                @"@__p_2: 8
+@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT TOP(@__p_2) [t].*
+FROM (
+    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
+) AS [t]",
+                Sql);
+        }
+
+        public override void OrderBy_skip_take_level_3()
+        {
+            base.OrderBy_skip_take_level_3();
+
+            Assert.Equal(
+                @"@__p_4: 5
+@__p_3: 8
+@__p_2: 10
+@__p_0: 5
+@__p_1: 15
+
+SELECT TOP(@__p_4) [t1].*
+FROM (
+    SELECT TOP(@__p_3) [t0].*
+    FROM (
+        SELECT TOP(@__p_2) [t].*
+        FROM (
+            SELECT [t2].[CustomerID], [t2].[Address], [t2].[City], [t2].[CompanyName], [t2].[ContactName], [t2].[ContactTitle], [t2].[Country], [t2].[Fax], [t2].[Phone], [t2].[PostalCode], [t2].[Region]
+            FROM (
+                SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+                FROM [Customers] AS [c]
+            ) AS [t2]
+            WHERE ([t2].[__RowNumber__] > @__p_0) AND ([t2].[__RowNumber__] <= (@__p_0 + @__p_1))
+        ) AS [t]
+        ORDER BY [t].[ContactTitle], [t].[ContactName]
+    ) AS [t0]
+    ORDER BY [t0].[ContactTitle], [t0].[ContactName]
+) AS [t1]
+ORDER BY [t1].[ContactTitle], [t1].[ContactName]",
                 Sql);
         }
 


### PR DESCRIPTION
Resolves #6736 
Issue for the specific case of #6736 is, when we do RowNumberPaging, we remove `OrderBy` clause. For a simple query, results are returned correctly but when we have include, we add ordering on PK property, which changes the order causing incorrect results.
For more general case, it can arise whenever we push down a subquery since outer query will not have any order by and Include can introduce one.

Fix would be to copy over the order by so that data is always in fixed order and will not be change. Also clear order by from a subquery level if there is not limit/offset.
