### PR TITLE
Query: Improve ExpressionVisitorBase by making it recursive.

### DIFF
--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -355,24 +355,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             queryModel.Print(removeFormatting: true, characterLimit: QueryModelStringLengthLimit)));
                 }
 
-                queryModel.TransformExpressions(new RecursiveQueryModelExpressionVisitor(this).Visit);
-            }
-
-            private class RecursiveQueryModelExpressionVisitor : ExpressionVisitorBase
-            {
-                private readonly NondeterministicResultCheckingVisitor _parentVisitor;
-
-                public RecursiveQueryModelExpressionVisitor(NondeterministicResultCheckingVisitor parentVisitor)
-                {
-                    _parentVisitor = parentVisitor;
-                }
-
-                protected override Expression VisitSubQuery(SubQueryExpression expression)
-                {
-                    _parentVisitor.VisitQueryModel(expression.QueryModel);
-
-                    return base.VisitSubQuery(expression);
-                }
+                queryModel.TransformExpressions(new TransformingQueryModelExpressionVisitor<NondeterministicResultCheckingVisitor>(this).Visit);
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
+++ b/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
@@ -3,8 +3,8 @@
 
 using System.Diagnostics;
 using System.Linq.Expressions;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
@@ -16,33 +16,34 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
     public abstract class ExpressionVisitorBase : RelinqExpressionVisitor
     {
         /// <summary>
-        ///     Visits the given node.
-        /// </summary>
-        /// <param name="node"> The expression to visit. </param>
-        /// <returns>
-        ///     An Expression.
-        /// </returns>
-        public override Expression Visit([CanBeNull] Expression node)
-            => node == null
-               || node.NodeType == ExpressionType.Block
-                ? node
-                : base.Visit(node);
-
-        /// <summary>
         ///     Visits the children of the extension expression.
         /// </summary>
         /// <returns>
         ///     The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
         /// </returns>
-        /// <param name="node">The expression to visit.</param>
-        protected override Expression VisitExtension(Expression node)
+        /// <param name="extensionExpression">The expression to visit.</param>
+        protected override Expression VisitExtension(Expression extensionExpression)
         {
-            if (node is NullConditionalExpression)
+            if (extensionExpression is NullConditionalExpression)
             {
-                return node;
+                return extensionExpression;
             }
 
-            return base.VisitExtension(node);
+            return base.VisitExtension(extensionExpression);
+        }
+
+        /// <summary>
+        ///     Visits the children of the subquery expression.
+        /// </summary>
+        /// <returns>
+        ///     The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
+        /// </returns>
+        /// <param name="subQueryExpression">The expression to visit.</param>
+        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+        {
+            subQueryExpression.QueryModel.TransformExpressions(Visit);
+
+            return base.VisitSubQuery(subQueryExpression);
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class EntityEqualityRewritingExpressionVisitor : RelinqExpressionVisitor
+    public class EntityEqualityRewritingExpressionVisitor : ExpressionVisitorBase
     {
         private readonly IModel _model;
 
@@ -111,19 +111,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             .Select(p => Expression.Convert(EntityQueryModelVisitor.CreatePropertyExpression(target, p), typeof(object)))
                             .Cast<Expression>()
                             .ToArray()));
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
-        {
-            Check.NotNull(subQueryExpression, nameof(subQueryExpression));
-
-            subQueryExpression.QueryModel.TransformExpressions(Visit);
-
-            return subQueryExpression;
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -1444,9 +1444,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     _queryModelVisitor = queryModelVisitor;
                 }
 
-                protected override Expression VisitSubQuery(SubQueryExpression expression)
-                    => expression;
-
                 protected override Expression VisitMember(MemberExpression node)
                 {
                     Check.NotNull(node, nameof(node));

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -99,17 +99,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override Expression VisitSubQuery(SubQueryExpression expression)
-        {
-            expression.QueryModel.TransformExpressions(Visit);
-
-            return expression;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         protected override Expression VisitBinary(BinaryExpression node)
         {
             return node.NodeType == ExpressionType.Coalesce

--- a/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
@@ -72,16 +72,5 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             return newMethodCallExpression;
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
-        {
-            subQueryExpression.QueryModel.TransformExpressions(Visit);
-
-            return subQueryExpression;
-        }
     }
 }

--- a/src/EFCore/Query/Internal/QueryModelExtensions.cs
+++ b/src/EFCore/Query/Internal/QueryModelExtensions.cs
@@ -149,13 +149,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 return expression;
             }
-
-            protected override Expression VisitSubQuery(SubQueryExpression expression)
-            {
-                expression.QueryModel.TransformExpressions(Visit);
-
-                return expression;
-            }
         }
     }
 }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -247,13 +247,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 return base.VisitMethodCall(methodCallExpression);
             }
-
-            protected override Expression VisitSubQuery(SubQueryExpression expression)
-            {
-                expression.QueryModel.TransformExpressions(Visit);
-
-                return expression;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
DRY up VisitSubQuery method
Use TransformingQueryModelExpressionVisitor instead of RecursiveQueryModelExpressionVisitor

