### PR TITLE
Build fixes for SqlServer 2008

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ExistsExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ExistsExpression.cs
@@ -72,6 +72,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     children, and if any of them change, should return a new copy of
         ///     itself with the modified children.
         /// </remarks>
-        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newExpression = visitor.Visit(Expression);
+            if (newExpression != Expression)
+            {
+                var selectExpression = newExpression as SelectExpression;
+                if (selectExpression != null
+                    && selectExpression.Limit == null
+                    && selectExpression.Offset == null)
+                {
+                    selectExpression.ClearOrderBy();
+                }
+                return new ExistsExpression(newExpression);
+            }
+
+            return this;
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -15,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class CompiledQueryCacheKeyGeneratorTest
     {
-        [Fact]
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public void It_creates_unique_query_cache_key()
         {
             using (var testStore = SqlServerTestStore.Create(nameof(CompiledQueryCacheKeyGeneratorTest)))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -6406,6 +6406,7 @@ WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND ([t1].[OrderID]
                 Sql);
         }
 
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void OrderBy_skip_take_level_1()
         {
             base.OrderBy_skip_take_level_1();
@@ -6421,6 +6422,7 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                 Sql);
         }
 
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void OrderBy_skip_take_level_2()
         {
             base.OrderBy_skip_take_level_2();
@@ -6441,6 +6443,7 @@ ORDER BY [t].[ContactTitle], [t].[ContactName]",
                 Sql);
         }
 
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void OrderBy_skip_take_distinct()
         {
             base.OrderBy_skip_take_distinct();
@@ -6460,6 +6463,7 @@ FROM (
                 Sql);
         }
 
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void OrderBy_skip_take_level_3()
         {
             base.OrderBy_skip_take_level_3();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -346,6 +346,49 @@ ORDER BY [t1].[ContactTitle], [t1].[ContactName]",
                 Sql);
         }
 
+        public override void Skip_Take_Any()
+        {
+            base.Skip_Take_Any();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 10
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT [t].[c0]
+        FROM (
+            SELECT 1 AS [c0], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+            FROM [Customers] AS [c]
+        ) AS [t]
+        WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1)))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
+        public override void Skip_Take_All()
+        {
+            base.Skip_Take_All();
+
+            Assert.Equal(
+                @"@__p_0: 5
+@__p_1: 10
+
+SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT [t].[c0]
+        FROM (
+            SELECT 1 AS [c0], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+            FROM [Customers] AS [c]
+            WHERE LEN([c].[CustomerID]) <> 5
+        ) AS [t]
+        WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1)))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
@anpete @maumar 
Some of the tests which relied on Supporting offset are made ConditionalFact
For, rownumberpaging we did not modify select expression if it was wrapped inside Exists. Causing invalid queries for SqlServer2008.