### PR TITLE
Make Lazy_connection_is_recreated_if_used_again_after_being_disposed more robust

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
@@ -242,12 +242,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             Assert.Equal(1, connection.DbConnections.Count);
 
             connection.Open();
+            Assert.Equal(1, dbConnection.OpenCount);
 
             connection.Close();
-            connection.Dispose();
-
-            Assert.Equal(1, dbConnection.OpenCount);
             Assert.Equal(1, dbConnection.CloseCount);
+
+            connection.Dispose();
             Assert.Equal(1, dbConnection.DisposeCount);
 
             Assert.Equal(1, connection.DbConnections.Count);
@@ -255,12 +255,12 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
             Assert.Equal(2, connection.DbConnections.Count);
 
             connection.Open();
+            Assert.Equal(1, dbConnection.OpenCount);
 
             connection.Close();
-            connection.Dispose();
-
-            Assert.Equal(1, dbConnection.OpenCount);
             Assert.Equal(1, dbConnection.CloseCount);
+
+            connection.Dispose();
             Assert.Equal(1, dbConnection.DisposeCount);
         }
 


### PR DESCRIPTION
`DbConnection.Dispose()` calls `Close()` on .NET Standard 1.2 causing `CloseCount` to be `2` afterwards.