### PR TITLE
Make appveyor builds opt-in

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+only_commits:
+  # Start a build if commit message contains 'appveyor'
+  message: /appveyor/
 init:
   - git config --global core.autocrlf true
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,5 +26,4 @@ matrix:
   fast_finish: true
 artifacts:
   - path: 'artifacts\build\*.nupkg'
-# Required for dotnet-test to work
 os: Visual Studio 2017 RC


### PR DESCRIPTION
EF is hogging the AppVeyor queue. It's builds take so long, and devs are not generally cancelling builds when they push new commits to a PR.

This will make running on AppVeyor opt-in. Add the word 'appveyor' to the commit message to run on AppVeyor.