### PR TITLE
Query: Improve the logic of null expansion in join conditions with an…

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -484,6 +484,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 && rightExpressions != null
                 && leftExpressions.Length == rightExpressions.Length)
             {
+                if (leftExpressions.Length == 1
+                    && expressionType == ExpressionType.Equal)
+                {
+                    var translatedExpression = TransformNullComparison(leftExpressions[0], rightExpressions[0], binaryExpression.NodeType)
+                                               ?? Expression.MakeBinary(expressionType, leftExpressions[0], rightExpressions[0]);
+                    return Expression.AndAlso(translatedExpression, Expression.Constant(true, translatedExpression.Type));
+                }
+
                 return leftExpressions
                     .Zip(rightExpressions, (l, r) =>
                         TransformNullComparison(l, r, binaryExpression.NodeType)

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -29,6 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         private IReadOnlyDictionary<string, object> _parametersValues;
         private ParameterNameGenerator _parameterNameGenerator;
         private RelationalTypeMapping _typeMapping;
+        private RelationalNullsExpandingVisitor _relationalNullsExpandingVisitor;
+        private PredicateReductionExpressionOptimizer _predicateReductionExpressionOptimizer;
+        private PredicateNegationExpressionOptimizer _predicateNegationExpressionOptimizer;
+        private ReducingExpressionVisitor _reducingExpressionVisitor;
+        private BooleanExpressionTranslatingVisitor _booleanExpressionTranslatingVisitor;
 
         private static readonly Dictionary<ExpressionType, string> _operatorMap = new Dictionary<ExpressionType, string>
         {
@@ -266,46 +271,61 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 = new NullComparisonTransformingVisitor(_parametersValues)
                     .Visit(expression);
 
-            var binaryExpression = newExpression as BinaryExpression;
-            var relationalNullsOptimizedExpandingVisitor = new RelationalNullsOptimizedExpandingVisitor();
-            var relationalNullsExpandingVisitor = new RelationalNullsExpandingVisitor();
+            if (_relationalNullsExpandingVisitor == null)
+            {
+                _relationalNullsExpandingVisitor = new RelationalNullsExpandingVisitor();
+            }
+
+            if (_predicateReductionExpressionOptimizer == null)
+            {
+                _predicateReductionExpressionOptimizer = new PredicateReductionExpressionOptimizer();
+            }
+
+            if (_predicateNegationExpressionOptimizer == null)
+            {
+                _predicateNegationExpressionOptimizer = new PredicateNegationExpressionOptimizer();
+            }
+
+            if (_reducingExpressionVisitor == null)
+            {
+                _reducingExpressionVisitor = new ReducingExpressionVisitor();
+            }
+
+            if (_booleanExpressionTranslatingVisitor == null)
+            {
+                _booleanExpressionTranslatingVisitor = new BooleanExpressionTranslatingVisitor();
+            }
 
             if (joinCondition
-                && binaryExpression != null)
+                && newExpression is BinaryExpression binaryExpression
+                    && binaryExpression.NodeType == ExpressionType.Equal)
             {
-                var optimizedLeftExpression = relationalNullsOptimizedExpandingVisitor.Visit(binaryExpression.Left);
-
-                optimizedLeftExpression
-                    = relationalNullsOptimizedExpandingVisitor.IsOptimalExpansion
-                        ? optimizedLeftExpression
-                        : relationalNullsExpandingVisitor.Visit(binaryExpression.Left);
-
-                relationalNullsOptimizedExpandingVisitor = new RelationalNullsOptimizedExpandingVisitor();
-                var optimizedRightExpression = relationalNullsOptimizedExpandingVisitor.Visit(binaryExpression.Right);
-
-                optimizedRightExpression
-                    = relationalNullsOptimizedExpandingVisitor.IsOptimalExpansion
-                        ? optimizedRightExpression
-                        : relationalNullsExpandingVisitor.Visit(binaryExpression.Right);
-
-                newExpression = Expression.MakeBinary(binaryExpression.NodeType, optimizedLeftExpression, optimizedRightExpression);
+                newExpression = Expression.MakeBinary(
+                    binaryExpression.NodeType,
+                    ApplyNullSemantics(binaryExpression.Left),
+                    ApplyNullSemantics(binaryExpression.Right));
             }
             else
             {
-                var optimizedExpression = relationalNullsOptimizedExpandingVisitor.Visit(newExpression);
-
-                newExpression
-                    = relationalNullsOptimizedExpandingVisitor.IsOptimalExpansion
-                        ? optimizedExpression
-                        : relationalNullsExpandingVisitor.Visit(newExpression);
+                newExpression = ApplyNullSemantics(newExpression);
             }
 
-            newExpression = new PredicateReductionExpressionOptimizer().Visit(newExpression);
-            newExpression = new PredicateNegationExpressionOptimizer().Visit(newExpression);
-            newExpression = new ReducingExpressionVisitor().Visit(newExpression);
-            newExpression = new BooleanExpressionTranslatingVisitor().Translate(newExpression, searchCondition: searchCondition);
+            newExpression = _predicateReductionExpressionOptimizer.Visit(newExpression);
+            newExpression = _predicateNegationExpressionOptimizer.Visit(newExpression);
+            newExpression = _reducingExpressionVisitor.Visit(newExpression);
+            newExpression = _booleanExpressionTranslatingVisitor.Translate(newExpression, searchCondition: searchCondition);
 
             return newExpression;
+        }
+
+        private Expression ApplyNullSemantics(Expression expression)
+        {
+            var relationalNullsOptimizedExpandingVisitor = new RelationalNullsOptimizedExpandingVisitor();
+            var optimizedRightExpression = relationalNullsOptimizedExpandingVisitor.Visit(expression);
+
+            return relationalNullsOptimizedExpandingVisitor.IsOptimalExpansion
+                    ? optimizedRightExpression
+                    : _relationalNullsExpandingVisitor.Visit(expression);
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2659,6 +2659,28 @@ ORDER BY [t].[Level2_Required_Id]",
                 Sql);
         }
 
+        public override void Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property()
+        {
+            base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_single_property();
+
+            Assert.Equal(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l2] ON ([l1].[OneToMany_Optional_Self_InverseId] = [l2].[Level1_Optional_Id]) OR ([l1].[OneToMany_Optional_Self_InverseId] IS NULL AND [l2].[Level1_Optional_Id] IS NULL)",
+                Sql);
+        }
+
+        public override void Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties()
+        {
+            base.Join_condition_optimizations_applied_correctly_when_anonymous_type_with_multiple_properties();
+
+            Assert.Equal(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l2] ON (([l1].[OneToMany_Optional_Self_InverseId] = [l2].[Level1_Optional_Id]) OR ([l1].[OneToMany_Optional_Self_InverseId] IS NULL AND [l2].[Level1_Optional_Id] IS NULL)) AND (([l1].[OneToOne_Optional_SelfId] = [l2].[OneToMany_Optional_Self_InverseId]) OR ([l1].[OneToOne_Optional_SelfId] IS NULL AND [l2].[OneToMany_Optional_Self_InverseId] IS NULL))",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
…onymous types

@maumar @anpete 

Due to the way LINQ processes `equals` with normal properties comparison & anonymous type comparison.