### PR TITLE
[SMALL] Fix metric collection when test runner serializes test case

### DIFF
--- a/test/EFCore.Benchmarks/BenchmarkTestCase.cs
+++ b/test/EFCore.Benchmarks/BenchmarkTestCase.cs
@@ -28,10 +28,13 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
             WarmupIterations = warmupIterations;
         }
 
-        public override IMetricCollector MetricCollector { get; } = new MetricCollector();
-
         public int Iterations { get; protected set; }
         public int WarmupIterations { get; protected set; }
+
+        protected override IMetricCollector CreateMetricCollector()
+        {
+            return new MetricCollector();
+        }
 
         public override Task<RunSummary> RunAsync(
             IMessageSink diagnosticMessageSink,

--- a/test/EFCore.Benchmarks/BenchmarkTestCaseBase.cs
+++ b/test/EFCore.Benchmarks/BenchmarkTestCaseBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
             DisplayName = $"{name} [Variation: {variation}]";
             Variation = variation;
 
-            var methodArguments = new List<object> { MetricCollector };
+            var methodArguments = new List<object> { CreateMetricCollector() };
             if (testMethodArguments != null)
             {
                 methodArguments.AddRange(testMethodArguments);
@@ -42,9 +42,12 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
             TestMethodArguments = methodArguments.ToArray();
         }
 
-        public abstract IMetricCollector MetricCollector { get; }
+
         public string TestMethodName { get; protected set; }
         public string Variation { get; protected set; }
+        public IMetricCollector MetricCollector => TestMethodArguments.OfType<IMetricCollector>().Single();
+
+        protected abstract IMetricCollector CreateMetricCollector();
 
         protected override string GetSkipReason(IAttributeInfo factAttribute) => EvaluateSkipConditions(TestMethod) ?? base.GetSkipReason(factAttribute);
 

--- a/test/EFCore.Benchmarks/NonCollectingBenchmarkTestCase.cs
+++ b/test/EFCore.Benchmarks/NonCollectingBenchmarkTestCase.cs
@@ -21,6 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         {
         }
 
-        public override IMetricCollector MetricCollector { get; } = new NullMetricCollector();
+        protected override IMetricCollector CreateMetricCollector()
+        {
+            return new NullMetricCollector();
+        }
     }
 }


### PR DESCRIPTION
The test case had a separate reference to the metric collector in
addition to the instance being added to the test method parameters. This
works fine until you serialize the test cases, as you end up with
separate references - one which the results are recorded in, and the
other that they are read from. The end result is reporting of zero
results. Serialization happens by default in the new MSBuild/csproj
project system (i.e. when you use the VS Test Runner or dotnet test).

There were two issues here. Test cases were creating a new metric
collector everytime they were created (i.e. they weren't
serialized/deserialized). Just fixing that wouldn't solve the problem
though, as serializing the refernce on the test case would have still
ended up with two separate instance on the test case and method
arguments. Instead, the test method arguments are the source of truth,
and the test case gets the metric collector from the argument array.