### PR TITLE
Query: new 'VisitUnderlyingQuerySources' extension method

### DIFF
--- a/src/EFCore/Query/Internal/QuerySourceExtensions.cs
+++ b/src/EFCore/Query/Internal/QuerySourceExtensions.cs
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -24,6 +28,55 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotEmpty(querySource.ItemName, nameof(querySource.ItemName));
 
             return querySource.ItemName.StartsWith("<generated>_", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void VisitUnderlyingQuerySources([NotNull] this IQuerySource querySource, Action<IQuerySource> action)
+        {
+            switch (querySource)
+            {
+                case GroupResultOperator groupResultOperator:
+                    VisitUnderlyingQuerySources(groupResultOperator.KeySelector, action);
+                    VisitUnderlyingQuerySources(groupResultOperator.ElementSelector, action);
+                    break;
+                case GroupJoinClause groupJoinClause:
+                    action(groupJoinClause.JoinClause);
+                    break;
+                case JoinClause joinClause:
+                    VisitUnderlyingQuerySources(joinClause.InnerSequence, action);
+                    break;
+                case FromClauseBase fromClauseBase:
+                    VisitUnderlyingQuerySources(fromClauseBase.FromExpression, action);
+                    break;
+            }
+        }
+
+        private static void VisitUnderlyingQuerySources(Expression expression, Action<IQuerySource> action)
+        {
+            switch (expression)
+            {
+                case QuerySourceReferenceExpression querySourceReferenceExpression:
+                    action(querySourceReferenceExpression.ReferencedQuerySource);
+                    break;
+                case SubQueryExpression subQueryExpression:
+                    VisitUnderlyingQuerySources(subQueryExpression, action);
+                    break;
+            }
+        }
+
+        private static void VisitUnderlyingQuerySources(SubQueryExpression subQueryExpression, Action<IQuerySource> action)
+        {
+            if (subQueryExpression.QueryModel.ResultOperators.LastOrDefault() is IQuerySource querySourceResultOperator)
+            {
+                action(querySourceResultOperator);
+            }
+            else
+            {
+                VisitUnderlyingQuerySources(subQueryExpression.QueryModel.SelectClause.Selector, action);
+            }
         }
     }
 }


### PR DESCRIPTION
- Split 'HandleUnderlyingQuerySources' out of RequiresMaterializationExpressionVisitor to create a new 'VisitUnderlyingQuerySources' extension method for 'IQuerySource'.

@maumar I was thinking about #7772 when I decided to do this. You found a use for the logic outside of `RequiresMaterializationExpressionVisitor` and I was interested in experimenting with reusing the logic too.