### PR TITLE
Query: Optimize certain types of GroupJoin/SelectMany queries

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3106,7 +3106,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void SelectMany_with_navigation_filter_paging_and_explicit_DefautltIfEmpty()
+        public virtual void SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty()
         {
             AssertQuery<Level1>(
                   l1s => from l1 in l1s

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -7047,6 +7047,46 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             .Contains(o.OrderID)));
         }
 
+        [ConditionalFact]
+        public virtual void GroupJoin_SelectMany_subquery_with_filter()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into lo
+                            from o in lo.Where(x => x.OrderID > 5)
+                            select new { c.ContactName, o.OrderID });
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_SelectMany_subquery_with_filter_orderby()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into lo
+                            from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate)
+                            select new { c.ContactName, o.OrderID });
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into lo
+                            from o in lo.Where(x => x.OrderID > 5).DefaultIfEmpty()
+                            select new { c.ContactName, o });
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into lo
+                            from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate).DefaultIfEmpty()
+                            select new { c.ContactName, o });
+        }
+
         private static IEnumerable<TElement> ClientDefaultIfEmpty<TElement>(IEnumerable<TElement> source)
         {
             return source?.Count() == 0 ? new[] { default(TElement) } : source;

--- a/src/EFCore/Query/ExpressionVisitors/Internal/AdditionalFromClauseOptimizingQueryModelVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/AdditionalFromClauseOptimizingQueryModelVisitor.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ExpressionVisitors;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class AdditionalFromClauseOptimizingQueryModelVisitor : QueryModelVisitorBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void VisitQueryModel([NotNull] QueryModel queryModel)
+        {
+            queryModel.TransformExpressions(new TransformingQueryModelExpressionVisitor<AdditionalFromClauseOptimizingQueryModelVisitor>(this).Visit);
+
+            base.VisitQueryModel(queryModel);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void VisitAdditionalFromClause(
+            [NotNull] AdditionalFromClause fromClause,
+            [NotNull] QueryModel queryModel,
+            int index)
+        {
+            if (fromClause.FromExpression is SubQueryExpression subQueryExpression
+                && subQueryExpression.QueryModel.MainFromClause.FromExpression is QuerySourceReferenceExpression qsre
+                && subQueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression
+                && qsre.ReferencedQuerySource is GroupJoinClause groupJoinClause
+                && !(groupJoinClause.JoinClause.InnerSequence is SubQueryExpression)
+                && queryModel.CountQuerySourceReferences(groupJoinClause) == 1
+                && subQueryExpression.QueryModel.BodyClauses.Any()
+                && subQueryExpression.QueryModel.BodyClauses.All(c => c is WhereClause))
+            {
+                var newMainFromClause = new MainFromClause(
+                    groupJoinClause.JoinClause.ItemName,
+                    groupJoinClause.JoinClause.ItemType,
+                    groupJoinClause.JoinClause.InnerSequence);
+
+                var newSelectClause = new SelectClause(
+                    new QuerySourceReferenceExpression(newMainFromClause));
+
+                var newSubQueryModel = new QueryModel(newMainFromClause, newSelectClause);
+
+                ShiftBodyClauses(subQueryExpression.QueryModel, newSubQueryModel);
+
+                var newSubQueryExpression = new SubQueryExpression(newSubQueryModel);
+
+                groupJoinClause.JoinClause.InnerSequence = newSubQueryExpression;
+
+                if (!subQueryExpression.QueryModel.ResultOperators.Any())
+                {
+                    fromClause.FromExpression = qsre;
+                }
+            }
+        }
+
+        private void ShiftBodyClauses(QueryModel oldQueryModel, QueryModel newQueryModel)
+        {
+            var querySourceMapping = new QuerySourceMapping();
+
+            querySourceMapping.AddMapping(
+                oldQueryModel.MainFromClause,
+                new QuerySourceReferenceExpression(newQueryModel.MainFromClause));
+
+            foreach (var bodyClause in oldQueryModel.BodyClauses.ToArray())
+            {
+                bodyClause.TransformExpressions(expression =>
+                    ReferenceReplacingExpressionVisitor.ReplaceClauseReferences(
+                        expression,
+                        querySourceMapping,
+                        throwOnUnmappedReferences: false));
+
+                oldQueryModel.BodyClauses.Remove(bodyClause);
+                newQueryModel.BodyClauses.Add(bodyClause);
+            }
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2223,10 +2223,14 @@ ORDER BY [l0].[OneToMany_Optional_InverseId]",
             base.SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
-LEFT JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
-ORDER BY [l1].[Id]",
+LEFT JOIN (
+    SELECT [l1.OneToMany_Optional].*
+    FROM [Level2] AS [l1.OneToMany_Optional]
+    WHERE [l1.OneToMany_Optional].[Id] > 5
+) AS [t] ON [l1].[Id] = [t].[OneToMany_Optional_InverseId]
+WHERE [t].[Id] IS NOT NULL",
                 Sql);
         }
 
@@ -2248,11 +2252,15 @@ WHERE [l1.OneToOne_Required_FK.OneToMany_Optional].[Id] IS NOT NULL",
             base.SelectMany_with_nested_navigation_filter_and_explicit_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 INNER JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
-LEFT JOIN [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional] ON [l1.OneToOne_Optional_FK].[Id] = [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId]
-ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+LEFT JOIN (
+    SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].*
+    FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+    WHERE [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id] > 5
+) AS [t] ON [l1.OneToOne_Optional_FK].[Id] = [t].[OneToMany_Optional_InverseId]
+WHERE [t].[Id] IS NOT NULL",
                 Sql);
         }
 
@@ -2261,22 +2269,30 @@ ORDER BY [l1.OneToOne_Optional_FK].[Id]",
             base.Multiple_SelectMany_with_navigation_and_explicit_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 INNER JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
-LEFT JOIN [Level3] AS [l1.OneToMany_Optional.OneToMany_Optional] ON [l1.OneToMany_Optional].[Id] = [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId]
-ORDER BY [l1.OneToMany_Optional].[Id]",
+LEFT JOIN (
+    SELECT [l1.OneToMany_Optional.OneToMany_Optional].*
+    FROM [Level3] AS [l1.OneToMany_Optional.OneToMany_Optional]
+    WHERE [l1.OneToMany_Optional.OneToMany_Optional].[Id] > 5
+) AS [t] ON [l1.OneToMany_Optional].[Id] = [t].[OneToMany_Optional_InverseId]
+WHERE [t].[Id] IS NOT NULL",
                 Sql);
         }
 
-        public override void SelectMany_with_navigation_filter_paging_and_explicit_DefautltIfEmpty()
+        public override void SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty()
         {
-            base.SelectMany_with_navigation_filter_paging_and_explicit_DefautltIfEmpty();
+            base.SelectMany_with_navigation_filter_paging_and_explicit_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToMany_Required].[Id], [l1.OneToMany_Required].[Date], [l1.OneToMany_Required].[Level1_Optional_Id], [l1.OneToMany_Required].[Level1_Required_Id], [l1.OneToMany_Required].[Name], [l1.OneToMany_Required].[OneToMany_Optional_InverseId], [l1.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Required].[OneToMany_Required_InverseId], [l1.OneToMany_Required].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
-LEFT JOIN [Level2] AS [l1.OneToMany_Required] ON [l1].[Id] = [l1.OneToMany_Required].[OneToMany_Required_InverseId]
+LEFT JOIN (
+    SELECT [l1.OneToMany_Required].[Id], [l1.OneToMany_Required].[Date], [l1.OneToMany_Required].[Level1_Optional_Id], [l1.OneToMany_Required].[Level1_Required_Id], [l1.OneToMany_Required].[Name], [l1.OneToMany_Required].[OneToMany_Optional_InverseId], [l1.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Required].[OneToMany_Required_InverseId], [l1.OneToMany_Required].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Required].[OneToOne_Optional_SelfId]
+    FROM [Level2] AS [l1.OneToMany_Required]
+    WHERE [l1.OneToMany_Required].[Id] > 5
+) AS [t] ON [l1].[Id] = [t].[OneToMany_Required_InverseId]
 ORDER BY [l1].[Id]",
                 Sql);
         }
@@ -2616,9 +2632,13 @@ ORDER BY [l1].[Id]",
             base.GroupJoin_with_subquery_on_inner();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
-LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+    FROM [Level2] AS [l2]
+    WHERE [l2].[Id] > 0
+) AS [t] ON [l1].[Id] = [t].[Level1_Optional_Id]
 ORDER BY [l1].[Id]",
                 Sql);
         }
@@ -2628,9 +2648,13 @@ ORDER BY [l1].[Id]",
             base.GroupJoin_with_subquery_on_inner_and_no_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_InverseId], [t].[OneToMany_Optional_Self_InverseId], [t].[OneToMany_Required_InverseId], [t].[OneToMany_Required_Self_InverseId], [t].[OneToOne_Optional_PK_InverseId], [t].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
-LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+    FROM [Level2] AS [l2]
+    WHERE [l2].[Id] > 0
+) AS [t] ON [l1].[Id] = [t].[Level1_Optional_Id]
 ORDER BY [l1].[Id]",
                 Sql);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -7188,6 +7188,60 @@ WHERE ([o].[OrderID] > 11000) AND [o].[OrderID] IN (
                 Sql);
         }
 
+        public override void GroupJoin_SelectMany_subquery_with_filter()
+        {
+            base.GroupJoin_SelectMany_subquery_with_filter();
+
+            Assert.Equal(
+                @"SELECT [c].[ContactName], [t].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o].*
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] > 5
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupJoin_SelectMany_subquery_with_filter_orderby()
+        {
+            base.GroupJoin_SelectMany_subquery_with_filter_orderby();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty()
+        {
+            base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty();
+
+            Assert.Equal(
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[ContactName]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] > 5
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]",
+                Sql);
+        }
+
+        public override void GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty()
+        {
+            base.GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
In some circumstances, a GroupJoin/SelectMany pattern (with or
without DefaultIfEmpty) can be optimized by shifting body clauses
from the AdditionalFromClause into the GroupJoinClause. These changes
implement that optimization.