### PR TITLE
Allow navigation backing fields to be assign-compatible

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/FieldMappingTestBase.cs
@@ -600,7 +600,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _id;
             private string _title;
-            private IEnumerable<PostFull> _posts;
+            private ICollection<PostFull> _posts;
 
             // ReSharper disable once ConvertToAutoProperty
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -621,7 +621,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public IEnumerable<PostFull> Posts
             {
                 get { return _posts; }
-                set { _posts = value; }
+                set { _posts = (ICollection<PostFull>)value; }
             }
 
             int IBlogAccesor.AccessId
@@ -708,7 +708,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _myid;
             private string _mytitle;
-            private IEnumerable<PostFullExplicit> _myposts;
+            private ICollection<PostFullExplicit> _myposts;
 
             // ReSharper disable once ConvertToAutoProperty
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -729,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             public IEnumerable<PostFullExplicit> Posts
             {
                 get { return _myposts; }
-                set { _myposts = value; }
+                set { _myposts = (ICollection<PostFullExplicit>)value; }
             }
 
             int IBlogAccesor.AccessId
@@ -816,7 +816,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _id;
             private string _title;
-            private IEnumerable<PostReadOnly> _posts;
+            private ICollection<PostReadOnly> _posts;
 
             // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -843,7 +843,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
                 get { return Posts; }
-                set { _posts = (IEnumerable<PostReadOnly>)value; }
+                set { _posts = (ICollection<PostReadOnly>)value; }
             }
         }
 
@@ -896,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _myid;
             private string _mytitle;
-            private IEnumerable<PostReadOnlyExplicit> _myposts;
+            private ICollection<PostReadOnlyExplicit> _myposts;
 
             // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -923,7 +923,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
                 get { return Posts; }
-                set { _myposts = (IEnumerable<PostReadOnlyExplicit>)value; }
+                set { _myposts = (ICollection<PostReadOnlyExplicit>)value; }
             }
         }
 
@@ -976,7 +976,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _id;
             private string _title;
-            private IEnumerable<PostWriteOnly> _posts;
+            private ICollection<PostWriteOnly> _posts;
 
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
@@ -991,7 +991,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             public IEnumerable<PostWriteOnly> Posts
             {
-                set { _posts = value; }
+                set { _posts = (ICollection<PostWriteOnly>)value; }
             }
 
             int IBlogAccesor.AccessId
@@ -1070,7 +1070,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             private int _myid;
             private string _mytitle;
-            private IEnumerable<PostWriteOnlyExplicit> _myposts;
+            private ICollection<PostWriteOnlyExplicit> _myposts;
 
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
@@ -1085,7 +1085,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             public IEnumerable<PostWriteOnlyExplicit> Posts
             {
-                set { _myposts = value; }
+                set { _myposts = (ICollection<PostWriteOnlyExplicit>)value; }
             }
 
             int IBlogAccesor.AccessId

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
@@ -71,22 +71,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var typeInfo = propertyType.GetTypeInfo();
 
             FieldInfo fieldInfo;
-            return (fields.TryGetValue("<" + propertyName + ">k__BackingField", out fieldInfo)
-                    && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+            return fields.TryGetValue("<" + propertyName + ">k__BackingField", out fieldInfo)
                    || (fields.TryGetValue(propertyName, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                    || (fields.TryGetValue(camelized, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                    || (fields.TryGetValue("_" + camelized, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                    || (fields.TryGetValue("_" + propertyName, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                    || (fields.TryGetValue("m_" + camelized, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                    || (fields.TryGetValue("m_" + propertyName, out fieldInfo)
-                       && fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(typeInfo))
+                       && IsConvertable(typeInfo, fieldInfo))
                 ? fieldInfo
                 : null;
+        }
+
+        private static bool IsConvertable(TypeInfo typeInfo, FieldInfo fieldInfo)
+        {
+            var fieldTypeInfo = fieldInfo.FieldType.GetTypeInfo();
+
+            return typeInfo.IsAssignableFrom(fieldTypeInfo)
+                   || fieldTypeInfo.IsAssignableFrom(typeInfo);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -96,7 +96,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         Expression.MakeMemberAccess(
                             entityParameter,
                             setterMemberInfo),
-                        valueParameter),
+                        Expression.Convert(
+                            valueParameter,
+                            setterMemberInfo.GetMemberType())),
                     entityParameter,
                     valueParameter).Compile();
             }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -110,16 +110,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual void SetFieldInfo(
             [CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource, bool runConventions = true)
         {
-            if (fieldInfo != null
-                && !fieldInfo.FieldType.GetTypeInfo().IsAssignableFrom(ClrType.GetTypeInfo()))
+            if (fieldInfo != null)
             {
-                throw new InvalidOperationException(
-                    CoreStrings.BadBackingFieldType(
-                        fieldInfo.Name,
-                        fieldInfo.FieldType.ShortDisplayName(),
-                        DeclaringType.DisplayName(),
-                        Name,
-                        ClrType.ShortDisplayName()));
+                var fieldTypeInfo = fieldInfo.FieldType.GetTypeInfo();
+                var typeInfo = ClrType.GetTypeInfo();
+
+                if (!typeInfo.IsAssignableFrom(fieldTypeInfo)
+                    && !fieldTypeInfo.IsAssignableFrom(typeInfo))
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.BadBackingFieldType(
+                            fieldInfo.Name,
+                            fieldInfo.FieldType.ShortDisplayName(),
+                            DeclaringType.DisplayName(),
+                            Name,
+                            ClrType.ShortDisplayName()));
+                }
             }
 
             UpdateFieldInfoConfigurationSource(configurationSource);


### PR DESCRIPTION
Issue #6893

This lets backing fields of, for example, `List<T>` be found and used for navigation properties of `IEnumerable<T>` while still allowing fields of `int?` to be found and used for properties of `int`.