### PR TITLE
Correctly scaffold generic types

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Design.Tests.Scaffolding.Internal
+{
+    public class CSharpUtilitiesTest
+    {
+        [Theory]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(int?), "int?")]
+        [InlineData(typeof(int[]), "int[]")]
+        [InlineData(typeof(Dictionary<string, List<int>>), "Dictionary<string, List<int>>")]
+        [InlineData(typeof(List<int?>), "List<int?>")]
+        [InlineData(typeof(SomeGenericStruct<int>?), "SomeGenericStruct<int>?")]
+        public void GetTypeName(Type type, string typeName)
+        {
+            Assert.Equal(typeName, new CSharpUtilities().GetTypeName(type));
+        }
+
+        struct SomeGenericStruct<T> {}
+    }
+}


### PR DESCRIPTION
Necessary for PostgreSQL range support, and possibly other.

Also added tests for CSharpUtilities.GetTypeName()