### PR TITLE
Add scripts to clean and speedup the default LocalDB instance

### DIFF
--- a/tools/CleanMSSQLLocalDB.cmd
+++ b/tools/CleanMSSQLLocalDB.cmd
@@ -1,0 +1,8 @@
+@echo off
+sqlcmd -S "(localdb)\mssqllocaldb" -i "DropAllDatabases.sql" -o "DropAll.sql"
+sqlcmd -S "(localdb)\mssqllocaldb" -i "DropAll.sql"
+del "DropAll.sql"
+sqllocaldb stop mssqllocaldb
+sqllocaldb delete mssqllocaldb
+
+ShrinkLocalDBModel.cmd

--- a/tools/ShrinkLocalDBModel.cmd
+++ b/tools/ShrinkLocalDBModel.cmd
@@ -1,0 +1,14 @@
+@echo off
+echo Shrinking the model database several times
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "DBCC SHRINKDATABASE (model) WITH NO_INFOMSGS"
+echo Configuring model database to grow with default settings
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "ALTER DATABASE model MODIFY FILE (NAME=modeldev,FILEGROWTH=10%%);" 
+sqlcmd -S "(localdb)\mssqllocaldb" -Q "ALTER DATABASE model MODIFY FILE (NAME=modellog,FILEGROWTH=10%%);"


### PR DESCRIPTION
All research and testing done by @divega

`CleanMSSQLLocalDB.cmd` drops all databases and deletes the default instance. This is useful to quickly get to a clean state, it doesn't have any perf benefits.

`ShrinkLocalDBModel.cmd` runs `DBCC ShrinkDatabase (model)` several times as this was empirically proven to yield the smallest `model` file resulting in faster database creation.
Then it changes the growth amount for the `model` database to 10%, this is the default for non-system dbs.

To use this you need to have sqlcmd and SQLClient ODBC drivers installed:
* https://www.microsoft.com/en-us/download/details.aspx?id=53591
* https://www.microsoft.com/en-us/download/details.aspx?id=53339

On my machine it sped up the SQLServer FTs on .NET Core from 4 min to 2.5 min