### PR TITLE
Reverse Engineer: Pluralize collection navigations

### DIFF
--- a/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -636,6 +636,12 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                     dependentEndNavigationPropertyName)
                 : CandidateNamingService.GetPrincipalEndCandidateNavigationPropertyName(
                     foreignKey, dependentEndNavigationPropertyName);
+
+            if (!foreignKey.IsUnique && !foreignKey.IsSelfReferencing())
+            {
+                principalEndNavigationPropertyCandidateName = _pluralizer.Pluralize(principalEndNavigationPropertyCandidateName);
+            }
+
             var principalEndNavigationPropertyName =
                 CSharpUtilities.Instance.GenerateCSharpIdentifier(
                     principalEndNavigationPropertyCandidateName,


### PR DESCRIPTION
Tested manually as there isn't really test coverage for any of this

As pointed out by @jwooley in https://github.com/aspnet/EntityFramework/pull/7634, I missed pluralizing collection navigation in the initial PR.