### PR TITLE
Stop special-casing the root entity on Attach

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -43,13 +43,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return false;
             }
 
-            if (node.InboundNavigation != null
-                && !internalEntityEntry.IsKeySet)
-            {
-                node.NodeState = EntityState.Added;
-            }
-
-            internalEntityEntry.SetEntityState((EntityState)node.NodeState, acceptChanges: true);
+            internalEntityEntry.SetEntityState(
+                internalEntityEntry.IsKeySet
+                    ? (EntityState)node.NodeState
+                    : EntityState.Added,
+                acceptChanges: true);
 
             return true;
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -958,7 +958,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool IsKeySet => !EntityType.FindPrimaryKey().Properties.Any(p => p.ClrType.IsDefaultValue(this[p]));
+        public virtual bool IsKeySet => !EntityType.FindPrimaryKey().Properties.Any(
+            p => p.ClrType.IsDefaultValue(this[p])
+                 && (p.ValueGenerated == ValueGenerated.OnAdd
+                     || p.IsForeignKey()));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/AggregatesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/AggregatesTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
 
                 context.Attach(blog);
 
-                Assert.Equal(EntityState.Unchanged, context.Entry(blog).State); // See Issue #3890
+                Assert.Equal(EntityState.Added, context.Entry(blog).State);
                 Assert.Equal(EntityState.Added, context.Entry(posts[0]).State);
                 Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
                 Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
 
                 context.Attach(category);
 
-                Assert.Equal(EntityState.Unchanged, context.Entry(category).State); // See Issue #3890
+                Assert.Equal(EntityState.Added, context.Entry(category).State);
                 Assert.Equal(EntityState.Added, context.Entry(category.Statistics).State);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
@@ -323,8 +323,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             using (var context = new FreezerContext())
             {
                 var cherry = new Cherry();
-                var chunky1 = new Chunky { Garcia = cherry };
-                var chunky2 = new Chunky { Garcia = cherry };
+                var chunky1 = new Chunky { Id = 1, Garcia = cherry };
+                var chunky2 = new Chunky { Id = 2, Garcia = cherry };
                 cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
                 context.AttachRange(cherry, chunky1, chunky2);
 
@@ -348,8 +348,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             using (var context = new FreezerContext())
             {
                 var cherry = new Cherry();
-                var chunky1 = new Chunky { Garcia = cherry };
-                var chunky2 = new Chunky { Garcia = cherry };
+                var chunky1 = new Chunky { Id = 1, Garcia = cherry };
+                var chunky2 = new Chunky { Id = 2, Garcia = cherry };
                 cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
                 context.AttachRange(cherry, chunky1, chunky2);
 
@@ -396,6 +396,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 => optionsBuilder.UseInMemoryDatabase();
 
             public DbSet<Chunky> Icecream { get; set; }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Chunky>().Property(e => e.Id).ValueGeneratedNever();
+                modelBuilder.Entity<Cherry>().Property(e => e.Id).ValueGeneratedNever();
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -690,6 +690,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 => optionsBuilder.UseInMemoryDatabase();
 
             public DbSet<Chunky> Icecream { get; set; }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Chunky>().Property(e => e.Id).ValueGeneratedNever();
+                modelBuilder.Entity<Cherry>().Property(e => e.Id).ValueGeneratedNever();
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -455,6 +455,12 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 => optionsBuilder.UseInMemoryDatabase();
 
             public DbSet<Chunky> Icecream { get; set; }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Chunky>().Property(e => e.Id).ValueGeneratedNever();
+                modelBuilder.Entity<Cherry>().Property(e => e.Id).ValueGeneratedNever();
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -569,13 +569,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
         [Fact]
         public async Task Can_add_existing_entities_with_default_value_to_context_to_be_attached_with_graph_method()
         {
-            await TrackEntitiesDefaultValueTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesDefaultValueTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Added);
         }
 
         [Fact]
         public async Task Can_add_existing_entities_with_default_value_to_context_to_be_updated_with_graph_method()
         {
-            await TrackEntitiesDefaultValueTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesDefaultValueTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Added);
         }
 
         private static Task TrackEntitiesDefaultValueTest(
@@ -628,13 +628,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
         [Fact]
         public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached()
         {
-            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AttachRange(e[0]), (c, e) => c.AttachRange(e[0]), EntityState.Unchanged);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.AttachRange(e[0]), (c, e) => c.AttachRange(e[0]), EntityState.Added);
         }
 
         [Fact]
         public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated()
         {
-            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.UpdateRange(e[0]), (c, e) => c.UpdateRange(e[0]), EntityState.Modified);
+            await TrackMultipleEntitiesDefaultValuesTest((c, e) => c.UpdateRange(e[0]), (c, e) => c.UpdateRange(e[0]), EntityState.Added);
         }
 
         [Fact]
@@ -902,13 +902,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
         [Fact]
         public async Task Can_add_existing_entities_with_default_value_to_context_to_be_attached_non_generic_graph()
         {
-            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Added);
         }
 
         [Fact]
         public async Task Can_add_existing_entities_with_default_value_to_context_to_be_updated_non_generic_graph()
         {
-            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            await TrackEntitiesDefaultValuesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Added);
         }
 
         private static Task TrackEntitiesDefaultValuesTestNonGeneric(
@@ -967,13 +967,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
         [Fact]
         public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_attached_Enumerable_graph()
         {
-            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Added);
         }
 
         [Fact]
         public async Task Can_add_multiple_existing_entities_with_default_values_to_context_to_be_updated_Enumerable_graph()
         {
-            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+            await TrackMultipleEntitiesDefaultValueTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Added);
         }
 
         private static Task TrackMultipleEntitiesDefaultValueTestEnumerable(


### PR DESCRIPTION
Issue #6990

Makes Attach/Update more useful by properly using the value-generation semantics built into the model.

Note that we haven't decided to do this yet, but I did the work to validate the approach. I will not merge until we decide to do it.
