### PR TITLE
Fix filter generation in CSharpMigrationOperationGenerator

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -628,7 +628,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .AppendLine(",")
                         .Append("filter: ")
-                        .Append(operation.Filter);
+                        .Append(_code.Literal(operation.Filter));
                 }
 
                 builder.Append(")");

--- a/test/Microsoft.EntityFrameworkCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -714,14 +714,16 @@ namespace Microsoft.EntityFrameworkCore.Design.Tests.Migrations.Design
                     Schema = "dbo",
                     Table = "Post",
                     Columns = new[] { "Title" },
-                    IsUnique = true
+                    IsUnique = true,
+                    Filter = "[Title] IS NOT NULL"
                 },
                 "mb.CreateIndex(" + EOL +
                 "    name: \"IX_Post_Title\"," + EOL +
                 "    schema: \"dbo\"," + EOL +
                 "    table: \"Post\"," + EOL +
                 "    column: \"Title\"," + EOL +
-                "    unique: true);",
+                "    unique: true," + EOL +
+                "    filter: \"[Title] IS NOT NULL\");",
                 o =>
                 {
                     Assert.Equal("IX_Post_Title", o.Name);


### PR DESCRIPTION
Summary of the changes
 - Adding a test for filter generation on the CreateIndexOperation
 - Fixing code in CSharpMigrationOperationGenerator to wrap filter in ""