### PR TITLE
Add a safeguard for fks updated in recursive calls to ForeignKeyPropertyDiscoveryConvention

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Internal/TypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/TypeExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
@@ -58,6 +59,25 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var sb = new StringBuilder();
             ProcessTypeName(type, sb, fullName);
             return sb.ToString();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static FieldInfo GetFieldInfo([NotNull] this Type type, [NotNull] string fieldName)
+        {
+            var typesInHierarchy = type.GetTypesInHierarchy().ToList();
+            foreach (var typeInHierarchy in typesInHierarchy)
+            {
+                var fields = typeInHierarchy.GetRuntimeFields().ToDictionary(f => f.Name);
+                FieldInfo fieldInfo;
+                if (fields.TryGetValue(fieldName, out fieldInfo))
+                {
+                    return fieldInfo;
+                }
+            }
+            return null;
         }
 
         private static void AppendGenericArguments(Type[] args, int startIndex, int numberOfArgsToAppend, StringBuilder sb, bool fullName)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -353,10 +353,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual void Apply(InternalEntityTypeBuilder entityTypeBuilder, Key key)
         {
-            foreach (var foreignKey in key.DeclaringEntityType.GetDerivedForeignKeysInclusive().ToList())
+            var fks = key.DeclaringEntityType.GetDerivedForeignKeysInclusive().ToList();
+            foreach (var foreignKey in fks)
             {
-                if (!foreignKey.IsUnique
-                    || foreignKey.DeclaringEntityType.BaseType != null)
+                if (foreignKey.Builder != null
+                    && (!foreignKey.IsUnique
+                        || foreignKey.DeclaringEntityType.BaseType != null))
                 {
                     Apply(foreignKey.Builder);
                 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -139,13 +139,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var key = Metadata.FindDeclaredKey(actualProperties);
             if (key == null)
             {
-                if ((configurationSource != ConfigurationSource.Explicit) // let it throw for explicit
-                    && (configurationSource == null
-                        || actualProperties.Any(p => p.GetContainingForeignKeys().Any(k => k.DeclaringEntityType != Metadata))
-                        || actualProperties.Any(p => !p.Builder.CanSetRequired(true, configurationSource))))
+                if (configurationSource == null)
                 {
                     return null;
                 }
+
+                var containingForeignKeys = actualProperties
+                    .SelectMany(p => p.GetContainingForeignKeys().Where(k => k.DeclaringEntityType != Metadata))
+                    .ToList();
+
+                if (containingForeignKeys.Any(fk => !configurationSource.Overrides(fk.GetForeignKeyPropertiesConfigurationSource())))
+                {
+                    return null;
+                }
+
+                if (configurationSource != ConfigurationSource.Explicit // let it throw for explicit
+                    && actualProperties.Any(p => !p.Builder.CanSetRequired(true, configurationSource)))
+                {
+                    return null;
+                }
+
+                var modifiedRelationships = containingForeignKeys
+                    .Where(fk => fk.GetForeignKeyPropertiesConfigurationSource() != ConfigurationSource.Explicit)  // let it throw for explicit
+                    .Select(foreignKey => foreignKey.Builder.HasForeignKey(null, configurationSource, runConventions: false))
+                    .ToList();
 
                 foreach (var actualProperty in actualProperties)
                 {
@@ -153,6 +170,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 key = Metadata.AddKey(actualProperties, configurationSource.Value);
+
+                foreach (var foreignKey in containingForeignKeys)
+                {
+                    ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyRemoved(foreignKey.DeclaringEntityType.Builder, foreignKey);
+                }
+
+                foreach (var relationship in modifiedRelationships)
+                {
+                    ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAdded(relationship);
+                }
             }
             else if (configurationSource.HasValue)
             {
@@ -939,24 +966,38 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var detachedRelationships = property.GetContainingForeignKeys().ToList()
                 .Select(DetachRelationship).ToList();
 
-            foreach (var key in Metadata.GetKeys().Where(i => i.Properties.Contains(property)).ToList())
+            var removedKeys = new List<Key>();
+            foreach (var key in property.GetContainingKeys().ToList())
             {
                 detachedRelationships.AddRange(key.GetReferencingForeignKeys().ToList()
                     .Select(DetachRelationship));
-                var removed = RemoveKey(key, configurationSource);
+                var removed = RemoveKey(key, configurationSource, runConventions: false);
                 Debug.Assert(removed.HasValue);
+                removedKeys.Add(key);
             }
 
-            foreach (var index in Metadata.GetIndexes().Where(i => i.Properties.Contains(property)).ToList())
+            var removedIndexes = new List<Index>();
+            foreach (var index in property.GetContainingIndexes().ToList())
             {
-                var removed = RemoveIndex(index, configurationSource);
+                var removed = RemoveIndex(index, configurationSource, runConventions: false);
                 Debug.Assert(removed.HasValue);
+                removedIndexes.Add(index);
             }
 
             if (Metadata.GetProperties().Contains(property))
             {
                 var removedProperty = Metadata.RemoveProperty(property.Name);
                 Debug.Assert(removedProperty == property);
+            }
+
+            foreach (var index in removedIndexes)
+            {
+                Metadata.Model.ConventionDispatcher.OnIndexRemoved(this, index);
+            }
+
+            foreach (var key in removedKeys)
+            {
+                Metadata.Model.ConventionDispatcher.OnKeyRemoved(this, key);
             }
 
             foreach (var detachedRelationship in detachedRelationships)
@@ -1143,7 +1184,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ConfigurationSource? RemoveIndex([NotNull] Index index, ConfigurationSource configurationSource)
+        public virtual ConfigurationSource? RemoveIndex([NotNull] Index index, ConfigurationSource configurationSource, bool runConventions = true)
         {
             var currentConfigurationSource = index.GetConfigurationSource();
             if (!configurationSource.Overrides(currentConfigurationSource))
@@ -1151,7 +1192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            var removedIndex = Metadata.RemoveIndex(index.Properties);
+            var removedIndex = Metadata.RemoveIndex(index.Properties, runConventions);
             Debug.Assert(removedIndex == index);
 
             RemoveShadowPropertiesIfUnused(index.Properties);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -533,19 +533,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<IKey> Keys { get; [param: CanBeNull] set; }
+        public virtual List<IKey> Keys { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<IForeignKey> ForeignKeys { get; [param: CanBeNull] set; }
+        public virtual List<IForeignKey> ForeignKeys { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<IIndex> Indexes { get; [param: CanBeNull] set; }
+        public virtual List<IIndex> Indexes { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -449,11 +449,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.
+        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {key}. All containing keys must be removed or redefined before the property can be removed.
         /// </summary>
-        public static string PropertyInUse([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string PropertyInUseKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyInUse", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyInUseKey", "property", "entityType", "key"), property, entityType, key);
         }
 
         /// <summary>
@@ -1462,6 +1462,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static string PropertyCalledOnNavigation([CanBeNull] object property, [CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("PropertyCalledOnNavigation", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKey} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.
+        /// </summary>
+        public static string PropertyInUseForeignKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object foreignKeyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyInUseForeignKey", "property", "entityType", "foreignKey", "foreignKeyType"), property, entityType, foreignKey, foreignKeyType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
+        /// </summary>
+        public static string PropertyInUseIndex([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object index, [CanBeNull] object indexType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyInUseIndex", "property", "entityType", "index", "indexType"), property, entityType, index, indexType);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -279,8 +279,8 @@
   <data name="ClrPropertyOnShadowEntity" xml:space="preserve">
     <value>The property '{property}' cannot exist on type '{entityType}' because the type is marked as shadow state while the property is not. Shadow state types can only contain shadow state properties.</value>
   </data>
-  <data name="PropertyInUse" xml:space="preserve">
-    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.</value>
+  <data name="PropertyInUseKey" xml:space="preserve">
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {key}. All containing keys must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="KeyInUse" xml:space="preserve">
     <value>Cannot remove key {key} from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
@@ -659,5 +659,11 @@
   </data>
   <data name="PropertyCalledOnNavigation" xml:space="preserve">
     <value>Cannot call Property for the property '{property}' on entity type '{entityType}' because it is configured as a navigation property. Property can only be used to configure scalar properties.</value>
+  </data>
+  <data name="PropertyInUseForeignKey" xml:space="preserve">
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKey} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.</value>
+  </data>
+  <data name="PropertyInUseIndex" xml:space="preserve">
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
   </data>
 </root>

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2402,7 +2402,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrSetPrimaryKey(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
+                CoreStrings.PropertyInUseKey("Id", typeof(Customer).Name, "{'Id'}"),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 
@@ -2416,7 +2416,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrAddKey(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
+                CoreStrings.PropertyInUseKey("Id", typeof(Customer).Name, "{'Id'}"),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 
@@ -2432,7 +2432,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             orderType.GetOrAddForeignKey(customerFk, customerPk, customerType);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("CustomerId", typeof(Order).Name),
+                CoreStrings.PropertyInUseForeignKey("CustomerId", typeof(Order).Name, "{'CustomerId'}", typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() => orderType.RemoveProperty(customerFk.Name)).Message);
         }
 
@@ -2446,7 +2446,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             entityType.GetOrAddIndex(property);
 
             Assert.Equal(
-                CoreStrings.PropertyInUse("Id", typeof(Customer).Name),
+                CoreStrings.PropertyInUseIndex("Id", typeof(Customer).Name, "{'Id'}", typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property.Name)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -863,12 +863,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit);
             var idProperty = dependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationship = derivedDependentEntityBuilder.Relationship(
+            derivedDependentEntityBuilder.Relationship(
                     principalEntityBuilder,
                     Order.CustomerProperty.Name,
                     nameof(Customer.SpecialOrders),
                     ConfigurationSource.Explicit)
-                .HasForeignKey(new[] { idProperty }, ConfigurationSource.Convention);
+                .HasForeignKey(new[] { idProperty }, ConfigurationSource.Explicit);
 
             Assert.Null(dependentEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.DataAnnotation));
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -300,6 +300,40 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
+            public virtual void Removing_a_key_triggers_fk_discovery_on_derived_types()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<BackOrder>();
+                modelBuilder.Ignore<OtherCustomer>();
+
+                var principalEntityBuilder = modelBuilder.Entity<Customer>();
+                var derivedPrincipalEntityBuilder = modelBuilder.Entity<SpecialCustomer>();
+                var dependentEntityBuilder = modelBuilder.Entity<Order>();
+                dependentEntityBuilder.Ignore(nameof(Order.Customer));
+                var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
+                dependentEntityBuilder.Property<int?>("SpecialCustomerId");
+
+                derivedPrincipalEntityBuilder
+                    .HasMany(e => (IEnumerable<SpecialOrder>)e.Orders)
+                    .WithOne(e => e.SpecialCustomer);
+
+                dependentEntityBuilder.HasKey("SpecialCustomerId");
+                dependentEntityBuilder.HasKey(o => o.OrderId);
+                dependentEntityBuilder.Ignore("SpecialCustomerId");
+                derivedDependentEntityBuilder.Property(e => e.SpecialCustomerId);
+
+                Assert.Null(dependentEntityBuilder.Metadata.FindProperty("SpecialCustomerId"));
+                Assert.NotNull(derivedDependentEntityBuilder.Metadata.FindProperty("SpecialCustomerId"));
+                Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
+                var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
+                Assert.Equal(nameof(SpecialOrder.SpecialCustomer), newFk.DependentToPrincipal.Name);
+                Assert.Equal(nameof(SpecialCustomer.Orders), newFk.PrincipalToDependent.Name);
+                Assert.Same(derivedPrincipalEntityBuilder.Metadata, newFk.PrincipalEntityType);
+            }
+
+            [Fact]
             public virtual void Index_removed_when_covered_by_an_inherited_foreign_key()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Make InternalEntityTypeBuilder.HasKey more resilient by removing conflicting fks of lower source
Reset FieldInfo when lifting properties if the field doesn't exist on the new type
Improve the exception message for removing a property that is still being referenced

Fixes #6867
