### PR TITLE
Fix extra brackets in csproj

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/Microsoft.EntityFrameworkCore.InMemory.csproj
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Microsoft.EntityFrameworkCore.InMemory.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>In-memory database provider for Entity Framework Core (to be used for testing purposes).</Description>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);In-Memory</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/Microsoft.EntityFrameworkCore.Relational.Design.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/Microsoft.EntityFrameworkCore.Relational.Design.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Shared design-time Entity Framework Core components for relational database providers.</Description>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/Microsoft.EntityFrameworkCore.Relational.Specification.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Shared test suite for Entity Framework Core relational database providers.</Description>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Shared Entity Framework Core components for relational database providers.</Description>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/Microsoft.EntityFrameworkCore.Specification.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Shared test suite for Entity Framework Core database providers.</Description>
     <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft SQL Server database provider for Entity Framework Core.</Description>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQL Server</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Microsoft.EntityFrameworkCore.Sqlite.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>SQLite database provider for Entity Framework Core.</Description>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-    <NoWarn>>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Maybe caused by `dotnet migrate`, might be worth checking for a bug there.