### PR TITLE
Query: Relational: Allows subqueries with OrderBy and Offset to be lifted

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1019,7 +1019,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var subSelectExpression = subQueryModelVisitor.Queries.First();
 
                 if ((!subSelectExpression.OrderBy.Any()
-                     || subSelectExpression.Limit != null)
+                     || subSelectExpression.Limit != null
+                     || subSelectExpression.Offset != null)
                     && (QueryCompilationContext.IsLateralJoinSupported
                         || !subSelectExpression.IsCorrelated()
                         || !(querySource is AdditionalFromClause)))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -329,13 +329,27 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Assert.StartsWith(
                     @"@__p_0: 20
 
-SELECT [c0].[CustomerID]
-FROM [Customers] AS [c0]
-ORDER BY [c0].[CustomerID]
-OFFSET @__p_0 ROWS
+SELECT [t].[CustomerID]
+FROM (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
+    OFFSET @__p_0 ROWS
+) AS [t]
+ORDER BY [t].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+@_outer_CustomerID: FAMIA (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+
+@_outer_CustomerID: FISSA (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                     Sql);
             }


### PR DESCRIPTION
Fixes minor issue in sub-query lifting.