### PR TITLE
Service dependencies parameter class for RelationalConnection

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/ServiceCollectionRelationalProviderInfrastructure.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/ServiceCollectionRelationalProviderInfrastructure.cs
@@ -87,6 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     .AddScoped<IExpressionFragmentTranslator, RelationalCompositeExpressionFragmentTranslator>()
                     .AddScoped<ISqlTranslatingExpressionVisitorFactory, SqlTranslatingExpressionVisitorFactory>());
 
+            // Add service dependencies parameter classes.
+            // These are added as concrete types because the classes are sealed and the registrations should
+            // not be changed by provider or application code.
+            serviceCollection
+                .TryAdd(new ServiceCollection()
+                    .AddScoped<RelationalConnectionDependencies>());
+
             ServiceCollectionProviderInfrastructure.TryAddDefaultEntityFrameworkServices(serviceCollection);
         }
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -339,6 +339,7 @@
     <Compile Include="Storage\RawSqlCommand.cs" />
     <Compile Include="Storage\RelationalCommandBuilderExtensions.cs" />
     <Compile Include="Storage\RelationalConnection.cs" />
+    <Compile Include="Storage\RelationalConnectionDependencies.cs" />
     <Compile Include="Storage\RelationalDatabase.cs" />
     <Compile Include="Storage\RelationalDatabaseCreator.cs" />
     <Compile Include="Storage\RelationalDataReader.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
@@ -37,21 +37,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private int _openedCount;
         private bool _openedInternally;
         private int? _commandTimeout;
-        private readonly ILogger _logger;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="IRelationalConnection" /> class.
+        ///     Initializes a new instance of the <see cref="RelationalConnection" /> class.
         /// </summary>
-        /// <param name="options"> The options for the context that this connection will be used with. </param>
-        /// <param name="logger"> The logger to write to. </param>
-        protected RelationalConnection([NotNull] IDbContextOptions options, [NotNull] ILogger logger)
+        /// <param name="dependencies">Parameter object containing dependencies for this service. </param>
+        protected RelationalConnection([NotNull] RelationalConnectionDependencies dependencies)
         {
-            Check.NotNull(options, nameof(options));
-            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(dependencies, nameof(dependencies));
 
-            _logger = logger;
+            Dependencies = dependencies;
 
-            var relationalOptions = RelationalOptionsExtension.Extract(options);
+            var relationalOptions = RelationalOptionsExtension.Extract(dependencies.ContextOptions);
 
             _commandTimeout = relationalOptions.CommandTimeout;
 
@@ -78,6 +75,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Parameter object containing service dependencies.
+        /// </summary>
+        protected virtual RelationalConnectionDependencies Dependencies { get; }
+
+        /// <summary>
         ///     Creates a <see cref="DbConnection" /> to the database.
         /// </summary>
         /// <returns> The connection. </returns>
@@ -86,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the logger to write to.
         /// </summary>
-        protected virtual ILogger Logger => _logger;
+        protected virtual ILogger Logger => Dependencies.Logger;
 
         /// <summary>
         ///     Gets the connection string for the database.
@@ -112,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             set
             {
                 if (value.HasValue
-                    && (value < 0))
+                    && value < 0)
                 {
                     throw new ArgumentException(RelationalStrings.InvalidCommandTimeout);
                 }
@@ -182,9 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private IDbContextTransaction BeginTransactionWithNoPreconditions(IsolationLevel isolationLevel)
         {
-            Check.NotNull(_logger, nameof(_logger));
-
-            _logger.LogDebug(
+            Logger.LogDebug(
                 RelationalEventId.BeginningTransaction,
                 isolationLevel,
                 il => RelationalStrings.RelationalLoggerBeginningTransaction(il.ToString("G")));
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 = new RelationalTransaction(
                     this,
                     DbConnection.BeginTransaction(isolationLevel),
-                    _logger,
+                    Logger,
                     transactionOwned: true);
 
             return CurrentTransaction;
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
                 Open();
 
-                CurrentTransaction = new RelationalTransaction(this, transaction, _logger, transactionOwned: false);
+                CurrentTransaction = new RelationalTransaction(this, transaction, Logger, transactionOwned: false);
             }
 
             return CurrentTransaction;
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             if (_connection.Value.State != ConnectionState.Open)
             {
-                _logger.LogDebug(
+                Logger.LogDebug(
                     RelationalEventId.OpeningConnection,
                     new
                     {
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             if (_connection.Value.State != ConnectionState.Open)
             {
-                _logger.LogDebug(
+                Logger.LogDebug(
                     RelationalEventId.OpeningConnection,
                     new
                     {
@@ -360,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 if (_connection.Value.State != ConnectionState.Closed)
                 {
-                    _logger.LogDebug(
+                    Logger.LogDebug(
                         RelationalEventId.ClosingConnection,
                         new
                         {
@@ -388,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual IValueBufferCursor ActiveCursor { get; set; }
 
         void IResettableService.Reset() => Dispose();
-        
+
         /// <summary>
         ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         Service dependencies parameter class for <see cref="RelationalConnection" />
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public sealed class RelationalConnectionDependencies
+    {
+        /// <summary>
+        ///     <para>
+        ///         Creates the service dependencies parameter object for a <see cref="RelationalConnection" />.
+        ///     </para>
+        ///     <para>
+        ///         Do not call this constructor directly from provider or application code as it may change
+        ///         as new dependencies are added. Use the 'With...' methods instead.
+        ///     </para>
+        /// </summary>
+        /// <param name="contextOptions"> The options for the current context instance. </param>
+        /// <param name="logger"> The logger to write to. </param>
+        public RelationalConnectionDependencies(
+            [NotNull] IDbContextOptions contextOptions,
+            [NotNull] ILogger<IRelationalConnection> logger)
+        {
+            Check.NotNull(contextOptions, nameof(contextOptions));
+            Check.NotNull(logger, nameof(logger));
+
+            ContextOptions = contextOptions;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     The options for the current context instance.
+        /// </summary>
+        public IDbContextOptions ContextOptions { get; }
+
+        /// <summary>
+        ///     The logger to write to.
+        /// </summary>
+        public ILogger<IRelationalConnection> Logger { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="contextOptions">
+        ///     A replacement for the current dependency of this type.
+        /// </param>
+        /// <returns></returns>
+        public RelationalConnectionDependencies With([NotNull] IDbContextOptions contextOptions)
+            => new RelationalConnectionDependencies(Check.NotNull(contextOptions, nameof(contextOptions)), Logger);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="logger">
+        ///     A replacement for the current dependency of this type.
+        /// </param>
+        /// <returns></returns>
+        public RelationalConnectionDependencies With([NotNull] ILogger<IRelationalConnection> logger)
+            => new RelationalConnectionDependencies(ContextOptions, Check.NotNull(logger, nameof(logger)));
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -14,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvi
         private readonly List<FakeDbConnection> _dbConnections = new List<FakeDbConnection>();
 
         public FakeRelationalConnection(IDbContextOptions options)
-            : base(options, new Logger<FakeRelationalConnection>(new LoggerFactory()))
+            : base(new RelationalConnectionDependencies(
+                options,
+                new Logger<FakeRelationalConnection>(new LoggerFactory())))
         {
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
@@ -7,11 +7,9 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
@@ -19,8 +17,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
     {
         private readonly ISqlServerConnection _realConnection;
 
-        public TestSqlServerConnection(IDbContextOptions options, ILogger<SqlServerConnection> logger)
-            : this(new SqlServerConnection(options, logger))
+        public TestSqlServerConnection(RelationalConnectionDependencies dependencies)
+            : this(new SqlServerConnection(dependencies))
         {
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             private readonly ILoggerFactory _loggerFactory;
 
             public FakeSqlServerConnection(IDbContextOptions options, ILoggerFactory loggerFactory)
-                : base(options, new Logger<SqlServerConnection>(loggerFactory))
+                : base(new RelationalConnectionDependencies(options, new Logger<SqlServerConnection>(loggerFactory)))
             {
                 _options = options;
                 _loggerFactory = loggerFactory;


### PR DESCRIPTION
This is a proof-of-concept implementation of parameter objects for service dependencies. Issue #7465.

Notes:
- Parameter class is sealed.
- Ended up going with Clone on the parameters object--cleaner than other things I tried, and general purpose. We can add overloads of Clone as needed when doing point releases without breaking existing code. (May want to consider whether parameter should be options.)
- Registration is not try-add and is of concrete class