### PR TITLE
Don't throw on referenced shadow primary key.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/CoreModelValidator.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/CoreModelValidator.cs
@@ -70,7 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     {
                         var referencingFk = key.GetReferencingForeignKeys().FirstOrDefault();
                         var conventionalKey = key as Key;
-                        if (referencingFk != null
+                        if (!key.IsPrimaryKey()
+                            && referencingFk != null
                             && conventionalKey != null
                             && ConfigurationSource.Convention.Overrides(conventionalKey.GetConfigurationSource()))
                         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -72,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.KeyRemovedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.KeyRemovedConventions.Add(foreignKeyIndexConvention);
+            conventionSet.KeyRemovedConventions.Add(keyDiscoveryConvention);
 
             var cascadeDeleteConvention = new CascadeDeleteConvention();
             conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAttributeConvention());

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -16,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class KeyDiscoveryConvention
-        : IEntityTypeConvention, IPropertyConvention, IBaseTypeConvention, IPropertyFieldChangedConvention
+        : IEntityTypeConvention, IPropertyConvention, IKeyRemovedConvention, IBaseTypeConvention, IPropertyFieldChangedConvention
     {
         private const string KeySuffix = "Id";
 
@@ -30,15 +31,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = entityTypeBuilder.Metadata;
 
             if (entityType.BaseType == null
-                && entityType.FindPrimaryKey() == null)
+                && ConfigurationSource.Convention.Overrides(entityType.GetPrimaryKeyConfigurationSource()))
             {
                 var candidateProperties = entityType.GetProperties().Where(p =>
                     !p.IsShadowProperty
                     || !ConfigurationSource.Convention.Overrides(p.GetConfigurationSource())).ToList();
-                var keyProperties = DiscoverKeyProperties(entityType, candidateProperties);
-                if (keyProperties.Count != 0)
+                var keyProperties = DiscoverKeyProperties(entityType, candidateProperties).Select(p => p.Name).ToList();
+                if (keyProperties.Count > 1)
                 {
-                    entityTypeBuilder.PrimaryKey(keyProperties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+                    //TODO - log using Strings.MultiplePropertiesMatchedAsKeys()
+                    return entityTypeBuilder;
+                }
+
+                if (keyProperties.Count > 0)
+                {
+                    entityTypeBuilder.PrimaryKey(keyProperties, ConfigurationSource.Convention);
                 }
             }
 
@@ -49,24 +56,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IReadOnlyList<Property> DiscoverKeyProperties([NotNull] EntityType entityType, [NotNull] IReadOnlyList<Property> candidateProperties)
+        public virtual IEnumerable<Property> DiscoverKeyProperties([NotNull] EntityType entityType, [NotNull] IReadOnlyList<Property> candidateProperties)
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            var keyProperties = candidateProperties.Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            if (keyProperties.Count == 0)
+            var keyProperties = candidateProperties.Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase));
+            if (!keyProperties.Any())
             {
+                var entityTypeName = entityType.DisplayName();
                 keyProperties = candidateProperties.Where(
-                    p => string.Equals(p.Name, entityType.DisplayName() + KeySuffix, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-            }
-
-            if (keyProperties.Count > 1)
-            {
-                //TODO - add in logging using resource Strings.MultiplePropertiesMatchedAsKeys()
-                return new Property[0];
+                    p => p.Name.Length == entityTypeName.Length + KeySuffix.Length
+                         && p.Name.StartsWith(entityTypeName, StringComparison.OrdinalIgnoreCase)
+                         && p.Name.EndsWith(KeySuffix, StringComparison.OrdinalIgnoreCase));
             }
 
             return keyProperties;
@@ -100,6 +101,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Apply(propertyBuilder);
             return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Apply(InternalEntityTypeBuilder entityTypeBuilder, Key key)
+        {
+            if (entityTypeBuilder.Metadata.FindPrimaryKey() == null)
+            {
+                Apply(entityTypeBuilder);
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
@@ -31,21 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         }
 
         [Fact]
-        public void Composite_primary_key_is_set_when_multiple_key_properties()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-            var convention = new Mock<KeyDiscoveryConvention> { CallBase = true };
-            convention.Setup(c => c.DiscoverKeyProperties(It.IsAny<EntityType>(), It.IsAny<IReadOnlyList<Property>>()))
-                .Returns<EntityType, IReadOnlyList<Property>>((t, properties) => t.GetProperties().ToList());
-
-            Assert.Same(entityBuilder, convention.Object.Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.FindPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
-        }
-
-        [Fact]
         public void Primary_key_is_set_when_shadow_property_not_defined_by_convention_matches()
         {
             var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -44,6 +44,33 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
+            public virtual void Entity_key_on_shadow_property_is_discovered_by_convention()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<Order>().Property<int>("Id");
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(Order));
+
+                modelBuilder.Validate();
+                Assert.Equal("Id", entity.FindPrimaryKey().Properties.Single().Name);
+            }
+
+            [Fact]
+            public virtual void Entity_key_on_secondary_property_is_discovered_by_convention_when_first_ignored()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<SelfRef>()
+                    .Ignore(s => s.SelfRef1)
+                    .Ignore(s => s.SelfRef2)
+                    .Ignore(s => s.Id);
+
+                modelBuilder.Validate();
+                var entity = modelBuilder.Model.FindEntityType(typeof(SelfRef));
+                Assert.Equal(nameof(SelfRef.SelfRefId), entity.FindPrimaryKey().Properties.Single().Name);
+            }
+
+            [Fact]
             public virtual void Can_set_entity_key_from_property_name_when_no_clr_property()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Rediscover primary key if the matched property is ignored.

Fixes #7377