### PR TITLE
Add back ThenInclude for ICollection to fix binary compat break (Note: 1.1.1 fix)

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkQueryableExtensions.cs
@@ -2243,10 +2243,23 @@ namespace Microsoft.EntityFrameworkCore
                     : source);
         }
 
+        internal static readonly MethodInfo ThenIncludeAfterEnumerableMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                .Single(mi =>
+                    {
+                        var typeArgument = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1];
+                        return typeArgument.IsGenericType && typeArgument.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+                    });
+
         internal static readonly MethodInfo ThenIncludeAfterCollectionMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Single(mi => !mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
+                .Single(mi =>
+                    {
+                        var typeArgument = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1];
+                        return typeArgument.IsGenericType && typeArgument.GetGenericTypeDefinition() == typeof(ICollection<>);
+                    });
 
         internal static readonly MethodInfo ThenIncludeAfterReferenceMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
@@ -2298,9 +2311,32 @@ namespace Microsoft.EntityFrameworkCore
                     ? source.Provider.CreateQuery<TEntity>(
                         Expression.Call(
                             null,
-                            ThenIncludeAfterCollectionMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty)),
+                            ThenIncludeAfterEnumerableMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty)),
                             new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
                     : source);
+
+        /// <summary>
+        ///     This method exists only for binary compatibility and is obsolete. Use
+        ///     <see
+        ///         cref="ThenInclude{TEntity,TPreviousProperty,TProperty}(IIncludableQueryable{TEntity,IEnumerable{TPreviousProperty}},Expression{System.Func{TPreviousProperty,TProperty}})" />
+        ///     instead.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
+        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="navigationPropertyPath">
+        ///     A lambda expression representing the navigation property to be included (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns>
+        ///     A new query with the related data included.
+        /// </returns>
+        [Obsolete("Use overload that takes an IEnumerable<> navigation property instead.")]
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            [NotNull] IIncludableQueryable<TEntity, ICollection<TPreviousProperty>> source,
+            [NotNull] Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            where TEntity : class
+            => ThenInclude((IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>>)source, navigationPropertyPath);
 
         /// <summary>
         ///     Specifies additional related data to be further included based on a related type that was just included.

--- a/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
+            EntityFrameworkQueryableExtensions.ThenIncludeAfterEnumerableMethodInfo,
             EntityFrameworkQueryableExtensions.ThenIncludeAfterCollectionMethodInfo,
             EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo
         };


### PR DESCRIPTION
Issue #7116

Method is obsolete and not an extension method since it only needs to be there for binary compat.
