### PR TITLE
Update SqlServerRetryingExecutionStrategy

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
@@ -38,6 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         // Cannot process request. Not enough resources to process request.
                         // The service is currently busy.Please retry the request later.
                         case 49918:
+                        // SQL Error Code: 41839
+                        // Transaction exceeded the maximum number of commit dependencies.
+                        case 41839:
                         // SQL Error Code: 41325
                         // The current transaction failed to commit due to a serializable validation failure.
                         case 41325:
@@ -47,6 +50,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         // SQL Error Code: 41302
                         // The current transaction attempted to update a record that has been updated since the transaction started.
                         case 41302:
+                        // SQL Error Code: 41301
+                        // Dependency failure: a dependency was taken on another transaction that later failed to commit.
+                        case 41301:
                         // SQL Error Code: 40613
                         // Database XXXX on server YYYY is not currently available. Please retry the connection later.
                         // If the problem persists, contact customer support, and provide them the session tracing ID of ZZZZZ.
@@ -81,6 +87,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         // A transport-level error has occurred when receiving results from the server.
                         // An established connection was aborted by the software in your host machine.
                         case 10053:
+                        // SQL Error Code: 1205
+                        // Deadlock
+                        case 1205:
                         // SQL Error Code: 233
                         // The client was unable to establish a connection because of an error during connection initialization process before login.
                         // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server;

--- a/src/Microsoft.EntityFrameworkCore/Storage/ExecutionStrategy.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/ExecutionStrategy.cs
@@ -385,7 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Returns the delay indicating how long to wait for before the next execution attempt if the operation should be retried;
         ///     <c>null</c> otherwise
         /// </returns>
-        protected internal virtual TimeSpan? GetNextDelay([NotNull] Exception lastException)
+        protected virtual TimeSpan? GetNextDelay([NotNull] Exception lastException)
         {
             var currentRetryCount = ExceptionsEncountered.Count - 1;
             if (currentRetryCount < MaxRetryCount)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -66,6 +66,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
             return false;
         }
 
+        public new virtual TimeSpan? GetNextDelay(Exception lastException)
+        {
+            ExceptionsEncountered.Add(lastException);
+            return base.GetNextDelay(lastException);
+        }
+
         public new static bool Suspended
         {
             get { return ExecutionStrategy.Suspended; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="SqlServerTypeMapperTest.cs" />
     <Compile Include="SqlServerValueGeneratorCacheTest.cs" />
     <Compile Include="SqlServerValueGeneratorSelectorTest.cs" />
+    <Compile Include="Storage\SqlServerRetryingExecutionStrategyTests.cs" />
     <Compile Include="Storage\SqlServerSqlGeneratorTest.cs" />
     <Compile Include="Storage\SqlServerTypeMappingTest.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchFactoryTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Storage/SqlServerRetryingExecutionStrategyTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Storage/SqlServerRetryingExecutionStrategyTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Storage
+{
+    public class SqlServerRetryingExecutionStrategyTests
+    {
+        [Fact]
+        public void GetNextDelay_returns_shorter_delay_for_InMemory_transient_errors()
+        {
+            var strategy = new TestSqlServerRetryingExecutionStrategy(CreateContext());
+            var inMemoryOltpError = SqlExceptionFactory.CreateSqlException(41302);
+            var delays = new List<TimeSpan>();
+            var delay = strategy.GetNextDelay(inMemoryOltpError);
+            while (delay != null)
+            {
+                delays.Add(delay.Value);
+                delay = strategy.GetNextDelay(inMemoryOltpError);
+            }
+
+            var expectedDelays = new List<TimeSpan>
+            {
+                TimeSpan.FromMilliseconds(0),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(3),
+                TimeSpan.FromMilliseconds(7),
+                TimeSpan.FromMilliseconds(15)
+            };
+
+            Assert.Equal(expectedDelays.Count, delays.Count);
+            for (var i = 0; i < expectedDelays.Count; i++)
+            {
+                Assert.True(
+                    Math.Abs((delays[i] - expectedDelays[i]).TotalMilliseconds) <=
+                    expectedDelays[i].TotalMilliseconds * 0.1 + 1,
+                    string.Format("Expected: {0}; Actual: {1}", expectedDelays[i], delays[i]));
+            }
+        }
+
+        protected DbContext CreateContext()
+            => SqlServerTestHelpers.Instance.CreateContext();
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/Storage/ExecutionStrategyTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Storage/ExecutionStrategyTests.cs
@@ -24,7 +24,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
             }
 
+            public TestExecutionStrategy(DbContext context, int retryCount)
+                : base(new ExecutionStrategyContext(context, null), retryCount, DefaultMaxDelay)
+            {
+            }
+
             protected internal override bool ShouldRetryOn(Exception exception) => false;
+
+            public new virtual TimeSpan? GetNextDelay(Exception lastException)
+            {
+                ExceptionsEncountered.Add(lastException);
+                return base.GetNextDelay(lastException);
+            }
 
             public new static bool Suspended
             {
@@ -37,10 +48,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void GetNextDelay_returns_the_expected_default_sequence()
         {
             var strategy = new TestExecutionStrategy(CreateContext());
-            var delays = new List<TimeSpan?>();
-            for (var i = 0; i < 5; i++)
+            var delays = new List<TimeSpan>();
+            var delay = strategy.GetNextDelay(new Exception());
+            while (delay != null)
             {
-                delays.Add(strategy.GetNextDelay(new Exception()));
+                delays.Add(delay.Value);
+                delay = strategy.GetNextDelay(new Exception());
             }
 
             var expectedDelays = new List<TimeSpan>
@@ -56,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             for (var i = 0; i < expectedDelays.Count; i++)
             {
                 Assert.True(
-                    (delays[i] - expectedDelays[i])?.TotalMilliseconds <=
+                    Math.Abs((delays[i] - expectedDelays[i]).TotalMilliseconds) <=
                     expectedDelays[i].TotalMilliseconds * 0.1 + 1,
                     string.Format("Expected: {0}; Actual: {1}", expectedDelays[i], delays[i]));
             }
@@ -318,13 +331,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var executionCount = 0;
 
-            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext(), 2)
             {
-                    CallBase = true
-                };
+                CallBase = true
+            };
 
-            executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
-                e => executionCount < 3 ? (TimeSpan?)TimeSpan.FromTicks(0) : null);
             executionStrategyMock.Protected().Setup<bool>("ShouldRetryOn", ItExpr.IsAny<Exception>()).Returns<Exception>(
                 e => e is ArgumentOutOfRangeException);
 
@@ -595,13 +606,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var executionCount = 0;
 
-            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext())
+            var executionStrategyMock = new Mock<TestExecutionStrategy>(CreateContext(), 2)
             {
                 CallBase = true
             };
 
-            executionStrategyMock.Setup(m => m.GetNextDelay(It.IsAny<Exception>())).Returns<Exception>(
-                e => executionCount < 3 ? (TimeSpan?)TimeSpan.FromTicks(0) : null);
             executionStrategyMock.Protected().Setup<bool>("ShouldRetryOn", ItExpr.IsAny<Exception>()).Returns<Exception>(
                 e => e is ArgumentOutOfRangeException);
 


### PR DESCRIPTION
Add 1205, 41301 and 41839 to the transient errors list.
Use a shorter retry delay for memory-optimized errors.

Fixes #6970