### PR TITLE
Don't throw when SqlServer ValueGenerationStrategy is configured on an incompatible property by a convention

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
@@ -41,6 +41,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected override bool ShouldThrowOnInvalidConfiguration => Annotations.ConfigurationSource == ConfigurationSource.Explicit;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool HasColumnName([CanBeNull] string value) => SetColumnName(value);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -13,8 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public class RelationalPropertyAnnotations : IRelationalPropertyAnnotations
     {
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalPropertyAnnotations([NotNull] IProperty property,
             [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
             : this(new RelationalAnnotations(property), providerFullAnnotationNames)
@@ -28,9 +26,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
 
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
+
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IProperty Property => (IProperty)Annotations.Metadata;
         protected virtual bool ShouldThrowOnConflict => true;
+        protected virtual bool ShouldThrowOnInvalidConfiguration => true;
 
         public virtual string ColumnName
         {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
@@ -28,7 +28,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected new virtual RelationalAnnotationsBuilder Annotations => (RelationalAnnotationsBuilder)base.Annotations;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override bool ShouldThrowOnConflict => false;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override bool ShouldThrowOnInvalidConfiguration => Annotations.ConfigurationSource == ConfigurationSource.Explicit;
 
 #pragma warning disable 109
         /// <summary>
@@ -91,6 +103,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public new virtual bool ValueGenerationStrategy(SqlServerValueGenerationStrategy? value)
         {
+            if (!SetValueGenerationStrategy(value))
+            {
+                return false;
+            }
+
             if (value == null)
             {
                 PropertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
@@ -108,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 PropertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
             }
 
-            return SetValueGenerationStrategy(value);
+            return true;
         }
 #pragma warning restore 109
     }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -124,15 +124,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 if (value == SqlServerValueGenerationStrategy.IdentityColumn
                     && !IsCompatibleIdentityColumn(propertyType))
                 {
-                    throw new ArgumentException(SqlServerStrings.IdentityBadType(
-                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    if (ShouldThrowOnInvalidConfiguration)
+                    {
+                        throw new ArgumentException(SqlServerStrings.IdentityBadType(
+                            Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    }
+
+                    return false;
                 }
 
                 if (value == SqlServerValueGenerationStrategy.SequenceHiLo
                     && !IsCompatibleSequenceHiLo(propertyType))
                 {
-                    throw new ArgumentException(SqlServerStrings.SequenceBadType(
-                        Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    if (ShouldThrowOnInvalidConfiguration)
+                    {
+                        throw new ArgumentException(SqlServerStrings.SequenceBadType(
+                            Property.Name, Property.DeclaringEntityType.DisplayName(), propertyType.ShortDisplayName()));
+                    }
+
+                    return false;
                 }
             }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
@@ -68,6 +70,38 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
 
             Assert.Equal(1, propertyBuilder.Metadata.GetAnnotations().Count(
                 a => a.Name.StartsWith(SqlServerAnnotationNames.Prefix, StringComparison.Ordinal)));
+        }
+
+        [Fact]
+        public void Throws_setting_sequence_generation_for_invalid_type_only_with_explicit()
+        {
+            var propertyBuilder = CreateBuilder()
+                .Entity(typeof(Splot), ConfigurationSource.Convention)
+                .Property("Name", typeof(string), ConfigurationSource.Convention);
+
+            Assert.False(propertyBuilder.SqlServer(ConfigurationSource.Convention)
+                .ValueGenerationStrategy(SqlServerValueGenerationStrategy.SequenceHiLo));
+
+            Assert.Equal(
+                SqlServerStrings.SequenceBadType("Name", nameof(Splot), "string"),
+                Assert.Throws<ArgumentException>(
+                    () => propertyBuilder.SqlServer(ConfigurationSource.Explicit).ValueGenerationStrategy(SqlServerValueGenerationStrategy.SequenceHiLo)).Message);
+        }
+
+        [Fact]
+        public void Throws_setting_identity_generation_for_invalid_type_only_with_explicit()
+        {
+            var propertyBuilder = CreateBuilder()
+                .Entity(typeof(Splot), ConfigurationSource.Convention)
+                .Property("Name", typeof(string), ConfigurationSource.Convention);
+
+            Assert.False(propertyBuilder.SqlServer(ConfigurationSource.Convention)
+                .ValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn));
+
+            Assert.Equal(
+                SqlServerStrings.IdentityBadType("Name", nameof(Splot), "string"),
+                Assert.Throws<ArgumentException>(
+                    () => propertyBuilder.SqlServer(ConfigurationSource.Explicit).ValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn)).Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #7208