### PR TITLE
Fix #7115 - DB query is executed with the parameters of the previous …

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -43,6 +43,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Method_with_constant_queryable_arg()
+        {
+            using (var context = CreateContext())
+            {
+                var count = QueryableArgQuery(context, new [] { "ALFKI" }.AsQueryable()).Count();
+
+                Assert.Equal(1, count);
+
+                count = QueryableArgQuery(context, new [] { "FOO" }.AsQueryable()).Count();
+
+                Assert.Equal(0, count);
+            }
+        }
+
+        private static IQueryable<Customer> QueryableArgQuery(NorthwindContext context, IQueryable<string> ids) 
+            => context.Customers.Where(c => ids.Contains(c.CustomerID));
+
+        [ConditionalFact]
         public void Query_composition_against_ienumerable_set()
         {
             using (var context = CreateContext())

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -91,9 +91,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             if (declaringType == typeof(Queryable)
-                || (declaringType == typeof(EntityFrameworkQueryableExtensions)
-                    && (!methodInfo.IsGenericMethod
-                        || methodInfo.GetGenericMethodDefinition() != EntityFrameworkQueryableExtensions.StringIncludeMethodInfo)))
+                || declaringType == typeof(EntityFrameworkQueryableExtensions)
+                && (!methodInfo.IsGenericMethod
+                    || methodInfo.GetGenericMethodDefinition() != EntityFrameworkQueryableExtensions.StringIncludeMethodInfo))
             {
                 return base.VisitMethodCall(methodCallExpression);
             }
@@ -261,8 +261,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (leftConstantExpression != null)
             {
                 var constantValue = (bool)leftConstantExpression.Value;
-                if ((constantValue && binaryExpression.NodeType == ExpressionType.OrElse)
-                    || (!constantValue && binaryExpression.NodeType == ExpressionType.AndAlso))
+                if (constantValue && binaryExpression.NodeType == ExpressionType.OrElse
+                    || !constantValue && binaryExpression.NodeType == ExpressionType.AndAlso)
                 {
                     return newLeftExpression;
                 }
@@ -274,8 +274,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (rightConstantExpression != null)
             {
                 var constantValue = (bool)rightConstantExpression.Value;
-                if ((constantValue && binaryExpression.NodeType == ExpressionType.OrElse)
-                    || (!constantValue && binaryExpression.NodeType == ExpressionType.AndAlso))
+                if (constantValue && binaryExpression.NodeType == ExpressionType.OrElse
+                    || !constantValue && binaryExpression.NodeType == ExpressionType.AndAlso)
                 {
                     return newRightExpression;
                 }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -420,6 +420,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     return false;
                 }
 
+                if (a.Value is EnumerableQuery
+                    && b.Value is EnumerableQuery)
+                {
+                    return false; // EnumerableQueries are opaque
+                }
+
                 if (a.Value is IQueryable
                     && b.Value is IQueryable
                     && a.Value.GetType() == b.Value.GetType())


### PR DESCRIPTION
- Fixes an issue in ExpressionEqualityComparer where we would incorrectly determine equality for constant EnumerableQuery nodes.