### PR TITLE
Query: Translate aggregate functions to server only if not on subquery

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -254,24 +254,28 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
 
-                var inputType = expression.Type;
-                var outputType = expression.Type;
-
-                var nonNullableInputType = inputType.UnwrapNullableType();
-                if (nonNullableInputType == typeof(int)
-                    || nonNullableInputType == typeof(long))
+                if (!(expression.RemoveConvert() is SelectExpression))
                 {
-                    outputType = inputType.IsNullableType() ? typeof(double?) : typeof(double);
+
+                    var inputType = expression.Type;
+                    var outputType = expression.Type;
+
+                    var nonNullableInputType = inputType.UnwrapNullableType();
+                    if (nonNullableInputType == typeof(int)
+                        || nonNullableInputType == typeof(long))
+                    {
+                        outputType = inputType.IsNullableType() ? typeof(double?) : typeof(double);
+                    }
+
+                    expression = new ExplicitCastExpression(expression, outputType);
+                    var averageExpression = new SqlFunctionExpression("AVG", expression.Type, new [] { expression });
+
+                    handlerContext.SelectExpression.SetProjectionExpression(averageExpression);
+
+                    return (Expression)_transformClientExpressionMethodInfo
+                        .MakeGenericMethod(averageExpression.Type)
+                        .Invoke(null, new object [] { handlerContext });
                 }
-
-                expression = new ExplicitCastExpression(expression, outputType);
-                var averageExpression = new SqlFunctionExpression("AVG", expression.Type, new[] { expression });
-
-                handlerContext.SelectExpression.SetProjectionExpression(averageExpression);
-
-                return (Expression)_transformClientExpressionMethodInfo
-                    .MakeGenericMethod(averageExpression.Type)
-                    .Invoke(null, new object[] { handlerContext });
             }
 
             return handlerContext.EvalOnClient();
@@ -597,13 +601,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var minExpression = new SqlFunctionExpression("MIN", expression.Type, new[] { expression });
 
-                handlerContext.SelectExpression.SetProjectionExpression(minExpression);
+                if (!(expression.RemoveConvert() is SelectExpression))
+                {
+                    var minExpression = new SqlFunctionExpression("MIN", expression.Type, new [] { expression });
 
-                return (Expression)_transformClientExpressionMethodInfo
-                    .MakeGenericMethod(minExpression.Type)
-                    .Invoke(null, new object[] { handlerContext });
+                    handlerContext.SelectExpression.SetProjectionExpression(minExpression);
+
+                    return (Expression)_transformClientExpressionMethodInfo
+                        .MakeGenericMethod(minExpression.Type)
+                        .Invoke(null, new object [] { handlerContext });
+                }
             }
 
             return handlerContext.EvalOnClient();
@@ -615,13 +623,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var maxExpression = new SqlFunctionExpression("MAX", expression.Type, new[] { expression });
 
-                handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
+                if (!(expression.RemoveConvert() is SelectExpression))
+                {
+                    var maxExpression = new SqlFunctionExpression("MAX", expression.Type, new [] { expression });
 
-                return (Expression)_transformClientExpressionMethodInfo
-                    .MakeGenericMethod(maxExpression.Type)
-                    .Invoke(null, new object[] { handlerContext });
+                    handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
+
+                    return (Expression)_transformClientExpressionMethodInfo
+                        .MakeGenericMethod(maxExpression.Type)
+                        .Invoke(null, new object [] { handlerContext });
+                }
             }
 
             return handlerContext.EvalOnClient();
@@ -666,13 +678,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 var expression = handlerContext.SelectExpression.Projection.First();
-                var sumExpression = new SqlFunctionExpression("SUM", expression.Type, new[] { expression });
 
-                handlerContext.SelectExpression.SetProjectionExpression(sumExpression);
+                if (!(expression.RemoveConvert() is SelectExpression))
+                {
+                    var sumExpression = new SqlFunctionExpression("SUM", expression.Type, new [] { expression });
 
-                return (Expression)_transformClientExpressionMethodInfo
-                    .MakeGenericMethod(sumExpression.Type)
-                    .Invoke(null, new object[] { handlerContext });
+                    handlerContext.SelectExpression.SetProjectionExpression(sumExpression);
+
+                    return (Expression)_transformClientExpressionMethodInfo
+                        .MakeGenericMethod(sumExpression.Type)
+                        .Invoke(null, new object [] { handlerContext });
+                }
             }
 
             return handlerContext.EvalOnClient();

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -2549,6 +2549,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Sum_over_subquery_is_client_eval()
+        {
+            await AssertQuery<Customer>(cs => cs.SumAsync(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual async Task Average_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).AverageAsync());
@@ -2581,6 +2587,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Average_over_subquery_is_client_eval()
+        {
+            await AssertQuery<Customer>(cs => cs.AverageAsync(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual async Task Min_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).MinAsync());
@@ -2599,6 +2611,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Min_over_subquery_is_client_eval()
+        {
+            await AssertQuery<Customer>(cs => cs.MinAsync(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual async Task Max_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).MaxAsync());
@@ -2614,6 +2632,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual async Task Max_with_coalesce()
         {
             await AssertQuery<Product>(ps => ps.Where(p => p.ProductID < 40).MaxAsync(p => p.UnitPrice ?? 0));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Max_over_subquery_is_client_eval()
+        {
+            await AssertQuery<Customer>(cs => cs.MaxAsync(c => c.Orders.Sum(o => o.OrderID)));
         }
 
         [ConditionalFact]

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -4045,6 +4045,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Sum_over_subquery_is_client_eval()
+        {
+            AssertQuery<Customer>(cs => cs.Sum(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual void Average_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Average());
@@ -4095,6 +4101,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Average_over_subquery_is_client_eval()
+        {
+            AssertQuery<Customer>(cs => cs.Average(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual void Min_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Min());
@@ -4113,6 +4125,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Min_over_subquery_is_client_eval()
+        {
+            AssertQuery<Customer>(cs => cs.Min(c => c.Orders.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
         public virtual void Max_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Max());
@@ -4128,6 +4146,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Max_with_coalesce()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.ProductID < 40).Max(p => p.UnitPrice ?? 0));
+        }
+
+        [ConditionalFact]
+        public virtual void Max_over_subquery_is_client_eval()
+        {
+            AssertQuery<Customer>(cs => cs.Max(c => c.Orders.Sum(o => o.OrderID)));
         }
 
         [ConditionalFact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1268,6 +1268,19 @@ WHERE [p].[ProductID] < 40",
                 Sql);
         }
 
+        public override void Sum_over_subquery_is_client_eval()
+        {
+            base.Sum_over_subquery_is_client_eval();
+
+            Assert.Equal(@"SELECT (
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+)
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void Average_with_no_arg()
         {
             base.Average_with_no_arg();
@@ -1332,6 +1345,19 @@ WHERE [p].[ProductID] < 40",
                 Sql);
         }
 
+        public override void Average_over_subquery_is_client_eval()
+        {
+            base.Average_over_subquery_is_client_eval();
+
+            Assert.Equal(@"SELECT (
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+)
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void Min_with_no_arg()
         {
             base.Min_with_no_arg();
@@ -1363,6 +1389,19 @@ WHERE [p].[ProductID] < 40",
                 Sql);
         }
 
+        public override void Min_over_subquery_is_client_eval()
+        {
+            base.Min_over_subquery_is_client_eval();
+
+            Assert.Equal(@"SELECT (
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+)
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void Max_with_no_arg()
         {
             base.Max_with_no_arg();
@@ -1391,6 +1430,19 @@ FROM [Orders] AS [o]",
                 @"SELECT MAX(COALESCE([p].[UnitPrice], 0.0))
 FROM [Products] AS [p]
 WHERE [p].[ProductID] < 40",
+                Sql);
+        }
+
+        public override void Max_over_subquery_is_client_eval()
+        {
+            base.Max_over_subquery_is_client_eval();
+
+            Assert.Equal(@"SELECT (
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+)
+FROM [Customers] AS [c]",
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #3792 
Aggregate over subquery generates invalid sql. For Max/Min/Average/Sum if the inner projection is a subquery (aka selectexpresion) then we force client eval.
