### PR TITLE
Query: Relational: only push down subqueries when needed.

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -184,15 +184,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var innerSelectExpression = handlerContext.SelectExpression.Clone();
 
-                innerSelectExpression.ClearProjection();
-                innerSelectExpression.AddToProjection(Expression.Constant(1));
                 innerSelectExpression.AddToPredicate(Expression.Not(predicate));
-
-                if (innerSelectExpression.Limit == null
-                    && innerSelectExpression.Offset == null)
-                {
-                    innerSelectExpression.ClearOrderBy();
-                }
+                innerSelectExpression.SetProjectionExpression(Expression.Constant(1));
+                innerSelectExpression.ClearOrderBy();
 
                 SetProjectionConditionalExpression(
                     handlerContext,

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1679,7 +1679,7 @@ WHERE EXISTS (
                 @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN (
-    SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+    SELECT [l2].*
     FROM [Level2] AS [l2]
     WHERE ([l2].[Name] <> N'L2 01') OR [l2].[Name] IS NULL
 ) AS [t] ON [l1].[Id] = [t].[Level1_Optional_Id]
@@ -1695,7 +1695,7 @@ ORDER BY [l1].[Id]",
                 @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN (
-    SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+    SELECT [l1.OneToOne_Required_FK].*
     FROM [Level1] AS [l10]
     LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
     WHERE ([l10].[Name] <> N'L1 01') OR [l10].[Name] IS NULL
@@ -1712,12 +1712,9 @@ ORDER BY [l1].[Id]",
             base.Null_protection_logic_work_for_inner_key_access_of_manually_created_GroupJoin1();
 
             Assert.Contains(
-                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
-FROM (
-    SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
-    FROM [Level1] AS [l10]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
-) AS [t]",
+                @"SELECT [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l10]
+LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l10].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]",
                 Sql);
 
             Assert.Contains(
@@ -1868,13 +1865,10 @@ ORDER BY [l3.OneToOne_Required_FK_Inverse0].[Id]",
             Assert.Equal(
                 @"@__p_0: 3
 
-SELECT [t].[Name]
-FROM (
-    SELECT TOP(@__p_0) [l2].*
-    FROM [Level2] AS [l2]
-    INNER JOIN [Level1] AS [l2.OneToOne_Required_FK_Inverse] ON [l2].[Level1_Required_Id] = [l2.OneToOne_Required_FK_Inverse].[Id]
-    WHERE [l2.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'
-) AS [t]",
+SELECT TOP(@__p_0) [l2].[Name]
+FROM [Level2] AS [l2]
+INNER JOIN [Level1] AS [l2.OneToOne_Required_FK_Inverse] ON [l2].[Level1_Required_Id] = [l2.OneToOne_Required_FK_Inverse].[Id]
+WHERE [l2.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'",
                 Sql);
         }
 
@@ -1900,14 +1894,11 @@ WHERE ([l10].[Name] = N'L1 03') AND ([l30].[Name] = N'L3 08')",
             Assert.Equal(
                 @"@__p_0: 3
 
-SELECT [t].[Name]
-FROM (
-    SELECT TOP(@__p_0) [l1].*
-    FROM [Level2] AS [l2]
-    INNER JOIN [Level1] AS [l1] ON [l2].[Level1_Required_Id] = [l1].[Id]
-    INNER JOIN [Level3] AS [l3] ON [l1].[Id] = [l3].[Level2_Required_Id]
-    WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')
-) AS [t]",
+SELECT TOP(@__p_0) [l1].[Name]
+FROM [Level2] AS [l2]
+INNER JOIN [Level1] AS [l1] ON [l2].[Level1_Required_Id] = [l1].[Id]
+INNER JOIN [Level3] AS [l3] ON [l1].[Id] = [l3].[Level2_Required_Id]
+WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')",
                 Sql);
         }
 
@@ -2324,12 +2315,9 @@ INNER JOIN [Level2] AS [l2] ON [l1].[Id] = (
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 WHERE 1 IN (
-    SELECT [t].[Id]
-    FROM (
-        SELECT DISTINCT [l].*
-        FROM [Level3] AS [l]
-        WHERE [l1.OneToOne_Optional_FK].[Id] = [l].[OneToMany_Optional_InverseId]
-    ) AS [t]
+    SELECT DISTINCT [l].[Id]
+    FROM [Level3] AS [l]
+    WHERE [l1.OneToOne_Optional_FK].[Id] = [l].[OneToMany_Optional_InverseId]
 )",
                 Sql);
         }
@@ -2538,13 +2526,10 @@ ORDER BY [l1].[Id]",
             Assert.Equal(
                 @"@__p_0: 15
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id] AS [c0], [l1.OneToOne_Optional_FK].[Date] AS [c1], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name] AS [c2], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId] AS [c3], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId] AS [c4], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
-    WHERE ([l1.OneToOne_Optional_FK].[Name] <> N'Foo') OR [l1.OneToOne_Optional_FK].[Name] IS NULL
-) AS [t]",
+SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+WHERE ([l1.OneToOne_Optional_FK].[Name] <> N'Foo') OR [l1.OneToOne_Optional_FK].[Name] IS NULL",
                 Sql);
         }
 
@@ -2555,13 +2540,10 @@ FROM (
             Assert.Equal(
                 @"@__p_0: 15
 
-SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_SelfId], [t].[c0], [t].[c1], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[c2], [t].[OneToMany_Optional_InverseId], [t].[c3], [t].[OneToMany_Required_InverseId], [t].[c4], [t].[OneToOne_Optional_PK_InverseId], [t].[c5]
-FROM (
-    SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id] AS [c0], [l2].[Date] AS [c1], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name] AS [c2], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId] AS [c3], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId] AS [c4], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId] AS [c5]
-    FROM [Level1] AS [l1]
-    LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
-    WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL
-) AS [t]",
+SELECT TOP(@__p_0) [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL",
                 Sql);
         }
 
@@ -2645,17 +2627,13 @@ LEFT JOIN [Level2] AS [l2] ON [l1_inner].[Id] = [l2].[Level1_Optional_Id]",
                 @"@__p_0: 0
 @__p_1: 10
 
-SELECT [t].[Name]
-FROM (
-    SELECT [l3].*
-    FROM [Level3] AS [l3]
-    INNER JOIN [Level2] AS [l3.OneToMany_Required_Inverse] ON [l3].[OneToMany_Required_InverseId] = [l3.OneToMany_Required_Inverse].[Id]
-    INNER JOIN [Level1] AS [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse] ON [l3.OneToMany_Required_Inverse].[Level1_Required_Id] = [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Id]
-    WHERE [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'
-    ORDER BY [l3].[Level2_Required_Id]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t]
-ORDER BY [t].[Level2_Required_Id]",
+SELECT [l3].[Name]
+FROM [Level3] AS [l3]
+INNER JOIN [Level2] AS [l3.OneToMany_Required_Inverse] ON [l3].[OneToMany_Required_InverseId] = [l3.OneToMany_Required_Inverse].[Id]
+INNER JOIN [Level1] AS [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse] ON [l3.OneToMany_Required_Inverse].[Level1_Required_Id] = [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Id]
+WHERE [l3.OneToMany_Required_Inverse.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'
+ORDER BY [l3].[Level2_Required_Id]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -198,13 +198,9 @@ ORDER BY [od].[OrderID], [od].[ProductID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT [t].[CustomerID]
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -227,17 +223,13 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT (
+SELECT TOP(@__p_0) (
     SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
-    WHERE [t].[CustomerID] = [o].[CustomerID]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]",
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
@@ -248,17 +240,13 @@ ORDER BY [t].[CustomerID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT (
+SELECT TOP(@__p_0) (
     SELECT TOP(1) [o].[CustomerID]
     FROM [Orders] AS [o]
-    WHERE [t].[CustomerID] = [o].[CustomerID]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]",
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
@@ -269,13 +257,9 @@ ORDER BY [t].[CustomerID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT [t].[CustomerID]
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -298,13 +282,9 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT [t].[CustomerID]
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -329,14 +309,10 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
                 Assert.StartsWith(
                     @"@__p_0: 20
 
-SELECT [t].[CustomerID]
-FROM (
-    SELECT [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-    OFFSET @__p_0 ROWS
-) AS [t]
-ORDER BY [t].[CustomerID]
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]
+OFFSET @__p_0 ROWS
 
 @_outer_CustomerID: FAMIA (Size = 450)
 

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -497,19 +497,13 @@ WHERE (
             Assert.StartsWith(
                 @"@__p_0: 2
 
-SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
-FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-    FROM [Orders] AS [o]
-) AS [t]
-ORDER BY [t].[OrderID]
+SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[OrderID]
 
-SELECT [t1].[OrderID]
-FROM (
-    SELECT TOP(2) [o1].*
-    FROM [Order Details] AS [o1]
-) AS [t1]
-ORDER BY [t1].[ProductID], [t1].[OrderID]
+SELECT TOP(2) [o1].[OrderID]
+FROM [Order Details] AS [o1]
+ORDER BY [o1].[ProductID], [o1].[OrderID]
 
 @_outer_CustomerID2: VINET (Size = 450)
 
@@ -1745,11 +1739,8 @@ FROM [Customers] AS [c3]",
             Assert.Equal(
                 @"@__p_0: 91
 
-SELECT [t].[City]
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-) AS [t]",
+SELECT TOP(@__p_0) [c].[City]
+FROM [Customers] AS [c]",
                 Sql);
         }
 
@@ -1811,13 +1802,9 @@ ORDER BY [c].[CustomerID]",
             Assert.Equal(
                 @"@__p_0: 2
 
-SELECT [t].[City]
-FROM (
-    SELECT TOP(@__p_0) [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[CustomerID]
-) AS [t]
-ORDER BY [t].[CustomerID]",
+SELECT TOP(@__p_0) [c].[City]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
@@ -2141,11 +2128,8 @@ FROM [Products] AS [p]",
             Assert.Equal(
                 @"@__p_0: 9
 
-SELECT [t].[EmployeeID]
-FROM (
-    SELECT TOP(@__p_0) [e].*
-    FROM [Employees] AS [e]
-) AS [t]",
+SELECT TOP(@__p_0) [e].[EmployeeID]
+FROM [Employees] AS [e]",
                 Sql);
         }
 
@@ -3877,10 +3861,13 @@ END",
 SELECT CASE
     WHEN NOT EXISTS (
         SELECT 1
-        FROM [Customers] AS [c]
-        WHERE LEN([c].[CustomerID]) <> 5
-        ORDER BY [c].[ContactName]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY)
+        FROM (
+            SELECT [c].*
+            FROM [Customers] AS [c]
+            ORDER BY [c].[ContactName]
+            OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+        ) AS [t]
+        WHERE [t].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [t].[CustomerID]) = 1))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -4006,12 +3993,9 @@ ORDER BY [t].[Country]",
             base.Distinct_OrderBy2();
 
             Assert.Equal(
-                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
-FROM (
-    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-    FROM [Customers] AS [c]
-) AS [t]
-ORDER BY [t].[CustomerID]",
+                @"SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
@@ -5590,12 +5574,9 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [t].[OrderDate]
-FROM (
-    SELECT TOP(3) [o].*
-    FROM [Orders] AS [o]
-    WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])
-) AS [t]",
+SELECT TOP(3) [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])",
                 Sql);
         }
 
@@ -5611,15 +5592,12 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
 @_outer_City: Berlin (Size = 6)
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [t].[OrderDate]
-FROM (
-    SELECT TOP(3) [o].*
-    FROM [Orders] AS [o]
-    WHERE EXISTS (
-        SELECT 1
-        FROM [Order Details] AS [d]
-        WHERE ([d].[Discount] > LEN(@_outer_City)) AND ([o].[OrderID] = [d].[OrderID])) AND (@_outer_CustomerID = [o].[CustomerID])
-) AS [t]",
+SELECT TOP(3) [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Order Details] AS [d]
+    WHERE ([d].[Discount] > LEN(@_outer_City)) AND ([o].[OrderID] = [d].[OrderID])) AND (@_outer_CustomerID = [o].[CustomerID])",
                 Sql);
         }
 
@@ -5647,12 +5625,9 @@ ORDER BY (
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [t].[OrderDate]
-FROM (
-    SELECT TOP(3) [o0].*
-    FROM [Orders] AS [o0]
-    WHERE @_outer_CustomerID = [o0].[CustomerID]
-) AS [t]",
+SELECT TOP(3) [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 Sql);
         }
 
@@ -6862,19 +6837,16 @@ WHERE [t].[c0] < @__nextYear_0",
             base.DefaultIfEmpty_without_group_join();
 
             Assert.Equal(
-                @"SELECT [t0].[CustomerID]
+                @"SELECT [t].[CustomerID]
 FROM (
-    SELECT [t].*
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty]
-    LEFT JOIN (
-        SELECT [c].*
-        FROM [Customers] AS [c]
-        WHERE [c].[City] = N'London'
-    ) AS [t] ON 1 = 1
-) AS [t0]
-WHERE [t0].[CustomerID] IS NOT NULL",
+    SELECT NULL AS [empty]
+) AS [empty]
+LEFT JOIN (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    WHERE [c].[City] = N'London'
+) AS [t] ON 1 = 1
+WHERE [t].[CustomerID] IS NOT NULL",
                 Sql);
         }
 
@@ -7172,6 +7144,99 @@ WHERE ([o].[OrderID] > 11000) AND [o].[OrderID] IN (
     INNER JOIN [Products] AS [od.Product] ON [od].[ProductID] = [od.Product].[ProductID]
     WHERE [od.Product].[ProductName] = N'Chai'
 )",
+                Sql);
+        }
+
+        public override void Where_simple_shadow_subquery()
+        {
+            base.Where_simple_shadow_subquery();
+
+            Assert.Equal(
+                @"@__p_0: 5
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+    ORDER BY [e].[EmployeeID]
+) AS [t]
+WHERE [t].[Title] = N'Sales Representative'
+ORDER BY [t].[EmployeeID]",
+                Sql);
+        }
+
+        public override void Where_simple_shadow_subquery2()
+        {
+            base.Where_simple_shadow_subquery2();
+
+            Assert.Equal(
+                @"@__p_0: 5
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+    ORDER BY [e].[EmployeeID]
+    OFFSET @__p_0 ROWS
+) AS [t]
+WHERE [t].[Title] = N'Sales Representative'
+ORDER BY [t].[EmployeeID]",
+                Sql);
+        }
+
+        public override void OrderBy_Take_OrderBy()
+        {
+            base.OrderBy_Take_OrderBy();
+
+            Assert.Equal(
+                @"@__p_0: 2
+
+SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice]
+FROM (
+    SELECT TOP(@__p_0) [d].[OrderID], [d].[ProductID], [d].[Discount], [d].[Quantity], [d].[UnitPrice]
+    FROM [Order Details] AS [d]
+    ORDER BY [d].[Quantity], [d].[OrderID]
+) AS [t]
+ORDER BY [t].[ProductID], [t].[Quantity]",
+                Sql);
+        }
+
+        public override void OrderBy_Skip_OrderBy()
+        {
+            base.OrderBy_Skip_OrderBy();
+
+            Assert.Equal(
+                @"@__p_0: 2153
+
+SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice]
+FROM (
+    SELECT [d].[OrderID], [d].[ProductID], [d].[Discount], [d].[Quantity], [d].[UnitPrice]
+    FROM [Order Details] AS [d]
+    ORDER BY [d].[Quantity], [d].[OrderID]
+    OFFSET @__p_0 ROWS
+) AS [t]
+ORDER BY [t].[ProductID], [t].[Quantity]",
+                Sql);
+        }
+
+        public override void Skip_Skip_Take()
+        {
+            base.Skip_Skip_Take();
+
+            Assert.Equal(
+                @"@__p_0: 23
+@__p_1: 19
+@__p_2: 11
+
+SELECT [t].*
+FROM (
+    SELECT [d].[OrderID], [d].[ProductID], [d].[Discount], [d].[Quantity], [d].[UnitPrice]
+    FROM [Order Details] AS [d]
+    ORDER BY [d].[OrderID], [d].[ProductID]
+    OFFSET @__p_0 ROWS
+) AS [t]
+ORDER BY [t].[OrderID], [t].[ProductID]
+OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY",
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #7766