### PR TITLE
Refactor SqlTranslatingExpressionVisitor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/QueryNoClientEvalTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/QueryNoClientEvalTestBase.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.Equal(CoreStrings.WarningAsErrorTemplate(
                         $"{nameof(RelationalEventId)}.{nameof(RelationalEventId.QueryClientEvaluationWarning)}",
                         RelationalStrings.ClientEvalWarning(
-                            "{from Customer c2 in value(Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1[Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind.Customer]) where (([c1].CustomerID == [c2].CustomerID) AndAlso [c2].IsLondon) select [c2] => Any()}")),
+                            "[c2].IsLondon")),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
                             .Where(c1 => context.Customers

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/AsyncQueryMethodProvider.cs
@@ -816,15 +816,48 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual MethodInfo InjectParametersMethod => _injectParametersMethodInfo;
+        public virtual MethodInfo InjectParametersItemMethod => _injectParametersItemMethodInfo;
 
-        private static readonly MethodInfo _injectParametersMethodInfo
+        private static readonly MethodInfo _injectParametersItemMethodInfo
             = typeof(AsyncQueryMethodProvider)
-                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParameters));
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParametersItem));
 
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IAsyncEnumerable<TElement> _InjectParameters<TElement>(
+        private static async Task<TItem> _InjectParametersItem<TItem>(
+            QueryContext queryContext,
+            Func<Task<TItem>> task,
+            string[] parameterNames,
+            object[] parameterValues)
+        {
+            for (var i = 0; i < parameterNames.Length; i++)
+            {
+                queryContext.AddParameter(parameterNames[i], parameterValues[i]);
+            }
+
+            var result = await task();
+
+            for (var i = 0; i < parameterNames.Length; i++)
+            {
+                queryContext.RemoveParameter(parameterNames[i]);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual MethodInfo InjectParametersSequenceMethod => _injectParametersMethodInfo;
+
+        private static readonly MethodInfo _injectParametersMethodInfo
+            = typeof(AsyncQueryMethodProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParametersSequence));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static IAsyncEnumerable<TElement> _InjectParametersSequence<TElement>(
             QueryContext queryContext,
             IAsyncEnumerable<TElement> source,
             string[] parameterNames,

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/ISqlTranslatingExpressionVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/ISqlTranslatingExpressionVisitorFactory.cs
@@ -3,7 +3,6 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Query.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 {
@@ -16,18 +15,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         ///     Creates a new SqlTranslatingExpressionVisitor.
         /// </summary>
         /// <param name="queryModelVisitor"> The query model visitor. </param>
-        /// <param name="targetSelectExpression"> The target select expression. </param>
         /// <param name="topLevelPredicate"> The top level predicate. </param>
-        /// <param name="bindParentQueries"> true to bind parent queries. </param>
         /// <param name="inProjection"> true if we are translating a projection. </param>
+        /// <param name="addToProjections"> false to avoid adding columns to projections. </param>
         /// <returns>
         ///     A SqlTranslatingExpressionVisitor.
         /// </returns>
         SqlTranslatingExpressionVisitor Create(
             [NotNull] RelationalQueryModelVisitor queryModelVisitor,
-            [CanBeNull] SelectExpression targetSelectExpression = null,
             [CanBeNull] Expression topLevelPredicate = null,
-            bool bindParentQueries = false,
-            bool inProjection = false);
+            bool inProjection = false,
+            bool addToProjections = true);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
@@ -115,6 +115,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 return node;
             }
 
+            if (node is OuterPropertyExpression outerPropertyExpression)
+            {
+                return Visit(outerPropertyExpression.BoundExpression);
+            }
+
             return node;
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             if (node.Method.MethodIsClosedFormOf(
-                _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
+                _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersSequenceMethod))
             {
                 var sourceArgument = (MethodCallExpression)Visit(node.Arguments[1]);
                 if (sourceArgument.Method.MethodIsClosedFormOf(
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     var getResultArgument = sourceArgument.Arguments[0];
                     var newGetResultArgument = Expression.Call(
-                        _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod.MakeGenericMethod(typeof(ValueBuffer)),
+                        _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersSequenceMethod.MakeGenericMethod(typeof(ValueBuffer)),
                         node.Arguments[0], getResultArgument, node.Arguments[2], node.Arguments[3]);
 
                     return ResultOperatorHandler.CallWithPossibleCancellationToken(sourceArgument.Method, newGetResultArgument);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -71,29 +71,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         private new RelationalQueryModelVisitor QueryModelVisitor => (RelationalQueryModelVisitor)base.QueryModelVisitor;
 
         /// <summary>
-        ///     Visit a sub-query expression.
-        /// </summary>
-        /// <param name="expression"> The expression. </param>
-        /// <returns>
-        ///     An Expression corresponding to the translated sub-query.
-        /// </returns>
-        protected override Expression VisitSubQuery(SubQueryExpression expression)
-        {
-            Check.NotNull(expression, nameof(expression));
-
-            var queryModelVisitor = (RelationalQueryModelVisitor)CreateQueryModelVisitor();
-
-            queryModelVisitor.VisitQueryModel(expression.QueryModel);
-
-            if (_querySource != null)
-            {
-                QueryModelVisitor.RegisterSubQueryVisitor(_querySource, queryModelVisitor);
-            }
-
-            return queryModelVisitor.Expression;
-        }
-
-        /// <summary>
         ///     Visit a member expression.
         /// </summary>
         /// <param name="node"> The expression to visit. </param>
@@ -111,8 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         => selectExpression.AddToProjection(
                             _relationalAnnotationProvider.For(property).ColumnName,
                             property,
-                            querySource),
-                    bindSubQueries: true);
+                            querySource));
 
             return base.VisitMember(node);
         }
@@ -135,8 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         => selectExpression.AddToProjection(
                             _relationalAnnotationProvider.For(property).ColumnName,
                             property,
-                            querySource),
-                    bindSubQueries: true);
+                            querySource));
 
             return base.VisitMethodCall(node);
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorFactory.cs
@@ -4,7 +4,6 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -54,19 +53,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         ///     Creates a new SqlTranslatingExpressionVisitor.
         /// </summary>
         /// <param name="queryModelVisitor"> The query model visitor. </param>
-        /// <param name="targetSelectExpression"> The target select expression. </param>
         /// <param name="topLevelPredicate"> The top level predicate. </param>
-        /// <param name="bindParentQueries"> true to bind parent queries. </param>
         /// <param name="inProjection"> true if we are translating a projection. </param>
+        /// <param name="addToProjections"> false to avoid adding columns to projections. </param>
         /// <returns>
         ///     A SqlTranslatingExpressionVisitor.
         /// </returns>
         public virtual SqlTranslatingExpressionVisitor Create(
             RelationalQueryModelVisitor queryModelVisitor,
-            SelectExpression targetSelectExpression = null,
             Expression topLevelPredicate = null,
-            bool bindParentQueries = false,
-            bool inProjection = false)
+            bool inProjection = false,
+            bool addToProjections = true)
             => new SqlTranslatingExpressionVisitor(
                 _relationalAnnotationProvider,
                 _compositeExpressionFragmentTranslator,
@@ -74,9 +71,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 _memberTranslator,
                 _relationalTypeMapper,
                 Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)),
-                targetSelectExpression,
                 topLevelPredicate,
-                bindParentQueries,
-                inProjection);
+                inProjection,
+                addToProjections);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/OuterPropertyExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/OuterPropertyExpression.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Clauses;
+using Microsoft.EntityFrameworkCore.Query.Sql;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions
+{
+    /// <summary>
+    ///     An expression that represents an AliasExpression from an outer query
+    ///     but may later be bound to a PropertyParameterExpression instead.
+    /// </summary>
+    public class OuterPropertyExpression : Expression
+    {
+        /// <summary>
+        ///     Creates a new instance of a ColumnExpression.
+        /// </summary>
+        /// <param name="sourceExpression"> The column name. </param>
+        /// <param name="property"> The corresponding property. </param>
+        /// <param name="querySource"> The target table expression. </param>
+        /// <param name="aliasExpression"> The target table expression. </param>
+        public OuterPropertyExpression(
+            [NotNull] Expression sourceExpression,
+            [NotNull] IProperty property,
+            [NotNull] IQuerySource querySource,
+            [NotNull] AliasExpression aliasExpression)
+            : this(sourceExpression, property, querySource, (Expression)aliasExpression)
+        {
+        }
+
+        private OuterPropertyExpression(
+            [NotNull] Expression sourceExpression,
+            [NotNull] IProperty property,
+            [NotNull] IQuerySource querySource,
+            [NotNull] Expression boundExpression)
+        {
+            SourceExpression = Check.NotNull(sourceExpression, nameof(sourceExpression));
+            Property = Check.NotNull(property, nameof(property));
+            QuerySource = Check.NotNull(querySource, nameof(querySource));
+            BoundExpression = Check.NotNull(boundExpression, nameof(boundExpression));
+        }
+
+        /// <summary>
+        ///     The target table.
+        /// </summary>
+        public virtual Expression SourceExpression { get; }
+
+#pragma warning disable 108
+
+        /// <summary>
+        ///     The corresponding property.
+        /// </summary>
+        public virtual IProperty Property { get; }
+
+#pragma warning restore 108
+
+        /// <summary>
+        ///     The target table alias.
+        /// </summary>
+        public virtual IQuerySource QuerySource { get; }
+
+        /// <summary>
+        ///     Gets the column name.
+        /// </summary>
+        /// <value>
+        ///     The column name.
+        /// </value>
+        public virtual Expression BoundExpression { get; private set; }
+
+        /// <summary>
+        ///     Gets a value indicating whether or not this outer property expression
+        ///     has been resolved.
+        /// </summary>
+        public virtual bool Resolved { get; private set; }
+
+        /// <summary>
+        ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
+        /// </summary>
+        /// <returns> The <see cref="ExpressionType" /> that represents this expression. </returns>
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     Gets the static type of the expression that this <see cref="Expression" /> represents. (Inherited from <see cref="Expression" />.)
+        /// </summary>
+        /// <returns> The <see cref="Type" /> that represents the static type of the expression. </returns>
+        public override Type Type => Property.ClrType;
+
+        /// <summary>
+        ///     Resolves this outer property expression to its current bound expression.
+        /// </summary>
+        public virtual void Resolve()
+        {
+            Resolved = true;
+        }
+
+        /// <summary>
+        ///     Resolves this outer property expression to a new bound expression.
+        /// </summary>
+        /// <param name="boundExpression"> The property parameter. </param>
+        public virtual void Resolve([NotNull] Expression boundExpression)
+        {
+            Check.NotNull(boundExpression, nameof(boundExpression));
+
+            BoundExpression = boundExpression;
+            Resolved = true;
+        }
+
+        /// <summary>
+        ///     Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is ISqlExpressionVisitor
+                ? visitor.Visit(BoundExpression)
+                : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(Expression)" /> method passing the
+        ///     reduced expression.
+        ///     Throws an exception if the node isn't reducible.
+        /// </summary>
+        /// <param name="visitor"> An instance of <see cref="ExpressionVisitor" />. </param>
+        /// <returns> The expression being visited, or an expression which should replace it in the tree. </returns>
+        /// <remarks>
+        ///     Override this method to provide logic to walk the node's children.
+        ///     A typical implementation will call visitor.Visit on each of its
+        ///     children, and if any of them change, should return a new copy of
+        ///     itself with the modified children.
+        /// </remarks>
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var boundExpression = visitor.Visit(BoundExpression);
+
+            if (boundExpression != BoundExpression)
+            {
+                var newOuterPropertyExpression
+                    = new OuterPropertyExpression(
+                        SourceExpression,
+                        Property,
+                        QuerySource,
+                        boundExpression);
+
+                newOuterPropertyExpression.Resolved = Resolved;
+
+                return newOuterPropertyExpression;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="string" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
+        public override string ToString()
+        {
+            return !Resolved
+                ? $"Unresolved({BoundExpression})"
+                : BoundExpression.ToString();
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -213,10 +213,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             {
                 if (!_correlated)
                 {
-                    var columnExpression = expression as ColumnExpression;
+                    var querySource
+                        = (expression as ColumnExpression)?.Table.QuerySource
+                            ?? (expression as OuterPropertyExpression)?.QuerySource;
 
-                    if (columnExpression?.Table.QuerySource != null
-                        && !_selectExpression.HandlesQuerySource(columnExpression.Table.QuerySource))
+                    if (querySource != null && !_selectExpression.HandlesQuerySource(querySource))
                     {
                         _correlated = true;
                     }
@@ -952,15 +953,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <param name="tableExpression"> The target table expression. </param>
         /// <param name="projection"> A sequence of expressions that should be added to the projection. </param>
-        public virtual void AddCrossJoin(
+        public virtual JoinExpressionBase AddCrossJoin(
             [NotNull] TableExpressionBase tableExpression,
             [NotNull] IEnumerable<Expression> projection)
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
             Check.NotNull(projection, nameof(projection));
 
-            _tables.Add(new CrossJoinExpression(tableExpression));
+            var crossJoinExpression = new CrossJoinExpression(tableExpression);
+
+            _tables.Add(crossJoinExpression);
             _projection.AddRange(projection);
+
+            return crossJoinExpression;
         }
 
         /// <summary>
@@ -968,15 +973,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <param name="tableExpression"> The target table expression. </param>
         /// <param name="projection"> A sequence of expressions that should be added to the projection. </param>
-        public virtual void AddCrossJoinLateral(
+        public virtual JoinExpressionBase AddCrossJoinLateral(
             [NotNull] TableExpressionBase tableExpression,
             [NotNull] IEnumerable<Expression> projection)
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
             Check.NotNull(projection, nameof(projection));
 
-            _tables.Add(new CrossJoinLateralExpression(tableExpression));
+            var crossJoinLateralExpression = new CrossJoinLateralExpression(tableExpression);
+
+            _tables.Add(crossJoinLateralExpression);
             _projection.AddRange(projection);
+
+            return crossJoinLateralExpression;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/IQueryMethodProvider.cs
@@ -95,12 +95,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         MethodInfo CreateCollectionRelatedEntitiesLoaderMethod { get; }
 
         /// <summary>
-        ///     Gets the inject parameters method.
+        ///     Gets the inject parameters method for non-sequence results.
         /// </summary>
         /// <value>
         ///     The pre execute method.
         /// </value>
-        MethodInfo InjectParametersMethod { get; }
+        MethodInfo InjectParametersItemMethod { get; }
+
+        /// <summary>
+        ///     Gets the inject parameters method for sequence results.
+        /// </summary>
+        /// <value>
+        ///     The pre execute method.
+        /// </value>
+        MethodInfo InjectParametersSequenceMethod { get; }
 
         /// <summary>
         ///     Gets the type of the group join include.

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/QueryMethodProvider.cs
@@ -529,15 +529,48 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual MethodInfo InjectParametersMethod => _injectParametersMethodInfo;
+        public virtual MethodInfo InjectParametersItemMethod => _injectParametersItemMethodInfo;
 
-        private static readonly MethodInfo _injectParametersMethodInfo
+        private static readonly MethodInfo _injectParametersItemMethodInfo
             = typeof(QueryMethodProvider)
-                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParameters));
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParametersItem));
 
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IEnumerable<TElement> _InjectParameters<TElement>(
+        private static TItem _InjectParametersItem<TItem>(
+            QueryContext queryContext,
+            Func<TItem> source,
+            string[] parameterNames,
+            object[] parameterValues)
+        {
+            for (var i = 0; i < parameterNames.Length; i++)
+            {
+                queryContext.AddParameter(parameterNames[i], parameterValues[i]);
+            }
+
+            var result = source();
+
+            for (var i = 0; i < parameterNames.Length; i++)
+            {
+                queryContext.RemoveParameter(parameterNames[i]);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual MethodInfo InjectParametersSequenceMethod => _injectParametersSequenceMethodInfo;
+
+        private static readonly MethodInfo _injectParametersSequenceMethodInfo
+            = typeof(QueryMethodProvider)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_InjectParametersSequence));
+
+        [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
+        private static IEnumerable<TElement> _InjectParametersSequence<TElement>(
             QueryContext queryContext,
             IEnumerable<TElement> source,
             string[] parameterNames,

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3202,7 +3202,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             where (from l1_inner in context.LevelOne.ToList()
                                    join l2_inner in context.LevelTwo.ToList() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping
                                    from l2_inner in grouping.DefaultIfEmpty()
-                                   select l1_inner).Distinct().Count() > 7
+                                   select ClientStringMethod(l1_inner.Name)).Count() > 7
                             where l1.Id < 3
                             select l1.Name).ToList();
             }
@@ -3321,7 +3321,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
         private static string ClientStringMethod(string argument)
         {
-            return argument;
+            return argument + " ";
         }
 
         [ConditionalFact]

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
@@ -46,20 +46,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Check.NotNull(expression, nameof(expression));
 
-            var queryModelVisitor = CreateQueryModelVisitor();
+            var compilationContext = QueryModelVisitor.QueryCompilationContext;
 
-            queryModelVisitor.VisitQueryModel(expression.QueryModel);
+            var subQueryModelVisitor = compilationContext.GetQueryModelVisitor(expression.QueryModel);
 
-            return queryModelVisitor.Expression;
+            if (subQueryModelVisitor == null)
+            {
+                subQueryModelVisitor
+                    = compilationContext.CreateQueryModelVisitor(
+                        expression.QueryModel,
+                        QueryModelVisitor);
+
+                subQueryModelVisitor.VisitQueryModel(expression.QueryModel);
+            }
+
+            return subQueryModelVisitor.Expression;
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected virtual EntityQueryModelVisitor CreateQueryModelVisitor()
-            => QueryModelVisitor.QueryCompilationContext
-                .CreateQueryModelVisitor(_entityQueryModelVisitor);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
@@ -36,11 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// </returns>
         protected override Expression VisitSubQuery(SubQueryExpression expression)
         {
-            var queryModelVisitor = CreateQueryModelVisitor();
-
-            queryModelVisitor.VisitQueryModel(expression.QueryModel);
-
-            var subExpression = queryModelVisitor.Expression;
+            var subExpression = base.VisitSubQuery(expression);
 
             if (subExpression.Type != expression.Type)
             {

--- a/src/Microsoft.EntityFrameworkCore/Storage/Database.cs
+++ b/src/Microsoft.EntityFrameworkCore/Storage/Database.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual Func<QueryContext, IEnumerable<TResult>> CompileQuery<TResult>(QueryModel queryModel)
             => _queryCompilationContextFactory
                 .Create(async: false)
-                .CreateQueryModelVisitor()
+                .CreateQueryModelVisitor(queryModel)
                 .CreateQueryExecutor<TResult>(Check.NotNull(queryModel, nameof(queryModel)));
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TResult>(QueryModel queryModel)
             => _queryCompilationContextFactory
                 .Create(async: true)
-                .CreateQueryModelVisitor()
+                .CreateQueryModelVisitor(queryModel)
                 .CreateAsyncQueryExecutor<TResult>(Check.NotNull(queryModel, nameof(queryModel)));
     }
 }

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace System
@@ -99,6 +100,18 @@ namespace System
 
             var underlyingEnumType = Enum.GetUnderlyingType(underlyingNonNullableType);
             return isNullable ? MakeNullable(underlyingEnumType) : underlyingEnumType;
+        }
+
+        public static Type UnwrapTaskResultType(this Type type) => UnwrapTaskResultType(type.GetTypeInfo());
+
+        public static Type UnwrapTaskResultType(this TypeInfo typeInfo)
+        {
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Task<>))
+            {
+                return typeInfo.GenericTypeArguments[0];
+            }
+
+            return typeInfo.AsType();
         }
 
         public static Type GetSequenceType(this Type type)

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -286,9 +286,9 @@ ORDER BY [c3].[ComplexNavigationStringDefaultText]",
                 @"SELECT [e1].[Id], [e2].[Id]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e2] ON [e1].[Id] = (
-    SELECT TOP(1) [subQuery0].[Id]
-    FROM [Level1] AS [subQuery0]
-    WHERE [subQuery0].[Id] = [e2].[Level1_Optional_Id]
+    SELECT TOP(1) [subQuery].[Id]
+    FROM [Level1] AS [subQuery]
+    WHERE [subQuery].[Id] = [e2].[Level1_Optional_Id]
 )",
                 Sql);
         }
@@ -480,9 +480,9 @@ INNER JOIN [Level1] AS [e1] ON [e3.OneToOne_Required_FK_Inverse.OneToOne_Optiona
                 @"SELECT [e2].[Id], [e1].[Id]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
-    SELECT TOP(1) [subQuery0].[Id]
-    FROM [Level2] AS [subQuery0]
-    WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
+    SELECT TOP(1) [subQuery].[Id]
+    FROM [Level2] AS [subQuery]
+    WHERE [subQuery].[Level1_Optional_Id] = [e1].[Id]
 )",
                 Sql);
         }
@@ -495,14 +495,14 @@ INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
                 @"SELECT [e2].[Id], [e1].[Id], [e3].[Id]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
-    SELECT TOP(1) [subQuery0].[Id]
-    FROM [Level2] AS [subQuery0]
-    WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
+    SELECT TOP(1) [subQuery].[Id]
+    FROM [Level2] AS [subQuery]
+    WHERE [subQuery].[Level1_Optional_Id] = [e1].[Id]
 )
 INNER JOIN [Level3] AS [e3] ON [e2].[Id] = (
-    SELECT TOP(1) [subQuery2].[Id]
-    FROM [Level2] AS [subQuery2]
-    WHERE [subQuery2].[Id] = [e3].[Level2_Optional_Id]
+    SELECT TOP(1) [subQuery0].[Id]
+    FROM [Level2] AS [subQuery0]
+    WHERE [subQuery0].[Id] = [e3].[Level2_Optional_Id]
 )",
                 Sql);
         }
@@ -515,9 +515,9 @@ INNER JOIN [Level3] AS [e3] ON [e2].[Id] = (
                 @"SELECT [e2].[Id], [e2].[Name], [e1].[Id], [e1].[Name]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Name] = (
-    SELECT TOP(1) [subQuery0].[Name]
-    FROM [Level2] AS [subQuery0]
-    WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
+    SELECT TOP(1) [subQuery].[Name]
+    FROM [Level2] AS [subQuery]
+    WHERE [subQuery].[Level1_Optional_Id] = [e1].[Id]
 )",
                 Sql);
         }
@@ -530,9 +530,9 @@ INNER JOIN [Level1] AS [e1] ON [e2].[Name] = (
                 @"SELECT [e1].[Id], [e2].[Id]
 FROM [Level1] AS [e1]
 INNER JOIN [Level1] AS [e2] ON [e1].[Id] = (
-    SELECT TOP(1) [subQuery0].[Id]
-    FROM [Level1] AS [subQuery0]
-    WHERE [subQuery0].[Id] = [e2].[OneToMany_Optional_Self_InverseId]
+    SELECT TOP(1) [subQuery].[Id]
+    FROM [Level1] AS [subQuery]
+    WHERE [subQuery].[Id] = [e2].[OneToMany_Optional_Self_InverseId]
 )",
                 Sql);
         }
@@ -590,11 +590,11 @@ FROM [Level4] AS [e4]",
                 @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
 FROM [Level1] AS [e1]
 INNER JOIN [Level4] AS [e4] ON [e1].[Name] = (
-    SELECT TOP(1) [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0].[Name]
-    FROM [Level3] AS [subQuery0]
-    INNER JOIN [Level2] AS [subQuery.OneToOne_Required_FK_Inverse0] ON [subQuery0].[Level2_Required_Id] = [subQuery.OneToOne_Required_FK_Inverse0].[Id]
-    INNER JOIN [Level1] AS [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0] ON [subQuery.OneToOne_Required_FK_Inverse0].[Id] = [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0].[Id]
-    WHERE [subQuery0].[Id] = [e4].[Level3_Required_Id]
+    SELECT TOP(1) [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse].[Name]
+    FROM [Level3] AS [subQuery]
+    INNER JOIN [Level2] AS [subQuery.OneToOne_Required_FK_Inverse] ON [subQuery].[Level2_Required_Id] = [subQuery.OneToOne_Required_FK_Inverse].[Id]
+    INNER JOIN [Level1] AS [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse] ON [subQuery.OneToOne_Required_FK_Inverse].[Id] = [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse].[Id]
+    WHERE [subQuery].[Id] = [e4].[Level3_Required_Id]
 )",
                 Sql);
         }
@@ -1628,9 +1628,9 @@ WHERE EXISTS (
                 @"SELECT [e1].[Name], [e2].[Id]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e2] ON [e1].[Id] = (
-    SELECT TOP(1) [subQuery0].[Id]
-    FROM [Level1] AS [subQuery0]
-    WHERE [subQuery0].[Id] = [e2].[Level1_Optional_Id]
+    SELECT TOP(1) [subQuery].[Id]
+    FROM [Level1] AS [subQuery]
+    WHERE [subQuery].[Id] = [e2].[Level1_Optional_Id]
 )
 WHERE EXISTS (
     SELECT 1
@@ -1660,28 +1660,14 @@ WHERE EXISTS (
             base.Correlated_nested_two_levels_up_subquery_doesnt_project_unnecessary_columns_in_top_level();
 
             Assert.StartsWith(
-                @"SELECT [l1].[Name]
+                @"SELECT DISTINCT [l1].[Name]
 FROM [Level1] AS [l1]
-
-SELECT 1
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level2] AS [l2]
+    WHERE EXISTS (
         SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT 1
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
+        FROM [Level3] AS [l3]))",
                 Sql);
         }
 
@@ -1706,13 +1692,10 @@ ORDER BY [l1].[Id]",
             base.GroupJoin_on_complex_subquery_and_set_operation_on_grouping_but_nothing_from_grouping_is_projected();
 
             Assert.Contains(
-                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
-FROM (
-    SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
-    FROM [Level1] AS [l10]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
-    WHERE ([l10].[Name] <> N'L1 01') OR [l10].[Name] IS NULL
-) AS [t]",
+                @"SELECT [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId], [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
+WHERE ([l10].[Name] <> N'L1 01') OR [l10].[Name] IS NULL",
                 Sql);
 
             Assert.Contains(
@@ -1726,12 +1709,9 @@ FROM [Level1] AS [l1]",
             base.Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin1();
 
             Assert.Contains(
-                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
-FROM (
-    SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
-    FROM [Level1] AS [l10]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
-) AS [t]",
+                @"SELECT [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId], [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]",
                 Sql);
 
             Assert.Contains(
@@ -1745,12 +1725,12 @@ FROM [Level1] AS [l1]",
             base.Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin2();
 
             Assert.Contains(
-                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
-FROM (
-    SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
-    FROM [Level1] AS [l10]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
-) AS [t]",
+                @"SELECT [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId], [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
+
+SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]",
                 Sql);
 
             Assert.Contains(
@@ -1866,10 +1846,10 @@ ORDER BY [t].[Id]",
             Assert.Equal(
                 @"@__p_0: 10
 
-SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse0].[Id], [l3.OneToOne_Required_FK_Inverse0].[Date], [l3.OneToOne_Required_FK_Inverse0].[Level1_Optional_Id], [l3.OneToOne_Required_FK_Inverse0].[Level1_Required_Id], [l3.OneToOne_Required_FK_Inverse0].[Name], [l3.OneToOne_Required_FK_Inverse0].[OneToMany_Optional_InverseId], [l3.OneToOne_Required_FK_Inverse0].[OneToMany_Optional_Self_InverseId], [l3.OneToOne_Required_FK_Inverse0].[OneToMany_Required_InverseId], [l3.OneToOne_Required_FK_Inverse0].[OneToMany_Required_Self_InverseId], [l3.OneToOne_Required_FK_Inverse0].[OneToOne_Optional_PK_InverseId], [l3.OneToOne_Required_FK_Inverse0].[OneToOne_Optional_SelfId], [l30].[Name]
-FROM [Level3] AS [l30]
-INNER JOIN [Level2] AS [l3.OneToOne_Required_FK_Inverse0] ON [l30].[Level2_Required_Id] = [l3.OneToOne_Required_FK_Inverse0].[Id]
-ORDER BY [l3.OneToOne_Required_FK_Inverse0].[Id]",
+SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse].[Id], [l3.OneToOne_Required_FK_Inverse].[Date], [l3.OneToOne_Required_FK_Inverse].[Level1_Optional_Id], [l3.OneToOne_Required_FK_Inverse].[Level1_Required_Id], [l3.OneToOne_Required_FK_Inverse].[Name], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_PK_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId], [l3].[Name]
+FROM [Level3] AS [l3]
+INNER JOIN [Level2] AS [l3.OneToOne_Required_FK_Inverse] ON [l3].[Level2_Required_Id] = [l3.OneToOne_Required_FK_Inverse].[Id]
+ORDER BY [l3.OneToOne_Required_FK_Inverse].[Id]",
                 Sql);
         }
 
@@ -1906,11 +1886,11 @@ FROM (
             Assert.Equal(
                 @"@__p_0: 3
 
-SELECT TOP(@__p_0) [l20].[Id], [l20].[Date], [l20].[Level1_Optional_Id], [l20].[Level1_Required_Id], [l20].[Name], [l20].[OneToMany_Optional_InverseId], [l20].[OneToMany_Optional_Self_InverseId], [l20].[OneToMany_Required_InverseId], [l20].[OneToMany_Required_Self_InverseId], [l20].[OneToOne_Optional_PK_InverseId], [l20].[OneToOne_Optional_SelfId], [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId]
-FROM [Level2] AS [l20]
-INNER JOIN [Level1] AS [l10] ON [l20].[Level1_Required_Id] = [l10].[Id]
-INNER JOIN [Level3] AS [l30] ON [l10].[Id] = [l30].[Level2_Required_Id]
-WHERE ([l10].[Name] = N'L1 03') AND ([l30].[Name] = N'L3 08')",
+SELECT TOP(@__p_0) [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId], [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+INNER JOIN [Level1] AS [l1] ON [l2].[Level1_Required_Id] = [l1].[Id]
+INNER JOIN [Level3] AS [l3] ON [l1].[Id] = [l3].[Level2_Required_Id]
+WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')",
                 Sql);
         }
 
@@ -2329,9 +2309,9 @@ INNER JOIN (
                 @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 INNER JOIN [Level2] AS [l2] ON [l1].[Id] = (
-    SELECT TOP(1) [l0].[Id]
-    FROM [Level2] AS [l0]
-    ORDER BY [l0].[Id]
+    SELECT TOP(1) [l].[Id]
+    FROM [Level2] AS [l]
+    ORDER BY [l].[Id]
 )",
                 Sql);
         }
@@ -2368,22 +2348,16 @@ WHERE 1 IN (
         {
             base.GroupJoin_on_left_side_being_a_subquery();
 
-            Assert.Contains(
+            Assert.Equal(
                 @"SELECT [x.OneToOne_Optional_FK].[Id], [x.OneToOne_Optional_FK].[Date], [x.OneToOne_Optional_FK].[Level1_Optional_Id], [x.OneToOne_Optional_FK].[Level1_Required_Id], [x.OneToOne_Optional_FK].[Name], [x.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
-FROM [Level2] AS [x.OneToOne_Optional_FK]",
-                Sql);
+FROM [Level2] AS [x.OneToOne_Optional_FK]
 
-            Assert.Contains(
-                @"@__p_0: 2
+@__p_0: 2
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id] AS [c0], [l1.OneToOne_Optional_FK].[Date] AS [c1], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name] AS [c2], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId] AS [c3], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId] AS [c4], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
-    ORDER BY [l1.OneToOne_Optional_FK].[Name]
-) AS [t]
-ORDER BY [t].[Name]",
+SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Name]",
                 Sql);
         }
 
@@ -2391,21 +2365,15 @@ ORDER BY [t].[Name]",
         {
             base.GroupJoin_on_right_side_being_a_subquery();
 
-            Assert.Contains(
+            Assert.Equal(
                 @"@__p_0: 2
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [x].[Id], [x].[Date], [x].[Name], [x].[OneToMany_Optional_Self_InverseId], [x].[OneToMany_Required_Self_InverseId], [x].[OneToOne_Optional_SelfId], [x.OneToOne_Optional_FK].[Id] AS [c0], [x.OneToOne_Optional_FK].[Date] AS [c1], [x.OneToOne_Optional_FK].[Level1_Optional_Id], [x.OneToOne_Optional_FK].[Level1_Required_Id], [x.OneToOne_Optional_FK].[Name] AS [c2], [x.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId] AS [c3], [x.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId] AS [c4], [x.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [x]
-    LEFT JOIN [Level2] AS [x.OneToOne_Optional_FK] ON [x].[Id] = [x.OneToOne_Optional_FK].[Level1_Optional_Id]
-    ORDER BY [x.OneToOne_Optional_FK].[Name]
-) AS [t]
-ORDER BY [t].[Name]",
-                Sql);
+SELECT TOP(@__p_0) [x].[Id], [x].[Date], [x].[Name], [x].[OneToMany_Optional_Self_InverseId], [x].[OneToMany_Required_Self_InverseId], [x].[OneToOne_Optional_SelfId], [x.OneToOne_Optional_FK].[Id], [x.OneToOne_Optional_FK].[Date], [x.OneToOne_Optional_FK].[Level1_Optional_Id], [x.OneToOne_Optional_FK].[Level1_Required_Id], [x.OneToOne_Optional_FK].[Name], [x.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [x]
+LEFT JOIN [Level2] AS [x.OneToOne_Optional_FK] ON [x].[Id] = [x.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [x.OneToOne_Optional_FK].[Name]
 
-            Assert.Contains(
-                @"SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l2]",
                 Sql);
         }
@@ -2439,12 +2407,12 @@ FROM [Level1] AS [l1]
 WHERE [l1].[Id] < 3
 
 SELECT COUNT(*)
-FROM [Level1] AS [l1_inner0]
-LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Optional_Id]
+FROM [Level1] AS [l1_inner]
+LEFT JOIN [Level2] AS [l2_inner] ON [l1_inner].[Id] = [l2_inner].[Level1_Optional_Id]
 
 SELECT COUNT(*)
-FROM [Level1] AS [l1_inner0]
-LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Optional_Id]",
+FROM [Level1] AS [l1_inner]
+LEFT JOIN [Level2] AS [l2_inner] ON [l1_inner].[Id] = [l2_inner].[Level1_Optional_Id]",
                 Sql);
         }
 
@@ -2462,12 +2430,8 @@ FROM [Level1] AS [l1_middle]
 LEFT JOIN [Level2] AS [l2_middle] ON [l1_middle].[Id] = [l2_middle].[Level1_Optional_Id]
 
 SELECT COUNT(*)
-FROM [Level1] AS [l1_inner0]
-LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Optional_Id]
-
-SELECT COUNT(*)
-FROM [Level1] AS [l1_inner0]
-LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Optional_Id]",
+FROM [Level1] AS [l1_inner]
+LEFT JOIN [Level2] AS [l2_inner] ON [l1_inner].[Id] = [l2_inner].[Level1_Optional_Id]",
                 Sql);
         }
 
@@ -2475,19 +2439,18 @@ LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Opti
         {
             base.GroupJoin_in_subquery_with_client_projection_nested2();
 
-            Assert.Equal(
+            Assert.StartsWith(
                 @"SELECT [l1_outer].[Id], [l1_outer].[Name]
 FROM [Level1] AS [l1_outer]
 WHERE [l1_outer].[Id] < 2
 
+SELECT [l1_middle].[Id], [l1_middle].[Date], [l1_middle].[Name], [l1_middle].[OneToMany_Optional_Self_InverseId], [l1_middle].[OneToMany_Required_Self_InverseId], [l1_middle].[OneToOne_Optional_SelfId], [l2_middle].[Id], [l2_middle].[Date], [l2_middle].[Level1_Optional_Id], [l2_middle].[Level1_Required_Id], [l2_middle].[Name], [l2_middle].[OneToMany_Optional_InverseId], [l2_middle].[OneToMany_Optional_Self_InverseId], [l2_middle].[OneToMany_Required_InverseId], [l2_middle].[OneToMany_Required_Self_InverseId], [l2_middle].[OneToOne_Optional_PK_InverseId], [l2_middle].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1_middle]
+LEFT JOIN [Level2] AS [l2_middle] ON [l1_middle].[Id] = [l2_middle].[Level1_Optional_Id]
+
 SELECT COUNT(*)
-FROM [Level1] AS [l1_middle0]
-LEFT JOIN [Level2] AS [l2_middle1] ON [l1_middle0].[Id] = [l2_middle1].[Level1_Optional_Id]
-WHERE (
-    SELECT COUNT(*)
-    FROM [Level1] AS [l1_inner0]
-    LEFT JOIN [Level2] AS [l2_inner1] ON [l1_inner0].[Id] = [l2_inner1].[Level1_Optional_Id]
-) > 7",
+FROM [Level1] AS [l1_inner]
+LEFT JOIN [Level2] AS [l2_inner] ON [l1_inner].[Id] = [l2_inner].[Level1_Optional_Id]",
                 Sql);
         }
 
@@ -2568,13 +2531,10 @@ ORDER BY [l1].[Id]",
             Assert.Equal(
                 @"@__p_0: 15
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id] AS [c0], [l1.OneToOne_Optional_FK].[Date] AS [c1], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name] AS [c2], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId] AS [c3], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId] AS [c4], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
-    WHERE ([l1.OneToOne_Optional_FK].[Name] <> N'Foo') OR [l1.OneToOne_Optional_FK].[Name] IS NULL
-) AS [t]",
+SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+WHERE ([l1.OneToOne_Optional_FK].[Name] <> N'Foo') OR [l1.OneToOne_Optional_FK].[Name] IS NULL",
                 Sql);
         }
 
@@ -2585,13 +2545,10 @@ FROM (
             Assert.Equal(
                 @"@__p_0: 15
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id] AS [c0], [l2].[Date] AS [c1], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name] AS [c2], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId] AS [c3], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId] AS [c4], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
-    WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL
-) AS [t]",
+SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL",
                 Sql);
         }
 
@@ -2600,10 +2557,10 @@ FROM (
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
 
             Assert.Equal(
-                @"SELECT [l10].[Id], [l10].[Date], [l10].[Name], [l10].[OneToMany_Optional_Self_InverseId], [l10].[OneToMany_Required_Self_InverseId], [l10].[OneToOne_Optional_SelfId], [l21].[Id], [l21].[Date], [l21].[Level1_Optional_Id], [l21].[Level1_Required_Id], [l21].[Name], [l21].[OneToMany_Optional_InverseId], [l21].[OneToMany_Optional_Self_InverseId], [l21].[OneToMany_Required_InverseId], [l21].[OneToMany_Required_Self_InverseId], [l21].[OneToOne_Optional_PK_InverseId], [l21].[OneToOne_Optional_SelfId]
-FROM [Level1] AS [l10]
-LEFT JOIN [Level2] AS [l21] ON [l10].[Id] = [l21].[Level1_Optional_Id]
-WHERE ([l21].[Name] <> N'Foo') OR [l21].[Name] IS NULL",
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1227,7 +1227,7 @@ WHERE [ct].[GearNickName] IS NULL AND [ct].[GearSquadId] IS NULL",
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected();
 
             Assert.Equal(
-                @"SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [ct2].[Id]
+                @"SELECT [ct1].[Id], [ct1].[GearNickName], [ct1].[GearSquadId], [ct1].[Note], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [ct2].[GearNickName], [ct2].[GearSquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [ct2].[Id]
 FROM [CogTag] AS [ct1]
 LEFT JOIN (
     SELECT [ct1.Gear].[Nickname], [ct1.Gear].[SquadId], [ct1.Gear].[AssignedCityName], [ct1.Gear].[CityOrBirthName], [ct1.Gear].[Discriminator], [ct1.Gear].[FullName], [ct1.Gear].[HasSoulPatch], [ct1.Gear].[LeaderNickname], [ct1.Gear].[LeaderSquadId], [ct1.Gear].[Rank]
@@ -1305,9 +1305,9 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
                 @"SELECT [g].[FullName], [t].[Note]
 FROM [Gear] AS [g]
 INNER JOIN [CogTag] AS [t] ON [g].[FullName] = (
-    SELECT TOP(1) [subQuery0].[FullName]
-    FROM [Gear] AS [subQuery0]
-    WHERE [subQuery0].[Discriminator] IN (N'Officer', N'Gear') AND (([subQuery0].[Nickname] = [t].[GearNickName]) AND ([subQuery0].[SquadId] = [t].[GearSquadId]))
+    SELECT TOP(1) [subQuery].[FullName]
+    FROM [Gear] AS [subQuery]
+    WHERE [subQuery].[Discriminator] IN (N'Officer', N'Gear') AND (([subQuery].[Nickname] = [t].[GearNickName]) AND ([subQuery].[SquadId] = [t].[GearSquadId]))
 )
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
                 Sql);
@@ -2086,12 +2086,6 @@ FROM [CogTag] AS [t]",
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
-                Sql);
-
-            Assert.Contains(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[Nickname] IS NULL",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -196,13 +196,16 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Assert.StartsWith(
                     @"@__p_0: 20
 
-SELECT [c0].[CustomerID]
-FROM [Customers] AS [c0]
-ORDER BY [c0].[CustomerID]
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 OFFSET @__p_0 ROWS
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+@_outer_CustomerID: FAMIA (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                     Sql);
             }
@@ -308,13 +311,13 @@ WHERE (([o.Customer].[City] = N'Seattle') AND [o.Customer].[City] IS NOT NULL) A
 
             Assert.Equal(
                 @"SELECT (
-    SELECT SUM([od0].[Quantity])
-    FROM [Order Details] AS [od0]
-    WHERE [o].[OrderID] = [od0].[OrderID]
+    SELECT SUM([od].[Quantity])
+    FROM [Order Details] AS [od]
+    WHERE [o].[OrderID] = [od].[OrderID]
 ) + (
     SELECT COUNT(*)
-    FROM [Order Details] AS [o1]
-    WHERE [o].[OrderID] = [o1].[OrderID]
+    FROM [Order Details] AS [o0]
+    WHERE [o].[OrderID] = [o0].[OrderID]
 )
 FROM [Orders] AS [o]",
                 Sql);
@@ -452,23 +455,41 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 WHERE [o].[CustomerID] = N'ALFKI'
 
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]",
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 Sql);
         }
 
@@ -481,8 +502,8 @@ FROM [Orders] AS [o0]",
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
-            FROM [Orders] AS [o0]
-            WHERE [c].[CustomerID] = [o0].[CustomerID])
+            FROM [Orders] AS [o]
+            WHERE [c].[CustomerID] = [o].[CustomerID])
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 )
@@ -544,8 +565,8 @@ WHERE EXISTS (
     SELECT CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM [Orders] AS [o0]
-            WHERE (([c].[CustomerID] = [o0].[CustomerID]) AND [o0].[CustomerID] IS NOT NULL) AND (([o0].[CustomerID] <> N'ALFKI') OR [o0].[CustomerID] IS NULL))
+            FROM [Orders] AS [o]
+            WHERE (([c].[CustomerID] = [o].[CustomerID]) AND [o].[CustomerID] IS NOT NULL) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 )
@@ -562,17 +583,17 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID1: ALFKI (Size = 450)
+@_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID1 = [o1].[CustomerID]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
 
-@_outer_CustomerID1: ANATR (Size = 450)
+@_outer_CustomerID: ANATR (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID1 = [o1].[CustomerID]",
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Sql);
         }
 
@@ -620,8 +641,8 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT(*)
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -679,8 +700,8 @@ ORDER BY (
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT_BIG(*)
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -693,14 +714,14 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT(*)
-    FROM [Order Details] AS [o2]
-    WHERE [o].[OrderID] = [o2].[OrderID]
+    FROM [Order Details] AS [o0]
+    WHERE [o].[OrderID] = [o0].[OrderID]
 ), [o].[OrderDate], (
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
-            FROM [Order Details] AS [od1]
-            WHERE ([od1].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od1].[OrderID]))
+            FROM [Order Details] AS [od]
+            WHERE ([od].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od].[OrderID]))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 ), CASE
@@ -710,14 +731,14 @@ END, [o].[OrderID], (
     SELECT CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM [Order Details] AS [od2]
-            WHERE ([o].[OrderID] = [od2].[OrderID]) AND ([od2].[OrderID] <> 42))
+            FROM [Order Details] AS [od0]
+            WHERE ([o].[OrderID] = [od0].[OrderID]) AND ([od0].[OrderID] <> 42))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 ), (
     SELECT COUNT_BIG(*)
-    FROM [Order Details] AS [o3]
-    WHERE [o].[OrderID] = [o3].[OrderID]
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]
 )
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)",
@@ -730,9 +751,9 @@ WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) =
 
             Assert.Equal(
                 @"SELECT (
-    SELECT SUM([o0].[OrderID])
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -970,26 +991,26 @@ WHERE EXISTS (
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o4].[OrderID]
-FROM [Orders] AS [o4]
+SELECT [o0].[OrderID]
+FROM [Orders] AS [o0]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o2].[OrderID]
-FROM [Orders] AS [o2]
-WHERE @_outer_CustomerID = [o2].[CustomerID]
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
 
-SELECT [o4].[OrderID]
-FROM [Orders] AS [o4]
+SELECT [o0].[OrderID]
+FROM [Orders] AS [o0]
 
 @_outer_CustomerID: ANATR (Size = 450)
 
-SELECT [o2].[OrderID]
-FROM [Orders] AS [o2]
-WHERE @_outer_CustomerID = [o2].[CustomerID]
+SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
 
-SELECT [o4].[OrderID]
-FROM [Orders] AS [o4]",
+SELECT [o0].[OrderID]
+FROM [Orders] AS [o0]",
                 Sql);
         }
 
@@ -1003,15 +1024,21 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 WHERE [o].[OrderID] IN (10643, 10692)
 
-SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order.Customer].[CustomerID], [od.Order.Customer].[Address], [od.Order.Customer].[City], [od.Order.Customer].[CompanyName], [od.Order.Customer].[ContactName], [od.Order.Customer].[ContactTitle], [od.Order.Customer].[Country], [od.Order.Customer].[Fax], [od.Order.Customer].[Phone], [od.Order.Customer].[PostalCode], [od.Order.Customer].[Region]
+@_outer_Country: Germany (Size = 4000)
+
+SELECT COUNT(*)
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
+WHERE @_outer_Country = [od.Order.Customer].[Country]
 
-SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order.Customer].[CustomerID], [od.Order.Customer].[Address], [od.Order.Customer].[City], [od.Order.Customer].[CompanyName], [od.Order.Customer].[ContactName], [od.Order.Customer].[ContactTitle], [od.Order.Customer].[Country], [od.Order.Customer].[Fax], [od.Order.Customer].[Phone], [od.Order.Customer].[PostalCode], [od.Order.Customer].[Region]
+@_outer_Country: Germany (Size = 4000)
+
+SELECT COUNT(*)
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
-LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]",
+LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
+WHERE @_outer_Country = [od.Order.Customer].[Country]",
                 Sql);
         }
 
@@ -1067,10 +1094,10 @@ ORDER BY [od.Order].[CustomerID]",
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], (
-    SELECT TOP(1) [o0].[OrderID]
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
-    ORDER BY [o0].[OrderID]
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -1130,24 +1157,24 @@ ORDER BY [o].[OrderID]
 
 @_outer_OrderID: 10248
 
-SELECT TOP(1) [od1].[OrderID]
-FROM [Order Details] AS [od1]
-WHERE @_outer_OrderID = [od1].[OrderID]
-ORDER BY [od1].[OrderID], [od1].[ProductID]
+SELECT TOP(1) [od].[OrderID]
+FROM [Order Details] AS [od]
+WHERE @_outer_OrderID = [od].[OrderID]
+ORDER BY [od].[OrderID], [od].[ProductID]
 
 @_outer_OrderID: 10249
 
-SELECT TOP(1) [od1].[OrderID]
-FROM [Order Details] AS [od1]
-WHERE @_outer_OrderID = [od1].[OrderID]
-ORDER BY [od1].[OrderID], [od1].[ProductID]
+SELECT TOP(1) [od].[OrderID]
+FROM [Order Details] AS [od]
+WHERE @_outer_OrderID = [od].[OrderID]
+ORDER BY [od].[OrderID], [od].[ProductID]
 
 @_outer_OrderID: 10250
 
-SELECT TOP(1) [od1].[OrderID]
-FROM [Order Details] AS [od1]
-WHERE @_outer_OrderID = [od1].[OrderID]
-ORDER BY [od1].[OrderID], [od1].[ProductID]",
+SELECT TOP(1) [od].[OrderID]
+FROM [Order Details] AS [od]
+WHERE @_outer_OrderID = [od].[OrderID]
+ORDER BY [od].[OrderID], [od].[ProductID]",
                 Sql);
         }
 
@@ -1155,18 +1182,13 @@ ORDER BY [od1].[OrderID], [od1].[ProductID]",
         {
             base.GroupJoin_with_complex_subquery_and_LOJ_does_not_get_flattened();
 
-            Assert.Contains(
-                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
-FROM (
-    SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
-    FROM [Order Details] AS [od]
-    INNER JOIN [Orders] AS [o] ON [od].[OrderID] = 10260
-    INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
-) AS [t]",
-                Sql);
+            Assert.Equal(
+                @"SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [o] ON [od].[OrderID] = 10260
+INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
 
-            Assert.Contains(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]",
                 Sql);
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -222,6 +222,18 @@ LEFT JOIN (
                 Sql);
         }
 
+        public override void GroupJoin_customers_employees_subquery_shadow()
+        {
+            base.GroupJoin_customers_employees_subquery_shadow();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+INNER JOIN [Employees] AS [e] ON [c].[City] = [e].[City]
+ORDER BY [e].[City]",
+                Sql);
+        }
+
         public override void Where_query_composition()
         {
             base.Where_query_composition();
@@ -261,12 +273,6 @@ SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], 
 FROM [Employees] AS [e2]
 WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
-
-            Assert.Contains(
-                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]
-WHERE [e2].[EmployeeID] IS NULL",
-                Sql);
         }
 
         public override void Where_query_composition_is_not_null()
@@ -293,12 +299,6 @@ SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], 
 FROM [Employees] AS [e2]
 WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
-
-            Assert.Contains(
-                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]
-WHERE [e2].[EmployeeID] IS NULL",
-                Sql);
         }
 
         public override void Where_query_composition_entity_equality_one_element_SingleOrDefault()
@@ -313,23 +313,17 @@ FROM [Employees] AS [e1]",
             Assert.Contains(
                 @"@_outer_ReportsTo: 2 (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+SELECT TOP(2) [e2].[EmployeeID]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
 
             Assert.Contains(
                 @"@_outer_ReportsTo: 5 (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
-                Sql);
-
-            Assert.Contains(
-                @"SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] IS NULL",
+SELECT TOP(2) [e2].[EmployeeID]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 Sql);
         }
 
@@ -356,9 +350,9 @@ WHERE (
                 @"SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
 FROM [Employees] AS [e1]
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = 42", Sql);
+SELECT TOP(2) [e2].[EmployeeID]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = 42", Sql);
         }
 
         public override void Where_query_composition_entity_equality_no_elements_FirstOrDefault()
@@ -457,15 +451,15 @@ FROM [Order Details] AS [od]
 
 @_outer_OrderID: 10248
 
-SELECT TOP(2) [o0].[CustomerID]
-FROM [Orders] AS [o0]
-WHERE @_outer_OrderID = [o0].[OrderID]
+SELECT TOP(2) [o].[CustomerID]
+FROM [Orders] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]
 
-@_outer_CustomerID1: VINET (Size = 450)
+@_outer_CustomerID: VINET (Size = 450)
 
-SELECT TOP(2) [c2].[City]
-FROM [Customers] AS [c2]
-WHERE @_outer_CustomerID1 = [c2].[CustomerID]",
+SELECT TOP(2) [c].[City]
+FROM [Customers] AS [c]
+WHERE @_outer_CustomerID = [c].[CustomerID]",
                 Sql);
         }
 
@@ -504,28 +498,27 @@ FROM (
 ) AS [t]
 ORDER BY [t].[OrderID]
 
-SELECT [t1].[OrderID]
+SELECT [t0].[OrderID]
 FROM (
-    SELECT TOP(2) [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
-    FROM [Order Details] AS [o1]
-) AS [t1]
-ORDER BY [t1].[ProductID], [t1].[OrderID]
+    SELECT TOP(2) [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+    FROM [Order Details] AS [o0]
+) AS [t0]
+ORDER BY [t0].[ProductID], [t0].[OrderID]
 
-SELECT [c3].[CustomerID], [c3].[Country]
-FROM [Customers] AS [c3]
-ORDER BY [c3].[CustomerID]
+@_outer_CustomerID: VINET (Size = 450)
 
-@_outer_OrderID1: 10285
+SELECT TOP(1) [c].[Country]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @_outer_CustomerID
+ORDER BY [c].[CustomerID]
 
-SELECT TOP(1) [c4].[Country]
-FROM [Orders] AS [o20]
-INNER JOIN [Customers] AS [c4] ON [o20].[CustomerID] = [c4].[CustomerID]
-WHERE [o20].[OrderID] = @_outer_OrderID1
-ORDER BY [o20].[OrderID], [c4].[CustomerID]
+@_outer_OrderID: 10285
 
-SELECT [c3].[CustomerID], [c3].[Country]
-FROM [Customers] AS [c3]
-ORDER BY [c3].[CustomerID]",
+SELECT TOP(1) [c0].[Country]
+FROM [Orders] AS [o2]
+INNER JOIN [Customers] AS [c0] ON [o2].[CustomerID] = [c0].[CustomerID]
+WHERE [o2].[OrderID] = @_outer_OrderID
+ORDER BY [o2].[OrderID], [c0].[CustomerID]",
                 Sql);
         }
 
@@ -590,13 +583,11 @@ WHERE @_outer_CustomerID = [c2].[CustomerID]",
             base.OrderBy_SelectMany();
 
             Assert.StartsWith(
-                @"SELECT [c].[CustomerID], [c].[ContactName]
+                @"SELECT [c].[ContactName], [o].[OrderID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-SELECT [o0].[CustomerID], [o0].[OrderID]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[OrderID]",
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
@@ -609,23 +600,23 @@ ORDER BY [o0].[OrderID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID1: ALFKI (Size = 450)
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
-        FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
+        FROM [Orders] AS [o]
+        WHERE [o].[CustomerID] = @_outer_CustomerID)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
 
-@_outer_CustomerID1: ANATR (Size = 450)
+@_outer_CustomerID: ANATR (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
-        FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
+        FROM [Orders] AS [o]
+        WHERE [o].[CustomerID] = @_outer_CustomerID)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -659,9 +650,9 @@ ORDER BY [c].[City]",
             base.GroupBy_nested_order_by_enumerable();
 
             Assert.Equal(
-                @"SELECT [c0].[Country], [c0].[CustomerID]
-FROM [Customers] AS [c0]
-ORDER BY [c0].[Country]",
+                @"SELECT [c].[Country], [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[Country]",
                 Sql);
         }
 
@@ -670,10 +661,10 @@ ORDER BY [c0].[Country]",
             base.GroupBy_join_default_if_empty_anonymous();
 
             Assert.Equal(
-                @"SELECT [order0].[OrderID], [order0].[CustomerID], [order0].[EmployeeID], [order0].[OrderDate], [orderDetail0].[OrderID], [orderDetail0].[ProductID], [orderDetail0].[Discount], [orderDetail0].[Quantity], [orderDetail0].[UnitPrice]
-FROM [Orders] AS [order0]
-LEFT JOIN [Order Details] AS [orderDetail0] ON [order0].[OrderID] = [orderDetail0].[OrderID]
-ORDER BY [order0].[OrderID]",
+                @"SELECT [order].[OrderID], [order].[CustomerID], [order].[EmployeeID], [order].[OrderDate], [orderDetail].[OrderID], [orderDetail].[ProductID], [orderDetail].[Discount], [orderDetail].[Quantity], [orderDetail].[UnitPrice]
+FROM [Orders] AS [order]
+LEFT JOIN [Order Details] AS [orderDetail] ON [order].[OrderID] = [orderDetail].[OrderID]
+ORDER BY [order].[OrderID]",
                 Sql);
         }
 
@@ -1709,8 +1700,8 @@ FROM (
             Assert.Equal(
                 @"@__p_0: 91
 
-SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM [Customers] AS [c0]",
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
                 Sql);
         }
 
@@ -2264,9 +2255,9 @@ WHERE [c].[CustomerID] = N'ALFKI'
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT TOP(1) [o0].[CustomerID]
-FROM [Orders] AS [o0]
-WHERE ([o0].[CustomerID] = N'ALFKI') AND (@_outer_CustomerID = [o0].[CustomerID])",
+SELECT TOP(1) [o].[CustomerID]
+FROM [Orders] AS [o]
+WHERE ([o].[CustomerID] = N'ALFKI') AND (@_outer_CustomerID = [o].[CustomerID])",
                 Sql);
         }
 
@@ -3121,14 +3112,11 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
             base.Join_customers_orders_with_subquery();
 
             Assert.Contains(
-                @"SELECT [o20].[CustomerID], [o20].[OrderID]
-FROM [Orders] AS [o20]
-ORDER BY [o20].[OrderID]",
-                Sql);
-
-            Assert.Contains(
-                @"SELECT [c].[CustomerID], [c].[ContactName]
-FROM [Customers] AS [c]",
+                @"SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[ContactName]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o2] ON [c].[CustomerID] = [o2].[CustomerID]
+WHERE [o2].[CustomerID] = N'ALFKI'
+ORDER BY [o2].[OrderID]",
                 Sql);
         }
 
@@ -3139,14 +3127,15 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"@__p_0: 5
 
-SELECT [c].[ContactName], [t].[OrderID]
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o2].*
+    SELECT TOP(@__p_0) [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
     FROM [Orders] AS [o2]
     ORDER BY [o2].[OrderID]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-WHERE [t].[CustomerID] = N'ALFKI'",
+WHERE [t].[CustomerID] = N'ALFKI'
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -3155,9 +3144,9 @@ WHERE [t].[CustomerID] = N'ALFKI'",
             base.Join_customers_orders_with_subquery_anonymous_property_method();
 
             Assert.Contains(
-                @"SELECT [o20].[OrderID], [o20].[CustomerID], [o20].[EmployeeID], [o20].[OrderDate]
-FROM [Orders] AS [o20]
-ORDER BY [o20].[OrderID]",
+                @"SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+ORDER BY [o2].[OrderID]",
                 Sql);
 
             Assert.Contains(
@@ -3173,9 +3162,9 @@ FROM [Customers] AS [c]",
             Assert.Contains(
                 @"@__p_0: 5
 
-SELECT TOP(@__p_0) [o20].[OrderID], [o20].[CustomerID], [o20].[EmployeeID], [o20].[OrderDate]
-FROM [Orders] AS [o20]
-ORDER BY [o20].[OrderID]",
+SELECT TOP(@__p_0) [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+ORDER BY [o2].[OrderID]",
                 Sql);
 
             Assert.Contains(
@@ -3188,16 +3177,12 @@ FROM [Customers] AS [c]",
         {
             base.Join_customers_orders_with_subquery_predicate();
 
-            Assert.Contains(
-                @"SELECT [o20].[CustomerID], [o20].[OrderID]
-FROM [Orders] AS [o20]
-WHERE [o20].[OrderID] > 0
-ORDER BY [o20].[OrderID]",
-                Sql);
-
-            Assert.Contains(
-                @"SELECT [c].[CustomerID], [c].[ContactName]
-FROM [Customers] AS [c]",
+            Assert.Equal(
+                @"SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate], [c].[ContactName]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o2] ON [c].[CustomerID] = [o2].[CustomerID]
+WHERE ([o2].[OrderID] > 0) AND ([o2].[CustomerID] = N'ALFKI')
+ORDER BY [o2].[OrderID]",
                 Sql);
         }
 
@@ -3208,15 +3193,16 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"@__p_0: 5
 
-SELECT [c].[ContactName], [t].[OrderID]
+SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT TOP(@__p_0) [o2].*
+    SELECT TOP(@__p_0) [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
     FROM [Orders] AS [o2]
     WHERE [o2].[OrderID] > 0
     ORDER BY [o2].[OrderID]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-WHERE [t].[CustomerID] = N'ALFKI'",
+WHERE [t].[CustomerID] = N'ALFKI'
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -3328,9 +3314,9 @@ ORDER BY [o].[CustomerID]",
             base.GroupBy_Distinct();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3339,9 +3325,9 @@ ORDER BY [o0].[CustomerID]",
             base.GroupBy_Count();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3350,9 +3336,9 @@ ORDER BY [o0].[CustomerID]",
             base.GroupBy_LongCount();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3384,9 +3370,9 @@ ORDER BY [o].[CustomerID]",
             base.Select_GroupBy_SelectMany();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[OrderID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID]
+FROM [Orders] AS [o]
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 
@@ -3395,9 +3381,9 @@ ORDER BY [o0].[OrderID]",
             base.GroupBy_with_orderby();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3406,9 +3392,9 @@ ORDER BY [o0].[CustomerID]",
             base.GroupBy_with_orderby_and_anonymous_projection();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3417,9 +3403,9 @@ ORDER BY [o0].[CustomerID]",
             base.GroupBy_with_orderby_take_skip_distinct();
 
             Assert.Equal(
-                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-ORDER BY [o0].[CustomerID]",
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]",
                 Sql);
         }
 
@@ -3631,7 +3617,8 @@ INNER JOIN (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]",
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[OrderID]",
                 Sql);
         }
 
@@ -4988,8 +4975,8 @@ SELECT 1
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
-FROM [Customers] AS [c2]",
+SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]",
                 Sql);
         }
 
@@ -5527,9 +5514,11 @@ ORDER BY [o].[OrderID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 
-SELECT [o0].[CustomerID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE [o0].[OrderID] < 10500",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(3) [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])",
                 Sql);
         }
 
@@ -6206,24 +6195,16 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
             Assert.StartsWith(
                 @"SELECT [e].[CustomerID], (
     SELECT COUNT(*)
-    FROM [Orders] AS [o1]
-    WHERE [e].[CustomerID] = [o1].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [e].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [e]
-WHERE [e].[ContactTitle] = N'Owner'
-ORDER BY [e].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
-
-SELECT COUNT(*)
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANTON (Size = 450)
-
-SELECT COUNT(*)
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
+WHERE ([e].[ContactTitle] = N'Owner') AND ((
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [e].[CustomerID] = [o].[CustomerID]
+) > 2)
+ORDER BY [e].[CustomerID]",
                 Sql);
         }
 
@@ -6628,9 +6609,9 @@ FROM [Orders] AS [o]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT TOP(2) [c0].[City]
-FROM [Customers] AS [c0]
-WHERE [c0].[CustomerID] = @_outer_CustomerID",
+SELECT TOP(2) [c].[City]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = @_outer_CustomerID",
                 Sql);
         }
 


### PR DESCRIPTION
This commit adds the `OuterPropertyExpression`, which is a dedicated expression to represent expressions bound to parent query models. This expression allows us to defer the decision of whether to bind directly to the parent query (i.e. an `AliasExpression`) or to bind via an outer parameter. There are several improved generated SQL queries in this PR as a result.

To facilitate this change, other changes take place:

- Subquery models are now visited only once, meaning no more unnecessary uniquification (things like `FROM Orders AS o4` instead of `FROM Orders AS o`)
- The `_bindParentQueries` field/parameter to `RelationalQueryModelVisitor` and `SqlTranslatingExpressionVisitor` is now gone, instead being driven by the context of the query model visitor and its ancestors via `CanBindOuterProperties`, `CanBindOuterParameters`, and `RequiresOuterParameterInjection`
- The `_targetSelectExpression` field/parameter to `SqlTranslatingExpressionVisitor` is now gone, being replaced by a `_mutateProjections` field/parameter. This helps to make it clearer what is being done every time and place the visitor is used (also, there were cases where the `_targetSelectExpression` comparison bit would hinder things from binding correctly.)

This PR is split from (and integral to) #7650 and #7543, and this PR includes/depends on the changes that make up #7619.