### PR TITLE
Flow property metadata more often during query binding.

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/FromSqlQueryTestBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(
-                    CoreStrings.ErrorMaterializingValueInvalidCast(typeof(string), typeof(int)),
+                    CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "ProductName", typeof(string), typeof(int)),
                     Assert.Throws<InvalidOperationException>(() =>
                         context.Set<Product>()
                             .FromSql(@"SELECT ""ProductID"", ""ProductName"" AS ""SupplierID"", ""SupplierID"" AS ""ProductName"", ""UnitPrice"", ""UnitsInStock"", ""Discontinued""
@@ -101,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 Assert.Equal(
-                    CoreStrings.ErrorMaterializingValueNullReference(typeof(bool)),
+                    CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
                     Assert.Throws<InvalidOperationException>(() =>
                         context.Set<Product>()
                             .FromSql(@"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", NULL AS ""Discontinued""

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -121,7 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             .CreateReadValueExpression(
                                 valueBufferParameter,
                                 discriminatorProperty.ClrType,
-                                discriminatorProperty.GetIndex())),
+                                discriminatorProperty.GetIndex(),
+                                discriminatorProperty)),
                     Expression.IfThenElse(
                         Expression.Equal(discriminatorValueVariable, firstDiscriminatorValue),
                         Expression.Return(returnLabelTarget, materializer),

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1690,7 +1690,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         Debug.Assert(projectionIndex > -1);
 
-                        return BindReadValueMethod(memberExpression.Type, expression, projectionIndex);
+                        return BindReadValueMethod(memberExpression.Type, expression, projectionIndex, property);
                     },
                 bindSubQueries: true);
         }
@@ -1717,7 +1717,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                                Debug.Assert(projectionIndex > -1);
 
-                               return BindReadValueMethod(methodCallExpression.Type, expression, projectionIndex);
+                               return BindReadValueMethod(methodCallExpression.Type, expression, projectionIndex, property);
                            },
                        bindSubQueries: true)
                    ?? ParentQueryModelVisitor?

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Expression valueBuffer,
                 Type type,
                 int index,
-                IProperty property = null)
+                IProperty property)
             => Expression.Call(
                 TryReadValueMethod.MakeGenericMethod(type),
                 valueBuffer,

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] Expression valueBuffer,
             [NotNull] Type type,
             int index,
-            [CanBeNull] IProperty property = null);
+            [CanBeNull] IProperty property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return BindMethodCallExpression(
                 methodCallExpression,
                 (property, querySource)
-                    => BindReadValueMethod(methodCallExpression.Type, expression, property.GetIndex()));
+                    => BindReadValueMethod(methodCallExpression.Type, expression, property.GetIndex(), property));
         }
 
         /// <summary>
@@ -1328,7 +1328,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 memberExpression,
                 null,
                 (property, querySource)
-                    => BindReadValueMethod(memberExpression.Type, expression, property.GetIndex()));
+                    => BindReadValueMethod(memberExpression.Type, expression, property.GetIndex(), property));
         }
 
         /// <summary>
@@ -1337,19 +1337,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="memberType"> Type of the member. </param>
         /// <param name="expression"> The target expression. </param>
         /// <param name="index"> A value buffer index. </param>
+        /// <param name="property">The property being bound.</param>
         /// <returns>
         ///     A value buffer read expression.
         /// </returns>
         public virtual Expression BindReadValueMethod(
             [NotNull] Type memberType,
             [NotNull] Expression expression,
-            int index)
+            int index,
+            [CanBeNull] IProperty property = null)
         {
             Check.NotNull(memberType, nameof(memberType));
             Check.NotNull(expression, nameof(expression));
 
             return _entityMaterializerSource
-                .CreateReadValueExpression(expression, memberType, index);
+                .CreateReadValueExpression(expression, memberType, index, property);
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
+++ b/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
@@ -15,12 +15,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbCommand.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="TestUtilities\FakeProvider\FakeDbConnection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This enables better error messages in more cases when we hit a bad data exception.