### PR TITLE
Fix to #7061 - the binary operator Equal is not defined for the types 'System.Nullable`1[System.Boolean]' and 'System.Boolean'

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -2038,6 +2038,21 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Complex_predicate_with_AndAlso_and_nullable_bool_property()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from w in context.Weapons
+                            where w.Id != 50 && !w.Owner.HasSoulPatch
+                            select w;
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2036,6 +2036,19 @@ END",
                 Sql);
         }
 
+        public override void Complex_predicate_with_AndAlso_and_nullable_bool_property()
+        {
+            base.Complex_predicate_with_AndAlso_and_nullable_bool_property();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [w.Owner].[Nickname], [w.Owner].[SquadId], [w.Owner].[AssignedCityName], [w.Owner].[CityOrBirthName], [w.Owner].[Discriminator], [w.Owner].[FullName], [w.Owner].[HasSoulPatch], [w.Owner].[LeaderNickname], [w.Owner].[LeaderSquadId], [w.Owner].[Rank]
+FROM [Weapon] AS [w]
+LEFT JOIN [Gear] AS [w.Owner] ON [w].[OwnerFullName] = [w.Owner].[FullName]
+WHERE ([w].[Id] <> 50) AND ([w.Owner].[HasSoulPatch] = 0)
+ORDER BY [w].[OwnerFullName]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"


### PR DESCRIPTION
Problem was that when we were fixing search conditions on a query, we did not take into account differences in nullability that could be created by those transformations.

e.g.:
myEntity.MyNullableBool (result type is bool?)

would get converted to:
myEntity.MyNullableBool == (bool?)true (result type bool)

If that in turn was a part of a bigger expression, e.g. AndAlso with another bool? expression, that did not have to be converted, then we would produce a type discrepancy which was resulting in an error.

Fix is to adjust types of the Left and Right expressions that we process before reconstructing a binary expression node.