### PR TITLE
Fix some pluralisation issues in method comments

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/DbSet`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbSet`.cs
@@ -286,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Begins tracking the given entity in the <see cref="EntityState.Deleted" /> state such that it will
+        ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will
         ///     be removed from the database when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <remarks>
@@ -389,7 +389,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Begins tracking the given entity in the <see cref="EntityState.Deleted" /> state such that it will
+        ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will
         ///     be removed from the database when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Simple change to fix pluralisation issues on the XML comments of 2 `*Range` methods 