### PR TITLE
Changing a way we extract MethodInfo to be used for TrimStart and TrimEnd translators

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     public class SqlServerStringTrimEndTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo _trimEnd = typeof(string).GetTypeInfo()
-            .GetDeclaredMethod(nameof(string.TrimEnd));
+            .GetDeclaredMethods(nameof(string.TrimEnd))
+            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     public class SqlServerStringTrimStartTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
-            .GetDeclaredMethod(nameof(string.TrimStart));
+            .GetDeclaredMethods(nameof(string.TrimStart))
+            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     public class SqliteStringTrimEndTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo _trimEnd = typeof(string).GetTypeInfo()
-            .GetDeclaredMethod(nameof(string.TrimEnd));
+            .GetDeclaredMethods(nameof(string.TrimEnd))
+            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     public class SqliteStringTrimStartTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
-            .GetDeclaredMethod(nameof(string.TrimStart));
+            .GetDeclaredMethods(nameof(string.TrimStart))
+            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
+
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
It was relying on only one method with that name being declated (i.e. no overloads), which will break once additional overloads are added.

Fix is to make method selection deterministic.