### PR TITLE
Allow SQL Server identity columns for byte properties, but warn

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerEventId.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerEventId.cs
@@ -13,6 +13,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     No explicit type for a decimal column
         /// </summary>
-        DefaultDecimalTypeWarning = 1
+        DefaultDecimalTypeWarning = 1,
+
+        /// <summary>
+        ///     A byte property is set up to use a SQL Server identity column
+        /// </summary>
+        ByteIdentityColumn = 2
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerModelValidator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/SqlServerModelValidator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -27,16 +28,29 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             base.Validate(model);
 
             EnsureNoDefaultDecimalMapping(model);
+            EnsureNoByteIdentityMapping(model);
             EnsureNoNonKeyValueGeneration(model);
         }
 
         protected virtual void EnsureNoDefaultDecimalMapping([NotNull] IModel model)
         {
             foreach (var property in model.GetEntityTypes().SelectMany(t => t.GetDeclaredProperties())
-                .Where(p => p.ClrType == typeof(decimal) && p.SqlServer().ColumnType == null))
+                .Where(p => p.ClrType.UnwrapNullableType() == typeof(decimal)
+                            && p.SqlServer().ColumnType == null))
             {
                 ShowWarning(SqlServerEventId.DefaultDecimalTypeWarning,
                     SqlServerStrings.DefaultDecimalTypeColumn(property.Name, property.DeclaringEntityType.DisplayName()));
+            }
+        }
+
+        protected virtual void EnsureNoByteIdentityMapping([NotNull] IModel model)
+        {
+            foreach (var property in model.GetEntityTypes().SelectMany(t => t.GetDeclaredProperties())
+                .Where(p => p.ClrType.UnwrapNullableType() == typeof(byte)
+                            && p.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.IdentityColumn))
+            {
+                ShowWarning(SqlServerEventId.ByteIdentityColumn,
+                    SqlServerStrings.ByteIdentityColumn(property.Name, property.DeclaringEntityType.DisplayName()));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -300,10 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         private static bool IsCompatibleIdentityColumn(Type type)
-            => type == typeof(decimal)
-            || (type.IsInteger()
-                && type != typeof(byte)
-                && type != typeof(byte?));
+            => type.IsInteger() || type == typeof(decimal);
 
         private static bool IsCompatibleSequenceHiLo(Type type) => type.IsInteger();
     }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -81,6 +81,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is of type 'byte', but is set up to use a SQL Server identity column. This requires that values starting at 255 and counting down will be used for temporary key values. A temporary key value is needed for every entity inserted in a single call to 'SaveChanges'. Care must be taken that these values do not collide with real key values.
+        /// </summary>
+        public static string ByteIdentityColumn([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ByteIdentityColumn", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
         /// The property '{property}' on entity type '{entityType}' is configured to use 'Identity' or 'SequenceHiLo' value generator, which are only intended for keys. If this was intentional configure an alternate key on the property, otherwise call `ValueGeneratedNever` or configure store generation for this property.
         /// </summary>
         public static string NonKeyValueGeneration([CanBeNull] object property, [CanBeNull] object entityType)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/SqlServerStrings.resx
@@ -141,6 +141,9 @@
   <data name="DefaultDecimalTypeColumn" xml:space="preserve">
     <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accomadate all the values using 'ForSqlServerHasColumnType()'.</value>
   </data>
+  <data name="ByteIdentityColumn" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is of type 'byte', but is set up to use a SQL Server identity column. This requires that values starting at 255 and counting down will be used for temporary key values. A temporary key value is needed for every entity inserted in a single call to 'SaveChanges'. Care must be taken that these values do not collide with real key values.</value>
+  </data>
   <data name="NonKeyValueGeneration" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is configured to use 'Identity' or 'SequenceHiLo' value generator, which are only intended for keys. If this was intentional configure an alternate key on the property, otherwise call `ValueGeneratedNever` or configure store generation for this property.</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/KeyConvention.cs
@@ -93,7 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 if (!property.IsForeignKey())
                 {
                     var propertyType = property.ClrType.UnwrapNullableType();
-                    if (propertyType.IsInteger()
+                    if ((propertyType.IsInteger()
+                         && propertyType != typeof(byte))
                         || propertyType == typeof(Guid)
                         || propertyType == typeof(string)
                         || propertyType == typeof(byte[]))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -56,6 +56,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             modelBuilder.Entity<OrderDetail>()
                 .Property(od => od.UnitPrice).ForSqlServerHasColumnType("money");
+            modelBuilder.Entity<Product>()
+                .Property(p => p.UnitPrice).ForSqlServerHasColumnType("money");
         }
 
         public override NorthwindContext CreateContext(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -25,13 +25,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
     public class SqlServerEndToEndTest : IClassFixture<SqlServerFixture>
     {
         [Fact]
-        public void Can_use_decimal_as_identity_column()
+        public void Can_use_decimal_and_byte_as_identity_columns()
         {
             using (var testDatabase = SqlServerTestStore.Create(DatabaseName))
             {
                 var optionsBuilder = new DbContextOptionsBuilder()
                     .UseSqlServer(testDatabase.ConnectionString, b => b.ApplyConfiguration())
                     .UseInternalServiceProvider(_fixture.ServiceProvider);
+
+                var nownNum1 = new NownNum { Id = 77.0m, TheWalrus = "Crying" };
+                var nownNum2 = new NownNum { Id = 78.0m, TheWalrus = "Walrus" };
 
                 var numNum1 = new NumNum { TheWalrus = "I" };
                 var numNum2 = new NumNum { TheWalrus = "Am" };
@@ -42,25 +45,83 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 var adNum1 = new AdNum { TheWalrus = "Eggman" };
                 var adNum2 = new AdNum { TheWalrus = "Eggmen" };
 
+                var byteNownNum1 = new ByteNownNum { Id = 77, Lucy = "Tangerine" };
+                var byteNownNum2 = new ByteNownNum { Id = 78, Lucy = "Trees" };
+
+                var byteNum1 = new ByteNum { Lucy = "Marmalade" };
+                var byteNum2 = new ByteNum { Lucy = "Skies" };
+
+                var byteAnNum1 = new ByteAnNum { Lucy = "Cellophane" };
+                var byteAnNum2 = new ByteAnNum { Lucy = "Flowers" };
+
+                var byteAdNum1 = new ByteAdNum { Lucy = "Kaleidoscope" };
+                var byteAdNum2 = new ByteAdNum { Lucy = "Eyes" };
+
+                decimal[] preSaveValues;
+                byte[] preSaveByteValues;
+
                 using (var context = new NumNumContext(optionsBuilder.Options))
                 {
                     context.Database.EnsureCreated();
 
-                    context.AddRange(numNum1, numNum2, adNum1, adNum2, anNum1, anNum2);
+                    context.AddRange(
+                        nownNum1, nownNum2, numNum1, numNum2, adNum1, adNum2, anNum1, anNum2,
+                        byteNownNum1, byteNownNum2, byteNum1, byteNum2, byteAdNum1, byteAdNum2, byteAnNum1, byteAnNum2);
+
+                    preSaveValues = new[]
+                    {
+                        numNum1.Id, numNum2.Id, adNum1.Id, adNum2.Id, anNum1.Id, anNum2.Id
+                    };
+
+                    preSaveByteValues = new[]
+                    {
+                        byteNum1.Id, byteNum2.Id, byteAdNum1.Id, byteAdNum2.Id, byteAnNum1.Id, byteAnNum2.Id
+                    };
 
                     context.SaveChanges();
                 }
 
                 using (var context = new NumNumContext(optionsBuilder.Options))
                 {
+                    Assert.Equal(nownNum1.Id, context.NownNums.Single(e => e.TheWalrus == "Crying").Id);
+                    Assert.Equal(nownNum2.Id, context.NownNums.Single(e => e.TheWalrus == "Walrus").Id);
+                    Assert.Equal(nownNum1.Id, 77.0m);
+                    Assert.Equal(nownNum2.Id, 78.0m);
+
                     Assert.Equal(numNum1.Id, context.NumNums.Single(e => e.TheWalrus == "I").Id);
                     Assert.Equal(numNum2.Id, context.NumNums.Single(e => e.TheWalrus == "Am").Id);
-
+                    Assert.NotEqual(numNum1.Id, preSaveValues[0]);
+                    Assert.NotEqual(numNum2.Id, preSaveValues[1]);
+                    
                     Assert.Equal(anNum1.Id, context.AnNums.Single(e => e.TheWalrus == "Goo goo").Id);
                     Assert.Equal(anNum2.Id, context.AnNums.Single(e => e.TheWalrus == "g'joob").Id);
-
+                    Assert.NotEqual(adNum1.Id, preSaveValues[2]);
+                    Assert.NotEqual(adNum2.Id, preSaveValues[3]);
+                    
                     Assert.Equal(adNum1.Id, context.AdNums.Single(e => e.TheWalrus == "Eggman").Id);
                     Assert.Equal(adNum2.Id, context.AdNums.Single(e => e.TheWalrus == "Eggmen").Id);
+                    Assert.NotEqual(anNum1.Id, preSaveValues[4]);
+                    Assert.NotEqual(anNum2.Id, preSaveValues[5]);
+
+                    Assert.Equal(byteNownNum1.Id, context.ByteNownNums.Single(e => e.Lucy == "Tangerine").Id);
+                    Assert.Equal(byteNownNum2.Id, context.ByteNownNums.Single(e => e.Lucy == "Trees").Id);
+                    Assert.Equal(byteNownNum1.Id, 77);
+                    Assert.Equal(byteNownNum2.Id, 78);
+
+                    Assert.Equal(byteNum1.Id, context.ByteNums.Single(e => e.Lucy == "Marmalade").Id);
+                    Assert.Equal(byteNum2.Id, context.ByteNums.Single(e => e.Lucy == "Skies").Id);
+                    Assert.NotEqual(byteNum1.Id, preSaveByteValues[0]);
+                    Assert.NotEqual(byteNum2.Id, preSaveByteValues[1]);
+
+                    Assert.Equal(byteAnNum1.Id, context.ByteAnNums.Single(e => e.Lucy == "Cellophane").Id);
+                    Assert.Equal(byteAnNum2.Id, context.ByteAnNums.Single(e => e.Lucy == "Flowers").Id);
+                    Assert.NotEqual(byteAdNum1.Id, preSaveByteValues[2]);
+                    Assert.NotEqual(byteAdNum2.Id, preSaveByteValues[3]);
+
+                    Assert.Equal(byteAdNum1.Id, context.ByteAdNums.Single(e => e.Lucy == "Kaleidoscope").Id);
+                    Assert.Equal(byteAdNum2.Id, context.ByteAdNums.Single(e => e.Lucy == "Eyes").Id);
+                    Assert.NotEqual(byteAnNum1.Id, preSaveByteValues[4]);
+                    Assert.NotEqual(byteAnNum2.Id, preSaveByteValues[5]);
                 }
             }
         }
@@ -72,9 +133,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             {
             }
 
+            public DbSet<NownNum> NownNums { get; set; }
             public DbSet<NumNum> NumNums { get; set; }
             public DbSet<AnNum> AnNums { get; set; }
             public DbSet<AdNum> AdNums { get; set; }
+
+            public DbSet<ByteNownNum> ByteNownNums { get; set; }
+            public DbSet<ByteNum> ByteNums { get; set; }
+            public DbSet<ByteAnNum> ByteAnNums { get; set; }
+            public DbSet<ByteAdNum> ByteAdNums { get; set; }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
@@ -89,7 +156,23 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     .Property(e => e.Id)
                     .HasColumnType("decimal(10, 0)")
                     .ValueGeneratedOnAdd();
+
+                modelBuilder
+                    .Entity<ByteNum>()
+                    .Property(e => e.Id)
+                    .UseSqlServerIdentityColumn();
+
+                modelBuilder
+                    .Entity<ByteAdNum>()
+                    .Property(e => e.Id)
+                    .ValueGeneratedOnAdd();
             }
+        }
+
+        private class NownNum
+        {
+            public decimal Id { get; set; }
+            public string TheWalrus { get; set; }
         }
 
         private class NumNum
@@ -111,6 +194,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             public decimal Id { get; set; }
             public string TheWalrus { get; set; }
+        }
+
+        private class ByteNownNum
+        {
+            public byte Id { get; set; }
+            public string Lucy { get; set; }
+        }
+
+        private class ByteNum
+        {
+            public byte Id { get; set; }
+            public string Lucy { get; set; }
+        }
+
+        private class ByteAnNum
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public byte Id { get; set; }
+
+            public string Lucy { get; set; }
+        }
+
+        private class ByteAdNum
+        {
+            public byte Id { get; set; }
+            public string Lucy { get; set; }
         }
 
         private class VariableDataTypes

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -759,38 +759,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         }
 
         [Fact]
-        public void Throws_setting_identity_generation_for_byte_property()
-        {
-            var modelBuilder = GetModelBuilder();
-
-            var property = modelBuilder
-                .Entity<Customer>()
-                .Property(e => e.Byte)
-                .Metadata;
-
-            Assert.Equal(
-                SqlServerStrings.IdentityBadType("Byte", nameof(Customer), "byte"),
-                Assert.Throws<ArgumentException>(
-                    () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.IdentityColumn).Message);
-        }
-
-        [Fact]
-        public void Throws_setting_identity_generation_for_nullable_byte_property()
-        {
-            var modelBuilder = GetModelBuilder();
-
-            var property = modelBuilder
-                .Entity<Customer>()
-                .Property(e => e.NullableByte)
-                .Metadata;
-
-            Assert.Equal(
-                SqlServerStrings.IdentityBadType("NullableByte", nameof(Customer), "Nullable<byte>"),
-                Assert.Throws<ArgumentException>(
-                    () => property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.IdentityColumn).Message);
-        }
-
-        [Fact]
         public void Can_get_and_set_sequence_name_on_property()
         {
             var modelBuilder = GetModelBuilder();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -116,6 +116,33 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         }
 
         [Fact]
+        public virtual void Detects_default_nullable_decimal_mapping()
+        {
+            var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());
+            modelBuilder.Entity<Animal>().Property<decimal?>("Price");
+
+            VerifyWarning(SqlServerStrings.DefaultDecimalTypeColumn("Price", nameof(Animal)), modelBuilder.Model);
+        }
+
+        [Fact]
+        public void Detects_byte_identity_column()
+        {
+            var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());
+            modelBuilder.Entity<Dog>().Property<byte>("Bite").UseSqlServerIdentityColumn();
+
+            VerifyError(SqlServerStrings.NonKeyValueGeneration("Bite", nameof(Dog)), modelBuilder.Model);
+        }
+
+        [Fact]
+        public void Detects_nullable_byte_identity_column()
+        {
+            var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());
+            modelBuilder.Entity<Dog>().Property<byte?>("Bite").UseSqlServerIdentityColumn();
+
+            VerifyError(SqlServerStrings.NonKeyValueGeneration("Bite", nameof(Dog)), modelBuilder.Model);
+        }
+
+        [Fact]
         public void Throws_for_non_key_identity()
         {
             var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());


### PR DESCRIPTION
Issue #7161

Byte properties are set to not be store-generated by convention, but if store-generation is configured, then SQL Server will use an identity column and a warning is issued in model validation.

Also a small fix to the warning for decimal properties to ensure that nullable decimals also get the warning if they have no explicit mapping.
