### PR TITLE
Fix: #7048 - EF Core 1.1 .ToString() translation causes exception

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -45,6 +45,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void ToString_guid_property_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Select(ct => new { A = ct.GearNickName, B = ct.Id.ToString() });
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+            }
+        }
+        
+        [ConditionalFact]
         public virtual void Include_multiple_one_to_one_and_one_to_many_self_reference()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -131,10 +131,26 @@ select c'
             materializer: (ValueBuffer valueBuffer) => 
             {
                 var3 = new Order()
-                var3.<OrderID>k__BackingField = try { (int) object valueBuffer.get_Item(0) } catch (Exception) { ... } 
-                var3.<CustomerID>k__BackingField = try { (string) object valueBuffer.get_Item(1) } catch (Exception) { ... } 
-                var3.<EmployeeID>k__BackingField = try { (Nullable<int>) object valueBuffer.get_Item(2) } catch (Exception) { ... } 
-                var3.<OrderDate>k__BackingField = try { (Nullable<DateTime>) object valueBuffer.get_Item(3) } catch (Exception) { ... } 
+                var3.<OrderID>k__BackingField = int TryReadValue(
+                    valueBuffer: valueBuffer, 
+                    index: 0, 
+                    property: OrderID
+                )
+                var3.<CustomerID>k__BackingField = string TryReadValue(
+                    valueBuffer: valueBuffer, 
+                    index: 1, 
+                    property: CustomerID
+                )
+                var3.<EmployeeID>k__BackingField = Nullable<int> TryReadValue(
+                    valueBuffer: valueBuffer, 
+                    index: 2, 
+                    property: EmployeeID
+                )
+                var3.<OrderDate>k__BackingField = Nullable<DateTime> TryReadValue(
+                    valueBuffer: valueBuffer, 
+                    index: 3, 
+                    property: OrderDate
+                )
                 return instance
             }
         )


### PR DESCRIPTION
Adding bad data error handling logic to materialization introduced the possibility
of hitting a known expression compiler limitation (as described here: https://github.com/dotnet/corefx/pull/13126).

This change works around the limitation by moving the read-value try-catch to a helper method, thus we no
longer insert a try-catch directly into the output ET.