### PR TITLE
[1.1.1] Query: Avoid binding to parent QMV if projection is client side produ…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -716,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             RelationalQueryModelVisitor queryModelVisitor,
             Func<RelationalQueryModelVisitor, AliasExpression> binder)
         {
-            if (queryModelVisitor == null)
+            if (queryModelVisitor == null || queryModelVisitor.RequiresClientProjection)
             {
                 return null;
             }

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        private static IQueryable<Customer> QueryableArgQuery(NorthwindContext context, IQueryable<string> ids) 
+        private static IQueryable<Customer> QueryableArgQuery(NorthwindContext context, IQueryable<string> ids)
             => context.Customers.Where(c => ids.Contains(c.CustomerID));
 
         [ConditionalFact]
@@ -2181,6 +2181,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                         Assert.Equal(l2oObjects, efObjects);
                     });
+        }
+
+        [ConditionalFact]
+        public virtual void Select_nested_collection_multi_level()
+        {
+            using (var context = CreateContext())
+            {
+                var customers = context.Customers
+                    .Where(c => c.CustomerID.StartsWith("A"))
+                    .Select(c => new
+                    {
+                        Orders = c.Orders
+                            .Where(o => o.OrderID < 10500)
+                            .Take(3)
+                            .Select(o => new { Date = o.OrderDate })
+                    })
+                    .ToList();
+
+                Assert.Equal(4, customers.Count);
+                Assert.All(customers, t => Assert.True(t.Orders.Count() <= 3));
+            }
         }
 
         [ConditionalFact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -576,17 +576,17 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID: ALFKI (Size = 450)
+@_outer_CustomerID1: ALFKI (Size = 450)
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID = [o1].[CustomerID]
+WHERE @_outer_CustomerID1 = [o1].[CustomerID]
 
-@_outer_CustomerID: ANATR (Size = 450)
+@_outer_CustomerID1: ANATR (Size = 450)
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID = [o1].[CustomerID]",
+WHERE @_outer_CustomerID1 = [o1].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -596,23 +596,23 @@ ORDER BY [o].[OrderID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID: ALFKI (Size = 450)
+@_outer_CustomerID1: ALFKI (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
 
-@_outer_CustomerID: ANATR (Size = 450)
+@_outer_CustomerID1: ANATR (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID)
+        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -5279,6 +5279,20 @@ SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
+                Sql);
+        }
+
+        public override void Select_nested_collection_multi_level()
+        {
+            base.Select_nested_collection_multi_level();
+
+            Assert.StartsWith(@"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+
+SELECT [o].[CustomerID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10500",
                 Sql);
         }
 


### PR DESCRIPTION
…cing N+1 queries

Resolves #7033 
The issue: We were binding to outermost query even though the query being generated was separate from it due to client side projection.
The fix is to limit traversing parent query model visitor for binding if client side projection is required