### PR TITLE
Add EF.Functions and SQL Like

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/RelationalQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/RelationalQueryTestBase.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Specification.Tests
+{
+    public abstract class RelationalQueryTestBase<TFixture> : QueryTestBase<TFixture>
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        [ConditionalFact]
+        public virtual void String_Like_Literal()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
+                Assert.Equal(19, count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_Like_Identity()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, c.ContactName));
+                Assert.Equal(91, count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void String_Like_Literal_With_Escape()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "!%", '!'));
+                Assert.Equal(0, count);
+            }
+        }
+
+        protected RelationalQueryTestBase(TFixture fixture) : base(fixture) {}
+    }
+}

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -483,6 +483,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("UnsupportedPropertyType", nameof(entity), nameof(property), nameof(clrType)),
                 entity, property, clrType);
 
+        /// <summary>
+        /// This function can only be invoked from LINQ to Entities.
+        /// </summary>
+        public static string DbFunctionsDirectCall
+        {
+            get { return GetString("DbFunctionsDirectCall"); }
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -307,4 +307,7 @@
   <data name="UnsupportedPropertyType" xml:space="preserve">
     <value>No mapping to a relational type can be found for property '{entity}.{property}' with the CLR type '{clrType}'.</value>
   </data>
+  <data name="DbFunctionsDirectCall" xml:space="preserve">
+    <value>This function can only be invoked from LINQ to Entities.</value>
+  </data>
 </root>

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class LikeTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(RelationalDbFunctionsExtensions).GetRuntimeMethod(nameof(RelationalDbFunctionsExtensions.Like),
+                new[] { typeof(DbFunctions), typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _methodInfoWithEscape
+            = typeof(RelationalDbFunctionsExtensions).GetRuntimeMethod(nameof(RelationalDbFunctionsExtensions.Like),
+                new[] { typeof(DbFunctions), typeof(string), typeof(string), typeof(char) });
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            if (Equals(methodCallExpression.Method, _methodInfo))
+            {
+                return new LikeExpression(methodCallExpression.Arguments[1], methodCallExpression.Arguments[2]);
+            }
+
+            if (Equals(methodCallExpression.Method, _methodInfoWithEscape))
+            {
+                return new LikeExpression(methodCallExpression.Arguments[1], methodCallExpression.Arguments[2], methodCallExpression.Arguments[3]);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -34,7 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
                 {
                     new EnumHasFlagTranslator(),
                     new EqualsTranslator(dependencies.Logger),
-                    new IsNullOrEmptyTranslator()
+                    new IsNullOrEmptyTranslator(),
+                    new LikeTranslator()
                 };
         }
 

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -597,7 +597,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     = methodCallExpression.Arguments
                         .Where(e => !(e is QuerySourceReferenceExpression)
                                     && !(e is SubQueryExpression))
-                        .Select(e => (e as ConstantExpression)?.Value is Array ? e : Visit(e))
+                        .Select(e => (e as ConstantExpression)?.Value is Array || e.Type == typeof(DbFunctions)
+                            ? e
+                            : Visit(e))
                         .Where(e => e != null)
                         .ToArray();
 

--- a/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
@@ -29,6 +29,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Creates a new instance of LikeExpression.
+        /// </summary>
+        /// <param name="match"> The expression to match. </param>
+        /// <param name="pattern"> The pattern to match. </param>
+        /// <param name="escapeChar"> The escape character to use in <paramref name="pattern"/>. </param>
+        public LikeExpression([NotNull] Expression match, [NotNull] Expression pattern, [CanBeNull] Expression escapeChar)
+        {
+            Check.NotNull(match, nameof(match));
+            Check.NotNull(pattern, nameof(pattern));
+
+            Match = match;
+            Pattern = pattern;
+            EscapeChar = escapeChar;
+        }
+
+        /// <summary>
         ///     Gets the match expression.
         /// </summary>
         /// <value>
@@ -43,6 +59,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     The pattern to match.
         /// </value>
         public virtual Expression Pattern { get; }
+
+        /// <summary>
+        ///     Gets the escape character to use in <see cref="Pattern"/>.
+        /// </summary>
+        /// <value>
+        ///     The escape character to use. If null, no escape character is used.
+        /// </value>
+        [CanBeNull]
+        public virtual Expression EscapeChar { get; }
 
         /// <summary>
         ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
@@ -87,10 +112,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             var newMatchExpression = visitor.Visit(Match);
             var newPatternExpression = visitor.Visit(Pattern);
+            var newEscapeCharExpression = EscapeChar == null ? null : visitor.Visit(EscapeChar);
 
             return (newMatchExpression != Match)
                    || (newPatternExpression != Pattern)
-                ? new LikeExpression(newMatchExpression, newPatternExpression)
+                   || (newEscapeCharExpression != EscapeChar)
+                ? new LikeExpression(newMatchExpression, newPatternExpression, newEscapeCharExpression)
                 : this;
         }
 
@@ -98,6 +125,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>
-        public override string ToString() => Match + " LIKE " + Pattern;
+        public override string ToString() => $"{Match} LIKE {Pattern}{(EscapeChar == null ? "" : $" ESCAPE {EscapeChar}")}";
     }
 }

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1243,6 +1243,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             Visit(likeExpression.Pattern);
 
+            if (likeExpression.EscapeChar != null)
+            {
+                _relationalCommandBuilder.Append(" ESCAPE ");
+                Visit(likeExpression.EscapeChar);
+            }
+
             _typeMapping = parentTypeMapping;
 
             return likeExpression;

--- a/src/EFCore.Relational/RelationalDbFunctionsExtensions.cs
+++ b/src/EFCore.Relational/RelationalDbFunctionsExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+    ///     The methods on this class are accessed via <see cref="EF.Functions"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class RelationalDbFunctionsExtensions
+    {
+        /// <summary>
+        /// Indicates whether the specified input string matches the given pattern by sending an SQL LIKE
+        /// expression to the database.
+        /// </summary>
+        /// <param name="functions">Should always be <see cref="EF.Functions"/>.</param>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns><string>true</string> if the LIKE expression finds a match; otherwise, <string>false</string>.</returns>
+        public static bool Like(
+            [NotNull] this DbFunctions functions,
+            [NotNull] string input,
+            [NotNull] string pattern)
+            => throw new NotSupportedException(RelationalStrings.DbFunctionsDirectCall);
+
+        /// <summary>
+        /// Indicates whether the specified input string matches the given pattern by sending an SQL LIKE
+        /// expression to the database.
+        /// </summary>
+        /// <param name="functions">Should always be <see cref="EF.Functions"/>.</param>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="escapeChar">Character to use as an escape character in <paramref name="pattern"/>.</param>
+        /// <returns><string>true</string> if the LIKE expression finds a match; otherwise, <string>false</string>.</returns>
+        public static bool Like(
+            [NotNull] this DbFunctions functions,
+            [NotNull] string input,
+            [NotNull] string pattern,
+            char escapeChar)
+            => throw new NotSupportedException(RelationalStrings.DbFunctionsDirectCall);
+    }
+}

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal

--- a/src/EFCore/DbFunctions.cs
+++ b/src/EFCore/DbFunctions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+    ///     The methods on this class are accessed via <see cref="EF.Functions"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public class DbFunctions
+    {
+        internal DbFunctions() { }
+    }
+}

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -41,5 +41,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             throw new InvalidOperationException(CoreStrings.PropertyMethodInvoked);
         }
+
+        /// <summary>
+        ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+        ///     Calling these methods in other contexts (e.g. LINQ to Objects) will throw a <see cref="NotSupportedException"/>.
+        /// </summary>
+        public static DbFunctions Functions { get; } = new DbFunctions();
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Relational.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +13,7 @@ using System.Threading;
 #endif
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
-    public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
+    public class QuerySqliteTest : RelationalQueryTestBase<NorthwindQuerySqliteFixture>
     {
         public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -123,6 +125,16 @@ FROM ""Products"" AS ""p""
 WHERE ""p"".""ProductID"" < 40",
                 Sql);
         }
+
+        public override void String_Like_Literal()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
+                Assert.Equal(34, count);
+            }
+        }
+
 
         private const string FileLineEnding = @"
 ";


### PR DESCRIPTION
To allow relational and providers to start defining extension methods on it, for #2850.

Hope this is more or less what you guys were thinking of, let me know of any nitpicks in terms of class/file naming etc.

Note that no actual methods (e.g. Like) are defined, that can come later in a separate PR.

