### PR TITLE
Proof-of-concept for re-writing ServiceCollection.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Internal/IServiceInjectionSite.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IServiceInjectionSite.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IServiceInjectionSite
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void InjectServices([NotNull] IServiceProvider serviceProvider);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -152,6 +152,7 @@
     <Compile Include="ChangeTracking\ReferenceEntry`.cs" />
     <Compile Include="EF.CompileAsyncQuery.cs" />
     <Compile Include="Infrastructure\IResettableService.cs" />
+    <Compile Include="Internal\IServiceInjectionSite.cs" />
     <Compile Include="Metadata\Internal\IndexExtensions.cs" />
     <Compile Include="Metadata\Conventions\Internal\NullConventionSetBuilder.cs" />
     <Compile Include="Query\AsyncEnumerable.cs" />

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.ValueGeneration
 {
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    public class ValueGeneratorSelector : IValueGeneratorSelector
+    public class ValueGeneratorSelector : IValueGeneratorSelector, IServiceInjectionSite
     {
         /// <summary>
         ///     The cache being used to store value generator instances.
@@ -37,6 +38,13 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
             Cache = cache;
         }
+
+        /// <summary>
+        /// </summary>
+        public virtual DbContext Context { get; private set; }
+
+        void IServiceInjectionSite.InjectServices(IServiceProvider serviceProvider) 
+            => Context = serviceProvider.GetService<ICurrentDbContext>().Context;
 
         /// <summary>
         ///     Selects the appropriate value generator for a given property.


### PR DESCRIPTION
This is an idea @anpete had to re-write the service collection in the equivalent of AddEntityFramework so that in cases where we need to inject a new service we can do so. This is working, but the problem is that it only works if the service has been registered as a concrete type by the provider. If it is registered as an object or delegete, then we don't have a type that we can use to re-register the original registration before overwriting the current one with our delegate. Thoughts? @anpete @AndriySvyryd @divega 
