### PR TITLE
Make DatabaseGeneratedOption.Identity not throw for non-integer properties on SQL Server

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
@@ -41,6 +41,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected override bool ShouldThrowOnInvalidConfiguration => Annotations.ConfigurationSource == ConfigurationSource.Explicit;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool HasColumnName([CanBeNull] string value) => SetColumnName(value);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IProperty Property => (IProperty)Annotations.Metadata;
         protected virtual bool ShouldThrowOnConflict => true;
+        protected virtual bool ShouldThrowOnInvalidConfiguration => true;
 
         public virtual string ColumnName
         {

--- a/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -56,5 +56,14 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
             return base.Create(property, entityType);
         }
+
+        protected override bool ShouldGenerateTemporaryValues(IProperty property)
+        {
+            var relationalProperty = RelationalExtensions.For(property);
+            return relationalProperty.DefaultValue != null
+                   || relationalProperty.DefaultValueSql != null
+                   || relationalProperty.ComputedColumnSql != null
+                   || base.ShouldGenerateTemporaryValues(property);
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -769,7 +769,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             var identity = entity.FindProperty(nameof(GeneratedEntity.Identity));
             Assert.Equal(ValueGenerated.OnAdd, identity.ValueGenerated);
-            Assert.False(identity.RequiresValueGenerator);
+            Assert.True(identity.RequiresValueGenerator);
 
             var version = entity.FindProperty(nameof(GeneratedEntity.Version));
             Assert.Equal(ValueGenerated.OnAddOrUpdate, version.ValueGenerated);
@@ -803,15 +803,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             var stringProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.String));
             Assert.Equal(ValueGenerated.OnAdd, stringProperty.ValueGenerated);
-            Assert.False(stringProperty.RequiresValueGenerator);
+            Assert.True(stringProperty.RequiresValueGenerator);
 
             var dateTimeProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.DateTime));
             Assert.Equal(ValueGenerated.OnAdd, dateTimeProperty.ValueGenerated);
-            Assert.False(dateTimeProperty.RequiresValueGenerator);
+            Assert.True(dateTimeProperty.RequiresValueGenerator);
 
             var guidProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.Guid));
             Assert.Equal(ValueGenerated.OnAdd, guidProperty.ValueGenerated);
-            Assert.False(guidProperty.RequiresValueGenerator);
+            Assert.True(guidProperty.RequiresValueGenerator);
 
             Validate(modelBuilder);
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -769,6 +769,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             var identity = entity.FindProperty(nameof(GeneratedEntity.Identity));
             Assert.Equal(ValueGenerated.OnAdd, identity.ValueGenerated);
+            Assert.False(identity.RequiresValueGenerator);
 
             var version = entity.FindProperty(nameof(GeneratedEntity.Version));
             Assert.Equal(ValueGenerated.OnAddOrUpdate, version.ValueGenerated);
@@ -789,6 +790,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
             [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
             public Guid Version { get; set; }
+        }
+
+        [Fact]
+        public virtual ModelBuilder DatabaseGeneratedOption_Identity_does_not_throw_on_noninteger_properties()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<GeneratedEntityNonInteger>();
+
+            var entity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntityNonInteger));
+
+            var stringProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.String));
+            Assert.Equal(ValueGenerated.OnAdd, stringProperty.ValueGenerated);
+            Assert.False(stringProperty.RequiresValueGenerator);
+
+            var dateTimeProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.DateTime));
+            Assert.Equal(ValueGenerated.OnAdd, dateTimeProperty.ValueGenerated);
+            Assert.False(dateTimeProperty.RequiresValueGenerator);
+
+            var guidProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.Guid));
+            Assert.Equal(ValueGenerated.OnAdd, guidProperty.ValueGenerated);
+            Assert.False(guidProperty.RequiresValueGenerator);
+
+            Validate(modelBuilder);
+
+            return modelBuilder;
+        }
+
+        public class GeneratedEntityNonInteger
+        {
+            public int Id { get; set; }
+
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public string String { get; set; }
+
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public DateTime DateTime { get; set; }
+
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public Guid Guid { get; set; }
         }
 
         [Fact]

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGenerationStrategyConvention.cs
@@ -11,19 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerValueGenerationStrategyConvention : DatabaseGeneratedAttributeConvention, IModelConvention
+    public class SqlServerValueGenerationStrategyConvention : IModelConvention
     {
-        public override InternalPropertyBuilder Apply(
-            InternalPropertyBuilder propertyBuilder, DatabaseGeneratedAttribute attribute, MemberInfo clrMember)
-        {
-            propertyBuilder.SqlServer(ConfigurationSource.DataAnnotation).ValueGenerationStrategy(
-                attribute.DatabaseGeneratedOption == DatabaseGeneratedOption.Identity
-                    ? SqlServerValueGenerationStrategy.IdentityColumn
-                    : (SqlServerValueGenerationStrategy?)null);
-
-            return base.Apply(propertyBuilder, attribute, clrMember);
-        }
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGeneratorConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/Internal/SqlServerValueGeneratorConvention.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class SqlServerValueGeneratorConvention : ValueGeneratorConvention
+    {
+        public override Annotation Apply(InternalPropertyBuilder propertyBuilder, string name, Annotation annotation, Annotation oldAnnotation)
+        {
+            if (name == SqlServerFullAnnotationNames.Instance.ValueGenerationStrategy)
+            {
+                SetRequiresValueGenerator(propertyBuilder, propertyBuilder.Metadata.GetValueGeneratorFactory() != null);
+            }
+
+            return base.Apply(propertyBuilder, name, annotation, oldAnnotation);
+        }
+
+        protected override void SetRequiresValueGenerator(InternalPropertyBuilder propertyBuilder, bool valueGeneratorFactorySet)
+            => propertyBuilder.RequiresValueGenerator(
+                valueGeneratorFactorySet
+                || propertyBuilder.Metadata.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
+                    ? true
+                    : (bool?)null,
+                ConfigurationSource.Convention);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -33,8 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var valueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
 
-            ReplaceConvention(conventionSet.PropertyAddedConventions, (DatabaseGeneratedAttributeConvention)valueGenerationStrategyConvention);
-
             var sqlServerInMemoryTablesConvention = new SqlServerMemoryOptimizedTablesConvention();
             conventionSet.EntityTypeAnnotationSetConventions.Add(sqlServerInMemoryTablesConvention);
 
@@ -48,11 +46,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             conventionSet.IndexAnnotationSetConventions.Add(sqlServerIndexConvention);
 
-            ReplaceConvention(conventionSet.PropertyFieldChangedConventions, (DatabaseGeneratedAttributeConvention)valueGenerationStrategyConvention);
-
             conventionSet.PropertyNullableChangedConventions.Add(sqlServerIndexConvention);
 
             conventionSet.PropertyAnnotationSetConventions.Add(sqlServerIndexConvention);
+            ReplaceConvention(conventionSet.PropertyAnnotationSetConventions, (ValueGeneratorConvention)new SqlServerValueGeneratorConvention());
 
             return conventionSet;
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
@@ -28,7 +28,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected new virtual RelationalAnnotationsBuilder Annotations => (RelationalAnnotationsBuilder)base.Annotations;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override bool ShouldThrowOnConflict => false;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool ShouldThrowOnInvalidConfiguration => Annotations.ConfigurationSource == ConfigurationSource.Explicit;
 
 #pragma warning disable 109
         /// <summary>
@@ -91,27 +103,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public new virtual bool ValueGenerationStrategy(SqlServerValueGenerationStrategy? value)
         {
+            if (!SetValueGenerationStrategy(value))
+            {
+                return false;
+            }
+
             if (value == null)
             {
                 PropertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
-                PropertyBuilder.RequiresValueGenerator(false, ConfigurationSource.Convention);
                 HiLoSequenceName(null);
                 HiLoSequenceSchema(null);
             }
             else if (value.Value == SqlServerValueGenerationStrategy.IdentityColumn)
             {
                 PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-                PropertyBuilder.RequiresValueGenerator(true, ConfigurationSource.Convention);
                 HiLoSequenceName(null);
                 HiLoSequenceSchema(null);
             }
             else if (value.Value == SqlServerValueGenerationStrategy.SequenceHiLo)
             {
                 PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
-                PropertyBuilder.RequiresValueGenerator(true, ConfigurationSource.Convention);
             }
 
-            return SetValueGenerationStrategy(value);
+            return true;
         }
 #pragma warning restore 109
     }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -124,15 +124,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 if (value == SqlServerValueGenerationStrategy.IdentityColumn
                     && !IsCompatibleIdentityColumn(propertyType))
                 {
-                    throw new ArgumentException(SqlServerStrings.IdentityBadType(
-                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    if (ShouldThrowOnInvalidConfiguration)
+                    {
+                        throw new ArgumentException(SqlServerStrings.IdentityBadType(
+                            Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    }
+
+                    return false;
                 }
 
                 if (value == SqlServerValueGenerationStrategy.SequenceHiLo
                     && !IsCompatibleSequenceHiLo(propertyType))
                 {
-                    throw new ArgumentException(SqlServerStrings.SequenceBadType(
-                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    if (ShouldThrowOnInvalidConfiguration)
+                    {
+                        throw new ArgumentException(SqlServerStrings.SequenceBadType(
+                            Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    }
+
+                    return false;
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Metadata\Conventions\Internal\SqlServerIndexConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\SqlServerMemoryOptimizedTablesConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\SqlServerValueGenerationStrategyConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\SqlServerValueGeneratorConvention.cs" />
     <Compile Include="Metadata\Conventions\SqlServerConventionSetBuilder.cs" />
     <Compile Include="Metadata\Internal\SqlServerAnnotationNames.cs" />
     <Compile Include="Metadata\Internal\SqlServerEntityTypeBuilderAnnotations.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
@@ -67,12 +67,17 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
             Check.NotNull(property, nameof(property));
             Check.NotNull(entityType, nameof(entityType));
 
-            return property.ClrType.UnwrapNullableType() == typeof(Guid)
-                ? property.ValueGenerated == ValueGenerated.Never
-                  || property.SqlServer().DefaultValueSql != null
+            var propertyType = property.ClrType.UnwrapNullableType().UnwrapEnumType();
+
+            if (propertyType == typeof(Guid))
+            {
+                return property.ValueGenerated == ValueGenerated.Never
+                  || ShouldGenerateTemporaryValues(property)
                     ? (ValueGenerator)new TemporaryGuidValueGenerator()
-                    : new SequentialGuidValueGenerator()
-                : base.Create(property, entityType);
+                    : new SequentialGuidValueGenerator();
+            }
+
+            return base.Create(property, entityType);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -119,6 +119,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyFieldChangedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(timestampAttributeConvention);
 
+            conventionSet.PropertyAnnotationSetConventions.Add(new ValueGeneratorConvention());
+
             return conventionSet;
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ValueGeneratorConvention : IPropertyAnnotationSetConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Annotation Apply(InternalPropertyBuilder propertyBuilder, string name, Annotation annotation, Annotation oldAnnotation)
+        {
+            if (name == CoreAnnotationNames.ValueGeneratorFactoryAnnotation)
+            {
+                SetRequiresValueGenerator(propertyBuilder, annotation != null);
+            }
+
+            return annotation;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void SetRequiresValueGenerator([NotNull] InternalPropertyBuilder propertyBuilder, bool valueGeneratorFactorySet)
+            => propertyBuilder.RequiresValueGenerator(valueGeneratorFactorySet ? true : (bool?)null, ConfigurationSource.Convention);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -119,7 +119,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             if (HasAnnotation(CoreAnnotationNames.ValueGeneratorFactoryAnnotation, factory, configurationSource))
             {
-                RequiresValueGenerator(factory != null, ConfigurationSource.Convention);
                 return true;
             }
 
@@ -234,10 +233,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool RequiresValueGenerator(bool generateValue, ConfigurationSource configurationSource)
+        public virtual bool RequiresValueGenerator(bool? generateValue, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetRequiresValueGeneratorConfigurationSource())
-                || (Metadata.RequiresValueGenerator == generateValue))
+                || Metadata.RequiresValueGenerator == generateValue)
             {
                 Metadata.SetRequiresValueGenerator(generateValue, configurationSource);
                 return true;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -194,6 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (valueGenerated == null)
             {
                 _valueGeneratedConfigurationSource = null;
+                SetValueGeneratedConfigurationSource(configurationSource);
             }
             else
             {
@@ -209,6 +210,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ConfigurationSource? GetValueGeneratedConfigurationSource() => _valueGeneratedConfigurationSource;
+
+        private void SetValueGeneratedConfigurationSource(ConfigurationSource configurationSource)
+            => _valueGeneratedConfigurationSource = configurationSource;
 
         private void UpdateValueGeneratedConfigurationSource(ConfigurationSource configurationSource)
             => _valueGeneratedConfigurationSource = configurationSource.Max(_valueGeneratedConfigurationSource);
@@ -311,15 +315,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void SetRequiresValueGenerator(bool requiresValueGenerator, ConfigurationSource configurationSource)
+        public virtual void SetRequiresValueGenerator(bool? requiresValueGenerator, ConfigurationSource configurationSource)
         {
-            SetFlag(requiresValueGenerator, PropertyFlags.RequiresValueGenerator);
-            UpdateRequiresValueGeneratorConfigurationSource(configurationSource);
+            if (requiresValueGenerator != null)
+            {
+                SetFlag(requiresValueGenerator.Value, PropertyFlags.RequiresValueGenerator);
+                UpdateRequiresValueGeneratorConfigurationSource(configurationSource);
+            }
+            else
+            {
+                ResetFlag(PropertyFlags.RequiresValueGenerator);
+                SetRequiresValueGeneratorConfigurationSource(null);
+            }
         }
 
         private bool DefaultRequiresValueGenerator
-            => this.IsKey()
-               && !this.IsForeignKey()
+            => !this.IsForeignKey()
                && ValueGenerated == ValueGenerated.OnAdd;
 
         /// <summary>
@@ -327,6 +338,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ConfigurationSource? GetRequiresValueGeneratorConfigurationSource() => _requiresValueGeneratorConfigurationSource;
+
+        private void SetRequiresValueGeneratorConfigurationSource(ConfigurationSource? configurationSource)
+            => _requiresValueGeneratorConfigurationSource = configurationSource;
 
         private void UpdateRequiresValueGeneratorConfigurationSource(ConfigurationSource configurationSource)
             => _requiresValueGeneratorConfigurationSource = configurationSource.Max(_requiresValueGeneratorConfigurationSource);
@@ -461,6 +475,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _flags = (_flags & ~(int)flag) | falseValue;
             }
         }
+
+        private void ResetFlag(PropertyFlags flag)
+            => _flags = _flags & ~(int)flag;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Internal\ReferenceEqualityComparer.cs" />
     <Compile Include="Internal\ServiceProviderCache.cs" />
     <Compile Include="Internal\TypeExtensions.cs" />
+    <Compile Include="Metadata\Conventions\Internal\ValueGeneratorConvention.cs" />
     <Compile Include="Query\Internal\IDetachableContext.cs" />
     <Compile Include="Metadata\Conventions\Internal\IPropertyAnnotationSetConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IIndexAnnotationSetConvention.cs" />

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -73,21 +73,30 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
             if (propertyType == typeof(Guid))
             {
-                return new GuidValueGenerator();
+                return ShouldGenerateTemporaryValues(property)
+                    ? new TemporaryGuidValueGenerator() : new GuidValueGenerator();
             }
 
             if (propertyType == typeof(string))
             {
-                return new StringValueGenerator(generateTemporaryValues: false);
+                return new StringValueGenerator(ShouldGenerateTemporaryValues(property));
             }
 
             if (propertyType == typeof(byte[]))
             {
-                return new BinaryValueGenerator(generateTemporaryValues: false);
+                return new BinaryValueGenerator(ShouldGenerateTemporaryValues(property));
             }
 
             throw new NotSupportedException(
                 CoreStrings.NoValueGenerator(property.Name, property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
         }
+
+        /// <summary>
+        ///     Indicates whether the generated value should be temorary.
+        /// </summary>
+        /// <param name="property"> The property to get the value generator for.</param>
+        /// <returns> Whether the generated value should be temorary. </returns>
+        protected virtual bool ShouldGenerateTemporaryValues([NotNull] IProperty property)
+            => property.IsReadOnlyBeforeSave;
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -168,6 +167,11 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             // In-memory store does not support store generation
         }
 
+        public override void Identity_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            // In-memory store does not support store generation
+        }
+
         public class StoreGeneratedInMemoryFixture : StoreGeneratedFixtureBase
         {
             private const string DatabaseName = "StoreGeneratedTest";
@@ -217,6 +221,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                     {
                         // In-memory store does not support store generationof keys
                         b.Property(e => e.Id).Metadata.IsReadOnlyBeforeSave = false;
+                        b.Property(e => e.AlwaysIdentityReadOnlyBeforeSave).Metadata.IsReadOnlyBeforeSave = false;
+                        b.Property(e => e.IdentityReadOnlyBeforeSave).Metadata.IsReadOnlyBeforeSave = false;
                     });
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -118,8 +118,25 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             var modelBuilder = base.DatabaseGeneratedOption_configures_the_property_correctly();
 
             var identity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntity)).FindProperty(nameof(GeneratedEntity.Identity));
-            Assert.True(identity.RequiresValueGenerator);
             Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, identity.SqlServer().ValueGenerationStrategy);
+
+            return modelBuilder;
+        }
+
+        public override ModelBuilder DatabaseGeneratedOption_Identity_does_not_throw_on_noninteger_properties()
+        {
+            var modelBuilder = base.DatabaseGeneratedOption_Identity_does_not_throw_on_noninteger_properties();
+
+            var entity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntityNonInteger));
+
+            var stringProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.String));
+            Assert.Null(stringProperty.SqlServer().ValueGenerationStrategy);
+
+            var dateTimeProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.DateTime));
+            Assert.Null(dateTimeProperty.SqlServer().ValueGenerationStrategy);
+
+            var guidProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.Guid));
+            Assert.Null(guidProperty.SqlServer().ValueGenerationStrategy);
 
             return modelBuilder;
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -189,6 +189,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             public string Id { get; set; }
             public string TheWalrus { get; set; }
+            public virtual int NumericId { get; set; }
         }
 
         private class EnNum

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -71,7 +71,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     var blogs = context.Blogs.OrderBy(e => e.Id).ToList();
 
                     Assert.Equal(1, blogs[0].Id);
-                    Assert.Equal(2, blogs[1].Id);
+                    Assert.Equal(2, blogs[0].OtherId);
+                    Assert.Equal(3, blogs[1].Id);
+                    Assert.Equal(4, blogs[1].OtherId);
                 }
             }
         }
@@ -84,7 +86,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.ForSqlServerUseSequenceHiLo();
+            {
+                modelBuilder.ForSqlServerUseSequenceHiLo();
+
+                modelBuilder.Entity<Blog>().Property(b => b.OtherId).ValueGeneratedOnAdd();
+            }
         }
 
         [ConditionalFact]
@@ -891,6 +897,7 @@ END");
             public int Id { get; set; }
             public string Name { get; set; }
             public DateTime CreatedOn { get; set; }
+            public int OtherId { get; set; }
         }
 
         public class NullableKeyBlog


### PR DESCRIPTION
Make DatabaseGeneratedOption.Identity only set ValueGenerated to OnAdd
Don't set RequiresValueGenerated when configuring Identity on a property
Add a convention to set RequiresValueGenerated when using Sequence or a custom value generator

Fixes #7010