### PR TITLE
Test: Use named in-memory database for the test which requires clean database

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -454,7 +454,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public DbSet<Question> Questions { get; set; }
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder.UseInMemoryDatabase();
+                => optionsBuilder.UseInMemoryDatabase(databaseName: "issue7119");
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -3642,7 +3642,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal(OneToOnePrincipalEntity.EntityMatchingProperty.Name, fk.Properties.Single().Name);
             }
 
-            [ConditionalFact(Skip = "Test is flaky due to concurrency issue.")] //TODO: Issue#7531
+            [Fact]
             public virtual void Can_use_self_referencing_overlapping_FK_PK()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
resolves #7531 