### PR TITLE
Update IRelationalConnection to return status of Open/Close calls

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalConnection.cs
@@ -44,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Opens the connection to the database.
         /// </summary>
-        void Open();
+        /// <returns> True if the underlying connection was actually opened; false otherwise. </returns>
+        bool Open();
 
         /// <summary>
         ///     Asynchronously opens the connection to the database.
@@ -52,13 +53,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
         /// </param>
-        /// <returns> A task that represents the asynchronous operation. </returns>
-        Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken));
+        /// <returns>
+        ///     A task that represents the asynchronous operation, with a value of true if the connection
+        ///     was actually opened.
+        /// </returns>
+        Task<bool> OpenAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     Closes the connection to the database.
         /// </summary>
-        void Close();
+        /// <returns> True if the underlying connection was actually closed; false otherwise. </returns>
+        bool Close();
 
         /// <summary>
         ///     Gets a value indicating whether the multiple active result sets feature is enabled.

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalConnection.cs
@@ -268,7 +268,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Opens the connection to the database.
         /// </summary>
-        public virtual void Open()
+        /// <returns> True if the underlying connection was actually opened; false otherwise. </returns>
+        public virtual bool Open()
         {
             CheckForAmbientTransactions();
 
@@ -276,6 +277,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 _connection.Value.Close();
             }
+
+            var wasOpened = false;
 
             if (_connection.Value.State != ConnectionState.Open)
             {
@@ -302,6 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 try
                 {
                     _connection.Value.Open();
+                    wasOpened = true;
 
                     var currentTimestamp = Stopwatch.GetTimestamp();
                     DiagnosticSource.WriteConnectionOpened(_connection.Value, 
@@ -334,6 +338,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 _openedCount++;
             }
+
+            return wasOpened;
         }
 
         /// <summary>
@@ -342,8 +348,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
         /// </param>
-        /// <returns> A task that represents the asynchronous operation. </returns>
-        public virtual async Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+        /// <returns>
+        ///     A task that represents the asynchronous operation, with a value of true if the connection
+        ///     was actually opened.
+        /// </returns>
+        public virtual async Task<bool> OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             CheckForAmbientTransactions();
 
@@ -351,6 +360,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 _connection.Value.Close();
             }
+
+            var wasOpened = false;
 
             if (_connection.Value.State != ConnectionState.Open)
             {
@@ -377,6 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 try
                 {
                     await _connection.Value.OpenAsync(cancellationToken);
+                    wasOpened = true;
 
                     var currentTimestamp = Stopwatch.GetTimestamp();
                     DiagnosticSource.WriteConnectionOpened(_connection.Value,
@@ -409,6 +421,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 _openedCount++;
             }
+
+            return wasOpened;
         }
 
         private void CheckForAmbientTransactions()
@@ -426,8 +440,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Closes the connection to the database.
         /// </summary>
-        public virtual void Close()
+        /// <returns> True if the underlying connection was actually closed; false otherwise. </returns>
+        public virtual bool Close()
         {
+            var wasClosed = false;
+
             if (_openedCount > 0
                 && --_openedCount == 0
                 && _openedInternally)
@@ -457,6 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     try
                     {
                         _connection.Value.Close();
+                        wasClosed = true;
 
                         var currentTimestamp = Stopwatch.GetTimestamp();
                         DiagnosticSource.WriteConnectionClosed(_connection.Value,
@@ -481,6 +499,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 }
                 _openedInternally = false;
             }
+
+            return wasClosed;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Storage/Internal/SqliteRelationalConnection.cs
@@ -20,7 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     {
         private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
         private readonly bool _enforceForeignKeys = true;
-        private int _openedCount;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -58,43 +57,30 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override void Open()
+        public override bool Open()
         {
-            base.Open();
-
-            _openedCount++;
-
-            if (_openedCount == 1)
+            if (base.Open())
             {
                 EnableForeignKeys();
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override async Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<bool> OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await base.OpenAsync(cancellationToken);
-
-            _openedCount++;
-
-            if (_openedCount == 1)
+            if (await base.OpenAsync(cancellationToken))
             {
                 EnableForeignKeys();
+                return true;
             }
-        }
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override void Close()
-        {
-            base.Close();
-
-            _openedCount--;
+            return false;
         }
 
         private void EnableForeignKeys()

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
@@ -154,34 +154,34 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             {
                 Assert.Equal(0, connection.DbConnections.Count);
 
-                connection.Open();
+                Assert.True(connection.Open());
 
                 Assert.Equal(1, connection.DbConnections.Count);
 
                 var dbConnection = connection.DbConnections[0];
                 Assert.Equal(1, dbConnection.OpenCount);
 
-                connection.Open();
-                connection.Open();
+                Assert.False(connection.Open());
+                Assert.False(connection.Open());
 
                 Assert.Equal(1, dbConnection.OpenCount);
 
-                connection.Close();
-                connection.Close();
+                Assert.False(connection.Close());
+                Assert.False(connection.Close());
 
                 Assert.Equal(1, dbConnection.OpenCount);
                 Assert.Equal(0, dbConnection.CloseCount);
 
-                connection.Close();
+                Assert.True(connection.Close());
 
                 Assert.Equal(1, dbConnection.OpenCount);
                 Assert.Equal(1, dbConnection.CloseCount);
 
-                connection.Open();
+                Assert.True(connection.Open());
 
                 Assert.Equal(2, dbConnection.OpenCount);
 
-                connection.Close();
+                Assert.True(connection.Close());
 
                 Assert.Equal(2, dbConnection.OpenCount);
                 Assert.Equal(2, dbConnection.CloseCount);
@@ -197,34 +197,34 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
                 Assert.Equal(0, connection.DbConnections.Count);
 
                 var cancellationToken = new CancellationTokenSource().Token;
-                await connection.OpenAsync(cancellationToken);
+                Assert.True(await connection.OpenAsync(cancellationToken));
 
                 Assert.Equal(1, connection.DbConnections.Count);
 
                 var dbConnection = connection.DbConnections[0];
                 Assert.Equal(1, dbConnection.OpenAsyncCount);
 
-                await connection.OpenAsync(cancellationToken);
-                await connection.OpenAsync(cancellationToken);
+                Assert.False(await connection.OpenAsync(cancellationToken));
+                Assert.False(await connection.OpenAsync(cancellationToken));
 
                 Assert.Equal(1, dbConnection.OpenAsyncCount);
 
-                connection.Close();
-                connection.Close();
+                Assert.False(connection.Close());
+                Assert.False(connection.Close());
 
                 Assert.Equal(1, dbConnection.OpenAsyncCount);
                 Assert.Equal(0, dbConnection.CloseCount);
 
-                connection.Close();
+                Assert.True(connection.Close());
 
                 Assert.Equal(1, dbConnection.OpenAsyncCount);
                 Assert.Equal(1, dbConnection.CloseCount);
 
-                await connection.OpenAsync(cancellationToken);
+                Assert.True(await connection.OpenAsync(cancellationToken));
 
                 Assert.Equal(2, dbConnection.OpenAsyncCount);
 
-                connection.Close();
+                Assert.True(connection.Close());
 
                 Assert.Equal(2, dbConnection.OpenAsyncCount);
                 Assert.Equal(2, dbConnection.CloseCount);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/Utilities/TestSqlServerConnection.cs
@@ -54,14 +54,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 
         public virtual bool IsMultipleActiveResultSetsEnabled => _realConnection.IsMultipleActiveResultSetsEnabled;
 
-        public virtual void Open()
+        public virtual bool Open()
         {
             PreOpen();
 
-            _realConnection.Open();
+            return _realConnection.Open();
         }
 
-        public virtual Task OpenAsync(CancellationToken cancellationToken = new CancellationToken())
+        public virtual Task<bool> OpenAsync(CancellationToken cancellationToken = new CancellationToken())
         {
             PreOpen();
 
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
             }
         }
 
-        public virtual void Close() => _realConnection.Close();
+        public virtual bool Close() => _realConnection.Close();
 
         public virtual IDbContextTransaction BeginTransaction()
             => BeginTransaction(IsolationLevel.Unspecified);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -167,22 +167,24 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             public int FailAfter { get; set; }
             public int OpenCount { get; set; }
 
-            public override void Open()
+            public override bool Open()
             {
                 if (++OpenCount < FailAfter)
                 {
                     throw SqlExceptionFactory.CreateSqlException(ErrorNumber);
                 }
+
+                return true;
             }
 
-            public override Task OpenAsync(CancellationToken cancellationToken = new CancellationToken())
+            public override Task<bool> OpenAsync(CancellationToken cancellationToken = new CancellationToken())
             {
                 if (++OpenCount < FailAfter)
                 {
                     throw SqlExceptionFactory.CreateSqlException(ErrorNumber);
                 }
 
-                return Task.FromResult(0);
+                return Task.FromResult(true);
             }
 
             public override ISqlServerConnection CreateMasterConnection() => new FakeSqlServerConnection(_options, _loggerFactory, Dependencies.DiagnosticSource);


### PR DESCRIPTION
Issue #7527

Removes the reference counting logic from SqliteRelationalConnection and instead uses information from the base implementation to determine if a connection was actually opened and therefore whether or not the pragma to enable FKs needs to be sent.
