### PR TITLE
Stop using '==' operator for reflection object comparisons.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/ContainsTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/ContainsTranslator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 _logger?.LogWarning(
                     RelationalEventId.PossibleIncorrectResultsUsingLikeOperator,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EndsWithTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EndsWithTranslator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 _logger?.LogWarning(
                     RelationalEventId.PossibleIncorrectResultsUsingLikeOperator,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var argument = methodCallExpression.Arguments[0];
                 argument = argument.RemoveConvert();

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/IsNullOrEmptyTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/IsNullOrEmptyTranslator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            return ReferenceEquals(methodCallExpression.Method, _methodInfo)
+            return Equals(methodCallExpression.Method, _methodInfo)
                 ? Expression.MakeBinary(
                     ExpressionType.OrElse,
                     new IsNullExpression(methodCallExpression.Arguments[0]),

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StartsWithTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StartsWithTranslator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 _logger?.LogWarning(
                     RelationalEventId.PossibleIncorrectResultsUsingLikeOperator,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StringCompareTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StringCompareTranslator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             ConstantExpression constant)
         {
             if ((methodCall != null)
-                && (methodCall.Method == _methodInfo)
+                && (methodCall.Method.Equals(_methodInfo))
                 && (methodCall.Type == typeof(int))
                 && (constant != null)
                 && (constant.Type == typeof(int)))

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StringConcatTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/Internal/StringConcatTranslator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             var binaryExpression = expression as BinaryExpression;
             if (binaryExpression != null
                 && binaryExpression.NodeType == ExpressionType.Add
-                && binaryExpression.Method == _stringConcatMethodInfo)
+                && _stringConcatMethodInfo.Equals(binaryExpression.Method))
             {
                 var newLeft = binaryExpression.Left.Type != typeof(string)
                     ? new ExplicitCastExpression(HandleNullTypedConstant(binaryExpression.Left.RemoveConvert()), typeof(string))

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
@@ -16,8 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
     /// </summary>
     public abstract class SingleOverloadStaticMethodCallTranslator : IMethodCallTranslator
     {
-        private readonly Type _declaringType;
-        private readonly string _clrMethodName;
+        private readonly MethodInfo _methodInfo;
         private readonly string _sqlFunctionName;
 
         /// <summary>
@@ -31,8 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
             [NotNull] string clrMethodName,
             [NotNull] string sqlFunctionName)
         {
-            _declaringType = declaringType;
-            _clrMethodName = clrMethodName;
+            _methodInfo = declaringType.GetTypeInfo().GetDeclaredMethods(clrMethodName).Single();
             _sqlFunctionName = sqlFunctionName;
         }
 
@@ -43,12 +41,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// <returns>
         ///     A SQL expression representing the translated MethodCallExpression.
         /// </returns>
-        public virtual Expression Translate(MethodCallExpression methodCallExpression)
-        {
-            var methodInfo = _declaringType.GetTypeInfo().GetDeclaredMethods(_clrMethodName).SingleOrDefault();
-            return methodInfo == methodCallExpression.Method
-                ? new SqlFunctionExpression(_sqlFunctionName, methodCallExpression.Type, methodCallExpression.Arguments)
-                : null;
-        }
+        public virtual Expression Translate(MethodCallExpression methodCallExpression) 
+            => _methodInfo.Equals(methodCallExpression.Method)
+            ? new SqlFunctionExpression(_sqlFunctionName, methodCallExpression.Type, methodCallExpression.Arguments)
+            : null;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 var existingGroupJoinIncludeExpression 
                     = existingGroupJoinIncludeWithAccessor != null
-                          && existingGroupJoinIncludeWithAccessor.Method == withAccessorMethodInfo
+                          && existingGroupJoinIncludeWithAccessor.Method.Equals(withAccessorMethodInfo)
                     ? existingGroupJoinIncludeWithAccessor.Object
                     : existingGroupJoinIncludeArgument;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -703,7 +703,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         aliasExpression
                             = selectExpression.Projection
                                 .OfType<AliasExpression>()
-                                .SingleOrDefault(ae => ae.SourceMember == expression.Member);
+                                .SingleOrDefault(ae => Equals(ae.SourceMember, expression.Member));
                     }
                 }
             }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerContainsOptimizedTranslator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerEndsWithOptimizedTranslator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringIsNullOrWhiteSpaceTranslator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_methodInfo == methodCallExpression.Method)
+            if (methodCallExpression.Method.Equals(_methodInfo))
             {
                 var argument = methodCallExpression.Arguments[0];
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method == _methodInfo
+            => _methodInfo.Equals(methodCallExpression.Method) 
                 ? new SqlFunctionExpression(
                     "REPLACE",
                     methodCallExpression.Type,

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
-            => methodCallExpression.Method == _methodInfo
+            => _methodInfo.Equals(methodCallExpression.Method)
                 ? new SqlFunctionExpression(
                     "SUBSTRING",
                     methodCallExpression.Type,

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -25,9 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if ((_trimEnd == methodCallExpression.Method)
+            if (_trimEnd.Equals(methodCallExpression.Method)
                 // SqlServer RTRIM does not take arguments
-                && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
+                && ((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0)
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
                 return new SqlFunctionExpression("RTRIM", methodCallExpression.Type, sqlArguments);

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if ((_trimStart == methodCallExpression.Method)
+            if (_trimStart.Equals(methodCallExpression.Method)
                 // SqlServer LTRIM does not take arguments
                 && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
             {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     {
         private static readonly MethodInfo _trim = typeof(string).GetTypeInfo()
             .GetDeclaredMethods(nameof(string.Trim))
-            .SingleOrDefault(m => !m.GetParameters().Any());
+            .Single(m => !m.GetParameters().Any());
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trim == methodCallExpression.Method)
+            if (_trim.Equals(methodCallExpression.Method))
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
                 return new SqlFunctionExpression(

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _methodInfo))
             {
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_methodInfo == methodCallExpression.Method)
+            if (_methodInfo .Equals(methodCallExpression.Method))
             {
                 var argument = methodCallExpression.Arguments[0];
 

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trimEnd == methodCallExpression.Method)
+            if (_trimEnd.Equals(methodCallExpression.Method))
             {
                 var sqlArguments = new List<Expression> { methodCallExpression.Object };
                 var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trimStart == methodCallExpression.Method)
+            if (_trimStart.Equals(methodCallExpression.Method))
             {
                 var sqlArguments = new List<Expression> { methodCallExpression.Object };
                 var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
@@ -48,11 +48,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 var propertyGetter = propertyInfo.GetMethod;
                 var interfaceMapping = parameterType.GetTypeInfo().GetRuntimeInterfaceMap(declaringType);
-                var index = Array.FindIndex(interfaceMapping.InterfaceMethods, p => p == propertyGetter);
+                var index = Array.FindIndex(interfaceMapping.InterfaceMethods, p => propertyGetter.Equals(p));
                 var targetMethod = interfaceMapping.TargetMethods[index];
                 foreach (var runtimeProperty in parameterType.GetRuntimeProperties())
                 {
-                    if (targetMethod == runtimeProperty.GetMethod)
+                    if (targetMethod.Equals(runtimeProperty.GetMethod))
                     {
                         return runtimeProperty;
                     }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/MethodInfoExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/MethodInfoExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Extensions.Internal
         /// </summary>
         public static bool MethodIsClosedFormOf([NotNull] this MethodInfo methodInfo, [NotNull] MethodInfo genericMethod)
             => methodInfo.IsGenericMethod
-               && ReferenceEquals(
+               && Equals(
                    methodInfo.GetGenericMethodDefinition(),
                    genericMethod);
     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         navigationPropertyInfo.Name, entityType.DisplayName(), attribute.Property, targetClrType.ShortDisplayName()));
             }
 
-            if (inverseNavigationPropertyInfo == navigationPropertyInfo)
+            if (Equals(inverseNavigationPropertyInfo, navigationPropertyInfo))
             {
                 throw new InvalidOperationException(
                     CoreStrings.SelfReferencingNavigationWithInverseProperty(
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var referencingTuple in referencingNavigationsWithAttribute)
             {
-                if (referencingTuple.Item1 == navigation
+                if (Equals(referencingTuple.Item1, navigation)
                     && referencingTuple.Item2 == entityType.ClrType)
                 {
                     return referencingNavigationsWithAttribute;
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 for (var index = 0; index < referencingNavigationsWithAttribute.Count; index++)
                 {
                     var referencingTuple = referencingNavigationsWithAttribute[index];
-                    if (referencingTuple.Item1 == navigation
+                    if (Equals(referencingTuple.Item1, navigation)
                         && referencingTuple.Item2 == entityType.ClrType)
                     {
                         referencingNavigationsWithAttribute.RemoveAt(index);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     var inverseTargetType = inverseCandidateTuple.Value;
 
                     if (inverseTargetType != entityType.ClrType
-                        || navigationPropertyInfo == inversePropertyInfo
+                        || Equals(navigationPropertyInfo, inversePropertyInfo)
                         || candidateTargetEntityTypeBuilder.IsIgnored(inversePropertyInfo.Name, ConfigurationSource.Convention))
                     {
                         continue;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                      || PropertyBase.IsCompatible(
                          fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
                          shouldThrow: configurationSource == ConfigurationSource.Explicit)))
-                || Metadata.FieldInfo == fieldInfo)
+                || Equals(Metadata.FieldInfo, fieldInfo))
             {
                 Metadata.SetFieldInfo(fieldInfo, configurationSource);
                 return true;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/PropertyBase.cs
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual void SetFieldInfo(
             [CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource, bool runConventions = true)
         {
-            if (ReferenceEquals(FieldInfo, fieldInfo))
+            if (Equals(FieldInfo, fieldInfo))
             {
                 UpdateFieldInfoConfigurationSource(configurationSource);
                 return;

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     True if <paramref name="methodInfo" /> is referencing <see cref="EF.Property{TProperty}(object, string)" />; otherwise fale;
         /// </returns>
         public static bool IsPropertyMethod([CanBeNull] MethodInfo methodInfo) =>
-            ReferenceEquals(methodInfo, EF.PropertyMethod)
+            Equals(methodInfo, EF.PropertyMethod)
             ||
             (
                 // fallback to string comparison because MethodInfo.Equals is not

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -309,10 +309,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                                    var maybeMethodCallExpression = newExpression.Arguments[0] as MethodCallExpression;
 
-                                   if ((maybeMethodCallExpression != null
-                                        && maybeMethodCallExpression.Method.IsGenericMethod
-                                        && maybeMethodCallExpression.Method.GetGenericMethodDefinition()
-                                        == DefaultQueryExpressionVisitor.GetParameterValueMethodInfo)
+                                   if (maybeMethodCallExpression != null
+                                       && maybeMethodCallExpression.Method.IsGenericMethod
+                                       && maybeMethodCallExpression.Method.GetGenericMethodDefinition()
+                                           .Equals(DefaultQueryExpressionVisitor.GetParameterValueMethodInfo)
                                        || (newExpression.Arguments[0].NodeType == ExpressionType.Parameter
                                            && !property.IsShadowProperty))
                                    {

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -97,8 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (declaringType == typeof(Queryable)
                 || declaringType == typeof(EntityFrameworkQueryableExtensions)
                 && (!methodInfo.IsGenericMethod
-                    || methodInfo.GetGenericMethodDefinition() 
-                        != EntityFrameworkQueryableExtensions.StringIncludeMethodInfo))
+                    || !methodInfo.GetGenericMethodDefinition() 
+                        .Equals(EntityFrameworkQueryableExtensions.StringIncludeMethodInfo)))
             {
                 return base.VisitMethodCall(methodCallExpression);
             }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -386,13 +386,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             private bool CompareUnary(UnaryExpression a, UnaryExpression b)
-                => a.Method == b.Method
+                => Equals(a.Method, b.Method)
                    && a.IsLifted == b.IsLifted
                    && a.IsLiftedToNull == b.IsLiftedToNull
                    && Compare(a.Operand, b.Operand);
 
             private bool CompareBinary(BinaryExpression a, BinaryExpression b)
-                => a.Method == b.Method
+                => Equals(a.Method, b.Method)
                    && a.IsLifted == b.IsLifted
                    && a.IsLiftedToNull == b.IsLiftedToNull
                    && Compare(a.Left, b.Left)
@@ -453,11 +453,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             private bool CompareMemberAccess(MemberExpression a, MemberExpression b)
-                => a.Member == b.Member
+                => Equals(a.Member, b.Member)
                    && Compare(a.Expression, b.Expression);
 
             private bool CompareMethodCall(MethodCallExpression a, MethodCallExpression b)
-                => a.Method == b.Method
+                => Equals(a.Method, b.Method)
                    && Compare(a.Object, b.Object)
                    && CompareExpressionList(a.Arguments, b.Arguments);
 
@@ -499,7 +499,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             private bool CompareNew(NewExpression a, NewExpression b)
-                => a.Constructor == b.Constructor
+                => Equals(a.Constructor, b.Constructor)
                    && CompareExpressionList(a.Arguments, b.Arguments)
                    && CompareMemberList(a.Members, b.Members);
 
@@ -638,15 +638,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             private bool CompareMemberAssignment(MemberAssignment a, MemberAssignment b)
-                => a.Member == b.Member
+                => Equals(a.Member, b.Member)
                    && Compare(a.Expression, b.Expression);
 
             private bool CompareMemberListBinding(MemberListBinding a, MemberListBinding b)
-                => a.Member == b.Member
+                => Equals(a.Member, b.Member)
                    && CompareElementInitList(a.Initializers, b.Initializers);
 
             private bool CompareMemberMemberBinding(MemberMemberBinding a, MemberMemberBinding b)
-                => a.Member == b.Member
+                => Equals(a.Member, b.Member)
                    && CompareBindingList(a.Bindings, b.Bindings);
 
             private bool CompareListInit(ListInitExpression a, ListInitExpression b)
@@ -683,7 +683,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             private bool CompareElementInit(ElementInit a, ElementInit b)
-                => a.AddMethod == b.AddMethod
+                => Equals(a.AddMethod, b.AddMethod)
                    && CompareExpressionList(a.Arguments, b.Arguments);
 
             private class ScopedDictionary<TKey, TValue>

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
@@ -331,7 +331,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression)
             {
-                if (methodCallExpression.Method == _guidNewGuid
+                if (_guidNewGuid.Equals(methodCallExpression.Method) 
                     || _randomNext.Contains(methodCallExpression.Method))
                 {
                     return false;

--- a/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/TrackingExpressionNode.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/TrackingExpressionNode.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
             => new TrackingResultOperator(
                 tracking: ParsedExpression.Method.GetGenericMethodDefinition()
-                          == EntityFrameworkQueryableExtensions.AsTrackingMethodInfo);
+                            .Equals(EntityFrameworkQueryableExtensions.AsTrackingMethodInfo));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
On .NET Core reflection types such as MethodInfo no longer override the == operator and so we get reference equality. This happens to work when the underlying runtime is caching these objects, but caching is not guaranteed. E.g. .NET Native is much less eager to cache here.

The fix is to use the instance Equals method (or object.Equals) to perform the comparison.
