### PR TITLE
Enable TestCases to run from Visual Studio Test Explorer

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Xunit/SkipReasonTestCase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Xunit/SkipReasonTestCase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit
     {
         public SkipXunitTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        {
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkipXunitTestCase()
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Xunit/SkipXunitTheoryTestCase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/TestUtilities/Xunit/SkipXunitTheoryTestCase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -12,6 +13,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit
     {
         public SkipXunitTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
             : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        {
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkipXunitTheoryTestCase()
         {
         }
 


### PR DESCRIPTION
by adding parameterless constructor

fixes #7320