### PR TITLE
Improve binding to parent query models

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/ISqlTranslatingExpressionVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/ISqlTranslatingExpressionVisitorFactory.cs
@@ -18,7 +18,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <param name="queryModelVisitor"> The query model visitor. </param>
         /// <param name="targetSelectExpression"> The target select expression. </param>
         /// <param name="topLevelPredicate"> The top level predicate. </param>
-        /// <param name="bindParentQueries"> true to bind parent queries. </param>
         /// <param name="inProjection"> true if we are translating a projection. </param>
         /// <returns>
         ///     A SqlTranslatingExpressionVisitor.
@@ -27,7 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             [NotNull] RelationalQueryModelVisitor queryModelVisitor,
             [CanBeNull] SelectExpression targetSelectExpression = null,
             [CanBeNull] Expression topLevelPredicate = null,
-            bool bindParentQueries = false,
             bool inProjection = false);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorFactory.cs
@@ -35,7 +35,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <param name="queryModelVisitor"> The query model visitor. </param>
         /// <param name="targetSelectExpression"> The target select expression. </param>
         /// <param name="topLevelPredicate"> The top level predicate. </param>
-        /// <param name="bindParentQueries"> true to bind parent queries. </param>
         /// <param name="inProjection"> true if we are translating a projection. </param>
         /// <returns>
         ///     A SqlTranslatingExpressionVisitor.
@@ -44,14 +43,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             RelationalQueryModelVisitor queryModelVisitor,
             SelectExpression targetSelectExpression = null,
             Expression topLevelPredicate = null,
-            bool bindParentQueries = false,
             bool inProjection = false)
             => new SqlTranslatingExpressionVisitor(
                 Dependencies,
                 Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)),
                 targetSelectExpression,
                 topLevelPredicate,
-                bindParentQueries,
                 inProjection);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -67,12 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     .HandleResultOperator(QueryModelVisitor, ResultOperator, QueryModel);
             }
 
-            public SqlTranslatingExpressionVisitor CreateSqlTranslatingVisitor(bool bindParentQueries = false)
-                => _sqlTranslatingExpressionVisitorFactory
-                    .Create(
-                        QueryModelVisitor,
-                        SelectExpression,
-                        bindParentQueries: bindParentQueries);
+            public SqlTranslatingExpressionVisitor CreateSqlTranslatingVisitor()
+                => _sqlTranslatingExpressionVisitorFactory.Create(QueryModelVisitor, SelectExpression);
         }
 
         private static readonly Dictionary<Type, Func<HandlerContext, Expression>>
@@ -178,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static Expression HandleAll(HandlerContext handlerContext)
         {
             var sqlTranslatingVisitor
-                = handlerContext.CreateSqlTranslatingVisitor(bindParentQueries: true);
+                = handlerContext.CreateSqlTranslatingVisitor();
 
             var predicate
                 = sqlTranslatingVisitor.Visit(
@@ -286,7 +282,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private static Expression HandleContains(HandlerContext handlerContext)
         {
-            var filteringVisitor = handlerContext.CreateSqlTranslatingVisitor(bindParentQueries: true);
+            var filteringVisitor = handlerContext.CreateSqlTranslatingVisitor();
 
             var itemResultOperator = (ContainsResultOperator)handlerContext.ResultOperator;
 
@@ -659,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var skipResultOperator = (SkipResultOperator)handlerContext.ResultOperator;
 
             var sqlTranslatingExpressionVisitor
-                = handlerContext.CreateSqlTranslatingVisitor(bindParentQueries: true);
+                = handlerContext.CreateSqlTranslatingVisitor();
 
             var offset = sqlTranslatingExpressionVisitor.Visit(skipResultOperator.Count);
             if (offset != null)
@@ -699,7 +695,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var takeResultOperator = (TakeResultOperator)handlerContext.ResultOperator;
 
             var sqlTranslatingExpressionVisitor
-                = handlerContext.CreateSqlTranslatingVisitor(bindParentQueries: true);
+                = handlerContext.CreateSqlTranslatingVisitor();
 
             var limit = sqlTranslatingExpressionVisitor.Visit(takeResultOperator.Count);
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -53,8 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly IConditionalRemovingExpressionVisitorFactory _conditionalRemovingExpressionVisitorFactory;
         private readonly IQueryFlattenerFactory _queryFlattenerFactory;
 
-        private bool _bindParentQueries;
-
         private bool _requiresClientSelectMany;
         private bool _requiresClientJoin;
         private bool _requiresClientFilter;
@@ -189,6 +187,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             get { return _requiresClientSingleColumnResultOperator || _requiresClientResultOperator || RequiresClientEval; }
             set { _requiresClientSingleColumnResultOperator = value; }
         }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether this query model visitor will be
+        ///     able to bind directly to properties from its parent query without requiring
+        ///     parameter injection.
+        /// </summary>
+        /// <value>
+        ///     true if the query model visitor can bind to its parent's properties, false if not.
+        /// </value>
+        public virtual bool CanBindToParentQueryModel { get; protected set; }
 
         /// <summary>
         ///     Context for the query compilation.
@@ -356,7 +364,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="queryModel"> The sub-query model. </param>
         public virtual void VisitSubQueryModel([NotNull] QueryModel queryModel)
         {
-            _bindParentQueries = true;
+            CanBindToParentQueryModel = true;
 
             VisitQueryModel(queryModel);
         }
@@ -1154,8 +1162,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (!requiresClientFilter)
             {
                 var sqlTranslatingExpressionVisitor
-                    = _sqlTranslatingExpressionVisitorFactory
-                        .Create(this, selectExpression, whereClause.Predicate, _bindParentQueries);
+                    = _sqlTranslatingExpressionVisitorFactory.Create(
+                        queryModelVisitor: this,
+                        targetSelectExpression: selectExpression,
+                        topLevelPredicate: whereClause.Predicate);
 
                 var sqlPredicateExpression = sqlTranslatingExpressionVisitor.Visit(whereClause.Predicate);
 
@@ -1211,8 +1221,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (!requiresClientOrderBy)
             {
                 var sqlTranslatingExpressionVisitor
-                    = _sqlTranslatingExpressionVisitorFactory
-                        .Create(this, selectExpression, bindParentQueries: _bindParentQueries);
+                    = _sqlTranslatingExpressionVisitorFactory.Create(
+                        queryModelVisitor: this,
+                        targetSelectExpression: selectExpression);
 
                 var orderings = new List<Ordering>();
 
@@ -1595,12 +1606,22 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private const string OuterQueryParameterNamePrefix = @"_outer_";
 
+        private readonly Dictionary<string, Expression> _injectedParameters = new Dictionary<string, Expression>();
+
         private ParameterExpression BindPropertyToOuterParameter(IQuerySource querySource, IProperty property, bool isMemberExpression)
         {
             if (querySource != null && _canBindPropertyToOuterParameter)
             {
-                var parentSelectExpression = ParentQueryModelVisitor?.TryGetQuery(querySource);
-                if (parentSelectExpression != null)
+                var outerQueryModelVisitor = ParentQueryModelVisitor;
+                var outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource);
+
+                while (outerSelectExpression == null && outerQueryModelVisitor != null)
+                {
+                    outerQueryModelVisitor = outerQueryModelVisitor.ParentQueryModelVisitor;
+                    outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource);
+                }
+
+                if (outerSelectExpression != null)
                 {
                     var parameterName = OuterQueryParameterNamePrefix + property.Name;
                     var parameterWithSamePrefixCount
@@ -1612,7 +1633,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }
 
                     QueryCompilationContext.ParentQueryReferenceParameters.Add(parameterName);
-                    Expression = CreateInjectParametersExpression(Expression, querySource, property, parameterName, isMemberExpression);
+                    
+                    var querySourceReference = new QuerySourceReferenceExpression(querySource);
+                    var propertyExpression = isMemberExpression
+                        ? Expression.Property(querySourceReference, property.PropertyInfo)
+                        : CreatePropertyExpression(querySourceReference, property);
+
+                    if (propertyExpression.Type.GetTypeInfo().IsValueType)
+                    {
+                        propertyExpression = Expression.Convert(propertyExpression, typeof(object));
+                    }
+
+                    _injectedParameters[parameterName] = propertyExpression;
+
+                    Expression 
+                        = CreateInjectParametersExpression(
+                            Expression, 
+                            new Dictionary<string, Expression> { [parameterName] = propertyExpression });
 
                     return Expression.Parameter(
                         property.ClrType,
@@ -1623,32 +1660,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             return null;
         }
 
-        private Expression CreateInjectParametersExpression(
-            Expression expression,
-            IQuerySource querySource,
-            IProperty property,
-            string parameterName,
-            bool isMemberExpression)
+        private Expression CreateInjectParametersExpression(Expression expression, Dictionary<string, Expression> parameters)
         {
-            var querySourceReference = new QuerySourceReferenceExpression(querySource);
-            var propertyExpression = isMemberExpression
-                ? Expression.Property(querySourceReference, property.PropertyInfo)
-                : CreatePropertyExpression(querySourceReference, property);
-
-            if (propertyExpression.Type.GetTypeInfo().IsValueType)
-            {
-                propertyExpression = Expression.Convert(propertyExpression, typeof(object));
-            }
-
             var parameterNameExpressions = new List<ConstantExpression>();
             var parameterValueExpressions = new List<Expression>();
 
-            var methodCallExpression = expression as MethodCallExpression;
-            if (methodCallExpression != null
+            if (expression is MethodCallExpression methodCallExpression
                 && methodCallExpression.Method.MethodIsClosedFormOf(QueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
             {
-                var existingParamterNamesExpression = (NewArrayExpression)methodCallExpression.Arguments[2];
-                parameterNameExpressions.AddRange(existingParamterNamesExpression.Expressions.Cast<ConstantExpression>());
+                var existingParameterNamesExpression = (NewArrayExpression)methodCallExpression.Arguments[2];
+                parameterNameExpressions.AddRange(existingParameterNamesExpression.Expressions.Cast<ConstantExpression>());
 
                 var existingParameterValuesExpression = (NewArrayExpression)methodCallExpression.Arguments[3];
                 parameterValueExpressions.AddRange(existingParameterValuesExpression.Expressions);
@@ -1656,8 +1677,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expression = methodCallExpression.Arguments[1];
             }
 
-            parameterNameExpressions.Add(Expression.Constant(parameterName));
-            parameterValueExpressions.Add(propertyExpression);
+            parameterNameExpressions.AddRange(parameters.Keys.Select(k => Expression.Constant(k)));
+            parameterValueExpressions.AddRange(parameters.Values);
 
             var elementType = expression.Type.GetTypeInfo().GenericTypeArguments.Single();
 
@@ -1667,6 +1688,29 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expression,
                 Expression.NewArrayInit(typeof(string), parameterNameExpressions),
                 Expression.NewArrayInit(typeof(object), parameterValueExpressions));
+        }
+
+        /// <summary>
+        ///     Lifts the outer parameters injected into a subquery into the query
+        ///     expression that is being built by this query model visitor, so that
+        ///     the subquery can be lifted.
+        /// </summary>
+        /// <param name="subQueryModelVisitor"> The query model visitor for the subquery being lifted. </param>
+        public virtual void LiftInjectedParameters([NotNull] RelationalQueryModelVisitor subQueryModelVisitor)
+        {
+            Check.NotNull(subQueryModelVisitor, nameof(subQueryModelVisitor));
+
+            if (!subQueryModelVisitor._injectedParameters.Any())
+            {
+                return;
+            }
+
+            foreach (var pair in subQueryModelVisitor._injectedParameters)
+            {
+                _injectedParameters[pair.Key] = pair.Value;
+            }
+
+            Expression = CreateInjectParametersExpression(Expression, subQueryModelVisitor._injectedParameters);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1660,28 +1660,14 @@ WHERE EXISTS (
             base.Correlated_nested_two_levels_up_subquery_doesnt_project_unnecessary_columns_in_top_level();
 
             Assert.StartsWith(
-                @"SELECT [l1].[Name]
+                @"SELECT DISTINCT [l1].[Name]
 FROM [Level1] AS [l1]
-
-SELECT 1
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
+WHERE EXISTS (
+    SELECT 1
+    FROM [Level2] AS [l2]
+    WHERE EXISTS (
         SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT 1
-FROM [Level2] AS [l20]
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Level3] AS [l32])
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
+        FROM [Level3] AS [l3]))",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -727,17 +727,17 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID1: ALFKI (Size = 450)
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID1 = [o1].[CustomerID]
+WHERE @_outer_CustomerID = [o1].[CustomerID]
 
-@_outer_CustomerID1: ANATR (Size = 450)
+@_outer_CustomerID: ANATR (Size = 450)
 
 SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
 FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID1 = [o1].[CustomerID]",
+WHERE @_outer_CustomerID = [o1].[CustomerID]",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -511,8 +511,11 @@ FROM (
 ) AS [t1]
 ORDER BY [t1].[ProductID], [t1].[OrderID]
 
-SELECT [c3].[CustomerID], [c3].[Country]
+@_outer_CustomerID2: VINET (Size = 450)
+
+SELECT TOP(1) [c3].[Country]
 FROM [Customers] AS [c3]
+WHERE [c3].[CustomerID] = @_outer_CustomerID2
 ORDER BY [c3].[CustomerID]
 
 @_outer_OrderID1: 10285
@@ -521,11 +524,7 @@ SELECT TOP(1) [c4].[Country]
 FROM [Orders] AS [o20]
 INNER JOIN [Customers] AS [c4] ON [o20].[CustomerID] = [c4].[CustomerID]
 WHERE [o20].[OrderID] = @_outer_OrderID1
-ORDER BY [o20].[OrderID], [c4].[CustomerID]
-
-SELECT [c3].[CustomerID], [c3].[Country]
-FROM [Customers] AS [c3]
-ORDER BY [c3].[CustomerID]",
+ORDER BY [o20].[OrderID], [c4].[CustomerID]",
                 Sql);
         }
 
@@ -609,23 +608,23 @@ ORDER BY [o0].[OrderID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-@_outer_CustomerID1: ALFKI (Size = 450)
+@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
 
-@_outer_CustomerID1: ANATR (Size = 450)
+@_outer_CustomerID: ANATR (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
         SELECT 1
         FROM [Orders] AS [o1]
-        WHERE [o1].[CustomerID] = @_outer_CustomerID1)
+        WHERE [o1].[CustomerID] = @_outer_CustomerID)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -5589,9 +5588,92 @@ ORDER BY [o].[OrderID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 
-SELECT [o0].[CustomerID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE [o0].[OrderID] < 10500",
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [t].[OrderDate]
+FROM (
+    SELECT TOP(3) [o].*
+    FROM [Orders] AS [o]
+    WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])
+) AS [t]",
+                Sql);
+        }
+
+        public override void Select_nested_collection_multi_level2()
+        {
+            base.Select_nested_collection_multi_level2();
+
+            Assert.StartsWith(
+                @"SELECT [c].[City], [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+
+@_outer_City: Berlin (Size = 6)
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [t].[OrderDate]
+FROM (
+    SELECT TOP(3) [o].*
+    FROM [Orders] AS [o]
+    WHERE EXISTS (
+        SELECT 1
+        FROM [Order Details] AS [d]
+        WHERE ([d].[Discount] > LEN(@_outer_City)) AND ([o].[OrderID] = [d].[OrderID])) AND (@_outer_CustomerID = [o].[CustomerID])
+) AS [t]",
+                Sql);
+        }
+
+        public override void Select_nested_collection_multi_level3()
+        {
+            base.Select_nested_collection_multi_level3();
+
+            Assert.StartsWith(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+ORDER BY (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE ((
+                SELECT COUNT(*)
+                FROM [Order Details] AS [d]
+                WHERE ([d].[Discount] > LEN([c].[City])) AND ([o].[OrderID] = [d].[OrderID])
+            ) > 0) AND ([c].[CustomerID] = [o].[CustomerID]))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+)
+
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [t].[OrderDate]
+FROM (
+    SELECT TOP(3) [o0].*
+    FROM [Orders] AS [o0]
+    WHERE @_outer_CustomerID = [o0].[CustomerID]
+) AS [t]",
+                Sql);
+        }
+
+        public override void Select_nested_collection_multi_level4()
+        {
+            base.Select_nested_collection_multi_level4();
+
+            Assert.StartsWith(
+                @"SELECT [c].[City], [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+
+@_outer_City: Berlin (Size = 6)
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT TOP(1) [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Order Details] AS [d]
+    WHERE ([d].[Discount] > LEN(@_outer_City)) AND ([o].[OrderID] = [d].[OrderID])) AND (@_outer_CustomerID = [o].[CustomerID])",
                 Sql);
         }
 


### PR DESCRIPTION
This is a much smaller, less radical version of #7663 that brings only enhancements (no regressions) to the plate.