### PR TITLE
Query: Use NullableExpression instead of ColumnExpression.IsNullable …

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -11,7 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public static class RelationalExpressionExtensions
     {
         public static ColumnExpression TryGetColumnExpression([NotNull] this Expression expression)
-            => expression as ColumnExpression ?? (expression as AliasExpression)?.TryGetColumnExpression();
+            => expression as ColumnExpression
+               ?? (expression as AliasExpression)?.TryGetColumnExpression()
+               ?? (expression as NullableExpression)?.Operand.TryGetColumnExpression();
 
         public static bool IsAliasWithColumnExpression([NotNull] this Expression expression)
             => (expression as AliasExpression)?.Expression is ColumnExpression;

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
@@ -80,38 +80,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitExtension(Expression node)
         {
-            var aliasExpression = node as AliasExpression;
-            if (aliasExpression != null)
+            if (node is AliasExpression aliasExpression)
             {
                 return Visit(aliasExpression.Expression);
             }
 
-            var notNullableExpression = node as NotNullableExpression;
-            if (notNullableExpression != null)
-            {
-                return node;
-            }
-
-            var columnExpression = node as ColumnExpression
-                                   ?? node.TryGetColumnExpression();
+            var columnExpression = node.TryGetColumnExpression();
 
             if (columnExpression != null
-                && columnExpression.IsNullable)
+                && columnExpression.Property.IsNullable)
             {
                 AddToResult(new IsNullExpression(node));
 
                 return node;
             }
 
-            var isNullExpression = node as IsNullExpression;
-            if (isNullExpression != null)
+            if (node is NullableExpression nullableExpression)
             {
-                return node;
-            }
+                AddToResult(new IsNullExpression(nullableExpression.Operand));
 
-            var inExpression = node as InExpression;
-            if (inExpression != null)
-            {
                 return node;
             }
 

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
@@ -72,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (node.NodeType == ExpressionType.Equal
                 && node.Left.Type.UnwrapNullableType() == typeof(bool)
                 && node.Right.Type.UnwrapNullableType() == typeof(bool)
-                && !NegatedNullableAliasOrColumn(node.Left)
-                && !NegatedNullableAliasOrColumn(node.Right))
+                && !NegatedNullableExpression(node.Left)
+                && !NegatedNullableExpression(node.Right))
             {
                 var newLeft = Visit(node.Left);
                 var newRight = Visit(node.Right);
@@ -98,13 +99,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return base.VisitBinary(node);
         }
 
-        private bool NegatedNullableAliasOrColumn(Expression expression)
+        private bool NegatedNullableExpression(Expression expression)
         {
             var unaryExpression = expression.RemoveConvert() as UnaryExpression;
 
-            return unaryExpression != null
-                && unaryExpression.Type == typeof(bool?)
-                && unaryExpression.Operand.RemoveConvert().TryGetColumnExpression() != null;
+            return unaryExpression?.Operand is NullableExpression;
         }
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -162,6 +162,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         if (!(node is QuerySourceReferenceExpression))
                         {
+                            if (sqlExpression is NullableExpression nullableExpression)
+                            {
+                                sqlExpression = nullableExpression.Operand;
+                            }
+
                             var columnExpression = sqlExpression.TryGetColumnExpression();
 
                             if (columnExpression != null)

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -553,16 +553,23 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             if (expressionType == ExpressionType.Equal
                 || expressionType == ExpressionType.NotEqual)
             {
-                var constantExpression
-                    = right.RemoveConvert() as ConstantExpression
-                      ?? left.RemoveConvert() as ConstantExpression;
 
-                if (constantExpression != null
-                    && constantExpression.Value == null)
+                var leftConstant = left.RemoveConvert() as ConstantExpression;
+                var isLeftNullConstant = leftConstant != null && leftConstant.Value == null;
+
+                var rightConstant = right.RemoveConvert() as ConstantExpression;
+                var isRightNullConstant = rightConstant != null && rightConstant.Value == null;
+
+                if (isLeftNullConstant || isRightNullConstant)
                 {
-                    var columnExpression
-                        = left.RemoveConvert().TryGetColumnExpression()
-                          ?? right.RemoveConvert().TryGetColumnExpression();
+                    var nonNullExpression = (isLeftNullConstant ? right : left).RemoveConvert();
+
+                    if (nonNullExpression is NullableExpression nullableExpression)
+                    {
+                        nonNullExpression = nullableExpression.Operand.RemoveConvert();
+                    }
+
+                    var columnExpression = nonNullExpression.TryGetColumnExpression();
 
                     if (columnExpression != null)
                     {
@@ -997,21 +1004,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             if (nullConditionalExpression != null)
             {
                 var newAccessOperation = Visit(nullConditionalExpression.AccessOperation);
-                var columnExpression = newAccessOperation.TryGetColumnExpression();
 
-                if (columnExpression != null)
+                if (newAccessOperation != null)
                 {
-                    columnExpression.IsNullable = true;
-                }
+                    if (newAccessOperation.Type != nullConditionalExpression.Type)
+                    {
+                        newAccessOperation = Expression.Convert(newAccessOperation, nullConditionalExpression.Type);
+                    }
 
-                if (newAccessOperation != null
-                    && newAccessOperation.Type != nullConditionalExpression.Type)
-                {
-                    newAccessOperation
-                        = Expression.Convert(newAccessOperation, nullConditionalExpression.Type);
+                    return new NullableExpression(newAccessOperation);
                 }
-
-                return newAccessOperation;
             }
 
             return base.VisitExtension(expression);

--- a/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -31,7 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             : this(name, Check.NotNull(property, nameof(property)).ClrType, tableExpression)
         {
             _property = property;
-            IsNullable = _property.IsNullable;
         }
 
         /// <summary>
@@ -91,11 +90,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <returns> The <see cref="Type" /> that represents the static type of the expression. </returns>
         public override Type Type { get; }
-
-        /// <summary>
-        ///     Gets a value indicating whether this column expression can contain null.
-        /// </summary>
-        public virtual bool IsNullable { get; set; }
 
         /// <summary>
         ///     Dispatches to the specific visit method for this node type.

--- a/src/EFCore.Relational/Query/Expressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/InExpression.cs
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             }
 
             return valuesChanged || newOperand != Operand || newSubQuery != SubQuery
-                ? new InExpression(newOperand, newValues.AsReadOnly(), newSubQuery)
+                ? new InExpression(newOperand, Values == null ? null : newValues.AsReadOnly(), newSubQuery)
                 : this;
         }
 

--- a/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     /// <summary>
     ///     Reducible annotation expression used to affect null expansion logic.
     /// </summary>
-    public class NotNullableExpression : Expression
+    public class NullableExpression : Expression
     {
         private readonly Expression _operand;
 
@@ -19,12 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     Creates an instance of NotNullableExpression.
         /// </summary>
         /// <param name="operand"> The operand. </param>
-        public NotNullableExpression([NotNull] Expression operand)
+        public NullableExpression([NotNull] Expression operand)
         {
             Check.NotNull(operand, nameof(operand));
 
             _operand = operand;
-            Type = _operand.Type?.UnwrapNullableType();
+            Type = _operand.Type?.MakeNullable();
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             var newExpression = visitor.Visit(_operand);
 
             return newExpression != _operand
-                ? new NotNullableExpression(newExpression)
+                ? new NullableExpression(newExpression)
                 : this;
         }
 

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -418,6 +418,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             {
                 var expression = ordering.Expression;
 
+                if (expression is NullableExpression nullableExpression)
+                {
+                    expression = nullableExpression.Operand;
+                }
+
                 var aliasExpression = expression as AliasExpression;
                 if (aliasExpression != null)
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1150,7 +1150,7 @@ SELECT COUNT(*)
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
-WHERE @_outer_Country = [od.Order.Customer].[Country]
+WHERE (@_outer_Country = [od.Order.Customer].[Country]) OR (@_outer_Country IS NULL AND [od.Order.Customer].[Country] IS NULL)
 
 @_outer_Country: Germany (Size = 4000)
 
@@ -1158,7 +1158,7 @@ SELECT COUNT(*)
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
-WHERE @_outer_Country = [od.Order.Customer].[Country]",
+WHERE (@_outer_Country = [od.Order.Customer].[Country]) OR (@_outer_Country IS NULL AND [od.Order.Customer].[Country] IS NULL)",
                 Sql);
         }
 


### PR DESCRIPTION
…property

@maumar @anpete 
This removes `IsNullable` from column expression and instead uses `NullableExpression` which used to represent an expression which can be nullable. This is pre-requisite for changes to SelectExpression as multiple expressions using same column expressions will have common reference.