### PR TITLE
[TINY] Fix to #7600 - Query : SqlServerMathRoundTranslator wrong argument index results in InvalidCastException

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4846,6 +4846,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Where_math_round2()
+        {
+            AssertQuery<OrderDetail>(
+                ods => ods.Where(od => Math.Round(od.UnitPrice, 2) > 100),
+                entryCount: 46);
+        }
+
+        [ConditionalFact]
         public virtual void Where_math_truncate()
         {
             AssertQuery<OrderDetail>(

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathRoundTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathRoundTranslator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                     methodCallExpression.Type,
                     methodCallExpression.Arguments.Count == 1
                         ? new[] { methodCallExpression.Arguments[0], Expression.Constant(0) }
-                        : new[] { methodCallExpression.Arguments[1], methodCallExpression.Arguments[1] })
+                        : new[] { methodCallExpression.Arguments[0], methodCallExpression.Arguments[1] })
                 : null;
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5015,6 +5015,17 @@ WHERE ROUND([od].[UnitPrice], 0) > 10.0",
                 Sql);
         }
 
+        public override void Where_math_round2()
+        {
+            base.Where_math_round2();
+
+            Assert.Equal(
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
+FROM [Order Details] AS [od]
+WHERE ROUND([od].[UnitPrice], 2) > 100.0",
+                Sql);
+        }
+
         public override void Where_math_truncate()
         {
             base.Where_math_truncate();


### PR DESCRIPTION
Fixing typo in the Round translator.