### PR TITLE
Query: Relational: Fix issues with problematic Take/Skip queries

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -171,9 +171,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var innerSelectExpression = handlerContext.SelectExpression.Clone();
 
-                innerSelectExpression.ClearProjection();
-                innerSelectExpression.AddToProjection(Expression.Constant(1));
+                if (innerSelectExpression.Limit != null
+                    || innerSelectExpression.Offset != null)
+                {
+                    predicate = innerSelectExpression.PushDownSubquery().LiftTableReferences(predicate);
+                }
+
                 innerSelectExpression.AddToPredicate(Expression.Not(predicate));
+                innerSelectExpression.SetProjectionExpression(Expression.Constant(1));
 
                 if (innerSelectExpression.Limit == null
                     && innerSelectExpression.Offset == null)

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1461,9 +1461,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 subSelectExpression.IsProjectStar = true;
                 subSelectExpression.QuerySource = joinClause;
 
-                predicate 
-                    = sqlTranslatingExpressionVisitor.Visit(
-                        Expression.Equal(joinClause.OuterKeySelector, joinClause.InnerKeySelector));
+                predicate = subSelectExpression.LiftTableReferences(predicate);
             }
 
             QueriesBySource.Remove(joinClause);

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -386,7 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Skip_Take_All()
         {
             AssertQuery<Customer>(
-                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10).All(p => p.CustomerID.Length == 5));
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10).All(p => !p.CustomerID.StartsWith("A")));
         }
 
         [ConditionalFact]
@@ -1088,6 +1088,16 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             AssertQuery<Employee>(
                 es => from e in es.OrderBy(e => e.EmployeeID).Take(5)
+                      where EF.Property<string>(e, "Title") == "Sales Representative"
+                      select e,
+                entryCount: 3);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_simple_shadow_subquery2()
+        {
+            AssertQuery<Employee>(
+                es => from e in es.OrderBy(e => e.EmployeeID).Skip(5)
                       where EF.Property<string>(e, "Title") == "Sales Representative"
                       select e,
                 entryCount: 3);
@@ -7085,6 +7095,30 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             join o in os on c.CustomerID equals o.CustomerID into lo
                             from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate).DefaultIfEmpty()
                             select new { c.ContactName, o });
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_Take_OrderBy()
+        {
+            AssertQuery<OrderDetail>(ods =>
+                ods.OrderBy(d => d.Quantity).ThenBy(d => d.OrderID).Take(2).OrderBy(d => d.ProductID).ThenBy(d => d.Quantity),
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_Skip_OrderBy()
+        {
+            AssertQuery<OrderDetail>(ods =>
+                ods.OrderBy(d => d.Quantity).ThenBy(d => d.OrderID).Skip(2153).OrderBy(d => d.ProductID).ThenBy(d => d.Quantity),
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void Skip_Skip_Take()
+        {
+            AssertQuery<OrderDetail>(ods =>
+                ods.OrderBy(d => d.OrderID).ThenBy(d => d.ProductID).Skip(23).Skip(19).Take(11),
+                entryCount: 11);
         }
 
         private static IEnumerable<TElement> ClientDefaultIfEmpty<TElement>(IEnumerable<TElement> source)


### PR DESCRIPTION
Certain queries like All needed to push down the select expression
into a subquery if it had a limit or offset. Other queries like
Skip().Skip() needed to push down the select expression into a subquery
when adding an Offset to a select expression that already had an offset.

This PR includes a `SelectExpression.LiftTableReferences` function as well that is used to avoid double translation of predicates in certain scenarios where the predicate has been translated already but the select expression needs to be pushed down before the predicate is used.