### PR TITLE
Query: Use discriminator type to create the discriminator constant values

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -89,7 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var firstDiscriminatorValue
                 = Expression.Constant(
-                    _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorValue);
+                    _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorValue,
+                    discriminatorColumn.Type);
 
             var discriminatorPredicate
                 = Expression.Equal(discriminatorColumn, firstDiscriminatorValue);
@@ -142,7 +143,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 var discriminatorValue
                     = Expression.Constant(
-                        _relationalAnnotationProvider.For(concreteEntityType).DiscriminatorValue);
+                        _relationalAnnotationProvider.For(concreteEntityType).DiscriminatorValue,
+                        discriminatorColumn.Type);
 
                 materializer
                     = _entityMaterializerSource

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -305,7 +305,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             var firstDiscriminatorValue
                 = Expression.Constant(
-                    _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorValue);
+                    _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorValue,
+                    discriminatorColumn.Type);
 
             var discriminatorPredicate
                 = Expression.Equal(discriminatorColumn, firstDiscriminatorValue);
@@ -324,7 +325,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     .Select(concreteEntityType
                         => Expression.Constant(
                             _relationalAnnotationProvider
-                                .For(concreteEntityType).DiscriminatorValue))
+                                .For(concreteEntityType).DiscriminatorValue,
+                            discriminatorColumn.Type))
                     .Aggregate(discriminatorPredicate, (current, discriminatorValue) =>
                         Expression.OrElse(
                             Expression.Equal(discriminatorColumn, discriminatorValue),

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -673,7 +673,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         .Select(concreteEntityType =>
                             Expression.Equal(
                                 discriminatorColumn,
-                                Expression.Constant(relationalMetadataExtensionProvider.For(concreteEntityType).DiscriminatorValue)))
+                                Expression.Constant(relationalMetadataExtensionProvider.For(concreteEntityType).DiscriminatorValue, discriminatorColumn.Type)))
                         .Aggregate((current, next) => Expression.OrElse(next, current));
 
                 handlerContext.SelectExpression.Predicate

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1336,7 +1336,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .Select(concreteEntityType =>
                                 Expression.Equal(
                                     discriminatorPropertyExpression,
-                                    Expression.Constant(_relationalAnnotationProvider.For(concreteEntityType).DiscriminatorValue)))
+                                    Expression.Constant(_relationalAnnotationProvider.For(concreteEntityType).DiscriminatorValue, discriminatorPropertyExpression.Type)))
                             .Aggregate((current, next) => Expression.OrElse(next, current));
 
                     return discriminatorPredicate;


### PR DESCRIPTION
Resolves #7359 

Whenever we make comparison of discriminator using `EF.Property` the property expression is generated to be null-able type. If the value is non-nullable type (like int) then it throws exception due to strong typing of `Expression.Equal`. Fix is to create the constant for value of type of the property expression to avoid mis-match.

It surfaces in materializer for shadow properties. For CLR property the `is` operator in predicate would throw exception.