### PR TITLE
Use verbatim strings for scaffolded index filters

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Configuration/Internal/IndexConfiguration.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Configuration/Internal/IndexConfiguration.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Configuration.Internal
 
                 if (Index.Relational().Filter != null)
                 {
-                    lines.Add($".{nameof(RelationalIndexBuilderExtensions.HasFilter)}(\"{Index.Relational().Filter}\")");
+                    lines.Add($".{nameof(RelationalIndexBuilderExtensions.HasFilter)}(@\"{Index.Relational().Filter.Replace("\"", "\"\"")}\")");
                 }
 
                 return lines;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/FilteredIndexContext.expected
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/FilteredIndexContext.expected
@@ -20,7 +20,7 @@ namespace E2ETest.Namespace
             {
                 entity.HasIndex(e => e.Number)
                     .HasName("Unicorn_Filtered_Index")
-                    .HasFilter("([Number]>(10))");
+                    .HasFilter(@"([Number]>(10))");
 
                 entity.Property(e => e.Id).ValueGeneratedNever();
             });


### PR DESCRIPTION
Expressions in index filters may contain backslashes, double-quotes, etc.
Scaffold these expressions as verbatim strings and escape double-quotes. Especially important for PostgreSQL where identifiers are surrounded by double-quotes.

cc @laskoviymishka