### PR TITLE
Query: Issue propert client eval warning for Last & LastOrDefault

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/WarningsTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/WarningsTestBase.cs
@@ -80,7 +80,69 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.NotNull(query2);
             }
         }
-      
+
+        [Fact]
+        public virtual void LastOrDefault_with_order_by_does_not_issue_client_eval_warning()
+        {
+            using (var context = CreateContext())
+            {
+                var query1 = context.Customers.Where(c => c.CustomerID == "ALFKI" && c.Orders.OrderBy(o => o.OrderID).LastOrDefault().OrderID > 1000).ToList();
+                Assert.NotNull(query1);
+
+                var query2 = context.Customers.OrderBy(c => c.CustomerID).LastOrDefault();
+                Assert.NotNull(query2);
+            }
+        }
+
+        [Fact]
+        public virtual void Last_with_order_by_does_not_issue_client_eval_warning_if_at_top_level()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.OrderBy(c => c.CustomerID).Last();
+                Assert.NotNull(query);
+            }
+        }
+
+        [Fact]
+        public virtual void Last_without_order_by_issues_client_eval_warning()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.WarningAsErrorTemplate(
+                        $"{nameof(RelationalEventId)}.{nameof(RelationalEventId.QueryClientEvaluationWarning)}",
+                        RelationalStrings.ClientEvalWarning("Last()")),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.Last()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Last_with_order_by_issues_client_eval_warning_in_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.WarningAsErrorTemplate(
+                        $"{nameof(RelationalEventId)}.{nameof(RelationalEventId.QueryClientEvaluationWarning)}",
+                        RelationalStrings.ClientEvalWarning("Last()")),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.Where(c => c.CustomerID == "ALFKI" && c.Orders.OrderBy(o => o.OrderID).Last().OrderID > 1000).ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void LastOrDefault_without_order_by_issues_client_eval_warning()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(CoreStrings.WarningAsErrorTemplate(
+                        $"{nameof(RelationalEventId)}.{nameof(RelationalEventId.QueryClientEvaluationWarning)}",
+                        RelationalStrings.ClientEvalWarning("LastOrDefault()")),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.LastOrDefault()).Message);
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected WarningsTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -338,9 +338,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             handlerContext.SelectExpression
                 .SetProjectionExpression(
                     new SqlFunctionExpression(
-                        "COUNT", 
-                        typeof(int), 
-                        new [] { new SqlFragmentExpression("*") }));
+                        "COUNT",
+                        typeof(int),
+                        new[] { new SqlFragmentExpression("*") }));
 
             handlerContext.SelectExpression.ClearOrderBy();
 
@@ -510,6 +510,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private static Expression HandleLast(HandlerContext handlerContext)
         {
+            var requiresClientResultOperator = true;
             if (handlerContext.SelectExpression.OrderBy.Any())
             {
                 foreach (var ordering in handlerContext.SelectExpression.OrderBy)
@@ -521,9 +522,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
 
                 handlerContext.SelectExpression.Limit = Expression.Constant(1);
+                requiresClientResultOperator = false;
             }
 
-            return handlerContext.EvalOnClient(requiresClientResultOperator: false);
+            requiresClientResultOperator
+                = requiresClientResultOperator
+                || (!((LastResultOperator)handlerContext.ResultOperator).ReturnDefaultWhenEmpty
+                    && handlerContext.QueryModelVisitor.ParentQueryModelVisitor != null);
+
+            return handlerContext.EvalOnClient(requiresClientResultOperator: requiresClientResultOperator);
         }
 
         private static Expression HandleLongCount(HandlerContext handlerContext)
@@ -531,9 +538,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             handlerContext.SelectExpression
                 .SetProjectionExpression(
                     new SqlFunctionExpression(
-                        "COUNT", 
-                        typeof(long), 
-                        new [] { new SqlFragmentExpression("*") }));
+                        "COUNT",
+                        typeof(long),
+                        new[] { new SqlFragmentExpression("*") }));
 
             handlerContext.SelectExpression.ClearOrderBy();
 
@@ -546,7 +553,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var minExpression = new SqlFunctionExpression("MIN", expression.Type, new [] { expression });
+                var minExpression = new SqlFunctionExpression("MIN", expression.Type, new[] { expression });
 
                 handlerContext.SelectExpression.SetProjectionExpression(minExpression);
 
@@ -564,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var maxExpression = new SqlFunctionExpression("MAX", expression.Type, new [] { expression });
+                var maxExpression = new SqlFunctionExpression("MAX", expression.Type, new[] { expression });
 
                 handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
 
@@ -721,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var sumExpression = new SqlFunctionExpression("SUM", expression.Type, new [] { expression });
+                var sumExpression = new SqlFunctionExpression("SUM", expression.Type, new[] { expression });
 
                 handlerContext.SelectExpression.SetProjectionExpression(sumExpression);
 


### PR DESCRIPTION
Resolves #6929 

Issue: we always set ClientEval as false even though it was required. Added proper handling.

Rules:
Last with order by can always be translated to Sql. Do not log warning.
LastOrDefault with order by gets translated but we still do client eval for the exception (just like FirstOrDefault), Do not log warning.
Warn when LastOrDefault is used inside subquery.
Warn when Last is used without order by because we need to evaluate on client to find the last record.

