### PR TITLE
Query: Improve logic to find the correct table in the select expression

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -470,9 +470,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     Alias = joinExpression.Alias
                 };
 
-            // Don't create new alias when adding tables to subquery
             subquery.AddTable(joinExpression.TableExpression);
-            subquery.ProjectStarAlias = joinExpression.Alias;
+            subquery.ProjectStarTable = joinExpression;
             subquery.IsProjectStar = true;
             subquery.Predicate = selectExpression.Predicate;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -143,9 +143,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     }
                     else
                     {
-                        if (QueryModelVisitor.ParentQueryModelVisitor != null)
+                        if (QueryModelVisitor.ParentQueryModelVisitor != null
+                            && selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
                         {
-                            selectExpression.ProjectStarAlias = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource).Alias;
+                            selectExpression.ProjectStarTable = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
                         }
                     }
                 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -416,7 +416,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             selectExpression.AddTable(leftOuterJoinExpression);
 
-            selectExpression.ProjectStarAlias = subquery.Alias;
+            selectExpression.ProjectStarTable = subquery;
 
             handlerContext.QueryModelVisitor.Expression
                 = new DefaultIfEmptyExpressionVisitor(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -695,7 +695,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                             tableExpression = selectExpression.Tables.Single();
                             innerSelectExpression.ClearProjection();
                             innerSelectExpression.IsProjectStar = true;
-                            innerSelectExpression.ProjectStarAlias = innerSelectExpression.Tables.Single().Alias;
                             tableExpression.QuerySource = joinClause;
 
                             predicate = sqlTranslatingExpressionVisitor.Visit(
@@ -1559,13 +1558,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     RelationalQueryModelVisitor subQueryModelVisitor;
                     if (_subQueryModelVisitorsBySource.TryGetValue(querySource, out subQueryModelVisitor))
                     {
-                        selectExpression = subQueryModelVisitor.Queries.SingleOrDefault();
+                        if (!subQueryModelVisitor.RequiresClientProjection)
+                        {
+                            selectExpression = subQueryModelVisitor.Queries.SingleOrDefault();
 
-                        selectExpression?
-                            .AddToProjection(
-                                _relationalAnnotationProvider.For(property).ColumnName,
-                                property,
-                                querySource);
+                            selectExpression?
+                                .AddToProjection(
+                                    _relationalAnnotationProvider.For(property).ColumnName,
+                                    property,
+                                    querySource);
+                        }
                     }
                 }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (selectExpression.IsProjectStar)
             {
-                var tableAlias = selectExpression.ProjectStarAlias;
+                var tableAlias = selectExpression.ProjectStarTable.Alias;
 
                 _relationalCommandBuilder
                     .Append(SqlGenerator.DelimitIdentifier(tableAlias))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -12,10 +12,143 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
     public class QueryNavigationsSqlServerTest : QueryNavigationsTestBase<NorthwindQuerySqlServerFixture>
     {
         public QueryNavigationsSqlServerTest(
+            // ReSharper disable once UnusedParameter.Local
             NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        public override void Join_with_nav_projected_in_subquery_when_client_eval()
+        {
+            base.Join_with_nav_projected_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void GroupJoin_with_nav_projected_in_subquery_when_client_eval()
+        {
+            base.GroupJoin_with_nav_projected_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Join_with_nav_in_predicate_in_subquery_when_client_eval()
+        {
+            base.Join_with_nav_in_predicate_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void GroupJoin_with_nav_in_predicate_in_subquery_when_client_eval()
+        {
+            base.GroupJoin_with_nav_in_predicate_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Join_with_nav_in_orderby_in_subquery_when_client_eval()
+        {
+            base.Join_with_nav_in_orderby_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void GroupJoin_with_nav_in_orderby_in_subquery_when_client_eval()
+        {
+            base.GroupJoin_with_nav_in_orderby_in_subquery_when_client_eval();
+
+            Assert.Contains(
+                @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
+FROM [Order Details] AS [od0]
+INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer1].[CustomerID], [o.Customer1].[Address], [o.Customer1].[City], [o.Customer1].[CompanyName], [o.Customer1].[ContactName], [o.Customer1].[ContactTitle], [o.Customer1].[Country], [o.Customer1].[Fax], [o.Customer1].[Phone], [o.Customer1].[PostalCode], [o.Customer1].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer1] ON [o0].[CustomerID] = [o.Customer1].[CustomerID]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
         }
 
         public override void Select_Where_Navigation()


### PR DESCRIPTION
- Use ProjectStarTable as default table when SelectExpression is unable to find table for querysource
- Change ProjectStarAlias to ProjectStarTable
- Don't bind with subquery when subquery has client side projection (fixes #7220)
- Set ProjectStarTable more correctly

The main issue here was:
We were trying to bind to subquery which had client side projection. We cannot bind directly to select expression in such case because client method can generate different result then what is returned by the query.

When similar client methods applied for Where/OrderBy, it should be able to bind but the issue arose was unable to find the correct table since we fell back to last table in subquery. The correct table would be table set by ProjectStarAlias which is set when we encounter QSRE in RelationalProjectionExpressionVisitor only if we are inside correct SelectExpression & querysource.
Further, in case of simple identity QMs, we may not go into ProjectionExpressionVisitor making us unable to set ProjectStarAlias correctly. If there is only 1 table then it is the table which should be used.

Since we now need TableExpressionBase more than the string Alias, converted ProjectStarAlias to ProjectStarTable.