### PR TITLE
Fix #7073 AfterExecuteCommand tracing is missing the result info.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceAfterMessage.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceAfterMessage.cs
@@ -11,6 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     {
         public DbCommand Command { get; set; }
         public string ExecuteMethod { get; set; }
+        public object Result { get; set; }
         public bool IsAsync { get; set; }
         public Guid InstanceId { get; set; }
         public long Timestamp { get; set; }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnostics.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnostics.cs
@@ -41,6 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             this DiagnosticSource diagnosticSource,
             DbCommand command,
             string executeMethod,
+            object result,
             Guid instanceId,
             long startTimestamp,
             long currentTimestamp,
@@ -54,6 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     {
                         Command = command,
                         ExecuteMethod = executeMethod,
+                        Result = result,
                         InstanceId = instanceId,
                         Timestamp = currentTimestamp,
                         Duration = currentTimestamp - startTimestamp,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -250,6 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 DiagnosticSource.WriteCommandAfter(
                     dbCommand,
                     executeMethod,
+                    result,
                     instanceId,
                     startTimestamp,
                     currentTimestamp);
@@ -368,6 +369,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 DiagnosticSource.WriteCommandAfter(
                     dbCommand,
                     executeMethod,
+                    result,
                     instanceId,
                     startTimestamp,
                     currentTimestamp,


### PR DESCRIPTION
Fix #7073 AfterExecuteCommand tracing is missing the result info. Now the result is added and can be used by applications that need to trace this info.
