### PR TITLE
Fixes #7230 - Infinite loop in compiled query cache.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/CompiledQueryCache.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/CompiledQueryCache.cs
@@ -65,12 +65,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     goto retry;
                 }
 
-                compiledQuery = compiler();
+                try
+                {
+                    compiledQuery = compiler();
 
-                _memoryCache.Set(cacheKey, compiledQuery);
-
-                object _;
-                _querySyncObjects.TryRemove(cacheKey, out _);
+                    _memoryCache.Set(cacheKey, compiledQuery);
+                }
+                finally
+                {
+                    object _;
+                    _querySyncObjects.TryRemove(cacheKey, out _);
+                }
             }
 
             return compiledQuery;


### PR DESCRIPTION
Ensure we let waiting threads proceed when query compilation fails.

Verified manually as tricky to create a test for.