### PR TITLE
WIP: Possible fix for SqlServer test timeouts 

### DIFF
--- a/EFCore.sln
+++ b/EFCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26214.1
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore", "src\EFCore\EFCore.csproj", "{715C38E9-B2F5-4DB2-8025-0C6492DEBDD4}"
 EndProject

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -141,8 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             => ExistsAsync(retryOnNotExists: false, cancellationToken: cancellationToken);
 
         private Task<bool> ExistsAsync(bool retryOnNotExists, CancellationToken cancellationToken)
-        {
-            return Dependencies.ExecutionStrategyFactory.Create().ExecuteAsync(
+            => Dependencies.ExecutionStrategyFactory.Create().ExecuteAsync(
                 async (giveUp, ct) =>
                     {
                         var retryCount = 0;
@@ -173,12 +172,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                             }
                         }
                     }, DateTime.UtcNow + TimeSpan.FromMinutes(1), cancellationToken);
-        }
 
         // Login failed is thrown when database does not exist (See Issue #776)
         // Unable to attach database file is thrown when file does not exist (See Issue #2810)
         // Unable to open the physical file is thrown when file does not exist (See Issue #2810)
-        private static bool IsDoesNotExist(SqlException exception) => exception.Number == 4060 || exception.Number == 1832 || exception.Number == 5120;
+        private static bool IsDoesNotExist(SqlException exception) =>
+            exception.Number == 4060 || exception.Number == 1832 || exception.Number == 5120;
 
         // See Issue #985
         private bool RetryOnExistsFailure(SqlException exception, ref int retryCount)
@@ -201,11 +200,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             //   System.Data.SqlClient.SqlException: Unable to Attach database file as database xxxxxxx.
             // And (Number 5120)
             //   System.Data.SqlClient.SqlException: Unable to open the physical file xxxxxxx.
-            if ((exception.Number == 233 || exception.Number == -2 || exception.Number == 4060 || exception.Number == 1832 || exception.Number == 5120)
-                && ++retryCount < 30)
+            if ((exception.Number == 233
+                 || exception.Number == -2
+                 || exception.Number == 4060
+                 || exception.Number == 1832
+                 || exception.Number == 5120)
+                && ++retryCount < 20)
             {
                 ClearPool();
-                Thread.Sleep(100);
+                Thread.Sleep(500);
                 return true;
             }
             return false;

--- a/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -4,7 +4,6 @@
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 [assembly: TestFramework("Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit.ConditionalTestFramework", "Microsoft.EntityFrameworkCore.Specification.Tests")]
 
 // Skip the entire assembly if not on Windows and no external SQL Server is configured

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
     public class SqlServerTestStore : RelationalTestStore
     {
-        public const int CommandTimeout = 90;
+        public const int CommandTimeout = 600;
 
 #if NET452
         private static string BaseDirectory => AppDomain.CurrentDomain.BaseDirectory;

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -89,6 +89,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
             CreateShared(typeof(SqlServerTestStore).Name + Name,
                 () =>
                     {
+                        if (DatabaseExists(Name))
+                        {
+                            DeleteDatabase(Name);
+                        }
+
                         if (CreateDatabase())
                         {
                             initializeDatabase?.Invoke();


### PR DESCRIPTION
Increase timeout used for creating SqlServer test databases to account for the increased delay when running in parallel.
Issue #7411

(shifted to feature branch for CI triggers)