### PR TITLE
Add Pluralization Hook to Reverse Engineer

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Configuration/Internal/ModelConfiguration.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Configuration/Internal/ModelConfiguration.cs
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Configuration.Internal
                         nameof(TableAttribute.Schema) + " = " + delimitedSchemaName));
             }
             else if (AnnotationProvider.For(entityType).TableName != null
-                     && AnnotationProvider.For(entityType).TableName != entityType.DisplayName())
+                     && AnnotationProvider.For(entityType).TableName != entityType.Scaffolding().DbSetName)
             {
                 var delimitedTableName =
                     CSharpUtilities.DelimitString(AnnotationProvider.For(entityType).TableName);

--- a/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Internal/DbContextWriter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Internal/DbContextWriter.cs
@@ -331,7 +331,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 _sb.AppendLine("public virtual DbSet<"
                                + entityConfig.EntityType.Name
-                               + "> " + entityConfig.EntityType.Name
+                               + "> " + entityConfig.EntityType.Scaffolding().DbSetName
                                + " { get; set; }");
             }
 

--- a/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
@@ -21,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<ReverseEngineeringGenerator>()
                 .AddSingleton<ScaffoldingUtilities>()
                 .AddSingleton<CandidateNamingService>()
+                .AddSingleton<IPluralizer, NullPluralizer>()
                 .AddSingleton<CSharpUtilities>()
                 .AddSingleton<ConfigurationFactory>()
                 .AddSingleton<DbContextWriter>()

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Infrastructure/IPluralizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Infrastructure/IPluralizer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     Converts identifiers to the plural and singular equivalents.
+    /// </summary>
+    public interface IPluralizer
+    {
+        /// <summary>
+        ///     Gets the plural version of the given identifier. Returns the same
+        ///     identifier if it is already pluralized.
+        /// </summary>
+        /// <param name="identifier"> The identifier to be pluralized. </param>
+        /// <returns> The pluralized identifier. </returns>
+        string Pluralize([CanBeNull] string identifier);
+
+        /// <summary>
+        ///     Gets the singular version of the given identifier. Returns the same
+        ///     identifier if it is already singularized.
+        /// </summary>
+        /// <param name="identifier"> The identifier to be singularized. </param>
+        /// <returns> The singularized identifier. </returns>
+        string Singularize([CanBeNull] string identifier);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Internal/NullPluralizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Internal/NullPluralizer.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class NullPluralizer : IPluralizer
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Pluralize(string identifier)
+        {
+            return identifier;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Singularize(string identifier)
+        {
+            return identifier;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
@@ -44,5 +44,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string EntityTypeErrors = "EntityTypeErrors";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string DbSetName = "DbSetName";
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/Internal/ScaffoldingFullAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/Internal/ScaffoldingFullAnnotationNames.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
             DependentEndNavigation = ScaffoldingAnnotationNames.DependentEndNavigation;
             PrincipalEndNavigation = ScaffoldingAnnotationNames.PrincipalEndNavigation;
             EntityTypeErrors = ScaffoldingAnnotationNames.EntityTypeErrors;
+            DbSetName = ScaffoldingAnnotationNames.DbSetName;
         }
 
         /// <summary>
@@ -62,5 +63,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public readonly string EntityTypeErrors;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public readonly string DbSetName;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ScaffoldingEntityTypeAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ScaffoldingEntityTypeAnnotations.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
+{
+    /// <summary>
+    ///     Provides strongly typed access to scaffolding related annotations on an 
+    ///     <see cref="IEntityType"/> instance. Instances of this class are typically obtained via the
+    ///     <see cref="ScaffoldingMetadataExtensions.Scaffolding(IEntityType)" /> extension method and it is not designed
+    ///     to be directly constructed in your application code.
+    /// </summary>
+    public class ScaffoldingEntityTypeAnnotations : RelationalEntityTypeAnnotations
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ScaffoldingEntityTypeAnnotations"/> class. 
+        ///     Instances of this class are typically obtained via the
+        ///     <see cref="ScaffoldingMetadataExtensions.Scaffolding(IEntityType)" /> extension method and it is not designed
+        ///     to be directly constructed in your application code.
+        /// </summary>
+        /// <param name="entity"> The entity type to access annotation on. </param>
+        public ScaffoldingEntityTypeAnnotations([NotNull] IEntityType entity)
+            : base(entity, ScaffoldingFullAnnotationNames.Instance)
+        {
+        }
+
+        /// <summary>
+        ///     Gets or set the name of the <see cref="DbSet{TEntity}"/> property for this entity type.
+        /// </summary>
+        public virtual string DbSetName
+        {
+            get { return (string)Annotations.GetAnnotation(ScaffoldingFullAnnotationNames.Instance.DbSetName, null); }
+            [param: CanBeNull]
+            set
+            {
+                Annotations.SetAnnotation(
+                    ScaffoldingFullAnnotationNames.Instance.DbSetName,
+                    null,
+                    Check.NullButNotEmpty(value, nameof(value)));
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
@@ -15,5 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         public static ScaffoldingPropertyAnnotations Scaffolding([NotNull] this IProperty property)
             => new ScaffoldingPropertyAnnotations(Check.NotNull(property, nameof(property)));
+
+        public static ScaffoldingEntityTypeAnnotations Scaffolding([NotNull] this IEntityType entityType)
+            => new ScaffoldingEntityTypeAnnotations(Check.NotNull(entityType, nameof(entityType)));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -40,8 +40,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
-            [NotNull] CandidateNamingService candidateNamingService)
-            : base(loggerFactory, typeMapper, databaseModelFactory, candidateNamingService)
+            [NotNull] CandidateNamingService candidateNamingService,
+            [NotNull] IPluralizer pluralizer)
+            : base(loggerFactory, typeMapper, databaseModelFactory, candidateNamingService, pluralizer)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
@@ -25,8 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
-            [NotNull] CandidateNamingService candidateNamingService)
-            : base(loggerFactory, typeMapper, databaseModelFactory, candidateNamingService)
+            [NotNull] CandidateNamingService candidateNamingService,
+            [NotNull] IPluralizer pluralizer)
+            : base(loggerFactory, typeMapper, databaseModelFactory, candidateNamingService, pluralizer)
         {
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/NullPluralizerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/NullPluralizerTest.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Relational.Design
+{
+    public class NullPluralizerTest
+    {
+        [Fact]
+        public void Returns_same_name()
+        {
+            var pluralizer = new NullPluralizer();
+            var name = "blogs";
+            Assert.Equal(name, pluralizer.Pluralize(name));
+            Assert.Equal(name, pluralizer.Singularize(name));
+        }
+
+        [Fact]
+        public void Returns_same_name_when_null()
+        {
+            var pluralizer = new NullPluralizer();
+            Assert.Equal(null, pluralizer.Pluralize(null));
+            Assert.Equal(null, pluralizer.Singularize(null));
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/ScaffoldingMetadataExtenstionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/ScaffoldingMetadataExtenstionsTest.cs
@@ -39,5 +39,15 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
             model.Scaffolding().EntityTypeErrors.Clear();
             Assert.Empty(model.Scaffolding().EntityTypeErrors.Values);
         }
+
+        [Fact]
+        public void It_sets_DbSet_name()
+        {
+            var model = new Model();
+            var entity = model.AddEntityType("Blog");
+            entity.Scaffolding().DbSetName = "Blogs";
+
+            Assert.Equal("Blogs", entity.Scaffolding().DbSetName);
+        }
     }
 }


### PR DESCRIPTION
Introduces a new IPluralizer service that is used to singularize entity type names and pluralize DbSet names. The default implementation is a no-op, so this is just a hook where folks can easily plug in their own pluralizer.

I left this separate from the existing CandidateNamingService, which is responsible for cleaning up the table name into a C# friendly identifier.

Here is what it looks like for a developer to hook in their own pluralizer (this example uses Inflector). Our code generation coverage is lacking, so I tested this against Northwind and verified by round tripping data.

```c#
public class MyDesignTimeServices : IDesignTimeServices
{
    public void ConfigureDesignTimeServices(IServiceCollection services)
    {
        services.AddSingleton<IPluralizer, MyPluralizer>();
    }
}

public class MyPluralizer : IPluralizer
{
    public string Pluralize(string name)
    {
        return Inflector.Inflector.Pluralize(name) ?? name;
    }

    public string Singularize(string name)
    {
        return Inflector.Inflector.Singularize(name) ?? name;
    }
}
```

Resolves #3060