### PR TITLE
Query: Small refactoring to make it easier to create QueryModels.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/AsyncQueryProviderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/AsyncQueryProviderExtensions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -20,15 +20,16 @@ namespace Microsoft.EntityFrameworkCore.Extensions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static ConstantExpression CreateEntityQueryable([NotNull] this IAsyncQueryProvider entityQueryProvider, [NotNull] IEntityType targetEntityType)
+        public static ConstantExpression CreateEntityQueryableExpression(
+            [NotNull] this IAsyncQueryProvider entityQueryProvider, [NotNull] Type type)
         {
             Check.NotNull(entityQueryProvider, nameof(entityQueryProvider));
-            Check.NotNull(targetEntityType, nameof(targetEntityType));
+            Check.NotNull(type, nameof(type));
 
             return Expression.Constant(
                 _createEntityQueryableMethod
-                    .MakeGenericMethod(targetEntityType.ClrType)
-                    .Invoke(null, new object []
+                    .MakeGenericMethod(type)
+                    .Invoke(null, new object[]
                     {
                         entityQueryProvider
                     }));

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/EntityQueryable`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/EntityQueryable`.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
@@ -43,41 +39,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             => ((IAsyncQueryProvider)Provider).ExecuteAsync<TResult>(Expression).GetEnumerator();
 
         IDetachableContext IDetachableContext.DetachContext()
-            => new EntityQueryable<TResult>(_nullAsyncQueryProvider);
-
-        private static readonly IAsyncQueryProvider _nullAsyncQueryProvider = new NullAsyncQueryProvider();
-
-        private class NullAsyncQueryProvider : IAsyncQueryProvider
-        {
-            public IQueryable CreateQuery(Expression expression)
-            {
-                throw new NotImplementedException();
-            }
-
-            public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
-            {
-                throw new NotImplementedException();
-            }
-
-            public object Execute(Expression expression)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TResult1 Execute<TResult1>(Expression expression)
-            {
-                throw new NotImplementedException();
-            }
-
-            public IAsyncEnumerable<TResult1> ExecuteAsync<TResult1>(Expression expression)
-            {
-                throw new NotImplementedException();
-            }
-
-            public Task<TResult1> ExecuteAsync<TResult1>(Expression expression, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-        }
+            => new EntityQueryable<TResult>(NullAsyncQueryProvider.Instance);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/NullAsyncQueryProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/NullAsyncQueryProvider.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class NullAsyncQueryProvider : IAsyncQueryProvider
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static readonly IAsyncQueryProvider Instance = new NullAsyncQueryProvider();
+
+        private NullAsyncQueryProvider()
+        {
+        }
+
+        IQueryable IQueryProvider.CreateQuery(Expression expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        IQueryable<TElement> IQueryProvider.CreateQuery<TElement>(Expression expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        object IQueryProvider.Execute(Expression expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        TResult1 IQueryProvider.Execute<TResult1>(Expression expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAsyncEnumerable<TResult1> IAsyncQueryProvider.ExecuteAsync<TResult1>(Expression expression)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<TResult1> IAsyncQueryProvider.ExecuteAsync<TResult1>(Expression expression, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryOptimizer.cs
@@ -257,15 +257,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         var oldQuerySource = queryModel.MainFromClause;
 
-                        var entityQueryProvider = ((oldQuerySource.FromExpression as ConstantExpression)?.Value as IQueryable)?.Provider as IAsyncQueryProvider;
+                        var entityQueryProvider 
+                            = ((oldQuerySource.FromExpression as ConstantExpression)?.Value as IQueryable)?.Provider as IAsyncQueryProvider;
+
                         if (entityQueryProvider != null)
                         {
                             queryModel.ResultOperators.RemoveAt(index);
 
-                            var newMainFromClause = new MainFromClause(
-                                oldQuerySource.ItemName,
-                                entityType.ClrType,
-                                entityQueryProvider.CreateEntityQueryable(entityType));
+                            var newMainFromClause 
+                                = new MainFromClause(
+                                    oldQuerySource.ItemName,
+                                    entityType.ClrType,
+                                    entityQueryProvider.CreateEntityQueryableExpression(entityType.ClrType));
+
                             queryModel.MainFromClause = newMainFromClause;
 
                             UpdateQuerySourceMapping(queryModel,


### PR DESCRIPTION
Pull NullAsyncQueryProvider out into an internal singleton.