### PR TITLE
Query: Relational: Introduce a new LeftOuterJoinClause class

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -74,12 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             var queryModelVisitor = (RelationalQueryModelVisitor)CreateQueryModelVisitor();
 
-            var queryModelMapping = new Dictionary<QueryModel, QueryModel>();
-            expression.QueryModel.PopulateQueryModelMapping(queryModelMapping);
-
             queryModelVisitor.VisitQueryModel(expression.QueryModel);
-
-            expression.QueryModel.RecreateQueryModelFromMapping(queryModelMapping);
 
             if (_querySource != null)
             {

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -601,8 +601,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             {
                 var arguments
                     = methodCallExpression.Arguments
-                        .Where(e => !(e is QuerySourceReferenceExpression)
-                                    && !(e is SubQueryExpression))
+                        .Where(IsValidForMethodOrMemberTranslation)
                         .Select(e => (e as ConstantExpression)?.Value is Array ? e : Visit(e))
                         .Where(e => e != null)
                         .ToArray();
@@ -640,8 +639,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         {
             Check.NotNull(memberExpression, nameof(memberExpression));
 
-            if (!(memberExpression.Expression is QuerySourceReferenceExpression)
-                && !(memberExpression.Expression is SubQueryExpression))
+            if (IsValidForMethodOrMemberTranslation(memberExpression.Expression))
             {
                 var newExpression = Visit(memberExpression.Expression);
 
@@ -667,6 +665,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 ?? TryBindQuerySourcePropertyExpression(memberExpression)
                 ?? _queryModelVisitor.BindMemberToOuterQueryParameter(memberExpression);
         }
+
+        private static bool IsValidForMethodOrMemberTranslation(Expression expression)
+            => !(expression is QuerySourceReferenceExpression)
+            && !(expression is SubQueryExpression)
+            && !(expression is NewExpression);
 
         private Expression TryBindQuerySourcePropertyExpression(MemberExpression memberExpression)
         {
@@ -885,9 +888,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         = _queryModelVisitor.Queries
                             .ToDictionary(k => k, s => s.Projection.Count);
 
-                    var queryModelMapping = new Dictionary<QueryModel, QueryModel>();
-                    subQueryModel.PopulateQueryModelMapping(queryModelMapping);
-
                     subQueryModelVisitor.VisitSubQueryModel(subQueryModel);
 
                     if (subQueryModelVisitor.IsLiftable)
@@ -905,8 +905,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         return selectExpression;
                     }
-
-                    subQueryModel.RecreateQueryModelFromMapping(queryModelMapping);
                 }
             }
 
@@ -1032,23 +1030,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             if (!_inProjection)
             {
-                var joinClause
-                    = expression.ReferencedQuerySource as JoinClause;
+                var entityType
+                    = _queryModelVisitor.QueryCompilationContext.Model
+                        .FindEntityType(expression.ReferencedQuerySource.ItemType);
 
-                if (joinClause != null)
+                if (entityType != null)
                 {
-                    var entityType
-                        = _queryModelVisitor.QueryCompilationContext.Model
-                            .FindEntityType(joinClause.ItemType);
-
-                    if (entityType != null)
-                    {
-                        return Visit(
-                            EntityQueryModelVisitor.CreatePropertyExpression(
-                                expression, entityType.FindPrimaryKey().Properties[0]));
-                    }
-
-                    return null;
+                    return Visit(
+                        EntityQueryModelVisitor.CreatePropertyExpression(
+                            expression, entityType.FindPrimaryKey().Properties[0]));
                 }
             }
 

--- a/src/EFCore.Relational/Query/Expressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Expressions/JoinExpressionBase.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Clauses;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
 {
@@ -30,6 +31,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     The target table expression.
         /// </summary>
         public virtual TableExpressionBase TableExpression => _tableExpression;
+        
+        /// <summary>
+        ///     Determines whether or not this JoinExpressionBase handles the given query source.
+        /// </summary>
+        /// <param name="querySource"> The query source. </param>
+        /// <returns>
+        ///     true if the supplied query source is handled by this JoinExpressionBase; otherwise false.
+        /// </returns>
+        public override bool HandlesQuerySource(IQuerySource querySource)
+        {
+            Check.NotNull(querySource, nameof(querySource));
+
+            return _tableExpression.HandlesQuerySource(querySource)
+                || base.HandlesQuerySource(querySource);
+        }
 
         /// <summary>
         ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(System.Linq.Expressions.Expression)" /> method passing the

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -250,10 +250,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public override bool HandlesQuerySource(IQuerySource querySource)
         {
             Check.NotNull(querySource, nameof(querySource));
-
-            var processedQuerySource = PreProcessQuerySource(querySource);
-
-            return _tables.Any(te => te.QuerySource == processedQuerySource || te.HandlesQuerySource(processedQuerySource))
+            
+            return _tables.Any(te => te.HandlesQuerySource(querySource))
                 || base.HandlesQuerySource(querySource);
         }
 
@@ -268,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             Check.NotNull(querySource, nameof(querySource));
 
-            return _tables.FirstOrDefault(te => te.QuerySource == querySource || te.HandlesQuerySource(querySource)) 
+            return _tables.FirstOrDefault(te => te.HandlesQuerySource(querySource)) 
                 ?? ProjectStarTable;
         }
 

--- a/src/EFCore.Relational/Query/Internal/LeftOuterJoinClause.cs
+++ b/src/EFCore.Relational/Query/Internal/LeftOuterJoinClause.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public sealed class LeftOuterJoinClause : ICompositeBodyClause, IQuerySource
+    {
+        public LeftOuterJoinClause(
+            [NotNull] GroupJoinClause groupJoinClause,
+            [NotNull] AdditionalFromClause additionalFromClause)
+        {
+            GroupJoinClause = groupJoinClause ?? throw new ArgumentNullException(nameof(groupJoinClause));
+            AdditionalFromClause = additionalFromClause ?? throw new ArgumentNullException(nameof(additionalFromClause));
+        }
+
+        public GroupJoinClause GroupJoinClause { get; }
+
+        public AdditionalFromClause AdditionalFromClause { get; }
+
+        public string ItemName => AdditionalFromClause.ItemName;
+
+        public Type ItemType => AdditionalFromClause.ItemType;
+
+        public IEnumerable<IBodyClause> BodyClauses
+        {
+            get
+            {
+                yield return GroupJoinClause;
+                yield return AdditionalFromClause;
+            }
+        }
+
+        public void Accept([NotNull] IQueryModelVisitor visitor, [NotNull] QueryModel queryModel, int index)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+            Check.NotNull(queryModel, nameof(queryModel));
+
+            if (visitor is RelationalQueryModelVisitor relationalQueryModelVisitor)
+            {
+                relationalQueryModelVisitor.VisitLeftOuterJoinClause(this, queryModel, index);
+            }
+            else
+            {
+                visitor.VisitGroupJoinClause(GroupJoinClause, queryModel, index);
+                visitor.VisitAdditionalFromClause(AdditionalFromClause, queryModel, index);
+            }
+        }
+
+        public IBodyClause Clone([NotNull] CloneContext cloneContext)
+        {
+            return new LeftOuterJoinClause(
+                GroupJoinClause.Clone(cloneContext),
+                AdditionalFromClause.Clone(cloneContext));
+        }
+
+        public void TransformExpressions([NotNull] Func<Expression, Expression> transformation)
+        {
+            GroupJoinClause.TransformExpressions(transformation);
+            AdditionalFromClause.TransformExpressions(transformation);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/LeftOuterJoinClauseQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/LeftOuterJoinClauseQueryModelVisitor.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ExpressionVisitors;
+using Remotion.Linq.Clauses.ResultOperators;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class LeftOuterJoinClauseQueryModelVisitor : QueryModelVisitorBase
+    {
+        private readonly IEnumerable<IQueryAnnotation> _queryAnnotations;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public LeftOuterJoinClauseQueryModelVisitor([NotNull] IEnumerable<IQueryAnnotation> queryAnnotations)
+        {
+            _queryAnnotations = queryAnnotations;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void VisitQueryModel([NotNull] QueryModel queryModel)
+        {
+            queryModel.TransformExpressions(new TransformingQueryModelExpressionVisitor<LeftOuterJoinClauseQueryModelVisitor>(this).Visit);
+
+            base.VisitQueryModel(queryModel);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void VisitGroupJoinClause(
+            [NotNull] GroupJoinClause groupJoinClause,
+            [NotNull] QueryModel queryModel, 
+            int index)
+        {
+            if (queryModel.CountQuerySourceReferences(groupJoinClause) == 1
+                && queryModel.BodyClauses.ElementAtOrDefault(index + 1) is AdditionalFromClause additionalFromClause 
+                && additionalFromClause.FromExpression is SubQueryExpression subQueryExpression
+                && subQueryExpression.QueryModel.MainFromClause.FromExpression is QuerySourceReferenceExpression subQsre
+                && subQsre.ReferencedQuerySource == groupJoinClause
+                && !subQueryExpression.QueryModel.BodyClauses.Any()
+                && subQueryExpression.QueryModel.ResultOperators.Count == 1
+                && subQueryExpression.QueryModel.ResultOperators[0] is DefaultIfEmptyResultOperator defaultIfEmptyResultOperator
+                && defaultIfEmptyResultOperator.OptionalDefaultValue == null)
+            {
+                var leftOuterJoinClause = new LeftOuterJoinClause(groupJoinClause, additionalFromClause);
+
+                queryModel.BodyClauses.Insert(index, leftOuterJoinClause);
+                queryModel.BodyClauses.Remove(groupJoinClause);
+                queryModel.BodyClauses.Remove(additionalFromClause);
+
+                var querySourceMapping = new QuerySourceMapping();
+
+                querySourceMapping.AddMapping(
+                    groupJoinClause.JoinClause,
+                    new QuerySourceReferenceExpression(additionalFromClause));
+
+                foreach (var queryAnnotation in _queryAnnotations)
+                {
+                    if (queryAnnotation.QuerySource == groupJoinClause.JoinClause)
+                    {
+                        queryAnnotation.QuerySource = additionalFromClause;
+
+                        if (queryAnnotation is IncludeResultOperator includeResultOperator)
+                        {
+                            includeResultOperator.PathFromQuerySource
+                                = ReferenceReplacingExpressionVisitor.ReplaceClauseReferences(
+                                    includeResultOperator.PathFromQuerySource,
+                                    querySourceMapping,
+                                    throwOnUnmappedReferences: false);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -24,8 +24,6 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Clauses.ExpressionVisitors;
-using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -60,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private bool _requiresClientResultOperator;
 
         private Dictionary<IncludeSpecification, List<int>> _navigationIndexMap = new Dictionary<IncludeSpecification, List<int>>();
-        private List<GroupJoinClause> _unflattenedGroupJoinClauses = new List<GroupJoinClause>();
+        private List<GroupJoinClause> _nonLeftJoinGroupJoinClauses = new List<GroupJoinClause>();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -169,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </value>
         public virtual bool RequiresClientResultOperator
         {
-            get { return _unflattenedGroupJoinClauses.Any() || _requiresClientResultOperator || RequiresClientEval; }
+            get { return _nonLeftJoinGroupJoinClauses.Any() || _requiresClientResultOperator || RequiresClientEval; }
             set { _requiresClientResultOperator = value; }
         }
 
@@ -498,6 +496,31 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        ///     Visit a left outer join clause.
+        /// </summary>
+        /// <param name="leftOuterJoinClause"> The left outer join clause being visited. </param>
+        /// <param name="queryModel"> The query model. </param>
+        /// <param name="index"> Index of the node being visited. </param>
+        public virtual void VisitLeftOuterJoinClause(
+            [NotNull] LeftOuterJoinClause leftOuterJoinClause,
+            [NotNull] QueryModel queryModel, 
+            int index)
+        {
+            Check.NotNull(leftOuterJoinClause, nameof(leftOuterJoinClause));
+            Check.NotNull(queryModel, nameof(queryModel));
+
+            if (!TryFlattenLeftJoin(leftOuterJoinClause, queryModel, index))
+            {
+                RequiresClientJoin = true;
+
+                base.VisitGroupJoinClause(leftOuterJoinClause.GroupJoinClause, queryModel, index);
+                base.VisitAdditionalFromClause(leftOuterJoinClause.AdditionalFromClause, queryModel, index);
+
+                WarnClientEval(leftOuterJoinClause.GroupJoinClause.JoinClause);
+            }
+        }
+
+        /// <summary>
         ///     Compile a join clause inner sequence expression.
         /// </summary>
         /// <param name="joinClause"> The join clause being compiled. </param>
@@ -538,20 +561,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             var previousQuerySource = FindPreviousQuerySource(queryModel, index);
             var previousSelectExpression = TryGetQuery(previousQuerySource);
             var previousProjectionCount = previousSelectExpression?.Projection.Count ?? 0;
-            var previousParameter = CurrentParameter;
-            var previousMapping = SnapshotQuerySourceMapping(queryModel);
 
             base.VisitGroupJoinClause(groupJoinClause, queryModel, index);
 
-            _unflattenedGroupJoinClauses.Add(groupJoinClause);
+            _nonLeftJoinGroupJoinClauses.Add(groupJoinClause);
 
             if (!TryFlattenGroupJoin(
                 groupJoinClause,
                 queryModel,
                 index,
-                previousProjectionCount,
-                previousParameter,
-                previousMapping))
+                previousProjectionCount))
             {
                 RequiresClientJoin = true;
             }
@@ -560,43 +579,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 WarnClientEval(groupJoinClause.JoinClause);
             }
-        }
-
-        private Dictionary<IQuerySource, Expression> SnapshotQuerySourceMapping(QueryModel queryModel)
-        {
-            var previousMapping
-                = new Dictionary<IQuerySource, Expression>
-                {
-                    {
-                        queryModel.MainFromClause,
-                        QueryCompilationContext.QuerySourceMapping
-                            .GetExpression(queryModel.MainFromClause)
-                    }
-                };
-
-            foreach (var querySource in queryModel.BodyClauses.OfType<IQuerySource>())
-            {
-                if (QueryCompilationContext.QuerySourceMapping.ContainsMapping(querySource))
-                {
-                    previousMapping[querySource]
-                        = QueryCompilationContext.QuerySourceMapping
-                            .GetExpression(querySource);
-
-                    var groupJoinClause = querySource as GroupJoinClause;
-
-                    if (groupJoinClause != null
-                        && QueryCompilationContext.QuerySourceMapping
-                            .ContainsMapping(groupJoinClause.JoinClause))
-                    {
-                        previousMapping.Add(
-                            groupJoinClause.JoinClause,
-                            QueryCompilationContext.QuerySourceMapping
-                                .GetExpression(groupJoinClause.JoinClause));
-                    }
-                }
-            }
-
-            return previousMapping;
         }
 
         private class OuterJoinOrderingExtractor : ExpressionVisitor
@@ -729,12 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 = (RelationalQueryModelVisitor)QueryCompilationContext
                     .CreateQueryModelVisitor(this);
 
-            var subQueryModel = subQueryExpression.QueryModel;
-
-            var queryModelMapping = new Dictionary<QueryModel, QueryModel>();
-            subQueryModel.PopulateQueryModelMapping(queryModelMapping);
-
-            subQueryModelVisitor.VisitSubQueryModel(subQueryModel);
+            subQueryModelVisitor.VisitSubQueryModel(subQueryExpression.QueryModel);
 
             if (subQueryModelVisitor.IsLiftable)
             {
@@ -765,8 +742,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return newExpression;
                 }
             }
-
-            subQueryModel.RecreateQueryModelFromMapping(queryModelMapping);
 
             return null;
         }
@@ -1096,6 +1071,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             queryModel.TransformExpressions(typeIsExpressionTranslatingVisitor.Visit);
 
             base.OptimizeQueryModel(queryModel, includeResultOperators);
+
+            new LeftOuterJoinClauseQueryModelVisitor(QueryCompilationContext.QueryAnnotations)
+                .VisitQueryModel(queryModel);
         }
 
         /// <summary>
@@ -1401,13 +1379,132 @@ namespace Microsoft.EntityFrameworkCore.Query
             return true;
         }
 
+        private bool TryFlattenLeftJoin(
+            LeftOuterJoinClause leftOuterJoinClause,
+            QueryModel queryModel,
+            int index)
+        {
+            if (RequiresClientJoin || RequiresClientSelectMany)
+            {
+                return false;
+            }
+
+            var outerShapedQuery = Expression as MethodCallExpression;
+            var outerQuerySource = FindPreviousQuerySource(queryModel, index);
+            var outerSelectExpression = TryGetQuery(outerQuerySource);
+
+            if (!IsShapedQueryExpression(outerShapedQuery) || outerSelectExpression == null)
+            {
+                return false;
+            }
+
+            var groupJoinClause = leftOuterJoinClause.GroupJoinClause;
+            var joinClause = leftOuterJoinClause.GroupJoinClause.JoinClause;
+            var additionalFromClause = leftOuterJoinClause.AdditionalFromClause;
+
+            var sqlTranslator = _sqlTranslatingExpressionVisitorFactory.Create(this);
+            var sqlOuterKeySelectorExpression = sqlTranslator.Visit(joinClause.OuterKeySelector);
+
+            if (sqlOuterKeySelectorExpression == null)
+            {
+                return false;
+            }
+
+            var innerSequenceExpression = CompileGroupJoinInnerSequenceExpression(groupJoinClause, queryModel);
+            var innerShapedQuery = innerSequenceExpression as MethodCallExpression;
+            var innerSelectExpression = TryGetQuery(joinClause);
+
+            if (!IsShapedQueryExpression(innerShapedQuery) || innerSelectExpression == null)
+            {
+                return false;
+            }
+
+            var sqlInnerKeySelectorExpression = sqlTranslator.Visit(joinClause.InnerKeySelector);
+
+            if (sqlInnerKeySelectorExpression == null)
+            {
+                return false;
+            }
+            else if (innerSelectExpression.Predicate != null)
+            {
+                var pushedDownSubQuery = innerSelectExpression.PushDownSubquery();
+                innerSelectExpression.ExplodeStarProjection();
+                pushedDownSubQuery.ClearProjection();
+            }
+
+            var predicate
+                = sqlTranslator.Visit(
+                    Expression.Equal(
+                        joinClause.OuterKeySelector,
+                        joinClause.InnerKeySelector));
+
+            QueriesBySource.Remove(joinClause);
+
+            var outerShaper = ExtractShaper(outerShapedQuery, 0);
+            var innerShaper = ExtractShaper(innerShapedQuery, outerSelectExpression.Projection.Count);
+
+            innerShaper.UpdateQuerySource(additionalFromClause);
+
+            var projection
+                = QueryCompilationContext.QuerySourceRequiresMaterialization(joinClause)
+                    ? innerSelectExpression.Projection
+                    : Enumerable.Empty<Expression>();
+
+            var joinExpression
+                = outerSelectExpression.AddLeftOuterJoin(
+                    innerSelectExpression.Tables.Single(),
+                    projection);
+
+            joinExpression.Predicate = predicate;
+            joinExpression.QuerySource = additionalFromClause;
+
+            var innerItemParameter
+                = Expression.Parameter(
+                    innerShaper.Type,
+                    additionalFromClause.ItemName);
+
+            AddOrUpdateMapping(additionalFromClause, innerItemParameter);
+
+            var transparentIdentifierType
+                = CreateTransparentIdentifierType(
+                    CurrentParameter.Type,
+                    innerItemParameter.Type);
+
+            var materializer
+                = Expression.Lambda(
+                    CallCreateTransparentIdentifier(
+                        transparentIdentifierType,
+                        CurrentParameter,
+                        innerItemParameter),
+                    CurrentParameter,
+                    innerItemParameter).Compile();
+
+            var compositeShaper
+                = CompositeShaper.Create(additionalFromClause, outerShaper, innerShaper, materializer);
+
+            IntroduceTransparentScope(additionalFromClause, queryModel, index, transparentIdentifierType);
+
+            compositeShaper.SaveAccessorExpression(QueryCompilationContext.QuerySourceMapping);
+
+            innerShaper.UpdateQuerySource(additionalFromClause);
+
+            Expression
+                = Expression.Call(
+                    outerShapedQuery.Method
+                        .GetGenericMethodDefinition()
+                        .MakeGenericMethod(transparentIdentifierType),
+                    outerShapedQuery.Arguments[0],
+                    outerShapedQuery.Arguments[1],
+                    Expression.Constant(compositeShaper));
+
+            return true;
+        }
+
         private bool TryFlattenGroupJoin(
             GroupJoinClause groupJoinClause,
             QueryModel queryModel,
             int index,
-            int previousProjectionCount,
-            ParameterExpression previousParameter,
-            Dictionary<IQuerySource, Expression> previousMapping)
+            int previousProjectionCount)
         {
             if (RequiresClientJoin || RequiresClientSelectMany)
             {
@@ -1483,17 +1580,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             joinExpression.Predicate = predicate;
             joinExpression.QuerySource = joinClause;
 
-            if (TryFlattenGroupJoinDefaultIfEmpty(
-                groupJoinClause, 
-                queryModel, 
-                index, 
-                previousProjectionCount, 
-                previousParameter, 
-                previousMapping))
-            {
-                return true;
-            }
-
             var outerJoinOrderingExtractor = new OuterJoinOrderingExtractor();
             outerJoinOrderingExtractor.Visit(predicate);
 
@@ -1544,123 +1630,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     groupJoinMethodCallExpression.Arguments[4],
                     defaultGroupJoinInclude,
                     defaultGroupJoinInclude);
-
-            return true;
-        }
-
-        private bool TryFlattenGroupJoinDefaultIfEmpty(
-            GroupJoinClause groupJoinClause,
-            QueryModel queryModel,
-            int index,
-            int previousProjectionCount,
-            ParameterExpression previousParameter,
-            Dictionary<IQuerySource, Expression> previousMapping)
-        {
-            var additionalFromClause
-                = queryModel.BodyClauses.ElementAtOrDefault(index + 1)
-                    as AdditionalFromClause;
-
-            var subQueryModel
-                = (additionalFromClause?.FromExpression as SubQueryExpression)
-                    ?.QueryModel;
-
-            var referencedQuerySource
-                = (subQueryModel?.MainFromClause.FromExpression as QuerySourceReferenceExpression)
-                    ?.ReferencedQuerySource;
-
-            if (referencedQuerySource != groupJoinClause
-                || queryModel.CountQuerySourceReferences(groupJoinClause) != 1
-                || subQueryModel.BodyClauses.Count != 0
-                || subQueryModel.ResultOperators.Count != 1
-                || !(subQueryModel.ResultOperators[0] is DefaultIfEmptyResultOperator))
-            {
-                return false;
-            }
-
-            var joinClause = groupJoinClause.JoinClause;
-
-            queryModel.BodyClauses.Insert(index, joinClause);
-            queryModel.BodyClauses.Remove(groupJoinClause);
-            queryModel.BodyClauses.Remove(additionalFromClause);
-
-            _unflattenedGroupJoinClauses.Remove(groupJoinClause);
-
-            var querySourceMapping = new QuerySourceMapping();
-
-            querySourceMapping.AddMapping(
-                additionalFromClause,
-                new QuerySourceReferenceExpression(joinClause));
-
-            queryModel.TransformExpressions(expression =>
-                ReferenceReplacingExpressionVisitor.ReplaceClauseReferences(
-                    expression,
-                    querySourceMapping,
-                    throwOnUnmappedReferences: false));
-
-            foreach (var annotation in QueryCompilationContext.QueryAnnotations
-                .OfType<IncludeResultOperator>()
-                .Where(a => a.QuerySource == additionalFromClause))
-            {
-                annotation.QuerySource = joinClause;
-                annotation.PathFromQuerySource 
-                    = ReferenceReplacingExpressionVisitor.ReplaceClauseReferences(
-                        annotation.PathFromQuerySource,
-                        querySourceMapping,
-                        throwOnUnmappedReferences: false);
-            }
-            
-            var groupJoinMethodCallExpression = (MethodCallExpression)Expression;
-
-            var outerShapedQuery = (MethodCallExpression)groupJoinMethodCallExpression.Arguments[0];
-            var innerShapedQuery = (MethodCallExpression)groupJoinMethodCallExpression.Arguments[1];
-
-            var outerShaper = ExtractShaper(outerShapedQuery, 0);
-            var innerShaper = ExtractShaper(innerShapedQuery, previousProjectionCount);
-
-            CurrentParameter = previousParameter;
-
-            foreach (var mapping in previousMapping)
-            {
-                QueryCompilationContext.QuerySourceMapping
-                    .ReplaceMapping(mapping.Key, mapping.Value);
-            }
-
-            var innerItemParameter
-                = Expression.Parameter(
-                    innerShaper.Type,
-                    joinClause.ItemName);
-
-            AddOrUpdateMapping(joinClause, innerItemParameter);
-
-            var transparentIdentifierType 
-                = CreateTransparentIdentifierType(
-                    previousParameter.Type, 
-                    innerShaper.Type);
-
-            var materializer
-                = Expression.Lambda(
-                    CallCreateTransparentIdentifier(
-                        transparentIdentifierType,
-                        previousParameter,
-                        innerItemParameter),
-                    previousParameter,
-                    innerItemParameter).Compile();
-
-            var compositeShaper
-                = CompositeShaper.Create(joinClause, outerShaper, innerShaper, materializer);
-
-            IntroduceTransparentScope(joinClause, queryModel, index, transparentIdentifierType);
-
-            compositeShaper.SaveAccessorExpression(QueryCompilationContext.QuerySourceMapping);
-
-            Expression
-                = Expression.Call(
-                    outerShapedQuery.Method
-                        .GetGenericMethodDefinition()
-                        .MakeGenericMethod(transparentIdentifierType),
-                    outerShapedQuery.Arguments[0],
-                    outerShapedQuery.Arguments[1],
-                    Expression.Constant(compositeShaper));
 
             return true;
         }

--- a/src/EFCore/Query/Internal/ICompositeBodyClause.cs
+++ b/src/EFCore/Query/Internal/ICompositeBodyClause.cs
@@ -1,13 +1,8 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Utilities;
+using System.Collections.Generic;
 using Remotion.Linq.Clauses;
-using Remotion.Linq;
-using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -15,18 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public static class QuerySourceExtensions
+    public interface ICompositeBodyClause : IBodyClause
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool HasGeneratedItemName([NotNull] this IQuerySource querySource)
-        {
-            Check.NotNull(querySource, nameof(querySource));
-            Check.NotEmpty(querySource.ItemName, nameof(querySource.ItemName));
-
-            return querySource.ItemName.StartsWith("<generated>_", StringComparison.Ordinal);
-        }
+        IEnumerable<IBodyClause> BodyClauses { get; }
     }
 }

--- a/src/EFCore/Query/Internal/QueryModelExtensions.cs
+++ b/src/EFCore/Query/Internal/QueryModelExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
@@ -23,97 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public static string Print([NotNull] this QueryModel queryModel, bool removeFormatting = false, int? characterLimit = null)
             => new QueryModelPrinter().Print(queryModel, removeFormatting, characterLimit);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static Dictionary<QueryModel, QueryModel> PopulateQueryModelMapping(
-            [NotNull] this QueryModel queryModel,
-            [NotNull] Dictionary<QueryModel, QueryModel> mapping)
-        {
-            var mappingPopulatingVisitor = new QueryModelMappingPopulatingVisitor(mapping);
-            mappingPopulatingVisitor.Visit(new SubQueryExpression(queryModel));
-
-            return mapping;
-        }
-
-        private class QueryModelMappingPopulatingVisitor : ExpressionVisitorBase
-        {
-            private readonly Dictionary<QueryModel, QueryModel> _mapping;
-
-            public QueryModelMappingPopulatingVisitor(Dictionary<QueryModel, QueryModel> mapping)
-            {
-                _mapping = mapping;
-            }
-
-            protected override Expression VisitSubQuery(SubQueryExpression expression)
-            {
-                var queryModel = expression.QueryModel;
-
-                var newQueryModel = new QueryModel(queryModel.MainFromClause, queryModel.SelectClause);
-                ShallowCopy(queryModel, newQueryModel);
-
-                _mapping.Add(queryModel, newQueryModel);
-
-                queryModel.TransformExpressions(Visit);
-
-                return expression;
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static QueryModel RecreateQueryModelFromMapping(
-            [NotNull] this QueryModel queryModel,
-            [NotNull] Dictionary<QueryModel, QueryModel> mapping)
-        {
-            var recreatingVisitor = new QueryModelRecreatingVisitor(mapping);
-            var resultExpression = recreatingVisitor.Visit(new SubQueryExpression(queryModel));
-
-            return ((SubQueryExpression)resultExpression).QueryModel;
-        }
-
-        private class QueryModelRecreatingVisitor : ExpressionVisitorBase
-        {
-            private readonly Dictionary<QueryModel, QueryModel> _mapping;
-
-            public QueryModelRecreatingVisitor(Dictionary<QueryModel, QueryModel> mapping)
-            {
-                _mapping = mapping;
-            }
-
-            protected override Expression VisitSubQuery(SubQueryExpression expression)
-            {
-                var queryModel = expression.QueryModel;
-
-                var originalQueryModel = _mapping[queryModel];
-                ShallowCopy(originalQueryModel, queryModel);
-
-                queryModel.TransformExpressions(Visit);
-
-                return expression;
-            }
-        }
-
-        private static void ShallowCopy(QueryModel sourceQueryModel, QueryModel targetQueryModel)
-        {
-            targetQueryModel.BodyClauses.Clear();
-            foreach (var bodyClause in sourceQueryModel.BodyClauses)
-            {
-                targetQueryModel.BodyClauses.Add(bodyClause);
-            }
-
-            targetQueryModel.ResultOperators.Clear();
-            foreach (var resultOperator in sourceQueryModel.ResultOperators)
-            {
-                targetQueryModel.ResultOperators.Add(resultOperator);
-            }
-
-            targetQueryModel.ResultTypeOverride = sourceQueryModel.ResultTypeOverride;
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1388,7 +1388,7 @@ ORDER BY [l20].[Id], [l20].[Id0]",
             base.Where_navigation_property_to_collection();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l1].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
 WHERE (
@@ -2332,7 +2332,7 @@ INNER JOIN [Level2] AS [l2] ON [l1].[Id] = (
             base.Contains_with_subquery_optional_navigation_and_constant_item();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 WHERE 1 IN (

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1507,7 +1507,7 @@ LEFT JOIN (
     WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g].[FullName], [t].[FullName]",
+ORDER BY [g].[FullName]",
                 Sql);
 
             Assert.Contains(
@@ -1554,7 +1554,7 @@ LEFT JOIN (
     WHERE [g2].[Discriminator] = N'Officer'
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g].[FullName], [t].[FullName]",
+ORDER BY [g].[FullName]",
                 Sql);
 
             Assert.Contains(
@@ -1601,7 +1601,7 @@ LEFT JOIN (
     WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g].[FullName], [t].[FullName]",
+ORDER BY [g].[FullName]",
                 Sql);
 
             Assert.Contains(
@@ -1648,7 +1648,7 @@ LEFT JOIN (
     WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g].[FullName], [t].[FullName]",
+ORDER BY [g].[FullName]",
                 Sql);
 
             Assert.Contains(

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -570,7 +570,7 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             base.Select_collection_navigation_multi_part();
 
             Assert.Equal(
-                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region], [o].[OrderID]
+                @"SELECT [o].[OrderID], [o.Customer].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 WHERE [o].[CustomerID] = N'ALFKI'

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -6920,7 +6920,7 @@ WHERE [t0].[OrderID] IS NOT NULL",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [t0].[OrderID], [t2].[OrderDate]
 FROM [Customers] AS [c]
-CROSS APPLY (
+CROSS JOIN (
     SELECT [t].*
     FROM (
         SELECT NULL AS [empty]


### PR DESCRIPTION
These changes introduce a new LeftOuterJoinClause class so that
the GroupJoin/SelectMany/DefaultIfEmpty pattern can be detected
and made explicit at optimization time, rather than at runtime,
which required modifications to the query model during compilation
(and complex code to compensate for such modifications.)