### PR TITLE
Add IsLiftable property to RelationalQueryModelVisitor

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -875,10 +875,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                     subQueryModelVisitor.VisitSubQueryModel(subQueryModel);
 
-                    if (subQueryModelVisitor.Queries.Count == 1
-                        && !subQueryModelVisitor.RequiresClientFilter
-                        && !subQueryModelVisitor.RequiresClientProjection
-                        && !subQueryModelVisitor.RequiresClientResultOperator)
+                    if (subQueryModelVisitor.IsLiftable)
                     {
                         var selectExpression = subQueryModelVisitor.Queries.First();
 

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -197,6 +197,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     true if the query model visitor can bind to its parent's properties, false if not.
         /// </value>
         public virtual bool CanBindToParentQueryModel { get; protected set; }
+        
+        /// <summary>
+        ///     Gets a value indicating whether query model visitor's resulting expression
+        ///     can be lifted into the parent query. Liftable queries contain a single SelectExpression.
+        /// </summary>
+        public virtual bool IsLiftable
+        {
+            get
+            {
+                return Queries.Count == 1
+                    && !RequiresClientEval
+                    && !RequiresClientSelectMany
+                    && !RequiresClientJoin
+                    && !RequiresClientFilter
+                    && !RequiresClientProjection
+                    && !RequiresClientOrderBy
+                    && !RequiresClientResultOperator;
+            }
+        }
 
         /// <summary>
         ///     Context for the query compilation.
@@ -1015,14 +1034,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             subQueryModelVisitor.VisitSubQueryModel(subQueryModel);
 
-            if (subQueryModelVisitor.Queries.Count == 1
-                && !subQueryModelVisitor.RequiresClientEval
-                && !subQueryModelVisitor.RequiresClientSelectMany
-                && !subQueryModelVisitor.RequiresClientJoin
-                && !subQueryModelVisitor.RequiresClientFilter
-                && !subQueryModelVisitor.RequiresClientProjection
-                && !subQueryModelVisitor.RequiresClientOrderBy
-                && !subQueryModelVisitor.RequiresClientResultOperator)
+            if (subQueryModelVisitor.IsLiftable)
             {
                 var subSelectExpression = subQueryModelVisitor.Queries.First();
 


### PR DESCRIPTION
This is another 🍬 🍰 🍨 🍭 PR that adds an `IsInlinable` property to the `RelationalQueryModelVisitor`. I feel this change brings the following benefits:

- Encapsulates duplicated logic
- Improves readability of the places it is used in, which are already very logic-heavy