### PR TITLE
Materialize shadow properties in derived types properly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -17,6 +18,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     public class BufferedEntityShaper<TEntity> : EntityShaper, IShaper<TEntity>
         where TEntity : class
     {
+        private readonly Dictionary<Type, int []> _typeIndexMap;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -26,9 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [CanBeNull] Dictionary<Type, int[]> typeIndexMap)
             : base(querySource, entityType, trackingQuery, key, materializer)
         {
+            _typeIndexMap = typeIndexMap;
         }
 
         /// <summary>
@@ -49,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 = (TEntity)queryContext.QueryBuffer
                     .GetEntity(
                         Key,
-                        new EntityLoadInfo(valueBuffer, Materializer),
+                        new EntityLoadInfo(valueBuffer, Materializer, _typeIndexMap),
                         queryStateManager: IsTrackingQuery,
                         throwOnNullKey: !AllowNullResult);
 
@@ -66,7 +71,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 EntityType,
                 IsTrackingQuery,
                 Key,
-                Materializer);
+                Materializer,
+                _typeIndexMap);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -78,7 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     EntityType,
                     IsTrackingQuery,
                     Key,
-                    Materializer)
+                    Materializer,
+                    _typeIndexMap)
                 .SetOffset(offset);
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -25,8 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
-            : base(querySource, entityType, trackingQuery, key, materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [CanBeNull] Dictionary<Type,int[]> typeIndexMap)
+            : base(querySource, entityType, trackingQuery, key, materializer, typeIndexMap)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IMaterializerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IMaterializerFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -25,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IEntityType entityType,
             [NotNull] SelectExpression selectExpression,
             [NotNull] Func<IProperty, SelectExpression, int> projectionAdder,
-            [CanBeNull] IQuerySource querySource);
+            [CanBeNull] IQuerySource querySource,
+            [CanBeNull] out Dictionary<Type, int[]> typeIndexMap);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -262,6 +262,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     var oldPredicate = selectExpression.Predicate;
 
+                    Dictionary<Type, int []> _;
                     var materializer
                         = _materializerFactory
                             .CreateMaterializer(
@@ -273,7 +274,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                                        _relationalAnnotationProvider.For(p).ColumnName,
                                                        p,
                                                        joinedTableExpression))) - valueBufferOffset,
-                                querySource: null);
+                                /*querySource:*/ null,
+                                out _);
 
                     if (selectExpression.Predicate != oldPredicate)
                     {
@@ -348,6 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     targetSelectExpression.AddTable(targetTableExpression, createUniqueAlias: false);
 
+                    Dictionary<Type, int[]> _;
                     var materializer
                         = _materializerFactory
                             .CreateMaterializer(
@@ -357,7 +360,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     _relationalAnnotationProvider.For(p).ColumnName,
                                     p,
                                     querySource),
-                                querySource: null);
+                                /*querySource:*/ null,
+                                out _);
 
                     if (canGenerateExists)
                     {

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -48,11 +49,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             IEntityType entityType,
             SelectExpression selectExpression,
             Func<IProperty, SelectExpression, int> projectionAdder,
-            IQuerySource querySource)
+            IQuerySource querySource,
+            out Dictionary<Type, int[]> typeIndexMap)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(selectExpression, nameof(selectExpression));
             Check.NotNull(projectionAdder, nameof(projectionAdder));
+
+            typeIndexMap = null;
 
             var valueBufferParameter
                 = Expression.Parameter(typeof(ValueBuffer), "valueBuffer");
@@ -133,11 +137,24 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 indexMap = new int[concreteEntityType.PropertyCount()];
                 propertyIndex = 0;
+                var shadowPropertyExists = false;
 
                 foreach (var property in concreteEntityType.GetProperties())
                 {
                     indexMap[propertyIndex++]
                         = projectionAdder(property, selectExpression);
+
+                    shadowPropertyExists = shadowPropertyExists || property.IsShadowProperty;
+                }
+
+                if (shadowPropertyExists)
+                {
+                    if (typeIndexMap == null)
+                    {
+                        typeIndexMap = new Dictionary<Type, int[]>();
+                    }
+
+                    typeIndexMap[concreteEntityType.ClrType] = indexMap;
                 }
 
                 var discriminatorValue

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityLoadInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityLoadInfo.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -20,20 +22,25 @@ namespace Microsoft.EntityFrameworkCore.Query
     public struct EntityLoadInfo
     {
         private readonly Func<ValueBuffer, object> _materializer;
+        private readonly Dictionary<Type, int[]> _typeIndexMap;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="EntityLoadInfo" /> struct.
         /// </summary>
         /// <param name="valueBuffer"> The row of data that represents this entity. </param>
         /// <param name="materializer"> The method to materialize the data into an entity instance. </param>
+        /// <param name="typeIndexMap"> Dictionary containing mapping from property indexes to values in ValueBuffer. </param>
         public EntityLoadInfo(
-            ValueBuffer valueBuffer, [NotNull] Func<ValueBuffer, object> materializer)
+            ValueBuffer valueBuffer,
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [CanBeNull] Dictionary<Type, int[]> typeIndexMap = null)
         {
             // hot path
             Debug.Assert(materializer != null);
 
             ValueBuffer = valueBuffer;
             _materializer = materializer;
+            _typeIndexMap = typeIndexMap;
         }
 
         /// <summary>
@@ -46,5 +53,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <returns> The entity instance. </returns>
         public object Materialize() => _materializer(ValueBuffer);
+
+        /// <summary>
+        ///     Creates a new ValueBuffer containing only the values needed for entities of a given type.
+        /// </summary>
+        /// <param name="clrType"> The type of this entity. </param>
+        /// <returns> Updated value buffer. </returns>
+        public ValueBuffer ForType([NotNull] Type clrType)
+        {
+            Check.NotNull(clrType, nameof(clrType));
+
+            if (_typeIndexMap == null || !_typeIndexMap.ContainsKey(clrType))
+            {
+                return ValueBuffer;
+            }
+
+            var indexMap = _typeIndexMap[clrType];
+            var values = new object[indexMap.Length];
+
+            for (var i = 0; i < indexMap.Length; i++)
+            {
+                values[i] = ValueBuffer[indexMap[i]];
+            }
+
+            return new ValueBuffer(values);
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryBuffer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryBuffer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     identityMap.Add(entityLoadInfo.ValueBuffer, entity);
                 }
 
-                _valueBuffers.Add(entity, entityLoadInfo.ValueBuffer);
+                _valueBuffers.Add(entity, entityLoadInfo.ForType(entity.GetType()));
             }
 
             return entity;


### PR DESCRIPTION
Resolves #6986 

The issue:
In inheritance scenario with derived type having shadow properties, when we query the base type, we generate a single query which select columns for all the derived type inclusive of current type. Therefore ValueBuffer contains values for different entity types at specific indexes. The map of which index refers to which property is in relational part of code and it is used when generating CLR entity. Though, Internal entity entry is created to store value of shadow property (which is in core) it is not aware about the complex structure of the ValueBuffer and it assumes that values corresponds to properties of current type only and uses property indexes. This assumption fails if a type has a sibling whose columns appears before. This would read incorrect value for shadow property. If the types/nullability matches then it is data corruption otherwise it throws exception (CastException/NRE).

~~This is one proposed solution, Since we need information about mapping of property indexes to value buffer indexes, we store that data inside value buffer only. When Materializer is called to create clr entity, it will update the value buffer to contain index map in it. Since ValueBuffer is struct, the materializer needs to return a tuple with entity and the updated valuebuffer. (Func with out patameter is invalid syntax). Following changes represents changes required to accommodate the change of return value of the materializer. (changes in actual materializer expression are pending)~~

Feedback?