### PR TITLE
Query: Add test for #7220

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3780,6 +3780,17 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Where_on_multilevel_reference_in_subquery_with_outer_projection()
+        {
+            AssertQuery<Level3>(
+                l3s => l3s
+                    .Where(l3 => l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse.Name == "L1 03")
+                    .OrderBy(l3 => l3.Level2_Required_Id)
+                    .Skip(0)
+                    .Take(10)
+                    .Select(l3 => l3.Name));
+        }
 
         private static TResult Maybe<TResult>(object caller, Func<TResult> expression) where TResult : class
         {

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2667,6 +2667,28 @@ LEFT JOIN [Level2] AS [l2] ON [l1_inner].[Id] = [l2].[Level1_Optional_Id]",
                 Sql);
         }
 
+        public override void Where_on_multilevel_reference_in_subquery_with_outer_projection()
+        {
+            base.Where_on_multilevel_reference_in_subquery_with_outer_projection();
+
+            Assert.Equal(
+                @"@__p_0: 0
+@__p_1: 10
+
+SELECT [t].[Name]
+FROM (
+    SELECT [l3].*
+    FROM [Level3] AS [l3]
+    INNER JOIN [Level2] AS [l3.OneToMany_Required_Inverse] ON [l3].[OneToMany_Required_InverseId] = [l3.OneToMany_Required_Inverse].[Id]
+    INNER JOIN [Level1] AS [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse] ON [l3.OneToMany_Required_Inverse].[Level1_Required_Id] = [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Id]
+    WHERE [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'
+    ORDER BY [l3].[Level2_Required_Id]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]
+ORDER BY [t].[Level2_Required_Id]",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
#7220 is working in current dev. Adding test.
Now it causes a subquery to be formed and `ProjectStarAlias` picks up table correctly.

Close #7220 