### PR TITLE
Query: Optimize OfType operator to only query for required columns

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1000,7 +1000,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
 
-            return AddInnerJoin(tableExpression, Enumerable.Empty<AliasExpression>());
+            return AddInnerJoin(tableExpression, Enumerable.Empty<AliasExpression>(), innerPredicate: null);
         }
 
         /// <summary>
@@ -1008,9 +1008,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <param name="tableExpression"> The target table expression. </param>
         /// <param name="projection"> A sequence of expressions that should be added to the projection. </param>
+        /// <param name="innerPredicate">A predicate which should be appended to current predicate. </param>
         public virtual JoinExpressionBase AddInnerJoin(
             [NotNull] TableExpressionBase tableExpression,
-            [NotNull] IEnumerable<Expression> projection)
+            [NotNull] IEnumerable<Expression> projection,
+            [CanBeNull] Expression innerPredicate)
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
             Check.NotNull(projection, nameof(projection));
@@ -1019,6 +1021,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             _tables.Add(innerJoinExpression);
             _projection.AddRange(projection);
+
+            if (innerPredicate != null)
+            {
+                Predicate = Predicate == null ? innerPredicate : AndAlso(Predicate, innerPredicate);
+            }
 
             return innerJoinExpression;
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -10,14 +10,12 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.ResultOperators;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -35,7 +33,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public HandlerContext(
                 IResultOperatorHandler resultOperatorHandler,
                 IModel model,
-                IRelationalAnnotationProvider relationalAnnotationProvider,
                 ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
                 ISelectExpressionFactory selectExpressionFactory,
                 RelationalQueryModelVisitor queryModelVisitor,
@@ -47,7 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _sqlTranslatingExpressionVisitorFactory = sqlTranslatingExpressionVisitorFactory;
 
                 Model = model;
-                RelationalAnnotationProvider = relationalAnnotationProvider;
                 SelectExpressionFactory = selectExpressionFactory;
                 QueryModelVisitor = queryModelVisitor;
                 ResultOperator = resultOperator;
@@ -56,7 +52,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public IModel Model { get; }
-            public IRelationalAnnotationProvider RelationalAnnotationProvider { get; }
             public ISelectExpressionFactory SelectExpressionFactory { get; }
             public ResultOperatorBase ResultOperator { get; }
             public SelectExpression SelectExpression { get; }
@@ -97,7 +92,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 { typeof(LastResultOperator), HandleLast },
                 { typeof(MaxResultOperator), HandleMax },
                 { typeof(MinResultOperator), HandleMin },
-                { typeof(OfTypeResultOperator), HandleOfType },
                 { typeof(SingleResultOperator), HandleSingle },
                 { typeof(SkipResultOperator), HandleSkip },
                 { typeof(SumResultOperator), HandleSum },
@@ -105,7 +99,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             };
 
         private readonly IModel _model;
-        private readonly IRelationalAnnotationProvider _relationalAnnotationProvider;
         private readonly ISqlTranslatingExpressionVisitorFactory _sqlTranslatingExpressionVisitorFactory;
         private readonly ISelectExpressionFactory _selectExpressionFactory;
         private readonly IResultOperatorHandler _resultOperatorHandler;
@@ -116,13 +109,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public RelationalResultOperatorHandler(
             [NotNull] IModel model,
-            [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider,
             [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IResultOperatorHandler resultOperatorHandler)
         {
             _model = model;
-            _relationalAnnotationProvider = relationalAnnotationProvider;
             _sqlTranslatingExpressionVisitorFactory = sqlTranslatingExpressionVisitorFactory;
             _selectExpressionFactory = selectExpressionFactory;
             _resultOperatorHandler = resultOperatorHandler;
@@ -148,7 +139,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 = new HandlerContext(
                     _resultOperatorHandler,
                     _model,
-                    _relationalAnnotationProvider,
                     _sqlTranslatingExpressionVisitorFactory,
                     _selectExpressionFactory,
                     relationalQueryModelVisitor,
@@ -171,11 +161,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (relationalQueryModelVisitor.RequiresClientSingleColumnResultOperator
                 && !(resultOperator is SkipResultOperator
-                    || resultOperator is TakeResultOperator 
+                    || resultOperator is TakeResultOperator
                     || resultOperator is FirstResultOperator
                     || resultOperator is SingleResultOperator
-                    || resultOperator is CountResultOperator 
-                    || resultOperator is AllResultOperator 
+                    || resultOperator is CountResultOperator
+                    || resultOperator is AllResultOperator
                     || resultOperator is AnyResultOperator
                     || resultOperator is GroupResultOperator))
             {
@@ -635,112 +625,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             return handlerContext.EvalOnClient();
-        }
-
-        private static Expression HandleOfType(HandlerContext handlerContext)
-        {
-            var ofTypeResultOperator
-                = (OfTypeResultOperator)handlerContext.ResultOperator;
-
-            var entityType = handlerContext.Model.FindEntityType(ofTypeResultOperator.SearchedItemType);
-
-            if (entityType == null)
-            {
-                return handlerContext.EvalOnClient();
-            }
-
-            var concreteEntityTypes
-                = entityType.GetConcreteTypesInHierarchy().ToList();
-
-            if (concreteEntityTypes.Count != 1
-                || concreteEntityTypes[0].RootType() != concreteEntityTypes[0])
-            {
-                var relationalMetadataExtensionProvider
-                    = handlerContext.RelationalAnnotationProvider;
-
-                var discriminatorProperty
-                    = relationalMetadataExtensionProvider.For(concreteEntityTypes[0]).DiscriminatorProperty;
-
-                var projectionIndex
-                    = handlerContext.SelectExpression
-                        .GetProjectionIndex(discriminatorProperty, handlerContext.QueryModel.MainFromClause);
-
-                if (projectionIndex < 0)
-                {
-                    projectionIndex
-                        = handlerContext.SelectExpression
-                            .AddToProjection(
-                                relationalMetadataExtensionProvider.For(discriminatorProperty).ColumnName,
-                                discriminatorProperty,
-                                handlerContext.QueryModel.MainFromClause);
-                }
-
-                var discriminatorColumn
-                    = handlerContext.SelectExpression.Projection[projectionIndex];
-
-                var discriminatorPredicate
-                    = concreteEntityTypes
-                        .Select(concreteEntityType =>
-                            Expression.Equal(
-                                discriminatorColumn,
-                                Expression.Constant(relationalMetadataExtensionProvider.For(concreteEntityType).DiscriminatorValue, discriminatorColumn.Type)))
-                        .Aggregate((current, next) => Expression.OrElse(next, current));
-
-                handlerContext.SelectExpression.Predicate
-                    = new DiscriminatorReplacingExpressionVisitor(
-                            discriminatorPredicate,
-                            handlerContext.QueryModel.MainFromClause)
-                        .Visit(handlerContext.SelectExpression.Predicate);
-            }
-
-            var shapedQueryMethod = (MethodCallExpression)handlerContext.QueryModelVisitor.Expression;
-            var entityShaper = (EntityShaper)((ConstantExpression)shapedQueryMethod.Arguments[2]).Value;
-
-            return Expression.Call(
-                shapedQueryMethod.Method
-                    .GetGenericMethodDefinition()
-                    .MakeGenericMethod(ofTypeResultOperator.SearchedItemType),
-                shapedQueryMethod.Arguments[0],
-                shapedQueryMethod.Arguments[1],
-                Expression.Constant(
-                    _createDowncastingShaperMethodInfo
-                        .MakeGenericMethod(ofTypeResultOperator.SearchedItemType)
-                        .Invoke(null, new object[] { entityShaper })));
-        }
-
-        private static readonly MethodInfo _createDowncastingShaperMethodInfo
-            = typeof(RelationalResultOperatorHandler).GetTypeInfo()
-                .GetDeclaredMethod(nameof(CreateDowncastingShaper));
-
-        [UsedImplicitly]
-        private static IShaper<TDerived> CreateDowncastingShaper<TDerived>(EntityShaper shaper)
-            where TDerived : class
-        => shaper.Cast<TDerived>();
-
-        private class DiscriminatorReplacingExpressionVisitor : RelinqExpressionVisitor
-        {
-            private readonly Expression _discriminatorPredicate;
-            private readonly IQuerySource _querySource;
-
-            public DiscriminatorReplacingExpressionVisitor(
-                Expression discriminatorPredicate, IQuerySource querySource)
-            {
-                _discriminatorPredicate = discriminatorPredicate;
-                _querySource = querySource;
-            }
-
-            protected override Expression VisitExtension(Expression expression)
-            {
-                var discriminatorExpression = expression as DiscriminatorPredicateExpression;
-
-                if (discriminatorExpression != null
-                    && discriminatorExpression.QuerySource == _querySource)
-                {
-                    return new DiscriminatorPredicateExpression(_discriminatorPredicate, _querySource);
-                }
-
-                return expression;
-            }
         }
 
         private static Expression HandleSingle(HandlerContext handlerContext)

--- a/src/Microsoft.EntityFrameworkCore.Relational/exceptions.net45.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational/exceptions.net45.json
@@ -402,5 +402,12 @@
     "OldMemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Boolean transactionOwned)",
     "NewMemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Diagnostics.DiagnosticSource diagnosticSource, System.Boolean transactionOwned)",
     "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+    "NewTypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+    "OldMemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+    "NewMemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection, System.Linq.Expressions.Expression innerPredicate)",
+    "Kind": "Modification"
   }
 ]

--- a/src/Microsoft.EntityFrameworkCore.Relational/exceptions.netcore.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational/exceptions.netcore.json
@@ -402,5 +402,12 @@
     "OldMemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Boolean transactionOwned)",
     "NewMemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Diagnostics.DiagnosticSource diagnosticSource, System.Boolean transactionOwned)",
     "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+    "NewTypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+    "OldMemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+    "NewMemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection, System.Linq.Expressions.Expression innerPredicate)",
+    "Kind": "Modification"
   }
 ]

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/AsyncQueryProviderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/AsyncQueryProviderExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Extensions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class AsyncQueryProviderExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ConstantExpression CreateEntityQueryable([NotNull] this IAsyncQueryProvider entityQueryProvider, [NotNull] IEntityType targetEntityType)
+        {
+            Check.NotNull(entityQueryProvider, nameof(entityQueryProvider));
+            Check.NotNull(targetEntityType, nameof(targetEntityType));
+
+            return Expression.Constant(
+                _createEntityQueryableMethod
+                    .MakeGenericMethod(targetEntityType.ClrType)
+                    .Invoke(null, new object []
+                    {
+                        entityQueryProvider
+                    }));
+        }
+
+        private static readonly MethodInfo _createEntityQueryableMethod
+            = typeof(AsyncQueryProviderExtensions)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_CreateEntityQueryable));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static EntityQueryable<TResult> _CreateEntityQueryable<TResult>(IAsyncQueryProvider entityQueryProvider)
+            => new EntityQueryable<TResult>(entityQueryProvider);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -151,6 +151,7 @@
     <Compile Include="ChangeTracking\ReferenceEntry.cs" />
     <Compile Include="ChangeTracking\ReferenceEntry`.cs" />
     <Compile Include="EF.CompileAsyncQuery.cs" />
+    <Compile Include="Extensions\Internal\AsyncQueryProviderExtensions.cs" />
     <Compile Include="Internal\IPatchServiceInjectionSite.cs" />
     <Compile Include="Infrastructure\IResettableService.cs" />
     <Compile Include="Infrastructure\ServiceCollectionMap.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -398,6 +398,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 queryModel.TransformExpressions(new RecursiveQueryModelExpressionVisitor(this).Visit);
             }
 
+
             private class RecursiveQueryModelExpressionVisitor : ExpressionVisitorBase
             {
                 private readonly NondeterministicResultCheckingVisitor _parentVisitor;

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryOptimizer.cs
@@ -6,7 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ResultOperators;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -49,6 +52,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         private IReadOnlyCollection<IQueryAnnotation> _queryAnnotations;
+        private readonly IModel _model;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public QueryOptimizer([NotNull] IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            _model = model;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -138,17 +153,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     queryModel.BodyClauses.RemoveAt(index);
                     queryModel.BodyClauses.Insert(index, groupJoinClause.JoinClause);
 
-                    var querySourceMapping = new QuerySourceMapping();
-
-                    querySourceMapping.AddMapping(
+                    UpdateQuerySourceMapping(
+                        queryModel,
                         additionalFromClause,
                         new QuerySourceReferenceExpression(groupJoinClause.JoinClause));
-
-                    queryModel.TransformExpressions(e =>
-                        ReferenceReplacingExpressionVisitor.ReplaceClauseReferences(
-                            e,
-                            querySourceMapping,
-                            throwOnUnmappedReferences: false));
                 }
             }
         }
@@ -194,13 +202,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 fromClause.CopyFromSource(fromClauseData);
 
-                var innerSelectorMapping = new QuerySourceMapping();
-
-                innerSelectorMapping.AddMapping(fromClause, subQueryExpression.QueryModel.SelectClause.Selector);
-
-                queryModel.TransformExpressions(
-                    ex => ReferenceReplacingExpressionVisitor
-                        .ReplaceClauseReferences(ex, innerSelectorMapping, false));
+                UpdateQuerySourceMapping(
+                    queryModel,
+                    fromClause,
+                    subQueryExpression.QueryModel.SelectClause.Selector);
 
                 InsertBodyClauses(subQueryExpression.QueryModel.BodyClauses, queryModel, destinationIndex);
 
@@ -209,22 +214,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     queryModel.ResultOperators.Insert(0, resultOperator);
                 }
 
-                var innerBodyClauseMapping = new QuerySourceMapping();
-
-                innerBodyClauseMapping
-                    .AddMapping(innerMainFromClause, new QuerySourceReferenceExpression(fromClause));
-
-                queryModel.TransformExpressions(
-                    ex => ReferenceReplacingExpressionVisitor
-                        .ReplaceClauseReferences(ex, innerBodyClauseMapping, false));
-
-                foreach (var queryAnnotation
-                    in _queryAnnotations
-                        .Where(qa => qa.QuerySource == subQueryExpression.QueryModel.MainFromClause))
-                {
-                    queryAnnotation.QuerySource = fromClause;
-                    queryAnnotation.QueryModel = queryModel;
-                }
+                UpdateQuerySourceMapping(
+                    queryModel,
+                    innerMainFromClause,
+                    new QuerySourceReferenceExpression(fromClause));
             }
         }
 
@@ -248,7 +241,66 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
             }
 
+            var ofTypeOperator = resultOperator as OfTypeResultOperator;
+            if (ofTypeOperator != null)
+            {
+                var searchedItemType = ofTypeOperator.SearchedItemType;
+                if (searchedItemType == queryModel.MainFromClause.ItemType)
+                {
+                    queryModel.ResultOperators.RemoveAt(index);
+                }
+                else
+                {
+                    var entityType = _model.FindEntityType(searchedItemType);
+
+                    if (entityType != null)
+                    {
+                        var oldQuerySource = queryModel.MainFromClause;
+
+                        var entityQueryProvider = ((oldQuerySource.FromExpression as ConstantExpression)?.Value as IQueryable)?.Provider as IAsyncQueryProvider;
+                        if (entityQueryProvider != null)
+                        {
+                            queryModel.ResultOperators.RemoveAt(index);
+
+                            var newMainFromClause = new MainFromClause(
+                                oldQuerySource.ItemName,
+                                entityType.ClrType,
+                                entityQueryProvider.CreateEntityQueryable(entityType));
+                            queryModel.MainFromClause = newMainFromClause;
+
+                            UpdateQuerySourceMapping(queryModel,
+                                oldQuerySource,
+                                new QuerySourceReferenceExpression(newMainFromClause));
+                        }
+                    }
+                }
+            }
+
             base.VisitResultOperator(resultOperator, queryModel, index);
+        }
+
+        private void UpdateQuerySourceMapping(
+            QueryModel queryModel,
+            IQuerySource oldQuerySource,
+            Expression newExpression)
+        {
+            var querySourceMapping = new QuerySourceMapping();
+            querySourceMapping.AddMapping(oldQuerySource, newExpression);
+
+            queryModel.TransformExpressions(e =>
+                                ReferenceReplacingExpressionVisitor
+                                    .ReplaceClauseReferences(e, querySourceMapping, throwOnUnmappedReferences: false));
+
+            var qsre = newExpression as QuerySourceReferenceExpression;
+            if (qsre != null)
+            {
+                var newQuerySource = qsre.ReferencedQuerySource;
+                foreach (var queryAnnotation in _queryAnnotations.Where(qa => qa.QuerySource == oldQuerySource))
+                {
+                    queryAnnotation.QuerySource = newQuerySource;
+                    queryAnnotation.QueryModel = queryModel;
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -5,11 +5,18 @@ using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class InheritanceSqlServerTest : InheritanceTestBase<InheritanceSqlServerFixture>
     {
+        public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
         [Fact]
         public virtual void Common_property_shares_column()
         {
@@ -68,13 +75,10 @@ WHERE [d].[Discriminator] IN (N'Tea', N'Lilt', N'Coke', N'Drink')",
             base.Can_use_of_type_animal();
 
             Assert.Equal(
-                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] IN (N'Kiwi', N'Eagle')
-) AS [t]
-ORDER BY [t].[Species]",
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')
+ORDER BY [a].[Species]",
                 Sql);
         }
 
@@ -105,7 +109,10 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND (([a].[Discriminator] = N'K
             base.Can_use_is_kiwi_in_projection();
 
             Assert.Equal(
-                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+                @"SELECT CASE
+    WHEN [a].[Discriminator] = N'Kiwi'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
 FROM [Animal] AS [a]
 WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')",
                 Sql);
@@ -116,13 +123,10 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')",
             base.Can_use_of_type_bird();
 
             Assert.Equal(
-                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] IN (N'Kiwi', N'Eagle')
-) AS [t]
-ORDER BY [t].[Species]",
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')
+ORDER BY [a].[Species]",
                 Sql);
         }
 
@@ -131,13 +135,10 @@ ORDER BY [t].[Species]",
             base.Can_use_of_type_bird_predicate();
 
             Assert.Equal(
-                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a0].[CountryId] = 1)
-) AS [t]
-ORDER BY [t].[Species]",
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+ORDER BY [a].[Species]",
                 Sql);
         }
 
@@ -146,12 +147,9 @@ ORDER BY [t].[Species]",
             base.Can_use_of_type_bird_with_projection();
 
             Assert.Equal(
-                @"SELECT [t].[EagleId]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] IN (N'Kiwi', N'Eagle')
-) AS [t]",
+                @"SELECT [b].[EagleId]
+FROM [Animal] AS [b]
+WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle')",
                 Sql);
         }
 
@@ -160,13 +158,10 @@ FROM (
             base.Can_use_of_type_bird_first();
 
             Assert.Equal(
-                @"SELECT TOP(1) [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] IN (N'Kiwi', N'Eagle')
-) AS [t]
-ORDER BY [t].[Species]",
+                @"SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')
+ORDER BY [a].[Species]",
                 Sql);
         }
 
@@ -175,7 +170,7 @@ ORDER BY [t].[Species]",
             base.Can_use_of_type_kiwi();
 
             Assert.Equal(
-                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
 FROM [Animal] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'",
                 Sql);
@@ -306,6 +301,26 @@ ORDER BY [c0].[Name], [c0].[Id]",
                 Sql);
         }
 
+        public override void Can_use_of_type_kiwi_where_north_on_derived_property()
+        {
+            base.Can_use_of_type_kiwi_where_north_on_derived_property();
+
+            Assert.Equal(@"SELECT [x].[Species], [x].[CountryId], [x].[Discriminator], [x].[Name], [x].[EagleId], [x].[IsFlightless], [x].[FoundOn]
+FROM [Animal] AS [x]
+WHERE ([x].[Discriminator] = N'Kiwi') AND ([x].[FoundOn] = 0)",
+                Sql);
+        }
+
+        public override void Can_use_of_type_kiwi_where_south_on_derived_property()
+        {
+            base.Can_use_of_type_kiwi_where_south_on_derived_property();
+
+            Assert.Equal(@"SELECT [x].[Species], [x].[CountryId], [x].[Discriminator], [x].[Name], [x].[EagleId], [x].[IsFlightless], [x].[FoundOn]
+FROM [Animal] AS [x]
+WHERE ([x].[Discriminator] = N'Kiwi') AND ([x].[FoundOn] = 1)",
+                Sql);
+        }
+
         public override void Discriminator_used_when_projection_over_derived_type()
         {
             base.Discriminator_used_when_projection_over_derived_type();
@@ -333,12 +348,9 @@ WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle')",
             base.Discriminator_used_when_projection_over_of_type();
 
             Assert.Equal(
-                @"SELECT [t].[FoundOn]
-FROM (
-    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
-    FROM [Animal] AS [a0]
-    WHERE [a0].[Discriminator] = N'Kiwi'
-) AS [t]",
+                @"SELECT [k].[FoundOn]
+FROM [Animal] AS [k]
+WHERE [k].[Discriminator] = N'Kiwi'",
                 Sql);
         }
 
@@ -390,11 +402,6 @@ SELECT COUNT(*)
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
                 Sql);
-        }
-
-        public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture)
-            : base(fixture)
-        {
         }
 
         private const string FileLineEnding = @"

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5539,13 +5539,10 @@ WHERE ([o].[CustomerID] = N'QUICK') AND ([o].[OrderDate] > '1998-01-01T00:00:00.
             base.OfType_Select();
 
             Assert.Equal(
-                @"SELECT TOP(1) [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
-FROM (
-    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-    FROM [Orders] AS [o0]
-) AS [t]
-LEFT JOIN [Customers] AS [o.Customer] ON [t].[CustomerID] = [o.Customer].[CustomerID]
-ORDER BY [t].[OrderID]",
+                @"SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 
@@ -5554,16 +5551,10 @@ ORDER BY [t].[OrderID]",
             base.OfType_Select_OfType_Select();
 
             Assert.Equal(
-                @"SELECT TOP(1) [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
-FROM (
-    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
-    FROM (
-        SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
-        FROM [Orders] AS [o2]
-    ) AS [t0]
-) AS [t1]
-LEFT JOIN [Customers] AS [o.Customer] ON [t1].[CustomerID] = [o.Customer].[CustomerID]
-ORDER BY [t1].[OrderID]",
+                @"SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 


### PR DESCRIPTION
Resolves #7451 

For OfType operators of entity type remove the operator by changing the type of entityqueryable.
Move TypeIs to query model level optimization