### PR TITLE
SqlServer type aliases can have schemas

### DIFF
--- a/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -89,8 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             if (column.DataType != null)
             {
                 string underlyingDataType = null;
-                column.Table.Database.SqlServer().TypeAliases
-                    ?.TryGetValue(column.DataType, out underlyingDataType);
+                column.Table.Database.SqlServer().TypeAliases?.TryGetValue(
+                    SqlServerDatabaseModelFactory.TableKey(column.DataType, column.SqlServer().DataTypeSchemaName), out underlyingDataType);
 
                 mapping = TypeMapper.FindMapping(underlyingDataType ?? column.DataType);
             }
@@ -201,7 +201,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
         private static bool HasTypeAlias(ColumnModel column)
             => column.DataType != null
-               && column.Table.Database.SqlServer().TypeAliases?.ContainsKey(column.DataType) == true;
+               && column.Table.Database.SqlServer().TypeAliases?.ContainsKey(
+                   SqlServerDatabaseModelFactory.TableKey(column.DataType, column.SqlServer().DataTypeSchemaName)) == true;
 
         // Turns an unqualified SQL Server type name (e.g. varchar) and its
         // max length into a qualified SQL Server type name (e.g. varchar(max))

--- a/src/EFCore.SqlServer.Design/Metadata/Internal/SqlServerColumnModelAnnotations.cs
+++ b/src/EFCore.SqlServer.Design/Metadata/Internal/SqlServerColumnModelAnnotations.cs
@@ -48,5 +48,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
             }
             [param: NotNull] set { _column[SqlServerDatabaseModelAnnotationNames.IsIdentity] = value; }
         }
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string DataTypeSchemaName
+        {
+            get
+            {
+                return _column[SqlServerDatabaseModelAnnotationNames.DataTypeSchemaName] as string;
+            }
+            set { _column[SqlServerDatabaseModelAnnotationNames.DataTypeSchemaName] = value; }
+        }
     }
 }

--- a/src/EFCore.SqlServer.Design/Metadata/Internal/SqlServerDatabaseModelAnnotationNames.cs
+++ b/src/EFCore.SqlServer.Design/Metadata/Internal/SqlServerDatabaseModelAnnotationNames.cs
@@ -38,5 +38,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string DateTimePrecision = Prefix + "DateTimePrecision";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string DataTypeSchemaName = Prefix + "DataTypeSchemaName";
     }
 }

--- a/src/EFCore.SqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
+++ b/src/EFCore.SqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
@@ -88,12 +88,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 schemaName, tableName);
 
         /// <summary>
-        ///     Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.
+        ///     Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, data type schema: {dataTypeSchema}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.
         /// </summary>
-        public static string FoundColumn([CanBeNull] object schema, [CanBeNull] object tableName, [CanBeNull] object columnName, [CanBeNull] object dataType, [CanBeNull] object ordinal, [CanBeNull] object isNullable, [CanBeNull] object primaryKeyOrdinal, [CanBeNull] object defaultValue, [CanBeNull] object computedValue, [CanBeNull] object precision, [CanBeNull] object scale, [CanBeNull] object maxLength, [CanBeNull] object isIdentity, [CanBeNull] object isComputed)
+        public static string FoundColumn([CanBeNull] object schema, [CanBeNull] object tableName, [CanBeNull] object columnName, [CanBeNull] object dataType, [CanBeNull] object dataTypeSchema, [CanBeNull] object ordinal, [CanBeNull] object isNullable, [CanBeNull] object primaryKeyOrdinal, [CanBeNull] object defaultValue, [CanBeNull] object computedValue, [CanBeNull] object precision, [CanBeNull] object scale, [CanBeNull] object maxLength, [CanBeNull] object isIdentity, [CanBeNull] object isComputed)
             => string.Format(
-                GetString("FoundColumn", nameof(schema), nameof(tableName), nameof(columnName), nameof(dataType), nameof(ordinal), nameof(isNullable), nameof(primaryKeyOrdinal), nameof(defaultValue), nameof(computedValue), nameof(precision), nameof(scale), nameof(maxLength), nameof(isIdentity), nameof(isComputed)),
-                schema, tableName, columnName, dataType, ordinal, isNullable, primaryKeyOrdinal, defaultValue, computedValue, precision, scale, maxLength, isIdentity, isComputed);
+                GetString("FoundColumn", nameof(schema), nameof(tableName), nameof(columnName), nameof(dataType), nameof(dataTypeSchema), nameof(ordinal), nameof(isNullable), nameof(primaryKeyOrdinal), nameof(defaultValue), nameof(computedValue), nameof(precision), nameof(scale), nameof(maxLength), nameof(isIdentity), nameof(isComputed)),
+                schema, tableName, columnName, dataType, dataTypeSchema, ordinal, isNullable, primaryKeyOrdinal, defaultValue, computedValue, precision, scale, maxLength, isIdentity, isComputed);
 
         /// <summary>
         ///     Found default schema {defaultSchema}.
@@ -136,12 +136,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 schema, name);
 
         /// <summary>
-        ///     Found type alias {alias} which maps to underlying data type {dataType}.
+        ///     Found type alias with schema: {schema} name: {alias} which maps to underlying data type {dataType}.
         /// </summary>
-        public static string FoundTypeAlias([CanBeNull] object alias, [CanBeNull] object dataType)
+        public static string FoundTypeAlias([CanBeNull] object schema, [CanBeNull] object alias, [CanBeNull] object dataType)
             => string.Format(
-                GetString("FoundTypeAlias", nameof(alias), nameof(dataType)),
-                alias, dataType);
+                GetString("FoundTypeAlias", nameof(schema), nameof(alias), nameof(dataType)),
+                schema, alias, dataType);
 
         /// <summary>
         ///     Index column {columnName} belongs to index {indexName} on table [{schema}].[{tableName}] which is not included in the selection set. Skipping.

--- a/src/EFCore.SqlServer.Design/Properties/SqlServerDesignStrings.resx
+++ b/src/EFCore.SqlServer.Design/Properties/SqlServerDesignStrings.resx
@@ -145,7 +145,7 @@
     <value>Found a foreign key on table [{schemaName}].[{tableName}] with an empty or null name. Skipping foreign key.</value>
   </data>
   <data name="FoundColumn" xml:space="preserve">
-    <value>Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.</value>
+    <value>Found column with schema: {schema}, table: {tableName}, column name: {columnName}, data type: {dataType}, data type schema: {dataTypeSchema}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}, computed: {isComputed}.</value>
   </data>
   <data name="FoundDefaultSchema" xml:space="preserve">
     <value>Found default schema {defaultSchema}.</value>
@@ -163,7 +163,7 @@
     <value>Found table with schema: {schema}, name: {name}.</value>
   </data>
   <data name="FoundTypeAlias" xml:space="preserve">
-    <value>Found type alias {alias} which maps to underlying data type {dataType}.</value>
+    <value>Found type alias with schema: {schema} name: {alias} which maps to underlying data type {dataType}.</value>
   </data>
   <data name="IndexColumnNotInSelectionSet" xml:space="preserve">
     <value>Index column {columnName} belongs to index {indexName} on table [{schema}].[{tableName}] which is not included in the selection set. Skipping.</value>


### PR DESCRIPTION
SqlServer type aliases have schemas. Previously these would clash when reverse engineering from the database if you have 2 with the same name in different schemas. This update fixes that.

Fixes #7576.
