### PR TITLE
Query: Relational: implement LEFT JOIN LATERAL / OUTER APPLY

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/LeftJoinLateralExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/LeftJoinLateralExpression.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions
+{
+    /// <summary>
+    ///     Represents a SQL LEFT JOIN LATERAL expression.
+    /// </summary>
+    public class LeftJoinLateralExpression : JoinExpressionBase
+    {
+        /// <summary>
+        ///     Creates a new instance of LeftJoinLateralExpression.
+        /// </summary>
+        /// <param name="tableExpression"> The target table expression. </param>
+        public LeftJoinLateralExpression([NotNull] TableExpressionBase tableExpression)
+            : base(Check.NotNull(tableExpression, nameof(tableExpression)))
+        {
+        }
+
+        /// <summary>
+        ///     Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is ISqlExpressionVisitor sqlExpressionVisitor
+                ? sqlExpressionVisitor.VisitLeftJoinLateral(this)
+                : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="string" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
+        public override string ToString() => "LEFT JOIN LATERAL " + TableExpression;
+    }
+}

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1002,6 +1002,26 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Adds a SQL LEFT JOIN LATERAL to this SelectExpression.
+        /// </summary>
+        /// <param name="tableExpression"> The target table expression. </param>
+        /// <param name="projection"> A sequence of expressions that should be added to the projection. </param>
+        public virtual JoinExpressionBase AddLeftJoinLateral(
+            [NotNull] TableExpressionBase tableExpression,
+            [NotNull] IEnumerable<Expression> projection)
+        {
+            Check.NotNull(tableExpression, nameof(tableExpression));
+            Check.NotNull(projection, nameof(projection));
+
+            var leftJoinLateralExpression = new LeftJoinLateralExpression(tableExpression);
+
+            _tables.Add(leftJoinLateralExpression);
+            _projection.AddRange(projection);
+
+            return leftJoinLateralExpression;
+        }
+
+        /// <summary>
         ///     Adds a SQL INNER JOIN to this SelectExpression.
         /// </summary>
         /// <param name="tableExpression"> The target table expression. </param>

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -630,6 +630,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         }
 
         /// <summary>
+        ///     Visit a LeftJoinLateralExpression expression.
+        /// </summary>
+        /// <param name="leftJoinLateralExpression"> The left lateral join expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public virtual Expression VisitLeftJoinLateral(LeftJoinLateralExpression leftJoinLateralExpression)
+        {
+            Check.NotNull(leftJoinLateralExpression, nameof(leftJoinLateralExpression));
+
+            _relationalCommandBuilder.Append("LEFT JOIN LATERAL ");
+
+            Visit(leftJoinLateralExpression.TableExpression);
+
+            return leftJoinLateralExpression;
+        }
+
+        /// <summary>
         ///     Visit a SqlFragmentExpression.
         /// </summary>
         /// <param name="sqlFragmentExpression"> The SqlFragmentExpression expression. </param>

--- a/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -94,6 +94,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         Expression VisitCrossJoinLateral([NotNull] CrossJoinLateralExpression crossJoinLateralExpression);
 
         /// <summary>
+        ///     Visit a LeftJoinLateralExpression.
+        /// </summary>
+        /// <param name="leftJoinLateralExpression"> The left join lateral expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        Expression VisitLeftJoinLateral([NotNull] LeftJoinLateralExpression leftJoinLateralExpression);
+
+        /// <summary>
         ///     Visit an InnerJoinExpression.
         /// </summary>
         /// <param name="innerJoinExpression"> The inner join expression. </param>

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -48,6 +48,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public override Expression VisitLeftJoinLateral(LeftJoinLateralExpression leftJoinLateralExpression)
+        {
+            Check.NotNull(leftJoinLateralExpression, nameof(leftJoinLateralExpression));
+
+            Sql.Append("OUTER APPLY ");
+
+            Visit(leftJoinLateralExpression.TableExpression);
+
+            return leftJoinLateralExpression;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override void GenerateLimitOffset(SelectExpression selectExpression)
         {
             if (selectExpression.Projection.OfType<RowNumberExpression>().Any())

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3791,19 +3791,13 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
             base.SelectMany_Joined_DefaultIfEmpty();
 
             Assert.Equal(
-                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c].[ContactName]
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [c].[ContactName]
 FROM [Customers] AS [c]
-CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty]
-    LEFT JOIN (
-        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-        FROM [Orders] AS [o]
-        WHERE [o].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t0]",
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID]
+) AS [t]",
                 Sql);
         }
 
@@ -3812,19 +3806,13 @@ CROSS APPLY (
             base.SelectMany_Joined_DefaultIfEmpty2();
 
             Assert.Equal(
-                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM [Customers] AS [c]
-CROSS APPLY (
-    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty]
-    LEFT JOIN (
-        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-        FROM [Orders] AS [o]
-        WHERE [o].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t0]",
+OUTER APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID]
+) AS [t]",
                 Sql);
         }
 
@@ -7000,20 +6988,14 @@ WHERE [t0].[CustomerID] IS NOT NULL",
             base.DefaultIfEmpty_in_subquery();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [t0].[OrderID]
+                @"SELECT [c].[CustomerID], [t].[OrderID]
 FROM [Customers] AS [c]
-CROSS APPLY (
-    SELECT [t].*
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty]
-    LEFT JOIN (
-        SELECT [o].*
-        FROM [Orders] AS [o]
-        WHERE [o].[CustomerID] = [c].[CustomerID]
-    ) AS [t] ON 1 = 1
-) AS [t0]
-WHERE [t0].[OrderID] IS NOT NULL",
+OUTER APPLY (
+    SELECT [o].*
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID]
+) AS [t]
+WHERE [t].[OrderID] IS NOT NULL",
                 Sql);
         }
 
@@ -7022,31 +7004,19 @@ WHERE [t0].[OrderID] IS NOT NULL",
             base.DefaultIfEmpty_in_subquery_nested();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [t0].[OrderID], [t2].[OrderDate]
+                @"SELECT [c].[CustomerID], [t].[OrderID], [t1].[OrderDate]
 FROM [Customers] AS [c]
-CROSS APPLY (
-    SELECT [t].*
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty]
-    LEFT JOIN (
-        SELECT [o].*
-        FROM [Orders] AS [o]
-        WHERE [o].[OrderID] > 11000
-    ) AS [t] ON 1 = 1
-) AS [t0]
-CROSS APPLY (
-    SELECT [t1].*
-    FROM (
-        SELECT NULL AS [empty]
-    ) AS [empty0]
-    LEFT JOIN (
-        SELECT [o0].*
-        FROM [Orders] AS [o0]
-        WHERE [o0].[CustomerID] = [c].[CustomerID]
-    ) AS [t1] ON 1 = 1
-) AS [t2]
-WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t2].[OrderID] IS NOT NULL)",
+OUTER APPLY (
+    SELECT [o].*
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] > 11000
+) AS [t]
+OUTER APPLY (
+    SELECT [o0].*
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] = [c].[CustomerID]
+) AS [t1]
+WHERE ([c].[City] = N'Seattle') AND ([t].[OrderID] IS NOT NULL AND [t1].[OrderID] IS NOT NULL)",
                 Sql);
         }
 


### PR DESCRIPTION
These changes simply pull up the pushed down subquery expression created by the `RelationalResultOperatorHandler` for the `DefaultIfEmptyResultOperator` and add it as a `LeftJoinLateralExpression` instead of a `CrossJoinLateralExpression`.

Another possible optimization that could be handled later is to re-order subquery result operators to 'float' `DefaultIfEmptyResultOperator`s to the end of the list, e.g. for cases like `.DefaultIfEmpty().Distinct()` or `.DefaultIfEmpty().Take(x).Skip(y)`. That would allow more queries to become `OUTER APPLY` instead of `CROSS APPLY`.