### PR TITLE
Add ForSqlServerHasFilter

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
@@ -30,6 +30,22 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Determines whether the specified index has filter expression when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="filterExpression"> The filter expression for the index. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder ForSqlServerHasFilter([NotNull] this IndexBuilder indexBuilder, [CanBeNull] string filterExpression)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+            Check.NullButNotEmpty(filterExpression, nameof(filterExpression));
+
+            indexBuilder.Metadata.SqlServer().Filter = filterExpression;
+
+            return indexBuilder;
+        }
+
+        /// <summary>
         ///     Configures whether the index is clustered when targeting SQL Server.
         /// </summary>
         /// <param name="indexBuilder"> The builder for the index being configured. </param>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -537,6 +537,23 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         }
 
         [Fact]
+        public void Can_set_index_filter()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .HasIndex(e => e.Id)
+                .HasFilter("Generic expression")
+                .ForSqlServerHasFilter("SqlServer-specific expression");
+
+            var index = modelBuilder.Model.FindEntityType(typeof(Customer)).GetIndexes().Single();
+
+            Assert.Equal("Generic expression", index.Relational().Filter);
+            Assert.Equal("SqlServer-specific expression", index.SqlServer().Filter);
+        }
+
+        [Fact]
         public void Can_set_table_name()
         {
             var modelBuilder = CreateConventionModelBuilder();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -406,6 +406,39 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         }
 
         [Fact]
+        public void Can_get_and_set_index_filter()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+
+            var index = modelBuilder
+                .Entity<Customer>()
+                .HasIndex(e => e.Id)
+                .Metadata;
+
+            Assert.Null(index.Relational().Filter);
+            Assert.Null(index.SqlServer().Filter);
+            Assert.Null(((IIndex)index).SqlServer().Filter);
+
+            index.Relational().Name = "Generic expression";
+
+            Assert.Equal("Generic expression", index.Relational().Name);
+            Assert.Equal("Generic expression", index.SqlServer().Name);
+            Assert.Equal("Generic expression", ((IIndex)index).SqlServer().Name);
+
+            index.SqlServer().Name = "SqlServer-specific expression";
+
+            Assert.Equal("Generic expression", index.Relational().Name);
+            Assert.Equal("SqlServer-specific expression", index.SqlServer().Name);
+            Assert.Equal("SqlServer-specific expression", ((IIndex)index).SqlServer().Name);
+
+            index.SqlServer().Name = null;
+
+            Assert.Null(index.Relational().Filter);
+            Assert.Null(index.SqlServer().Filter);
+            Assert.Null(((IIndex)index).SqlServer().Filter);
+        }
+
+        [Fact]
         public void Can_get_and_set_index_clustering()
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());


### PR DESCRIPTION
As filtered index expressions are very likely to be provider-specific.

Closes #7087

Not sure if that's all that needed to add a provider-specific setting? Hope I didn't miss anything...