### PR TITLE
Add back EntityTypeExtensions.DisplayName to fix binary break

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -27,6 +27,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Call TypeBaseExtensions.DisplayName() instead.")]
+        public static string DisplayName([NotNull] IEntityType entityType)
+            => entityType.DisplayName();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static IEnumerable<IEntityType> GetAllBaseTypesInclusive([NotNull] this IEntityType entityType)
         {
             var baseTypes = new List<IEntityType>();


### PR DESCRIPTION
Issue #6914

Method is not an extension method and is obsolete but should allow code already bound it to continue working.