### PR TITLE
Query: Small improvement to projection-shaper optimization

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ProjectionShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ProjectionShaper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ProjectionShaper
+    public static class ProjectionShaper
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -77,23 +77,23 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 _selector = selector;
             }
 
-            public override Expression GetAccessorExpression([NotNull] IQuerySource querySource)
+            public override Expression GetAccessorExpression(IQuerySource querySource)
                 => _shaper.GetAccessorExpression(querySource);
 
-            public override void UpdateQuerySource([NotNull] IQuerySource querySource)
+            public override void UpdateQuerySource(IQuerySource querySource)
                 => _shaper.UpdateQuerySource(querySource);
 
-            public override bool IsShaperForQuerySource([NotNull] IQuerySource querySource)
+            public override bool IsShaperForQuerySource(IQuerySource querySource)
                 => _shaper.IsShaperForQuerySource(querySource);
 
-            public override void SaveAccessorExpression([NotNull] QuerySourceMapping querySourceMapping)
+            public override void SaveAccessorExpression(QuerySourceMapping querySourceMapping)
                 => _shaper.SaveAccessorExpression(querySourceMapping);
 
             public override IQuerySource QuerySource => _shaper.QuerySource;
 
             public override Type Type => typeof(TOut);
 
-            public TOut Shape([NotNull] QueryContext queryContext, ValueBuffer valueBuffer)
+            public TOut Shape(QueryContext queryContext, ValueBuffer valueBuffer)
                 => _selector(queryContext, _shaper.Shape(queryContext, valueBuffer));
 
             public override Shaper WithOffset(int offset)

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
@@ -107,5 +107,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             return this;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Shaper Unwrap([NotNull] IQuerySource querySource)
+        {
+            return _querySource == querySource ? this : null;
+        }
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// <returns>
         ///     true if the supplied query source is handled by this SelectExpression; otherwise false.
         /// </returns>
-        public override bool HandlesQuerySource([NotNull] IQuerySource querySource)
+        public override bool HandlesQuerySource(IQuerySource querySource)
         {
             Check.NotNull(querySource, nameof(querySource));
 

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1015,8 +1015,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="selectClause"> The node being visited. </param>
         /// <param name="queryModel"> The query. </param>
-        public override void VisitSelectClause(
-            [NotNull] SelectClause selectClause, [NotNull] QueryModel queryModel)
+        public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
         {
             Check.NotNull(selectClause, nameof(selectClause));
             Check.NotNull(queryModel, nameof(queryModel));
@@ -1048,8 +1047,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         if (!qsreFinder.FoundAny)
                         {
-                            var newShaper = ProjectionShaper.Create(oldShaper, materializer);
+                            Shaper newShaper = null;
 
+                            if (selectClause.Selector is QuerySourceReferenceExpression querySourceReferenceExpression)
+                            {
+                                newShaper = oldShaper.Unwrap(querySourceReferenceExpression.ReferencedQuerySource);
+                            }
+                            
+                            newShaper = newShaper ?? ProjectionShaper.Create(oldShaper, materializer);
+                            
                             Expression =
                                 Expression.Call(
                                     shapedQuery.Method


### PR DESCRIPTION
If we are projecting a simple QSRE then we can avoid introducing a ProjectionShaper.

