### PR TITLE
Fix #7293 - Queries fail after upgrading to EF Core 1.1

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -830,10 +830,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 if (QueryCompilationContext.QuerySourceMapping.ContainsMapping(querySource))
                 {
-                    previousMapping.Add(
-                        querySource,
-                        QueryCompilationContext.QuerySourceMapping
-                            .GetExpression(querySource));
+                    previousMapping[querySource] 
+                        = QueryCompilationContext.QuerySourceMapping
+                            .GetExpression(querySource);
 
                     var groupJoinClause = querySource as GroupJoinClause;
 


### PR DESCRIPTION
Corrected a bad assumption in RelationalQueryModelVisitor.SnapshotQuerySourceMappings.
