### PR TITLE
Update test specification to netstandard1.7

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/TestUtilities/BuildReference.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/TestUtilities/BuildReference.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_7
 using Microsoft.Extensions.DependencyModel;
 using System.Linq;
 #endif
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.Te
 {
     public class BuildReference
     {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_7
         private static readonly DependencyContext DefaultDependencyContext =
             DependencyContext.Load(typeof(BuildReference).GetTypeInfo().Assembly);
 #endif
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests.Te
 
         public static BuildReference ByName(string name, bool copyLocal = false, Assembly depContextAssembly = null)
         {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_7
             var depContext = depContextAssembly == null
                 ? DefaultDependencyContext
                 : DependencyContext.Load(depContextAssembly);

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
@@ -35,7 +35,7 @@
     "NETStandard.Library": "1.6.2-*"
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.7": {
       "dependencies": {
         "System.Threading.Tasks.Parallel": "4.4.0-*"
       }


### PR DESCRIPTION
This ensures references from the netstandard1.7 TFM are resolved by Microsoft.EntityFrameworkCore.Design.FunctionalTests.

