### PR TITLE
AppVeyor: Run only SqlServer FunctionalTests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,14 @@
-only_commits:
-  # Start a build if commit message contains 'appveyor'
-  message: /appveyor/
+version: 1.2.0-preview1-{build}
 init:
   - git config --global core.autocrlf true
 build_script:
-  - ps: .\build.ps1
+  - ps: .\build.ps1 /p:TestGroup=SqlServer
 clone_depth: 1
 test: off
 deploy: off
 # See http://www.appveyor.com/docs/services-databases
 services:
-  - mssql2014
+  - mssql2016
 branches:
   only:
     - master
@@ -21,7 +19,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    Test__SqlServer__DefaultConnection: Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!
+    Test__SqlServer__DefaultConnection: Server=(local)\SQL2016;Database=master;User ID=sa;Password=Password12!
 matrix:
   fast_finish: true
 artifacts:

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,0 +1,15 @@
+<Project>
+  <ItemGroup>
+    <!-- SQL Server functional tests which needs SQL connection but no exsting database. -->
+    <SqlServerTests Include="$(RepositoryRoot)test\EFCore.SqlServer*FunctionalTests\*.csproj" />
+  </ItemGroup>
+
+  <Target Name="_FilterTestProjects" BeforeTargets="TestProjects">
+    <ItemGroup Condition="'$(TestGroup)' != ''">
+      <ProjectsToTest Remove="@(ProjectsToTest)" Condition="'$(TestGroup)' != 'All'" />
+      <ProjectsToTest Include="@(SqlServerTests)" Condition="'$(TestGroup)' == 'SqlServer'" />
+    </ItemGroup>
+
+    <Error Text="Could not find test projects to run" Condition="@(ProjectsToTest->Count()) == 0" />
+  </Target>
+</Project>


### PR DESCRIPTION
This PR enables only SqlServer Functional Tests on AppVeyor. It takes about ~23 minutes for 1 run to finish.
Since we already had made groups of testsin #7842 this PR just run the group which travis cannot run.

Also had to change to SqlServer 2016 because for some reason SqlServer 2014 is not starting up in AppVeyor.