### PR TITLE
PVS-Studio: fixed the potential vulnerability CWE-670 (Always-Incorrect Control Flow Implementation)

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -2392,7 +2392,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     var expectedInnerNames = expectedElement.OneToMany_Optional.Select(e => e.Name).ToList();
                     for (var j = 0; j < expectedInnerNames.Count; j++)
                     {
-                        Assert.True(result[i].OneToMany_Optional.Select(e => e.Name).Contains(expectedInnerNames[i]));
+                        Assert.True(result[i].OneToMany_Optional.Select(e => e.Name).Contains(expectedInnerNames[j]));
                     }
                 }
             }

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -211,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     break;
                                 case MemberBindingType.ListBinding:
                                     var memberListBinding = (MemberListBinding)memberBinding;
-                                    for (var j = 0; i < memberListBinding.Initializers.Count; i++)
+                                    for (var j = 0; j < memberListBinding.Initializers.Count; j++)
                                     {
                                         hashCode += (hashCode * 397) ^ GetHashCode(memberListBinding.Initializers[j].Arguments);
                                     }

--- a/test/EFCore.Tests/ExpressionCompareByHashCodeTest.cs
+++ b/test/EFCore.Tests/ExpressionCompareByHashCodeTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using System.Reflection;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests
+{
+    public class ExpressionCompareByHashCodeTest
+    {
+        [ConditionalFact]
+        public void Compare_member_init_expressions_by_hash_code()
+        {
+            MethodInfo addMethod = typeof(List<string>).GetMethod("Add");
+
+            MemberListBinding bindingMessages = Expression.ListBind(
+                typeof(Node).GetProperty("Messages"),
+                Expression.ElementInit(addMethod, Expression.Constant("Greeting from PVS-Studio developers!"))
+            );
+
+            MemberListBinding bindingDescriptions = Expression.ListBind(
+                typeof(Node).GetProperty("Descriptions"),
+                Expression.ElementInit(addMethod, Expression.Constant("PVS-Studio is a static code analyzer for C, C++ and C#."))
+            );
+
+            Expression query1 = Expression.MemberInit(
+                Expression.New(typeof(Node)),
+                new List<MemberBinding>() {
+                    bindingMessages
+                }
+            );
+
+            Expression query2 = Expression.MemberInit(
+                Expression.New(typeof(Node)),
+                new List<MemberBinding>() {
+                    bindingMessages,
+                    bindingDescriptions
+                }
+            );
+
+            var comparer = new ExpressionEqualityComparer();
+            var key1Hash = comparer.GetHashCode(query1);
+            var key2Hash = comparer.GetHashCode(query2);
+
+            Assert.NotEqual(key1Hash, key2Hash);
+        }
+
+        private class Node
+        {
+            public List<string> Messages { set; get; }
+            public List<string> Descriptions { set; get; }
+        }
+    }
+}


### PR DESCRIPTION
**We have found and fixed a vulnerability CWE-670 (Always-Incorrect Control Flow Implementation) using PVS-Studio tool.**
Analyzer warnings: [V3014](https://www.viva64.com/en/w/V3014/), [V3015](https://www.viva64.com/en/w/V3015/) and [V3081](https://www.viva64.com/en/w/V3081/).
PVS-Studio is a static code analyzer for C, C++ and C#.

**Fixes:**

 - When comparing two statements through ExpressionEqualityComparer, the method GetHashCode was returning incorrect result for the expressions of the MemberInit with a list of arguments.
   We have written a unit test that proves that (See ExpressionCompareByHashCodeTest)
>    - [V3014](https://www.viva64.com/en/w/V3014/) It is likely that a wrong variable is being incremented inside the 'for' operator. Consider reviewing 'i'. EFCore ExpressionEqualityComparer.cs 214
>    - [V3015](https://www.viva64.com/en/w/V3015/) It is likely that a wrong variable is being compared inside the 'for' operator. Consider reviewing 'i' EFCore ExpressionEqualityComparer.cs 214
  
 - Also, we have corrected one of the unit tests, that was working incorrectly, to our mind.
>   - [V3081](https://www.viva64.com/en/w/V3081/) The 'j' counter is not used inside a nested loop. Consider inspecting usage of 'i' counter. EFCore.Specification.Tests ComplexNavigationsQueryTestBase.cs 2393