### PR TITLE
Remove special handling for concat operator

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -153,11 +153,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual IRelationalCommandBuilder Sql => _relationalCommandBuilder;
 
         /// <summary>
-        ///     The default string concatenation operator SQL.
-        /// </summary>
-        protected virtual string ConcatOperator => "+";
-
-        /// <summary>
         ///     The default true literal SQL.
         /// </summary>
         protected virtual string TypedTrueLiteral => "CAST(1 AS BIT)";
@@ -1506,8 +1501,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             switch (expression.NodeType)
             {
-                case ExpressionType.Add:
-                    return expression.Type == typeof(string) ? " " + ConcatOperator + " " : " + ";
                 case ExpressionType.Extension:
                 {
                     var asStringCompareExpression = expression as StringCompareExpression;

--- a/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
@@ -15,8 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
     /// </summary>
     public class SqliteQuerySqlGenerator : DefaultQuerySqlGenerator
     {
-        protected override string ConcatOperator => "||";
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -27,6 +25,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             : base(dependencies, selectExpression)
         {
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override string GenerateOperator([NotNull] Expression expression)
+            => expression.NodeType == ExpressionType.Add && expression.Type == typeof(string)
+                ? " || "
+                : base.GenerateOperator(expression);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
A special string concat operator was added at some point to support PostgreSQL (which uses || to concat strings). This is an overridable property that is by default +.

After the introduction of a more generic GenerateOperator(), this no longer makes sense - a provider that needs a special concat operator (or any other) can simply override GenerateOperator() and do that there without any special support from Relational.

Removing to simplify/cleanup DefaultQuerySqlGenerator.