### PR TITLE
SQL Server Migrations: Handle GO and (Backslash) utilities statements

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/MigrationsFixtureBase.cs
@@ -77,8 +77,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
                 if (ActiveProvider == "Microsoft.EntityFrameworkCore.SqlServer")
                 {
-                    migrationBuilder.Sql("CREATE DATABASE TransactionSuppressed", suppressTransaction: true);
-                    migrationBuilder.Sql("DROP DATABASE TransactionSuppressed", suppressTransaction: true);
+                    migrationBuilder.Sql("CREATE DATABASE TransactionSuppressed;", suppressTransaction: true);
+                    migrationBuilder.Sql("DROP DATABASE TransactionSuppressed;", suppressTransaction: true);
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -617,9 +617,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            builder
-                .Append(operation.Sql)
-                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+            builder.AppendLine(operation.Sql);
 
             EndStatement(builder, operation.SuppressTransaction);
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -764,6 +767,57 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             Rename(qualifiedName.ToString(), operation.NewName, "COLUMN", builder);
             builder.EndCommand();
+        }
+
+        protected override void Generate([NotNull] SqlOperation operation, [CanBeNull] IModel model, [NotNull] MigrationCommandListBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            var batches = Regex.Split(
+                Regex.Replace(
+                    operation.Sql,
+                    @"\\\r?\n",
+                    string.Empty,
+                    default(RegexOptions),
+                    TimeSpan.FromMilliseconds(1000.0)),
+                @"^\s*(GO[ \t]+[0-9]+|GO)(?:\s+|$)",
+                RegexOptions.IgnoreCase | RegexOptions.Multiline,
+                TimeSpan.FromMilliseconds(1000.0));
+            for (var i = 0; i < batches.Length; i++)
+            {
+                if (batches[i].StartsWith("GO", StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrWhiteSpace(batches[i]))
+                {
+                    continue;
+                }
+
+                var count = 1;
+                if (i != batches.Length - 1
+                    && batches[i + 1].StartsWith("GO", StringComparison.OrdinalIgnoreCase))
+                {
+                    var match = Regex.Match(
+                        batches[i + 1], "([0-9]+)",
+                        default(RegexOptions),
+                        TimeSpan.FromMilliseconds(1000.0));
+                    if (match.Success)
+                    {
+                        count = int.Parse(match.Value);
+                    }
+                }
+
+                for (var j = 0; j < count; j++)
+                {
+                    builder.Append(batches[i]);
+
+                    if (i == batches.Length - 1)
+                    {
+                        builder.AppendLine();
+                    }
+
+                    EndStatement(builder, operation.SuppressTransaction);
+                }
+            }
         }
 
         protected override void ColumnDefinition(

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -299,8 +299,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
         public void Generate_doesnt_batch_by_default()
         {
             Generate(
-                new SqlOperation { Sql = "SELECT 1" },
-                new SqlOperation { Sql = "SELECT 2" });
+                new SqlOperation { Sql = "SELECT 1;" },
+                new SqlOperation { Sql = "SELECT 2;" });
 
             Assert.Equal(
                 "SELECT 1;" + EOL +

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -1029,6 +1029,88 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 Sql);
         }
 
+        [Fact]
+        public virtual void SqlOperation_handles_backslash()
+        {
+            Generate(
+                new SqlOperation
+                {
+                    Sql = @"-- Multiline \" + EOL +
+                        "comment"
+                });
+
+            Assert.Equal(
+                "-- Multiline comment" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void SqlOperation_ignores_sequential_gos()
+        {
+            Generate(
+                new SqlOperation
+                {
+                    Sql = "-- Ready set" + EOL +
+                        "GO" + EOL +
+                        "GO"
+                });
+
+            Assert.Equal(
+                "-- Ready set" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void SqlOperation_handles_go()
+        {
+            Generate(
+                new SqlOperation
+                {
+                    Sql = "-- I" + EOL +
+                        "go" + EOL +
+                        "-- Too"
+                });
+
+            Assert.Equal(
+                "-- I" + EOL +
+                "GO" + EOL +
+                EOL +
+                "-- Too" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void SqlOperation_handles_go_with_count()
+        {
+            Generate(
+                new SqlOperation
+                {
+                    Sql = "-- I" + EOL +
+                        "GO 2"
+                });
+
+            Assert.Equal(
+                "-- I" + EOL +
+                "GO" + EOL +
+                EOL +
+                "-- I" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void SqlOperation_ignores_non_go()
+        {
+            Generate(
+                new SqlOperation
+                {
+                    Sql = "-- I GO 2"
+                });
+
+            Assert.Equal(
+                "-- I GO 2" + EOL,
+                Sql);
+        }
+
         public SqlServerMigrationSqlGeneratorTest()
             : base(SqlServerTestHelpers.Instance)
         {


### PR DESCRIPTION
Resolves #6747

I found a few issues with this (it's more permissive than it should be with things after the statement), but it's more-or-less the same implementation as EF6, and nobody has reported them yet...

**Providers**: This PR is 99% SQL Server, but it also updates `MigrationsSqlGenerator` to stop tacking on a statement terminator (`;`) to the user's `.Sql()` calls. This will only have a functional impact if you've gone above and beyond the base implementation to add batching to Migrations.

@ErikEJ: You may want to support this in SQL CE too.