### PR TITLE
[1.1.2] Fix to #7714 - Invalid query produced when projecting DTO containing subquery that returns a single element

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -924,7 +924,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     if (queryModelVisitor.Queries.Count == 1
                         && !queryModelVisitor.RequiresClientFilter
                         && !queryModelVisitor.RequiresClientProjection
-                        && !queryModelVisitor.RequiresClientResultOperator)
+                        && !queryModelVisitor.RequiresClientResultOperator
+                        && !_queryModelVisitor.RequiresClientProjection)
                     {
                         var selectExpression = queryModelVisitor.Queries.First();
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5297,13 +5297,64 @@ ORDER BY [o].[OrderID]",
         {
             base.Select_nested_collection_multi_level();
 
-            Assert.StartsWith(@"SELECT [c].[CustomerID]
+            Assert.StartsWith(
+                @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 
 SELECT [o].[CustomerID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] < 10500",
+                Sql);
+        }
+
+        public override void Select_nested_collection_count_using_anonymous_type()
+        {
+            base.Select_nested_collection_count_using_anonymous_type();
+
+            Assert.Equal(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]
+)
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+                Sql);
+        }
+
+        public override void Select_nested_collection_count_using_DTO()
+        {
+            base.Select_nested_collection_count_using_DTO();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+
+@_outer_CustomerID1: ALFKI (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID1 = [o0].[CustomerID]
+
+@_outer_CustomerID1: ANATR (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID1 = [o0].[CustomerID]
+
+@_outer_CustomerID1: ANTON (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID1 = [o0].[CustomerID]
+
+@_outer_CustomerID1: AROUT (Size = 450)
+
+SELECT COUNT(*)
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID1 = [o0].[CustomerID]",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was that in the fix for #7033 we force client evaluation on queries that try to bind to parents, when the parent has a client projection.
However, for the case when single element is returned (e.g. cusotmers.Select(c => new DTO { Count = c.Orders.Count() })) we don't need to do client evaluation.
We actually try to merge the subquery into the parent query, but this causes a problem because earlier in the pipeline we assumed that client eval is needed (since parent QM has client projection)

Fix is to be consistent and never try to lift subquery if the parent QM has a client projection. This causes more scenarios to produce N+1 queries, but the proper fix would require a breaking change:
we need additional information passed to the SqlTranslatingExpressionVisitor to know that the subquery that is being visited returns a single value.