### PR TITLE
WIP: Possible fix for SqlServer test timeouts

### DIFF
--- a/EFCore.sln
+++ b/EFCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26214.1
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore", "src\EFCore\EFCore.csproj", "{715C38E9-B2F5-4DB2-8025-0C6492DEBDD4}"
 EndProject

--- a/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -4,7 +4,7 @@
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(DisableTestParallelization = false)]
 [assembly: TestFramework("Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit.ConditionalTestFramework", "Microsoft.EntityFrameworkCore.Specification.Tests")]
 
 // Skip the entire assembly if not on Windows and no external SQL Server is configured

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
     public class SqlServerTestStore : RelationalTestStore
     {
-        public const int CommandTimeout = 90;
+        public const int CommandTimeout = 600;
 
 #if NET452
         private static string BaseDirectory => AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
Increase timeout used for creating SqlServer test databases to account for the increased delay when running in parallel.

Issue #7411