### PR TITLE
Fix to #7112 - Remove redundant call to String.Format() in LogCommand…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalLoggerExtensions.cs
@@ -71,9 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                             var elapsedMilliseconds = DeriveTimespan(startTimestamp, currentTimestamp);
 
                             return RelationalStrings.RelationalLoggerExecutedCommand(
-                                string.Format(
-                                    CultureInfo.InvariantCulture,
-                                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", elapsedMilliseconds)),
+                                string.Format(CultureInfo.InvariantCulture, "{0:N0}", elapsedMilliseconds),
                                 state.Parameters
                                     // Interpolation okay here because value is always a string.
                                     .Select(p => $"{p.Name}={p.FormatParameter()}")


### PR DESCRIPTION
### The fix
Just remove the unnecessary call to String.Format() ...

What a big performance boost ;-) 