### PR TITLE
Fix SQL Server test timeouts

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -4,7 +4,6 @@
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
 [assembly: TestFramework("Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit.ConditionalTestFramework", "Microsoft.EntityFrameworkCore.Specification.Tests")]
 
 // Skip the entire assembly if not on Windows and no external SQL Server is configured

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -768,7 +768,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
-                    .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration())
+                    .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration().CommandTimeout(600))
                     .UseInternalServiceProvider(CreateServiceProvider());
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     .BuildServiceProvider();
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseSqlServer(testStore.ConnectionString, b => b.ApplyConfiguration())
+                .UseSqlServer(testStore.ConnectionString, b => b.ApplyConfiguration().CommandTimeout(600))
                 .UseInternalServiceProvider(serviceProvider);
 
             return new BloggingContext(optionsBuilder.Options);

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
     public class SqlServerTestStore : RelationalTestStore
     {
-        public const int CommandTimeout = 90;
+        public const int CommandTimeout = 600;
 
 #if NET452
         private static string BaseDirectory => AppDomain.CurrentDomain.BaseDirectory;

--- a/test/EFCore.SqlServer.FunctionalTests/config.json
+++ b/test/EFCore.SqlServer.FunctionalTests/config.json
@@ -1,7 +1,7 @@
 {
     "Test": {
       "SqlServer": {
-        "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Database=master;Integrated Security=True;Connect Timeout=30",
+        "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Database=master;Integrated Security=True;Connect Timeout=60;ConnectRetryCount=0",
         "ElasticPoolName": "",
         "SupportsSequences": true,
         "SupportsOffset": true,


### PR DESCRIPTION
* Remove the transient failure retry count limit in SqlServerDatabaseCreator.Exists so it's only limited by time (1 minute by default)
* Increase timeout used for creating SqlServer test databases to account for the increased delay when running in parallel.
* Speed up SqlServerDatabaseCreatorTest by decreasing the timeouts used
* Make SqlServer.FunctionalTests run in parallel
* Turn off SqlClient connection resiliency in tests

Fixes #7411
