### PR TITLE
Refactor RequiresMaterializationExpressionVisitor

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -192,7 +192,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     if (newAccessOperation != nullConditionalExpression.AccessOperation)
                     {
-                        return newAccessOperation;
+                        return Expression.Condition(
+                            test: ValueBufferNullComparisonCheck(newCaller),
+                            ifTrue: newAccessOperation.Type != nullConditionalExpression.Type
+                                ? Expression.Convert(newAccessOperation, nullConditionalExpression.Type)
+                                : newAccessOperation,
+                            ifFalse: Expression.Default(nullConditionalExpression.Type));
                     }
                 }
             }

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitSubQuery(SubQueryExpression expression)
         {
-            Visit(expression.QueryModel.SelectClause.Selector);
+            expression.QueryModel.TransformExpressions(Visit);
 
             return expression;
         }

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -1,15 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
@@ -21,10 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     {
         private readonly IModel _model;
         private readonly EntityQueryModelVisitor _queryModelVisitor;
-        private readonly Dictionary<IQuerySource, int> _querySources = new Dictionary<IQuerySource, int>();
-
-        private QueryModel _queryModel;
-        private Expression _selector;
+        private readonly Stack<QueryModel> _queryModelStack = new Stack<QueryModel>();
+        private readonly Dictionary<IQuerySource, int> _querySourceReferences = new Dictionary<IQuerySource, int>();
+        private readonly QuerySourceTracingExpressionVisitor _querySourceTracingExpressionVisitor
+            = new QuerySourceTracingExpressionVisitor();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -44,17 +47,28 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         public virtual ISet<IQuerySource> FindQuerySourcesRequiringMaterialization([NotNull] QueryModel queryModel)
         {
-            _querySources.Clear();
-            _queryModel = queryModel;
-            _selector = queryModel.SelectClause.Selector;
+            // Top-level query source result operators need to be promoted manually here
+            // because unlike subquerys' result operators, they won't be promoted via
+            // HandleUnderlyingQuerySources
+            foreach (var querySourceResultOperator in queryModel.ResultOperators.OfType<IQuerySource>())
+            {
+                PromoteQuerySource(querySourceResultOperator);
+            }
 
-            _queryModel.TransformExpressions(Visit);
+            _queryModelStack.Push(queryModel);
 
-            var querySources
-                = new HashSet<IQuerySource>(
-                    _querySources.Where(kv => kv.Value > 0).Select(kv => kv.Key));
+            queryModel.TransformExpressions(Visit);
 
-            return querySources;
+            _queryModelStack.Pop();
+
+            AdjustForResultOperators(queryModel);
+
+            var querySources =
+                from entry in _querySourceReferences
+                where entry.Value > 0
+                select entry.Key;
+
+            return new HashSet<IQuerySource>(querySources);
         }
 
         /// <summary>
@@ -64,22 +78,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         protected override Expression VisitQuerySourceReference(
             QuerySourceReferenceExpression expression)
         {
-            AddQuerySource(expression.ReferencedQuerySource);
+            PromoteQuerySource(expression.ReferencedQuerySource);
 
             return base.VisitQuerySourceReference(expression);
         }
 
-        private void AddQuerySource(IQuerySource querySource)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitExtension(Expression node)
         {
-            if (!_querySources.ContainsKey(querySource))
+            if (node is NullConditionalExpression nullConditionalExpression)
             {
-                _querySources.Add(querySource, 0);
+                Visit(nullConditionalExpression.AccessOperation);
+
+                return node;
             }
 
-            if (_model.FindEntityType(querySource.ItemType) != null)
-            {
-                _querySources[querySource]++;
-            }
+            return base.VisitExtension(node);
         }
 
         /// <summary>
@@ -92,16 +109,23 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             if (node.Expression != null)
             {
-                _queryModelVisitor
-                    .BindMemberExpression(
-                        node,
-                        (property, querySource) =>
-                            {
-                                if (querySource != null)
-                                {
-                                    _querySources[querySource]--;
-                                }
-                            });
+                if (node.Expression.Type.IsGrouping() && node.Member.Name == "Key")
+                {
+                    if (node.Expression is QuerySourceReferenceExpression qsre)
+                    {
+                        DemoteQuerySource(qsre.ReferencedQuerySource);
+                    }
+                }
+                else
+                {
+                    _queryModelVisitor.BindMemberExpression(node, (property, querySource) =>
+                    {
+                        if (querySource != null)
+                        {
+                            DemoteQuerySource(querySource);
+                        }
+                    });
+                }
             }
 
             return newExpression;
@@ -113,18 +137,27 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
-            var newExpression = base.VisitMethodCall(node);
+            var newExpression = (MethodCallExpression)base.VisitMethodCall(node);
 
-            _queryModelVisitor
-                .BindMethodCallExpression(
-                    node,
-                    (property, querySource) =>
-                        {
-                            if (querySource != null)
-                            {
-                                _querySources[querySource]--;
-                            }
-                        });
+            _queryModelVisitor.BindMethodCallExpression(node, (property, querySource) =>
+            {
+                if (querySource != null)
+                {
+                    DemoteQuerySource(querySource);
+                }
+            });
+
+            foreach (var subQueryExpression in newExpression.Arguments.OfType<SubQueryExpression>())
+            {
+                if (subQueryExpression.QueryModel.ResultOperators.LastOrDefault() is IQuerySource querySourceResultOperator)
+                {
+                    PromoteQuerySource(querySourceResultOperator);
+                }
+                else if (subQueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression qsre)
+                {
+                    PromoteQuerySource(qsre.ReferencedQuerySource);
+                }
+            }
 
             return newExpression;
         }
@@ -135,39 +168,45 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitBinary(BinaryExpression node)
         {
-            var oldParentSelector = _selector;
+            return node.Update(
+                left: VisitBinaryOperand(node.Left, node.NodeType),
+                conversion: node.Conversion,
+                right: VisitBinaryOperand(node.Right, node.NodeType));
+        }
 
-            var leftSubQueryExpression = node.Left as SubQueryExpression;
-
-            if ((leftSubQueryExpression != null)
-                && (_model.FindEntityType(leftSubQueryExpression.Type) != null))
+        private Expression VisitBinaryOperand(Expression operand, ExpressionType comparison)
+        {
+            if (comparison == ExpressionType.Equal || comparison == ExpressionType.NotEqual)
             {
-                _selector = leftSubQueryExpression.QueryModel.SelectClause.Selector;
+                var isEntityTypeExpression = _model.FindEntityType(operand.Type) != null;
 
-                leftSubQueryExpression.QueryModel.TransformExpressions(Visit);
+                if (isEntityTypeExpression)
+                {
+                    // An equality comparison of query source reference expressions
+                    // that reference an entity query source does not suggest that
+                    // materialization of that entity type may be required. This is true
+                    // whether in a join predicate, where predicate, selector, etc.
+                    // because it is rewritten into a key equality comparison.
+                    if (operand is QuerySourceReferenceExpression)
+                    {
+                        return operand;
+                    }
+
+                    // Same as above, key comparison, except coming from a subquery
+                    if (operand is SubQueryExpression subQueryExpression)
+                    {
+                        _queryModelStack.Push(subQueryExpression.QueryModel);
+
+                        subQueryExpression.QueryModel.TransformExpressions(Visit);
+
+                        _queryModelStack.Pop();
+
+                        return operand;
+                    }
+                }
             }
-            else
-            {
-                Visit(node.Left);
-            }
 
-            var rightSubQueryExpression = node.Right as SubQueryExpression;
-
-            if ((rightSubQueryExpression != null)
-                && (_model.FindEntityType(rightSubQueryExpression.Type) != null))
-            {
-                _selector = rightSubQueryExpression.QueryModel.SelectClause.Selector;
-
-                rightSubQueryExpression.QueryModel.TransformExpressions(Visit);
-            }
-            else
-            {
-                Visit(node.Right);
-            }
-
-            _selector = oldParentSelector;
-
-            return node;
+            return Visit(operand);
         }
 
         /// <summary>
@@ -176,61 +215,35 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitSubQuery(SubQueryExpression expression)
         {
-            var oldParentSelector = _selector;
-            var oldQueryModel = _queryModel;
+            _queryModelStack.Push(expression.QueryModel);
 
-            _selector = expression.QueryModel.SelectClause.Selector;
-            _queryModel = expression.QueryModel;
+            expression.QueryModel.TransformExpressions(Visit);
 
-            _queryModel.TransformExpressions(Visit);
+            _queryModelStack.Pop();
 
-            _selector = oldParentSelector;
-            _queryModel = oldQueryModel;
+            AdjustForResultOperators(expression.QueryModel);
 
-            var querySourceReferenceExpression
-                = expression.QueryModel.SelectClause.Selector
-                    as QuerySourceReferenceExpression;
+            var parentQueryModel = _queryModelStack.Peek();
 
-            if (querySourceReferenceExpression != null)
+            var referencedQuerySource
+                = (expression.QueryModel.SelectClause.Selector
+                    as QuerySourceReferenceExpression)?
+                        .ReferencedQuerySource;
+
+            if (referencedQuerySource != null)
             {
-                var querySourceTracingExpressionVisitor = new QuerySourceTracingExpressionVisitor();
+                var parentQuerySource =
+                    (parentQueryModel.SelectClause.Selector as QuerySourceReferenceExpression)
+                        ?.ReferencedQuerySource;
 
-                if (expression.QueryModel.ResultOperators.LastOrDefault() is DefaultIfEmptyResultOperator)
+                if (referencedQuerySource.ItemType == parentQuerySource?.ItemType)
                 {
-                    var underlyingQuerySource = (((querySourceReferenceExpression.ReferencedQuerySource as MainFromClause)
-                            ?.FromExpression as QuerySourceReferenceExpression)
-                        ?.ReferencedQuerySource as GroupJoinClause)?.JoinClause;
+                    var resultSetOperators = GetSetResultOperatorSourceExpressions(parentQueryModel);
 
-                    if (underlyingQuerySource != null)
+                    if (resultSetOperators.Any(r => r.Equals(expression))
+                        && _querySourceReferences[parentQuerySource] > 0)
                     {
-                        AddQuerySource(underlyingQuerySource);
-                    }
-                }
-
-                var resultQuerySource
-                    = querySourceTracingExpressionVisitor
-                        .FindResultQuerySourceReferenceExpression(
-                            _selector,
-                            querySourceReferenceExpression.ReferencedQuerySource);
-
-                if ((resultQuerySource == null)
-                    && !(expression.QueryModel.ResultOperators.LastOrDefault() is OfTypeResultOperator))
-                {
-                    _querySources[querySourceReferenceExpression.ReferencedQuerySource]--;
-                }
-
-                foreach (var sourceExpression 
-                    in _queryModel.ResultOperators.Select(SetResultOperationSourceExpression).Where(e => e != null))
-                {
-                    if (sourceExpression.Equals(expression))
-                    {
-                        var parentQuerySource = _selector as QuerySourceReferenceExpression;
-                        if ((parentQuerySource != null)
-                            && (_querySources[parentQuerySource.ReferencedQuerySource] > 0)
-                            && (parentQuerySource.Type == querySourceReferenceExpression.Type))
-                        {
-                            _querySources[querySourceReferenceExpression.ReferencedQuerySource]++;
-                        }
+                        PromoteQuerySource(referencedQuerySource);
                     }
                 }
             }
@@ -238,29 +251,216 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return expression;
         }
 
-        private static Expression SetResultOperationSourceExpression(ResultOperatorBase resultOperator)
+        private void DemoteQuerySource(IQuerySource querySource)
         {
-            var concatOperator = resultOperator as ConcatResultOperator;
-            if (concatOperator != null)
+            HandleUnderlyingQuerySources(querySource, DemoteQuerySource);
+
+            if (_querySourceReferences.ContainsKey(querySource))
             {
-                return concatOperator.Source2;
+                _querySourceReferences[querySource]--;
+            }
+        }
+
+        private void PromoteQuerySource(IQuerySource querySource)
+        {
+            HandleUnderlyingQuerySources(querySource, PromoteQuerySource);
+
+            if (!_querySourceReferences.ContainsKey(querySource))
+            {
+                _querySourceReferences[querySource] = 1;
+            }
+            else
+            {
+                _querySourceReferences[querySource]++;
+            }
+        }
+
+        private void HandleUnderlyingQuerySources(IQuerySource querySource, Action<IQuerySource> action)
+        {
+            if (querySource is GroupResultOperator groupResultOperator)
+            {
+                var keySelectorExpression
+                    = groupResultOperator.KeySelector is SubQueryExpression keySelectorSubQuery
+                        ? keySelectorSubQuery.QueryModel.SelectClause.Selector
+                        : groupResultOperator.KeySelector;
+
+                if (keySelectorExpression is QuerySourceReferenceExpression keySelectorQsre)
+                {
+                    action(keySelectorQsre.ReferencedQuerySource);
+                }
+
+                var elementSelectorExpression
+                    = groupResultOperator.ElementSelector is SubQueryExpression elementSelectorSubQuery
+                        ? elementSelectorSubQuery.QueryModel.SelectClause.Selector
+                        : groupResultOperator.ElementSelector;
+
+                if (elementSelectorExpression is QuerySourceReferenceExpression elementSelectorQsre)
+                {
+                    action(elementSelectorQsre.ReferencedQuerySource);
+                }
+            }
+            else if (querySource is GroupJoinClause groupJoinClause)
+            {
+                action(groupJoinClause.JoinClause);
+            }
+            else
+            {
+                var underlyingExpression
+                    = ((querySource as FromClauseBase)?.FromExpression)
+                        ?? ((querySource as JoinClause)?.InnerSequence);
+
+                if (underlyingExpression is SubQueryExpression subQueryExpression)
+                {
+                    var finalResultOperator = subQueryExpression.QueryModel.ResultOperators.LastOrDefault();
+
+                    if (finalResultOperator is IQuerySource querySourceResultOperator)
+                    {
+                        action(querySourceResultOperator);
+                    }
+                    else if (subQueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression qsre)
+                    {
+                        action(qsre.ReferencedQuerySource);
+                    }
+                }
+                else if (underlyingExpression is QuerySourceReferenceExpression qsre)
+                {
+                    action(qsre.ReferencedQuerySource);
+                }
+            }
+        }
+
+        private void AdjustForResultOperators(QueryModel queryModel)
+        {
+            var referencedQuerySource
+               = (queryModel.SelectClause.Selector
+                   as QuerySourceReferenceExpression)?
+                       .ReferencedQuerySource;
+
+            // The selector may not have been a QSRE but this query model may still have something that needs adjusted.
+            // Example:
+            // context.Orders.GroupBy(o => o.CustomerId).Select(g => new { g.Key, g.Sum(o => o.TotalAmount) })
+            // The g.Sum(...) will result in a subquery model like { from Order o in [g] select o.TotalAmount => Sum() }.
+            // In that case we need to ensure that the referenced query source [g] is demoted.
+            if (referencedQuerySource == null)
+            {
+                referencedQuerySource
+                    = (queryModel.MainFromClause.FromExpression
+                        as QuerySourceReferenceExpression)?
+                            .ReferencedQuerySource;
             }
 
-            var exceptOperator = resultOperator as ExceptResultOperator;
-            if (exceptOperator != null)
+            if (referencedQuerySource == null)
             {
-                return exceptOperator.Source2;
+                return;
             }
 
-            var intersectOperator = resultOperator as IntersectResultOperator;
-            if (intersectOperator != null)
+            var isSubQuery = _queryModelStack.Count > 0;
+            var finalResultOperator = queryModel.ResultOperators.LastOrDefault();
+
+            if (isSubQuery && finalResultOperator is GroupResultOperator groupResultOperator)
             {
-                return intersectOperator.Source2;
+                // These two lines should be uncommented to implement GROUP BY translation.
+                //DemoteQuerySource(referencedQuerySource);
+                //DemoteQuerySource(groupResultOperator);
+                return;
             }
 
-            var unionOperator = resultOperator as UnionResultOperator;
+            var unreachableFromParentSelector =
+                 isSubQuery && _querySourceTracingExpressionVisitor
+                     .FindResultQuerySourceReferenceExpression(
+                         _queryModelStack.Peek().SelectClause.Selector,
+                         referencedQuerySource) == null;
 
-            return unionOperator?.Source2;
+            if (finalResultOperator is SingleResultOperator
+                || finalResultOperator is FirstResultOperator
+                || finalResultOperator is LastResultOperator)
+            {
+                // If not a subquery or if reachable from the parent selector
+                // we would not want to fall through to one of the next blocks.
+                if (unreachableFromParentSelector)
+                {
+                    DemoteQuerySourceAndUnderlyingFromClause(referencedQuerySource);
+                }
+
+                return;
+            }
+
+            if (ConvergesToSingleValue(queryModel))
+            {
+                // This is a top-level query that was not Single/First/Last
+                // but returns a single/scalar value (Avg/Min/Max/etc.)
+                // or a subquery that belongs to some outer-level query that returns 
+                // a single or scalar value. The referenced query source should be 
+                // re-promoted later if necessary.
+                DemoteQuerySourceAndUnderlyingFromClause(referencedQuerySource);
+                return;
+            }
+
+            if (isSubQuery && (unreachableFromParentSelector || finalResultOperator is DefaultIfEmptyResultOperator))
+            {
+                DemoteQuerySourceAndUnderlyingFromClause(referencedQuerySource);
+                return;
+            }
+        }
+
+        private bool ConvergesToSingleValue(QueryModel queryModel)
+        {
+            var outputInfo = queryModel.GetOutputDataInfo();
+
+            if (outputInfo is StreamedSingleValueInfo || outputInfo is StreamedScalarValueInfo)
+            {
+                return true;
+            }
+
+            foreach (var ancestorQueryModel in _queryModelStack)
+            {
+                outputInfo = ancestorQueryModel.GetOutputDataInfo();
+
+                if (outputInfo is StreamedSingleValueInfo || outputInfo is StreamedScalarValueInfo)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void DemoteQuerySourceAndUnderlyingFromClause(IQuerySource querySource)
+        {
+            DemoteQuerySource(querySource);
+
+            var underlyingQuerySource
+                = ((querySource as FromClauseBase)
+                    ?.FromExpression as QuerySourceReferenceExpression)
+                        ?.ReferencedQuerySource;
+
+            if (underlyingQuerySource != null)
+            {
+                DemoteQuerySource(underlyingQuerySource);
+            }
+        }
+
+        private static IEnumerable<Expression> GetSetResultOperatorSourceExpressions(QueryModel queryModel)
+        {
+            foreach (var resultOperator in queryModel.ResultOperators)
+            {
+                if (resultOperator is ConcatResultOperator concatOperator)
+                {
+                    yield return concatOperator.Source2;
+                }
+                else if (resultOperator is ExceptResultOperator exceptOperator)
+                {
+                    yield return exceptOperator.Source2;
+                }
+                else if (resultOperator is IntersectResultOperator intersectOperator)
+                {
+                    yield return intersectOperator.Source2;
+                }
+                else if (resultOperator is UnionResultOperator unionOperator)
+                {
+                    yield return unionOperator.Source2;
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
@@ -107,18 +107,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
             Query_logs_DatabaseErrorLogState(c => c.Blogs.FirstOrDefaultAsync().Wait());
         }
 
-        [Fact]
-        public void Query_logs_DatabaseErrorLogState_during_scalar()
-        {
-            Query_logs_DatabaseErrorLogState(c => c.Blogs.Count());
-        }
-
-        [Fact]
-        public void Query_logs_DatabaseErrorLogState_during_scalar_async()
-        {
-            Query_logs_DatabaseErrorLogState(c => c.Blogs.CountAsync().Wait());
-        }
-
         public void Query_logs_DatabaseErrorLogState(Action<BloggingContext> test)
         {
             var loggerFactory = new TestLoggerFactory();

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2394,9 +2394,9 @@ ORDER BY [t].[Name]",
             Assert.Contains(
                 @"@__p_0: 2
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
+SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM (
-    SELECT TOP(@__p_0) [x].[Id], [x].[Date], [x].[Name], [x].[OneToMany_Optional_Self_InverseId], [x].[OneToMany_Required_Self_InverseId], [x].[OneToOne_Optional_SelfId], [x.OneToOne_Optional_FK].[Id] AS [c0], [x.OneToOne_Optional_FK].[Date] AS [c1], [x.OneToOne_Optional_FK].[Level1_Optional_Id], [x.OneToOne_Optional_FK].[Level1_Required_Id], [x.OneToOne_Optional_FK].[Name] AS [c2], [x.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId] AS [c3], [x.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [x.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId] AS [c4], [x.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [x.OneToOne_Optional_FK].[OneToOne_Optional_SelfId] AS [c5]
+    SELECT TOP(@__p_0) [x].[Id], [x].[Date], [x].[Name], [x].[OneToMany_Optional_Self_InverseId], [x].[OneToMany_Required_Self_InverseId], [x].[OneToOne_Optional_SelfId]
     FROM [Level1] AS [x]
     LEFT JOIN [Level2] AS [x.OneToOne_Optional_FK] ON [x].[Id] = [x.OneToOne_Optional_FK].[Level1_Optional_Id]
     ORDER BY [x.OneToOne_Optional_FK].[Name]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -506,7 +506,7 @@ ORDER BY [t].[OrderID]
 
 SELECT [t1].[OrderID]
 FROM (
-    SELECT TOP(2) [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice]
+    SELECT TOP(2) [o1].*
     FROM [Order Details] AS [o1]
 ) AS [t1]
 ORDER BY [t1].[ProductID], [t1].[OrderID]
@@ -1453,7 +1453,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT DISTINCT [c].*
     FROM [Customers] AS [c]
 ) AS [t]",
                 Sql);
@@ -1665,7 +1665,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT DISTINCT TOP(@__p_0) [o].*
     FROM [Orders] AS [o]
 ) AS [t]",
                 Sql);
@@ -1680,7 +1680,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT DISTINCT TOP(@__p_0) [o].*
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = N'FRANK'
 ) AS [t]",
@@ -1831,7 +1831,7 @@ ORDER BY [t].[CustomerID]",
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].*
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [t]",
@@ -1847,7 +1847,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].*
     FROM [Orders] AS [o]
 ) AS [t]",
                 Sql);
@@ -6272,20 +6272,12 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
     WHERE [e].[CustomerID] = [o1].[CustomerID]
 )
 FROM [Customers] AS [e]
-WHERE [e].[ContactTitle] = N'Owner'
-ORDER BY [e].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
-
-SELECT COUNT(*)
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANTON (Size = 450)
-
-SELECT COUNT(*)
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
+WHERE ([e].[ContactTitle] = N'Owner') AND ((
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [e].[CustomerID] = [o].[CustomerID]
+) > 2)
+ORDER BY [e].[CustomerID]",
                 Sql);
         }
 
@@ -7011,7 +7003,7 @@ ORDER BY [e1].[EmployeeID]",
 
 SELECT COUNT(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].*
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
@@ -7028,7 +7020,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].*
     FROM [Customers] AS [c]
     ORDER BY (SELECT 1)
     OFFSET @__p_0 ROWS
@@ -7045,7 +7037,7 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].*
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS
@@ -7062,7 +7054,7 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT [c].*
     FROM [Customers] AS [c]
     ORDER BY [c].[Country]
     OFFSET @__p_0 ROWS

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -397,9 +397,9 @@ END",
 
 SELECT COUNT(*)
 FROM (
-    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    SELECT [t0].*
     FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
         FROM [Customers] AS [c]
     ) AS [t0]
     WHERE [t0].[__RowNumber__] > @__p_0
@@ -416,9 +416,9 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    SELECT [t0].*
     FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
         FROM [Customers] AS [c]
     ) AS [t0]
     WHERE [t0].[__RowNumber__] > @__p_0
@@ -435,9 +435,9 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    SELECT [t0].*
     FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
         FROM [Customers] AS [c]
     ) AS [t0]
     WHERE [t0].[__RowNumber__] > @__p_0
@@ -454,9 +454,9 @@ FROM (
 
 SELECT COUNT_BIG(*)
 FROM (
-    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    SELECT [t0].*
     FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
         FROM [Customers] AS [c]
     ) AS [t0]
     WHERE [t0].[__RowNumber__] > @__p_0


### PR DESCRIPTION
This is the code at the heart of the efforts I made in #7543 and #7650. 

I don't know why it didn't occur to me to make a branch that had just this in it without removing the 'training wheels' in the `QueryCompilationContext` (the code that brute-force flags all group joins as requiring materialization.) It actually went really easy, I just had to make a tiny little patch to SelectExpression and update some tests' SQL output (one which has a MUCH better query now, another which doesn't pull unnecessary columns anymore, and the rest which just have smaller resulting SQL text.)

Whenever the team is ready to work on the things I accomplished in those other two PRs, all that would need to be done is:

- Uncomment lines 416 and 417 in `RequiresMaterializationExpressionVisitor.cs`
- Remove the code in `QueryCompilationContext` that forces all group joins to be materialized
- Have fun