### PR TITLE
Implement VisitChildren for InExpression and ExistsExpression

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ExistsExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/ExistsExpression.cs
@@ -72,6 +72,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     children, and if any of them change, should return a new copy of
         ///     itself with the modified children.
         /// </remarks>
-        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var expression = visitor.Visit(Expression);
+
+            return expression != Expression
+                ? new ExistsExpression(expression)
+                : this;
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1963,7 +1963,7 @@ ORDER BY [t0].[SquadId]",
         LEFT JOIN (
             SELECT [t.Gear].[Nickname], [t.Gear].[SquadId], [t.Gear].[AssignedCityName], [t.Gear].[CityOrBirthName], [t.Gear].[Discriminator], [t.Gear].[FullName], [t.Gear].[HasSoulPatch], [t.Gear].[LeaderNickname], [t.Gear].[LeaderSquadId], [t.Gear].[Rank]
             FROM [Gear] AS [t.Gear]
-            WHERE ([t.Gear].[Discriminator] = N'Officer') OR ([t.Gear].[Discriminator] = N'Gear')
+            WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
         ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
         WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND ([t0].[HasSoulPatch] = 0))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
@@ -1986,7 +1986,7 @@ LEFT JOIN (
 WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND [t0].[SquadId] IN (
     SELECT [g].[SquadId]
     FROM [Gear] AS [g]
-    WHERE ([g].[Discriminator] = N'Officer') OR ([g].[Discriminator] = N'Gear')
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
 )",
                 Sql);
         }
@@ -2302,7 +2302,7 @@ SELECT CASE
         SELECT 1
         FROM [Gear] AS [m]
         LEFT JOIN [CogTag] AS [m.Tag] ON ([m].[Nickname] = [m.Tag].[GearNickName]) AND ([m].[SquadId] = [m.Tag].[GearSquadId])
-        WHERE ((([m].[Discriminator] = N'Officer') OR ([m].[Discriminator] = N'Gear')) AND ([m.Tag].[Note] = N'Dom''s Tag')) AND (@_outer_Id = [m].[SquadId]))
+        WHERE ([m].[Discriminator] IN (N'Officer', N'Gear') AND ([m.Tag].[Note] = N'Dom''s Tag')) AND (@_outer_Id = [m].[SquadId]))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
 
@@ -2313,7 +2313,7 @@ SELECT CASE
         SELECT 1
         FROM [Gear] AS [m]
         LEFT JOIN [CogTag] AS [m.Tag] ON ([m].[Nickname] = [m.Tag].[GearNickName]) AND ([m].[SquadId] = [m.Tag].[GearSquadId])
-        WHERE ((([m].[Discriminator] = N'Officer') OR ([m].[Discriminator] = N'Gear')) AND ([m.Tag].[Note] = N'Dom''s Tag')) AND (@_outer_Id = [m].[SquadId]))
+        WHERE ([m].[Discriminator] IN (N'Officer', N'Gear') AND ([m.Tag].[Note] = N'Dom''s Tag')) AND (@_outer_Id = [m].[SquadId]))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -2329,7 +2329,7 @@ END",
         SELECT 1
         FROM [Gear] AS [g]
         LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-        WHERE (([g].[Discriminator] = N'Officer') OR ([g].[Discriminator] = N'Gear')) AND (([g.Tag].[Note] = N'Foo') AND [g.Tag].[Note] IS NOT NULL))
+        WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Note] = N'Foo'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);


### PR DESCRIPTION
- Introduce CompositeExpression to explicitly represent a set of various expressions

-----

More changes being split out of #7543. The immediate benefits are that further optimizations are applied to subqueries within `InExpression` and `ExistExpression`, and instead of using various odd means of representing a small collection of `Expression`s (such as `IReadOnlyCollection<Expression>` and `ConstantExpression` with an `Expression[]` value) we have an explicit expression type to represent that concept. 

In the longer term, `CompositeExpression` will gain a `Flatten` method which allows for more opportunities like complex/nested grouping keys and easier processing of complex/nested projections.