### PR TITLE
Fix handling of setting property to modified on detached Entity (Note: 1.1.1 fix)

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -295,8 +295,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
 
-            if (currentState != EntityState.Modified
-                && currentState != EntityState.Unchanged)
+            if (currentState == EntityState.Added
+                || currentState == EntityState.Deleted)
             {
                 return;
             }
@@ -312,6 +312,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             if (changeState)
             {
                 if (!isModified
+                    && currentState != EntityState.Detached
                     && property.GetOriginalValueIndex() != -1)
                 {
                     SetProperty(property, GetOriginalValue(property), setModified: false);
@@ -319,9 +320,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 _stateData.FlagProperty(propertyIndex, PropertyFlag.TemporaryOrModified, isModified);
             }
 
-            // Don't change entity state if it is Added or Deleted
             if (isModified
-                && currentState == EntityState.Unchanged)
+                && (currentState == EntityState.Unchanged
+                    || currentState == EntityState.Detached))
             {
                 if (changeState)
                 {
@@ -337,7 +338,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     StateManager.Notify.StateChanged(this, currentState, fromQuery: false);
                 }
             }
-            else if (changeState
+            else if (currentState != EntityState.Detached
+                     && changeState
                      && !isModified
                      && !_stateData.AnyPropertiesFlagged(PropertyFlag.TemporaryOrModified))
             {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -583,6 +583,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             // truth and not attempt to ascertain relationships from navigation properties
             if (!fromQuery)
             {
+                var setModified = entry.EntityState != EntityState.Unchanged
+                                  && entry.EntityState != EntityState.Modified;
+
                 foreach (var foreignKey in entityType.GetReferencingForeignKeys())
                 {
                     var principalToDependent = foreignKey.PrincipalToDependent;
@@ -591,7 +594,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         var navigationValue = entry[principalToDependent];
                         if (navigationValue != null)
                         {
-                            var setModified = entry.EntityState != EntityState.Unchanged;
 
                             if (principalToDependent.IsCollection())
                             {
@@ -649,7 +651,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             }
                             else
                             {
-                                FixupToPrincipal(entry, principalEntry, foreignKey, entry.EntityState != EntityState.Unchanged);
+                                FixupToPrincipal(entry, principalEntry, foreignKey, setModified);
                             }
                         }
                     }
@@ -670,7 +672,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (navigationValue != null)
             {
-                var setModified = referencedEntry.EntityState != EntityState.Unchanged;
+                var setModified = referencedEntry.EntityState != EntityState.Unchanged
+                                  && referencedEntry.EntityState != EntityState.Modified;
 
                 if (!navigation.IsDependentToPrincipal())
                 {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/CollectionEntryTest.cs
@@ -342,16 +342,70 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             }
         }
 
-        [Fact]
-        public void IsModified_can_set_fk_to_modified_principal()
+        [Theory]
+        [InlineData(EntityState.Detached, EntityState.Added)]
+        [InlineData(EntityState.Added, EntityState.Added)]
+        [InlineData(EntityState.Modified, EntityState.Added)]
+        [InlineData(EntityState.Deleted, EntityState.Added)]
+        [InlineData(EntityState.Unchanged, EntityState.Added)]
+        [InlineData(EntityState.Detached, EntityState.Deleted)]
+        [InlineData(EntityState.Added, EntityState.Deleted)]
+        [InlineData(EntityState.Modified, EntityState.Deleted)]
+        [InlineData(EntityState.Deleted, EntityState.Deleted)]
+        [InlineData(EntityState.Unchanged, EntityState.Deleted)]
+        public void IsModified_can_set_fk_to_modified_principal_with_Added_or_Deleted_dependents(
+            EntityState principalState, EntityState dependentState)
         {
             using (var context = new FreezerContext())
             {
                 var cherry = new Cherry();
-                var chunky1 = new Chunky { Garcia = cherry };
-                var chunky2 = new Chunky { Garcia = cherry };
+                var chunky1 = new Chunky { Id = 1, Garcia = cherry };
+                var chunky2 = new Chunky { Id = 2, Garcia = cherry };
                 cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
-                context.AttachRange(cherry, chunky1, chunky2);
+
+                context.Entry(cherry).State = principalState;
+                context.Entry(chunky1).State = dependentState;
+                context.Entry(chunky2).State = dependentState;
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.False(collection.IsModified);
+
+                collection.IsModified = true;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+
+                collection.IsModified = false;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+                Assert.Equal(dependentState, context.Entry(chunky1).State);
+                Assert.Equal(dependentState, context.Entry(chunky2).State);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Detached, EntityState.Unchanged)]
+        [InlineData(EntityState.Added, EntityState.Unchanged)]
+        [InlineData(EntityState.Modified, EntityState.Unchanged)]
+        [InlineData(EntityState.Deleted, EntityState.Unchanged)]
+        [InlineData(EntityState.Unchanged, EntityState.Unchanged)]
+        public void IsModified_can_set_fk_to_modified_principal_with_Unchanged_dependents(
+            EntityState principalState, EntityState dependentState)
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Id = 1, Garcia = cherry };
+                var chunky2 = new Chunky { Id = 2, Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+
+                context.Entry(cherry).State = principalState;
+                context.Entry(chunky1).State = dependentState;
+                context.Entry(chunky2).State = dependentState;
 
                 var collection = context.Entry(cherry).Collection(e => e.Monkeys);
 
@@ -368,8 +422,48 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.False(collection.IsModified);
                 Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
                 Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
-                Assert.Equal(EntityState.Unchanged, context.Entry(chunky1).State);
-                Assert.Equal(EntityState.Unchanged, context.Entry(chunky2).State);
+                Assert.Equal(dependentState, context.Entry(chunky1).State);
+                Assert.Equal(dependentState, context.Entry(chunky2).State);
+            }
+        }
+        
+        [Theory]
+        [InlineData(EntityState.Detached, EntityState.Modified)]
+        [InlineData(EntityState.Added, EntityState.Modified)]
+        [InlineData(EntityState.Modified, EntityState.Modified)]
+        [InlineData(EntityState.Deleted, EntityState.Modified)]
+        [InlineData(EntityState.Unchanged, EntityState.Modified)]
+        public void IsModified_can_set_fk_to_modified_principal_with_Modified_dependents(
+            EntityState principalState, EntityState dependentState)
+        {
+            using (var context = new FreezerContext())
+            {
+                var cherry = new Cherry();
+                var chunky1 = new Chunky { Id = 1, Garcia = cherry };
+                var chunky2 = new Chunky { Id = 2, Garcia = cherry };
+                cherry.Monkeys = new List<Chunky> { chunky1, chunky2 };
+
+                context.Entry(cherry).State = principalState;
+                context.Entry(chunky1).State = dependentState;
+                context.Entry(chunky2).State = dependentState;
+
+                var collection = context.Entry(cherry).Collection(e => e.Monkeys);
+
+                Assert.True(collection.IsModified);
+
+                collection.IsModified = false;
+
+                Assert.False(collection.IsModified);
+                Assert.False(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.False(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+
+                collection.IsModified = true;
+
+                Assert.True(collection.IsModified);
+                Assert.True(context.Entry(chunky1).Property(e => e.GarciaId).IsModified);
+                Assert.True(context.Entry(chunky2).Property(e => e.GarciaId).IsModified);
+                Assert.Equal(dependentState, context.Entry(chunky1).State);
+                Assert.Equal(dependentState, context.Entry(chunky2).State);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -1027,6 +1027,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 new SomeEntity { Id = 1, Name = "Kool" },
                 new ValueBuffer(new object[] { 1, "Kool" }));
 
+            entry.SetEntityState(EntityState.Added);
+
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Kool", entry[nameProperty]);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -98,26 +98,53 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_set_and_clear_modified()
+        public void Can_set_and_clear_modified_on_Modified_entity()
         {
             var entity = new Wotty { Id = 1, Primate = "Monkey" };
 
-            var entry = TestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
-
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
-
-            new PropertyEntry(entry, "Primate").IsModified = true;
-
+            var entry = TestHelpers.Instance.CreateInternalEntry(BuildModel(), EntityState.Modified, entity);
             Assert.True(new PropertyEntry(entry, "Primate").IsModified);
 
             new PropertyEntry(entry, "Primate").IsModified = false;
+            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
 
+            new PropertyEntry(entry, "Primate").IsModified = true;
+            Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Deleted)]
+        public void Can_set_and_clear_modified_on_Added_or_Deleted_entity(EntityState initialState)
+        {
+            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(BuildModel(), initialState, entity);
+            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+
+            new PropertyEntry(entry, "Primate").IsModified = true;
+            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+
+            new PropertyEntry(entry, "Primate").IsModified = false;
             Assert.False(new PropertyEntry(entry, "Primate").IsModified);
         }
 
+        [Theory]
+        [InlineData(EntityState.Detached)]
+        [InlineData(EntityState.Unchanged)]
+        public void Can_set_and_clear_modified_on_Unchanged_or_Detached_entity(EntityState initialState)
+        {
+            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+
+            var entry = TestHelpers.Instance.CreateInternalEntry(BuildModel(), initialState, entity);
+            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+
+            new PropertyEntry(entry, "Primate").IsModified = true;
+            Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+
+            new PropertyEntry(entry, "Primate").IsModified = false;
+            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+        }
         [Fact]
         public void Can_reject_changes_when_clearing_modified_flag()
         {


### PR DESCRIPTION
Issue #7227

Ensures that the entity is attached with the property set to modified and that fixup does not inappropriately do more than it should (i.e. marking FK is modified).
