### PR TITLE
Fix #7251 - Possible race condition affecting DbContext pooling.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Internal/DbContextPool.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbContextPool.cs
@@ -115,6 +115,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             if (Interlocked.Increment(ref _count) <= _maxSize)
             {
+                ((IDbContextPoolable)context).ResetState();
+
                 _pool.Enqueue(context);
 
                 return true;

--- a/src/Microsoft.EntityFrameworkCore/Internal/IDbContextPoolable.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IDbContextPoolable.cs
@@ -28,5 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         void Resurrect([NotNull] DbContextPoolConfigurationSnapshot configurationSnapshot);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void ResetState();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -42,10 +42,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
         // Using context/service locator here so that the context will be initialized the first time the
         // set is used and services will be obtained from the correctly scoped container when this happens.
         private EntityQueryable<TEntity> EntityQueryable
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _entityQueryable, 
-                this, 
-                internalSet => internalSet.CreateEntityQueryable());
+        {
+            get
+            {
+                _context.CheckDisposed();
+
+                return NonCapturingLazyInitializer.EnsureInitialized(
+                    ref _entityQueryable,
+                    this,
+                    internalSet => internalSet.CreateEntityQueryable());
+            }
+        }
 
         private EntityQueryable<TEntity> CreateEntityQueryable()
         {
@@ -62,7 +69,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override LocalView<TEntity> Local
-            => _localView ?? (_localView = new LocalView<TEntity>(this));
+        {
+            get
+            {
+                _context.CheckDisposed();
+
+                return _localView ?? (_localView = new LocalView<TEntity>(this));
+            }
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             Assert.Null(context3.Database.CurrentTransaction);
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
+        [ConditionalFact]
         public async Task Concurrency_test()
         {
             // This test is for measuring different pooling approaches.
@@ -380,15 +380,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 var currentElapsed = elapsed - lastElapsed;
                 lastElapsed = elapsed;
 
-                _testOutputHelper
+                _testOutputHelper?
                     .WriteLine(
                         $"[{DateTime.Now:HH:mm:ss.fff}] Requests: {_requests}, "
                         + $"RPS: {Math.Round(currentRequests / currentElapsed.TotalSeconds)}");
 
                 if (elapsed > _duration)
                 {
-                    _testOutputHelper.WriteLine("");
-                    _testOutputHelper.WriteLine($"Average RPS: {Math.Round(_requests / elapsed.TotalSeconds)}");
+                    _testOutputHelper?.WriteLine("");
+                    _testOutputHelper?.WriteLine($"Average RPS: {Math.Round(_requests / elapsed.TotalSeconds)}");
 
                     _stopwatch.Stop();
                 }
@@ -396,11 +396,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             // ReSharper disable once FunctionNeverReturns
         }
 
-        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly ITestOutputHelper _testOutputHelper = null;
 
+        // ReSharper disable once UnusedParameter.Local
         public DbContextPoolingTest(ITestOutputHelper testOutputHelper)
         {
-            _testOutputHelper = testOutputHelper;
+            //_testOutputHelper = testOutputHelper;
         }
     }
 }


### PR DESCRIPTION
- Fixed race condition between pool return and context state reset.
- Added missing dispose checks to DbContext. These are helpful for uncovering pooling issues because pooled instances are treated as disposed when not in use.
