### PR TITLE
Maintain connection state in BatchExecutor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Update/Internal/BatchExecutor.cs
@@ -77,8 +77,14 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
             finally
             {
-                startedTransaction?.Dispose();
-                connection.Close();
+                if (startedTransaction != null)
+                {
+                    startedTransaction.Dispose();
+                }
+                else
+                {
+                    connection.Close();
+                }
             }
 
             return rowsAffected;
@@ -124,8 +130,14 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
             finally
             {
-                startedTransaction?.Dispose();
-                connection.Close();
+                if (startedTransaction != null)
+                {
+                    startedTransaction.Dispose();
+                }
+                else
+                {
+                    connection.Close();
+                }
             }
 
             return rowsAffected;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/BatchExecutorTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
             await batchExecutor.ExecuteAsync(new[] { mockModificationCommandBatch.Object }, mockRelationalConnection.Object, cancellationToken);
 
             mockRelationalConnection.Verify(rc => rc.BeginTransactionAsync(cancellationToken));
-            mockRelationalConnection.Verify(rc => rc.Close());
+            mockRelationalConnection.Verify(rc => rc.Close(), Times.Never);
             transactionMock.Verify(t => t.Commit());
 
             mockModificationCommandBatch.Verify(mcb => mcb.ExecuteAsync(


### PR DESCRIPTION
Resolves #6968 
Issue here was, we were closing the connection while saving changes even if we did not open it.

Question: Where should I add tests?