### PR TITLE
Defensively copy navigation properties during graph attach

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -38,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     if (navigation.IsCollection())
                     {
-                        foreach (var relatedEntity in (IEnumerable)navigationValue)
+                        foreach (var relatedEntity in ((IEnumerable)navigationValue).Cast<object>().ToList())
                         {
                             TraverseGraph(
                                 node.CreateNode(node, stateManager.GetOrCreateEntry(relatedEntity), navigation),
@@ -81,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     if (navigation.IsCollection())
                     {
-                        foreach (var relatedEntity in (IEnumerable)navigationValue)
+                        foreach (var relatedEntity in ((IEnumerable)navigationValue).Cast<object>().ToList())
                         {
                             await TraverseGraphAsync(
                                 node.CreateNode(node, stateManager.GetOrCreateEntry(relatedEntity), navigation),


### PR DESCRIPTION
Issue #7119

The fundamental problem here is that Answer.AuthorId is being used as the FK for two different relationships. The navigation properties for the relationships effectively pointed to different objects during fixup, which caused the FK to change value, resulting in an inconsistent graph. This kind of overlapping FKs will only work if great care is taken with the entities assigned and FK values given, which was not the case in the repro code.

All that being said, the framework should be resilient to modification of navigations while attaching, so defensive copy code has been added to ensure this.
