### PR TITLE
[1.1.1] Uniquify FK and index names if there's another FK or index with the same name configured explicitly.

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -333,6 +333,22 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         }
 
         [Fact]
+        public virtual void Passes_for_incompatible_foreignKeys_within_hierarchy_when_one_name_configured_explicitly()
+        {
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            var fk1 = modelBuilder.Entity<Cat>().HasOne<Person>().WithMany().HasForeignKey(c => c.Name).HasPrincipalKey(p => p.Name)
+                .OnDelete(DeleteBehavior.Cascade).HasConstraintName("FK_Animal_Person_Name").Metadata;
+            var fk2 = modelBuilder.Entity<Dog>().HasOne<Person>().WithMany().HasForeignKey(d => d.Name).HasPrincipalKey(p => p.Name)
+                .OnDelete(DeleteBehavior.SetNull).Metadata;
+
+            Validate(modelBuilder.Model);
+
+            Assert.Equal("FK_Animal_Person_Name", fk1.Relational().Name);
+            Assert.Equal("FK_Animal_Person_Name0", fk2.Relational().Name);
+        }
+
+        [Fact]
         public virtual void Passes_for_compatible_duplicate_foreignKey_names_within_hierarchy()
         {
             var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
@@ -421,6 +437,20 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                     "{'" + nameof(Cat.Name) + "'}", nameof(Cat),
                     nameof(Animal), "IX_Animal_Name"),
                 modelBuilder.Model);
+        }
+
+        [Fact]
+        public virtual void Passes_for_incompatible_indexes_within_hierarchy_when_one_name_configured_explicitly()
+        {
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            var index1 = modelBuilder.Entity<Cat>().HasIndex(c => c.Name).IsUnique().HasName("IX_Animal_Name").Metadata;
+            var index2 = modelBuilder.Entity<Dog>().HasIndex(d => d.Name).IsUnique(false).Metadata;
+
+            Validate(modelBuilder.Model);
+
+            Assert.Equal("IX_Animal_Name", index1.Relational().Name);
+            Assert.Equal("IX_Animal_Name0", index2.Relational().Name);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Storage\SqlServerRetryingExecutionStrategyTests.cs" />
     <Compile Include="Storage\SqlServerSqlGeneratorTest.cs" />
     <Compile Include="Storage\SqlServerTypeMappingTest.cs" />
+    <Compile Include="TestSqlServerAnnotationProvider.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchFactoryTest.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchTest.cs" />
     <Compile Include="Update\SqlServerUpdateSqlGeneratorTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -48,17 +48,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
-        public virtual void Throws_for_unsupported_data_types()
-        {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
-            modelBuilder.Entity<Cheese>().Property(e => e.Name).HasColumnType("nvarchar");
-
-            Assert.Equal(
-                SqlServerStrings.UnqualifiedDataType("nvarchar"),
-                Assert.Throws<ArgumentException>(() => Validate(modelBuilder.Model)).Message);
-        }
-
-        [Fact]
         public virtual void Detects_duplicate_column_names_within_hierarchy_with_different_unicode()
         {
             var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
@@ -68,6 +57,51 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             VerifyError(RelationalStrings.DuplicateColumnNameDataTypeMismatch(
                 nameof(Cat), nameof(Cat.Breed), nameof(Dog), nameof(Dog.Breed), nameof(Cat.Breed), nameof(Animal), "varchar(max)", "nvarchar(max)"), modelBuilder.Model);
+        }
+
+        [Fact]
+        public virtual void Passes_for_incompatible_foreignKeys_within_hierarchy_when_one_name_configured_explicitly_for_sqlServer()
+        {
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            var fk1 = modelBuilder.Entity<Cat>().HasOne<Person>().WithMany().HasForeignKey(c => c.Name).HasPrincipalKey(p => p.Name)
+                .OnDelete(DeleteBehavior.Cascade).ForSqlServerHasConstraintName("FK_Animal_Person_Name").Metadata;
+            var fk2 = modelBuilder.Entity<Dog>().HasOne<Person>().WithMany().HasForeignKey(d => d.Name).HasPrincipalKey(p => p.Name)
+                .OnDelete(DeleteBehavior.SetNull).Metadata;
+
+            Validate(modelBuilder.Model);
+
+            Assert.Equal("FK_Animal_Person_Name", fk1.Relational().Name);
+            Assert.Equal("FK_Animal_Person_Name", fk1.SqlServer().Name);
+            Assert.Equal("FK_Animal_Person_Name", fk2.Relational().Name);
+            Assert.Equal("FK_Animal_Person_Name0", fk2.SqlServer().Name);
+        }
+
+        [Fact]
+        public virtual void Passes_for_incompatible_indexes_within_hierarchy_when_one_name_configured_explicitly_for_sqlServer()
+        {
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            var index1 = modelBuilder.Entity<Cat>().HasIndex(c => c.Name).IsUnique().ForSqlServerHasName("IX_Animal_Name").Metadata;
+            var index2 = modelBuilder.Entity<Dog>().HasIndex(d => d.Name).IsUnique(false).Metadata;
+
+            Validate(modelBuilder.Model);
+
+            Assert.Equal("IX_Animal_Name", index1.Relational().Name);
+            Assert.Equal("IX_Animal_Name", index1.SqlServer().Name);
+            Assert.Equal("IX_Animal_Name", index2.Relational().Name);
+            Assert.Equal("IX_Animal_Name0", index2.SqlServer().Name);
+        }
+
+        [Fact]
+        public virtual void Throws_for_unsupported_data_types()
+        {
+            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
+            modelBuilder.Entity<Cheese>().Property(e => e.Name).HasColumnType("nvarchar");
+
+            Assert.Equal(
+                SqlServerStrings.UnqualifiedDataType("nvarchar"),
+                Assert.Throws<ArgumentException>(() => Validate(modelBuilder.Model)).Message);
         }
 
         private class Cheese
@@ -83,10 +117,5 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
                     new ListLoggerFactory(Log, l => l == typeof(RelationalModelValidator).FullName)),
                 new TestSqlServerAnnotationProvider(),
                 new SqlServerTypeMapper());
-    }
-
-    public class TestSqlServerAnnotationProvider : TestAnnotationProvider
-    {
-        public override IRelationalPropertyAnnotations For(IProperty property) => new SqlServerPropertyAnnotations(property);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/TestSqlServerAnnotationProvider.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/TestSqlServerAnnotationProvider.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Relational.Tests;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
+{
+    public class TestSqlServerAnnotationProvider : TestAnnotationProvider
+    {
+        public override IRelationalModelAnnotations For(IModel model) => new SqlServerModelAnnotations(model);
+        public override IRelationalPropertyAnnotations For(IProperty property) => new SqlServerPropertyAnnotations(property);
+        public override IRelationalEntityTypeAnnotations For(IEntityType entityType) => new SqlServerEntityTypeAnnotations(entityType);
+        public override IRelationalForeignKeyAnnotations For(IForeignKey foreignKey) => new RelationalForeignKeyAnnotations(foreignKey, SqlServerFullAnnotationNames.Instance);
+        public override IRelationalIndexAnnotations For(IIndex index) => new SqlServerIndexAnnotations(index);
+        public override IRelationalKeyAnnotations For(IKey key) => new SqlServerKeyAnnotations(key);
+    }
+}


### PR DESCRIPTION
This will still result in a validation error if the conflicting name is configured by convention as in this case the uniquification would be dependent on the convention order.

Fixes #7082