### PR TITLE
Add an AddToPredicate method to SelectExpression...

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -383,10 +383,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                         var existsPredicateExpression = new ExistsExpression(subqueryExpression);
 
-                        AddToPredicate(targetSelectExpression, existsPredicateExpression);
+                        targetSelectExpression.AddToPredicate(existsPredicateExpression);
 
-                        AddToPredicate(
-                            subqueryExpression,
+                        subqueryExpression.AddToPredicate(
                             BuildJoinEqualityExpression(navigation, targetTableExpression, subqueryTable, querySource));
 
                         compositePredicateExpressionVisitor.Visit(subqueryExpression);
@@ -656,12 +655,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 ? ExtractProjections(joinExpression.TableExpression)
                 : Enumerable.Empty<Expression>();
         }
-
-        private static void AddToPredicate(SelectExpression selectExpression, Expression predicateToAdd)
-            => selectExpression.Predicate
-                = selectExpression.Predicate == null
-                    ? predicateToAdd
-                    : Expression.AndAlso(selectExpression.Predicate, predicateToAdd);
 
         private static bool IsOrderingOnNonPrincipalKeyProperties(
                 IEnumerable<Ordering> orderings, IReadOnlyList<IProperty> properties)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1017,7 +1017,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             if (innerPredicate != null)
             {
-                Predicate = Predicate == null ? innerPredicate : AndAlso(Predicate, innerPredicate);
+                AddToPredicate(innerPredicate);
             }
 
             return innerJoinExpression;
@@ -1078,6 +1078,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             Check.NotNull(tableExpression, nameof(tableExpression));
 
             _tables.Remove(tableExpression);
+        }
+
+        /// <summary>
+        ///     Adds a predicate expression to this SelectExpression, combining it with
+        ///     any existing predicate if necessary.
+        /// </summary>
+        /// <param name="predicate"> The predicate expression to add. </param>
+        public virtual void AddToPredicate([NotNull] Expression predicate)
+        {
+            Check.NotNull(predicate, nameof(predicate));
+
+            Predicate = Predicate != null ? AndAlso(Predicate, predicate) : predicate;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -190,18 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 innerSelectExpression.ClearProjection();
                 innerSelectExpression.AddToProjection(Expression.Constant(1));
-
-                if (handlerContext.SelectExpression.Predicate != null)
-                {
-                    innerSelectExpression.Predicate
-                        = Expression.AndAlso(
-                            handlerContext.SelectExpression.Predicate,
-                            Expression.Not(predicate));
-                }
-                else
-                {
-                    innerSelectExpression.Predicate = Expression.Not(predicate);
-                }
+                innerSelectExpression.AddToPredicate(Expression.Not(predicate));
 
                 if (innerSelectExpression.Limit == null
                     && innerSelectExpression.Offset == null)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1165,11 +1165,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         _conditionalRemovingExpressionVisitorFactory
                             .Create()
                             .Visit(sqlPredicateExpression);
-
-                    selectExpression.Predicate
-                        = selectExpression.Predicate == null
-                            ? sqlPredicateExpression
-                            : Expression.AndAlso(selectExpression.Predicate, sqlPredicateExpression);
+                    
+                    selectExpression.AddToPredicate(sqlPredicateExpression);
                 }
                 else
                 {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -134,13 +134,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 subQuery.ClearOrderBy();
                 subQuery.AddToProjection(rowNumber, false);
 
-                Expression predicate = null;
-
                 var offset = subQuery.Offset ?? Expression.Constant(0);
 
                 if (subQuery.Offset != null)
                 {
-                    predicate = Expression.GreaterThan(columnExpression, offset);
+                    selectExpression.AddToPredicate
+                        (Expression.GreaterThan(columnExpression, offset));
                 }
 
                 if (subQuery.Limit != null)
@@ -154,17 +153,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             ? (Expression)Expression.Constant((int)offsetValue + (int)constantValue)
                             : Expression.Add(offset, subQuery.Limit);
 
-                    var expression = Expression.LessThanOrEqual(columnExpression, limitExpression);
-
-                    if (predicate != null)
-                    {
-                        expression = Expression.AndAlso(predicate, expression);
-                    }
-
-                    predicate = expression;
+                    selectExpression.AddToPredicate(
+                        Expression.LessThanOrEqual(columnExpression, limitExpression));
                 }
-
-                selectExpression.Predicate = predicate;
 
                 if (selectExpression.Alias != null)
                 {


### PR DESCRIPTION
 ...to eliminate redundant logic.

Just a little 🍬 🍰 🍭 🍨 thing that centralizes a common operation that may be used more than it is now. @anpete had already done so in `IncludeExpressionVisitor`.