### PR TITLE
[TINY] Fix to #7864 - OrderBy_correlated_subquery_lol2 seems to be a very slow test

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -3386,24 +3386,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void OrderBy_correlated_subquery_lol()
+        public virtual void OrderBy_correlated_subquery1()
         {
             AssertQuery<Customer>(
                 cs => from c in cs
+                      where c.CustomerID.StartsWith("A")
                       orderby cs.Any(c2 => c2.CustomerID == c.CustomerID)
                       select c,
-                entryCount: 91);
+                entryCount: 4);
         }
 
         [ConditionalFact]
-        public virtual void OrderBy_correlated_subquery_lol2()
+        public virtual void OrderBy_correlated_subquery2()
         {
             AssertQuery<Order, Customer>(
                 (os, cs) => os.Where(
-                    o => cs.OrderBy(
-                                 c => cs.Any(
-                                     c2 => c2.CustomerID == "ALFKI"))
-                             .FirstOrDefault().City != "Nowhere"));
+                    o => o.OrderID <= 10250 
+                    && cs.OrderBy(
+                        c => cs.Any(
+                            c2 => c2.CustomerID == "ALFKI"))
+                        .FirstOrDefault().City != "Nowhere"));
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4069,13 +4069,14 @@ END",
                 Sql);
         }
 
-        public override void OrderBy_correlated_subquery_lol()
+        public override void OrderBy_correlated_subquery1()
         {
-            base.OrderBy_correlated_subquery_lol();
+            base.OrderBy_correlated_subquery1();
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 ORDER BY (
     SELECT CASE
         WHEN EXISTS (
@@ -4088,14 +4089,14 @@ ORDER BY (
                 Sql);
         }
 
-        public override void OrderBy_correlated_subquery_lol2()
+        public override void OrderBy_correlated_subquery2()
         {
-            base.OrderBy_correlated_subquery_lol2();
+            base.OrderBy_correlated_subquery2();
 
             Assert.Equal(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE (
+WHERE ([o].[OrderID] <= 10250) AND ((
     SELECT TOP(1) [c].[City]
     FROM [Customers] AS [c]
     ORDER BY (
@@ -4107,7 +4108,7 @@ WHERE (
             THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
         END
     )
-) <> N'Nowhere'",
+) <> N'Nowhere')",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was in the in-memory portion of the test. We would execute 830 subqueries and that took the vast majority of the time. Fix is to introduce additional predicate, cutting the number of subqueries down to 4.