### PR TITLE
Change signatures of ExecuteSqlCommand/Async to be more natural to use

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/SqlExecutorTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/SqlExecutorTestBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 var parameter = CreateDbParameter("@CustomerID", "ALFKI");
 
-                Assert.Equal(-1, await context.Database.ExecuteSqlCommandAsync(CustomerOrderHistorySproc, default(CancellationToken), parameter));
+                Assert.Equal(-1, await context.Database.ExecuteSqlCommandAsync(CustomerOrderHistorySproc, parameter));
             }
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(-1, await context.Database.ExecuteSqlCommandAsync(CustomerOrderHistoryWithGeneratedParameterSproc, default(CancellationToken), "ALFKI"));
+                Assert.Equal(-1, await context.Database.ExecuteSqlCommandAsync(CustomerOrderHistoryWithGeneratedParameterSproc, "ALFKI"));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -107,8 +107,17 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this DatabaseFacade databaseFacade,
             [NotNull] string sql,
             [NotNull] params object[] parameters)
+            => ExecuteSqlCommand(databaseFacade, sql, (IEnumerable<object>)parameters);
+
+        // Note that this method doesn't start a transaction hence it doesn't use ExecutionStrategy
+        public static int ExecuteSqlCommand(
+            [NotNull] this DatabaseFacade databaseFacade,
+            [NotNull] string sql,
+            [NotNull] IEnumerable<object> parameters)
         {
             Check.NotNull(databaseFacade, nameof(databaseFacade));
+            Check.NotNull(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
 
             var concurrencyDetector = databaseFacade.GetService<IConcurrencyDetector>();
 
@@ -122,18 +131,34 @@ namespace Microsoft.EntityFrameworkCore
                     .RelationalCommand
                     .ExecuteNonQuery(
                         databaseFacade.GetRelationalService<IRelationalConnection>(),
-                        parameterValues: rawSqlCommand.ParameterValues);
+                        rawSqlCommand.ParameterValues);
             }
         }
+
+        // Note that this method doesn't start a transaction hence it doesn't use ExecutionStrategy
+        public static Task<int> ExecuteSqlCommandAsync(
+            [NotNull] this DatabaseFacade databaseFacade,
+            [NotNull] string sql,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => ExecuteSqlCommandAsync(databaseFacade, sql, Enumerable.Empty<object>(), cancellationToken);
+
+        // Note that this method doesn't start a transaction hence it doesn't use ExecutionStrategy
+        public static Task<int> ExecuteSqlCommandAsync(
+            [NotNull] this DatabaseFacade databaseFacade,
+            [NotNull] string sql,
+            [NotNull] params object[] parameters)
+            => ExecuteSqlCommandAsync(databaseFacade, sql, (IEnumerable<object>)parameters);
 
         // Note that this method doesn't start a transaction hence it doesn't use ExecutionStrategy
         public static async Task<int> ExecuteSqlCommandAsync(
             [NotNull] this DatabaseFacade databaseFacade,
             [NotNull] string sql,
-            CancellationToken cancellationToken = default(CancellationToken),
-            [NotNull] params object[] parameters)
+            [NotNull] IEnumerable<object> parameters,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(databaseFacade, nameof(databaseFacade));
+            Check.NotNull(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
 
             var concurrencyDetector = databaseFacade.GetService<IConcurrencyDetector>();
 
@@ -148,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
                     .ExecuteNonQueryAsync(
                         databaseFacade.GetRelationalService<IRelationalConnection>(),
                         rawSqlCommand.ParameterValues,
-                        cancellationToken: cancellationToken);
+                        cancellationToken);
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRawSqlCommandBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRawSqlCommandBuilder.cs
@@ -32,6 +32,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The newly created command. </returns>
         RawSqlCommand Build(
             [NotNull] string sql,
-            [NotNull] IReadOnlyList<object> parameters);
+            [NotNull] IEnumerable<object> parameters);
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Storage\RawSqlCommandBuilderTest.cs" />
     <Compile Include="Storage\RelationalCommandBuilderTest.cs" />
     <Compile Include="Storage\RelationalCommandTest.cs" />
+    <Compile Include="Storage\RelationalDatabaseFacadeExtensionsTest.cs" />
     <Compile Include="Storage\RelationalParameterBuilderTest.cs" />
     <Compile Include="Storage\RelationalSqlGeneratorTest.cs" />
     <Compile Include="Storage\RelationalTransactionExtensionsTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalDatabaseFacadeExtensionsTest.cs
@@ -1,0 +1,298 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class RelationalDatabaseFacadeExtensionsTest
+    {
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_no_params(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>");
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>");
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object>(), commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_array_of_int_params_as_object(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new object[] { 1, 2 }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", 1, 2);
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", 1, 2);
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1, 2 }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Can_pass_ints_as_params(bool async)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    await context.Database.ExecuteSqlCommandAsync("<Some query>", 1, 2);
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", 1, 2);
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1, 2 }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_mixed_array_of_params(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new object[] { 1, "Cheese" }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", 1, "Cheese");
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", 1, "Cheese");
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1, "Cheese" }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_list_of_int_params_as_object(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new List<object> { 1, 2 }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new List<object> { 1, 2 });
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", new List<object> { 1, 2 });
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1, 2 }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_mixed_list_of_params(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new List<object> { 1, "Pickle" }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new List<object> { 1, "Pickle" });
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", new List<object> { 1, "Pickle" });
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1, "Pickle" }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_single_int_as_object(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new object[] { 1 }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", 1);
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", 1);
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { 1 }, commandBuilder.Parameters);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task Can_pass_single_string(bool async, bool cancellation)
+        {
+            using (var context = new ThudContext())
+            {
+                var commandBuilder = (TestRawSqlCommandBuilder)context.GetService<IRawSqlCommandBuilder>();
+
+                if (async)
+                {
+                    if (cancellation)
+                    {
+                        var cancellationToken = new CancellationToken();
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", new[] { "Branston" }, cancellationToken);
+                    }
+                    else
+                    {
+                        await context.Database.ExecuteSqlCommandAsync("<Some query>", "Branston");
+                    }
+                }
+                else
+                {
+                    context.Database.ExecuteSqlCommand("<Some query>", "Branston");
+                }
+
+                Assert.Equal("<Some query>", commandBuilder.Sql);
+                Assert.Equal(new List<object> { "Branston" }, commandBuilder.Parameters);
+            }
+        }
+
+        private class ThudContext : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddScoped<IRawSqlCommandBuilder, TestRawSqlCommandBuilder>()
+                    .AddSingleton(p => Mock.Of<IRelationalConnection>())
+                    .BuildServiceProvider();
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase();
+        }
+
+        private class TestRawSqlCommandBuilder : IRawSqlCommandBuilder
+        {
+            public string Sql { get; set; }
+            public IEnumerable<object> Parameters { get; set; }
+
+            public IRelationalCommand Build(string sql)
+            {
+                throw new NotImplementedException();
+            }
+
+            public RawSqlCommand Build(string sql, IEnumerable<object> parameters)
+            {
+                Sql = sql;
+                Parameters = parameters;
+
+                return new RawSqlCommand(Mock.Of<IRelationalCommand>(), new Dictionary<string, object>());
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             public IRelationalCommand Build(string sql) => new FakeRelationalCommand(this);
 
-            public RawSqlCommand Build(string sql, IReadOnlyList<object> parameters)
+            public RawSqlCommand Build(string sql, IEnumerable<object> parameters)
                 => new RawSqlCommand(
                     new FakeRelationalCommand(this),
                     new Dictionary<string, object>());


### PR DESCRIPTION
Issue #7100

Allow:
- Async without explicit cancellation token
- Strongly typed arrays/lists
- Not accidentally passing cancellation token as parameter

There is no overload taking `IEnumerable<TParam>` because this results in a single string parameter being passed as `IEnumerbale<char>`. A similar situation still exists for parameters that implement IList of something, but this seems much less likely. Another option would be to add an explicit overload that takes string and revert to IEnumerable, but this would only cover the string case and not any other parameter type that implements IEnumerable.
