### PR TITLE
[1.1.1] Fix to #7289 - Query : Compilation error for queries with optional navigation, client side method and parameter

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -2159,6 +2159,24 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Client_side_equality_with_parameter_works_with_optional_navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var prm = "Marcus's Tag";
+                var query = context.Gears.Where(g => ClientEquals(g.Tag.Note, prm));
+
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Marcus", result[0].Nickname);
+            }
+        }
+
+        private static bool ClientEquals(string first, string second)
+            => first == second;
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses.Expressions;
@@ -75,6 +77,31 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             return node;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitExtension(Expression node)
+        {
+            var nullConditionalExpression = node as NullConditionalExpression;
+            if (nullConditionalExpression != null)
+            {
+                var newNullableCaller = Visit(nullConditionalExpression.NullableCaller);
+                var newCaller = Visit(nullConditionalExpression.Caller);
+                var newAccessOperation = Visit(nullConditionalExpression.AccessOperation);
+
+                return newNullableCaller != nullConditionalExpression.NullableCaller
+                    || newCaller != nullConditionalExpression.Caller
+                    || newAccessOperation != nullConditionalExpression.AccessOperation
+                    ? new NullConditionalExpression(newNullableCaller, newCaller, newAccessOperation)
+                    : node;
+            }
+
+            Debug.Assert(false, "Unexpected extension expression: " + node);
+
+            return base.VisitExtension(node);
         }
 
         /// <summary>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2160,6 +2160,19 @@ ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
         }
 
+        public override void Client_side_equality_with_parameter_works_with_optional_navigations()
+        {
+            base.Client_side_equality_with_parameter_works_with_optional_navigations();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
+FROM [Gear] AS [g]
+LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"


### PR DESCRIPTION
Problem was that DefaultQueryExpressionVisitor was not visiting extension expressions. During optional navigations we introduced NullConditional expressions to protect against null references - fix is to visit this expression as well.