### PR TITLE
[1.1.1] Only consider navigations to be ambiguous if there's more than one with InversePropertyAttribute.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1492,6 +1492,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)));
         }
 
+        [Fact]
+        public virtual void InversePropertyAttribute_removes_ambiguity_from_the_ambiguous_end()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+            modelBuilder.Ignore<BookLabel>();
+            modelBuilder.Ignore<AnotherBookLabel>();
+            modelBuilder.Ignore<SpecialBookLabel>();
+            modelBuilder.Entity<Book>().Ignore(e => e.AlternateLabel);
+            modelBuilder.Entity<ExtraSpecialBookLabel>();
+
+            Assert.Null(model.FindEntityType(typeof(BookLabel)));
+            Assert.Equal(nameof(Book.Label), model.FindEntityType(typeof(ExtraSpecialBookLabel))
+                .FindNavigation(nameof(ExtraSpecialBookLabel.Book)).FindInverse()?.Name);
+            Assert.Null(model.FindEntityType(typeof(ExtraSpecialBookLabel))
+                .FindNavigation(nameof(ExtraSpecialBookLabel.ExtraSpecialBook)).FindInverse());
+        }
+
         private class Book
         {
             public static readonly PropertyInfo BookdDetailsNavigation = typeof(Book).GetTypeInfo().GetDeclaredProperty("Details");
@@ -1541,6 +1559,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         private class ExtraSpecialBookLabel : SpecialBookLabel
         {
+            public Book ExtraSpecialBook { get; set; }
         }
 
         private class AnotherBookLabel : BookLabel

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -243,6 +243,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private static bool IsAmbiguousInverse(
             EntityType entityType, PropertyInfo navigation, List<Tuple<PropertyInfo, Type>> referencingNavigationsWithAttribute)
         {
+            if (referencingNavigationsWithAttribute.Count == 1)
+            {
+                return false;
+            }
+
             foreach (var referencingTuple in referencingNavigationsWithAttribute)
             {
                 var inverseTargetEntityType = entityType.Model.FindEntityType(referencingTuple.Item2);


### PR DESCRIPTION
Fixes #7266