### PR TITLE
Query: Fixes another case of query cache keys leaking context instances (#6737)

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/EntityQueryable`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/EntityQueryable`.cs
@@ -45,6 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         IDetachableContext IDetachableContext.DetachContext()
             => new EntityQueryable<TResult>(_nullAsyncQueryProvider);
 
+        bool IDetachableContext.IsDetached => Provider == _nullAsyncQueryProvider;
+
         private static readonly IAsyncQueryProvider _nullAsyncQueryProvider = new NullAsyncQueryProvider();
 
         private class NullAsyncQueryProvider : IAsyncQueryProvider

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/IDetachableContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/IDetachableContext.cs
@@ -14,5 +14,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         IDetachableContext DetachContext();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        bool IsDetached { get; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -56,6 +56,28 @@ WHERE [e].[EmployeeID] = 1",
                 Sql);
         }
 
+        [Fact]
+        public void Test()
+        {
+            using (var context = CreateContext())
+            {
+                (from c in context.Set<Customer>()
+                 from o in context.Set<Order>()
+                 select new { c, o }).ToList();
+            }
+        }
+
+        [Fact]
+        public void Test2()
+        {
+            using (var context = CreateContext())
+            {
+                (from c in context.Set<Customer>()
+                 from o in context.Set<Order>()
+                 select new { c, o }).ToList();
+            }
+        }
+
         public override void Project_to_int_array()
         {
             base.Project_to_int_array();


### PR DESCRIPTION
Additional case was when context instances are captured in method call expressions (via Set<T>)