### PR TITLE
Query: Refactor SelectExpression for referential integrity

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -4,37 +4,42 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     public static class RelationalExpressionExtensions
     {
-        public static ColumnExpression TryGetColumnExpression([NotNull] this Expression expression)
-            => expression as ColumnExpression
-               ?? (expression as AliasExpression)?.TryGetColumnExpression()
-               ?? (expression as NullableExpression)?.Operand.TryGetColumnExpression();
-
-        public static bool IsAliasWithColumnExpression([NotNull] this Expression expression)
-            => (expression as AliasExpression)?.Expression is ColumnExpression;
-
-        public static bool IsAliasWithSelectExpression([NotNull] this Expression expression)
-            => (expression as AliasExpression)?.Expression is SelectExpression;
-
-        public static bool HasColumnExpression([CanBeNull] this AliasExpression aliasExpression)
-            => aliasExpression?.Expression is ColumnExpression;
-
-        public static ColumnExpression TryGetColumnExpression([NotNull] this AliasExpression aliasExpression)
-            => aliasExpression.Expression as ColumnExpression;
-
         public static bool IsSimpleExpression([NotNull] this Expression expression)
         {
+            Check.NotNull(expression, nameof(expression));
+
             var unwrappedExpression = expression.RemoveConvert();
 
             return unwrappedExpression is ConstantExpression
                    || unwrappedExpression is ColumnExpression
                    || unwrappedExpression is ParameterExpression
-                   || unwrappedExpression.IsAliasWithColumnExpression();
+                   || unwrappedExpression is ColumnReferenceExpression
+                   || unwrappedExpression is AliasExpression;
+        }
+
+        public static ColumnReferenceExpression LiftExpressionFromSubquery([NotNull] this Expression expression, [NotNull] TableExpressionBase table)
+        {
+            Check.NotNull(expression, nameof(expression));
+            Check.NotNull(table, nameof(table));
+
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    return new ColumnReferenceExpression(columnExpression, table);
+                case AliasExpression aliasExpression:
+                    return new ColumnReferenceExpression(aliasExpression, table);
+                case ColumnReferenceExpression columnReferenceExpression:
+                    return new ColumnReferenceExpression(columnReferenceExpression, table);
+            }
+
+            return null;
         }
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         .GetTypeInfo()
                         .GetDeclaredMethod(nameof(GroupJoinInclude.WithEntityAccessor));
 
-                var existingGroupJoinIncludeExpression 
+                var existingGroupJoinIncludeExpression
                     = existingGroupJoinIncludeWithAccessor != null
                           && existingGroupJoinIncludeWithAccessor.Method.Equals(withAccessorMethodInfo)
                     ? existingGroupJoinIncludeWithAccessor.Object
@@ -266,20 +266,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     var oldPredicate = selectExpression.Predicate;
 
-                    Dictionary<Type, int []> _;
                     var materializer
                         = _materializerFactory
                             .CreateMaterializer(
                                 targetEntityType,
                                 selectExpression,
                                 (p, se) => se.AddToProjection(
-                                               new AliasExpression(
-                                                   new ColumnExpression(
-                                                       _relationalAnnotationProvider.For(p).ColumnName,
-                                                       p,
-                                                       joinedTableExpression))) - valueBufferOffset,
+                                               _relationalAnnotationProvider.For(p).ColumnName,
+                                               p,
+                                               joinedTableExpression,
+                                               querySource) - valueBufferOffset,
                                 /*querySource:*/ null,
-                                out _);
+                                out var _);
 
                     if (selectExpression.Predicate != oldPredicate)
                     {
@@ -309,8 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     .CreateReferenceRelatedEntitiesLoaderMethod,
                                 Expression.Constant(valueBufferOffset),
                                 Expression.Constant(queryIndex),
-                                materializer
-                            ),
+                                materializer),
                             queryContextParameter));
                 }
                 else
@@ -335,9 +332,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     {
                         selectExpression
                             .AddToOrderBy(
-                                _relationalAnnotationProvider.For(property).ColumnName,
                                 property,
                                 principalTable,
+                                querySource,
                                 OrderingDirection.Asc);
                     }
 
@@ -352,18 +349,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     targetSelectExpression.AddTable(targetTableExpression);
 
-                    Dictionary<Type, int[]> _;
                     var materializer
                         = _materializerFactory
                             .CreateMaterializer(
                                 targetEntityType,
                                 targetSelectExpression,
                                 (p, se) => se.AddToProjection(
-                                    _relationalAnnotationProvider.For(p).ColumnName,
                                     p,
                                     querySource),
                                 /*querySource:*/ null,
-                                out _);
+                                out var _);
 
                     if (canGenerateExists)
                     {
@@ -396,28 +391,23 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                         foreach (var ordering in selectExpression.OrderBy)
                         {
-                            // ReSharper disable once PossibleNullReferenceException
                             var principalKeyProperty
-                                = ((ordering.Expression as AliasExpression)?.Expression as ColumnExpression).Property;
+                                = TryGetProperty(ordering.Expression);
 
                             var referencedForeignKeyProperty = pkPropertiesToFkPropertiesMap[principalKeyProperty];
 
                             targetSelectExpression
                                 .AddToOrderBy(
-                                    _relationalAnnotationProvider.For(referencedForeignKeyProperty).ColumnName,
                                     referencedForeignKeyProperty,
                                     targetTableExpression,
+                                    querySource,
                                     ordering.OrderingDirection);
                         }
                     }
                     else
                     {
                         var innerJoinSelectExpression
-                            = selectExpression.Clone(
-                                selectExpression.OrderBy
-                                    .Select(o => o.Expression)
-                                    .Last(o => o.IsAliasWithColumnExpression())
-                                    .TryGetColumnExpression().TableAlias);
+                            = selectExpression.Clone(principalTable.Alias);
 
                         innerJoinSelectExpression.ClearProjection();
 
@@ -490,61 +480,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             SelectExpression targetSelectExpression,
             TableExpressionBase innerJoinExpression)
         {
-            var needOrderingChanges
-                = innerJoinSelectExpression.OrderBy
-                    .Any(x => x.Expression is SelectExpression
-                              || x.Expression.IsAliasWithColumnExpression()
-                              || x.Expression.IsAliasWithSelectExpression());
-
             var orderings = innerJoinSelectExpression.OrderBy.ToList();
-            if (needOrderingChanges)
-            {
-                innerJoinSelectExpression.ClearOrderBy();
-            }
 
             foreach (var ordering in orderings)
             {
-                var orderingExpression = ordering.Expression;
-
-                var aliasExpression = ordering.Expression as AliasExpression;
-
-                if (aliasExpression?.Alias != null)
-                {
-                    var columnExpression = aliasExpression.TryGetColumnExpression();
-                    if (columnExpression != null)
-                    {
-                        orderingExpression
-                            = new ColumnExpression(
-                                aliasExpression.Alias,
-                                columnExpression.Property,
-                                columnExpression.Table);
-                    }
-                }
-
-                var index = orderingExpression is ColumnExpression || orderingExpression.IsAliasWithColumnExpression()
-                    ? innerJoinSelectExpression.AddToProjection(orderingExpression)
-                    : innerJoinSelectExpression.AddToProjection(
-                        new AliasExpression(
-                            innerJoinSelectExpression.Alias + "_" + innerJoinSelectExpression.Projection.Count,
-                            orderingExpression));
-
-                var expression = innerJoinSelectExpression.Projection[index];
-
-                if (needOrderingChanges)
-                {
-                    innerJoinSelectExpression.AddToOrderBy(new Ordering(expression.TryGetColumnExpression() ?? expression, ordering.OrderingDirection));
-                }
-
-                var projectedAliasExpression = expression as AliasExpression;
-                var newExpression = projectedAliasExpression?.Alias != null
-                    ? new ColumnExpression(projectedAliasExpression.Alias, projectedAliasExpression.Type, innerJoinExpression)
-                    : targetSelectExpression.UpdateColumnExpression(expression, innerJoinExpression);
-
-                targetSelectExpression.AddToOrderBy(new Ordering(newExpression, ordering.OrderingDirection));
+                targetSelectExpression.AddToOrderBy(
+                    new Ordering(
+                        innerJoinSelectExpression.Projection[innerJoinSelectExpression.AddToProjection(ordering.Expression)]
+                            .LiftExpressionFromSubquery(innerJoinExpression), ordering.OrderingDirection));
             }
 
-            if ((innerJoinSelectExpression.Limit == null)
-                && (innerJoinSelectExpression.Offset == null))
+            if (innerJoinSelectExpression.Limit == null
+                && innerJoinSelectExpression.Offset == null)
             {
                 innerJoinSelectExpression.ClearOrderBy();
             }
@@ -620,21 +567,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     tableExpression);
             }
 
-            var aliasExpressions
+            var candidates
                 = projections
-                    .OfType<AliasExpression>()
-                    .Where(p => p.TryGetColumnExpression()?.Property == property)
+                    .Where(p => TryGetProperty(p) == property)
                     .ToList();
 
-            var aliasExpression
-                = aliasExpressions.Count == 1
-                    ? aliasExpressions[0]
-                    : aliasExpressions.Last(ae => ae.TryGetColumnExpression().Table.QuerySource == querySource);
-
-            return new ColumnExpression(
-                aliasExpression.Alias ?? aliasExpression.TryGetColumnExpression().Name,
-                property,
-                tableExpression);
+            return candidates.Count == 1
+                ? candidates[0].LiftExpressionFromSubquery(tableExpression)
+                : candidates.Last(c => TryGetQuerySource(c) == querySource).LiftExpressionFromSubquery(tableExpression);
         }
 
         private static IEnumerable<Expression> ExtractProjections(TableExpressionBase tableExpression)
@@ -659,7 +599,37 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private static bool IsOrderingOnNonPrincipalKeyProperties(
                 IEnumerable<Ordering> orderings, IReadOnlyList<IProperty> properties)
             => orderings
-                .Select(ordering => ((ordering.Expression as AliasExpression)?.Expression as ColumnExpression)?.Property)
-                .Any(property => !properties.Contains(property));
+                .Select(ordering => TryGetProperty(ordering.Expression))
+                .Any(property => property == null || !properties.Contains(property));
+
+        private static IProperty TryGetProperty(Expression expression)
+        {
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    return columnExpression.Property;
+                case AliasExpression aliasExpression:
+                    return TryGetProperty(aliasExpression.Expression);
+                case ColumnReferenceExpression columnReferenceExpression:
+                    return TryGetProperty(columnReferenceExpression.Expression);
+            }
+
+            return null;
+        }
+
+        private IQuerySource TryGetQuerySource(Expression expression)
+        {
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    return columnExpression.Table.QuerySource;
+                case AliasExpression aliasExpression:
+                    return TryGetQuerySource(aliasExpression.Expression);
+                case ColumnReferenceExpression columnReferenceExpression:
+                    return columnReferenceExpression.Table.QuerySource;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -87,9 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var discriminatorProperty = _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorProperty;
 
             var discriminatorColumn
-                = selectExpression.Projection
-                    .OfType<AliasExpression>()
-                    .Last(c => c.TryGetColumnExpression()?.Property == discriminatorProperty);
+                = selectExpression.Projection.Last(c => (c as ColumnExpression)?.Property == discriminatorProperty);
 
             var firstDiscriminatorValue
                 = Expression.Constant(

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitorDependencies.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -45,35 +44,26 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        /// <param name="relationalAnnotationProvider"> The relational annotation provider. </param>
         /// <param name="compositeExpressionFragmentTranslator"> The composite expression fragment translator. </param>
         /// <param name="methodCallTranslator"> The method call translator. </param>
         /// <param name="memberTranslator"> The member translator. </param>
         /// <param name="relationalTypeMapper"> The relational type mapper. </param>
         public SqlTranslatingExpressionVisitorDependencies(
-            [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider,
             [NotNull] IExpressionFragmentTranslator compositeExpressionFragmentTranslator,
             [NotNull] IMethodCallTranslator methodCallTranslator,
             [NotNull] IMemberTranslator memberTranslator,
             [NotNull] IRelationalTypeMapper relationalTypeMapper)
         {
-            Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
             Check.NotNull(compositeExpressionFragmentTranslator, nameof(compositeExpressionFragmentTranslator));
             Check.NotNull(methodCallTranslator, nameof(methodCallTranslator));
             Check.NotNull(memberTranslator, nameof(memberTranslator));
             Check.NotNull(relationalTypeMapper, nameof(relationalTypeMapper));
 
-            RelationalAnnotationProvider = relationalAnnotationProvider;
             CompositeExpressionFragmentTranslator = compositeExpressionFragmentTranslator;
             MethodCallTranslator = methodCallTranslator;
             MemberTranslator = memberTranslator;
             RelationalTypeMapper = relationalTypeMapper;
         }
-
-        /// <summary>
-        ///     The relational annotation provider.
-        /// </summary>
-        public IRelationalAnnotationProvider RelationalAnnotationProvider { get; }
 
         /// <summary>
         ///     The composite expression fragment translator.
@@ -98,24 +88,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
-        /// <param name="relationalAnnotationProvider"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public SqlTranslatingExpressionVisitorDependencies With([NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
-            => new SqlTranslatingExpressionVisitorDependencies(
-                relationalAnnotationProvider,
-                CompositeExpressionFragmentTranslator,
-                MethodCallTranslator,
-                MemberTranslator,
-                RelationalTypeMapper);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
         /// <param name="compositeExpressionFragmentTranslator"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public SqlTranslatingExpressionVisitorDependencies With([NotNull] IExpressionFragmentTranslator compositeExpressionFragmentTranslator)
             => new SqlTranslatingExpressionVisitorDependencies(
-                RelationalAnnotationProvider,
                 compositeExpressionFragmentTranslator,
                 MethodCallTranslator,
                 MemberTranslator,
@@ -128,7 +104,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <returns> A new parameter object with the given service replaced. </returns>
         public SqlTranslatingExpressionVisitorDependencies With([NotNull] IMethodCallTranslator methodCallTranslator)
             => new SqlTranslatingExpressionVisitorDependencies(
-                RelationalAnnotationProvider,
                 CompositeExpressionFragmentTranslator,
                 methodCallTranslator,
                 MemberTranslator,
@@ -141,7 +116,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <returns> A new parameter object with the given service replaced. </returns>
         public SqlTranslatingExpressionVisitorDependencies With([NotNull] IMemberTranslator memberTranslator)
             => new SqlTranslatingExpressionVisitorDependencies(
-                RelationalAnnotationProvider,
                 CompositeExpressionFragmentTranslator,
                 MethodCallTranslator,
                 memberTranslator,
@@ -154,7 +128,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <returns> A new parameter object with the given service replaced. </returns>
         public SqlTranslatingExpressionVisitorDependencies With([NotNull] IRelationalTypeMapper relationalTypeMapper)
             => new SqlTranslatingExpressionVisitorDependencies(
-                RelationalAnnotationProvider,
                 CompositeExpressionFragmentTranslator,
                 MethodCallTranslator,
                 MemberTranslator,

--- a/src/EFCore.Relational/Query/Expressions/AliasExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/AliasExpression.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -17,30 +16,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     {
         private readonly Expression _expression;
 
-        private string _alias;
-
-        private Expression _sourceExpression;
-
-        /// <summary>
-        ///     Creates a new instance of an AliasExpression.
-        /// </summary>
-        /// <param name="expression"> The expression being aliased. </param>
-        public AliasExpression([NotNull] Expression expression)
-        {
-            Check.NotNull(expression, nameof(expression));
-
-            _expression = expression;
-        }
-
-        // TODO: Revisit the design here, "alias" should really be required.
+        private readonly string _alias;
 
         /// <summary>
         ///     Creates a new instance of an AliasExpression.
         /// </summary>
         /// <param name="alias"> The alias. </param>
         /// <param name="expression"> The expression being aliased. </param>
-        public AliasExpression([CanBeNull] string alias, [NotNull] Expression expression)
+        public AliasExpression([NotNull] string alias, [NotNull] Expression expression)
         {
+            Check.NotEmpty(alias, nameof(alias));
             Check.NotNull(expression, nameof(expression));
 
             _alias = alias;
@@ -48,38 +33,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Gets or sets the alias.
+        ///     Gets the alias.
         /// </summary>
         /// <value>
         ///     The alias.
         /// </value>
-        public virtual string Alias
-        {
-            get { return _alias; }
-            [param: NotNull]
-            // TODO: Remove mutability here
-            set
-            {
-                Check.NotNull(value, nameof(value));
-
-                _alias = value;
-            }
-        }
+        public virtual string Alias => _alias;
 
         /// <summary>
         ///     The expression being aliased.
         /// </summary>
         public virtual Expression Expression => _expression;
-
-        // TODO: Revisit why we need this. Try and remove
-
-        /// <summary>
-        ///     Gets or sets a value indicating whether the expression is being projected.
-        /// </summary>
-        /// <value>
-        ///     true if projected, false if not.
-        /// </value>
-        public virtual bool IsProjected { get; set; } = false;
 
         /// <summary>
         ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
@@ -92,32 +56,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <returns> The <see cref="Type" /> that represents the static type of the expression. </returns>
         public override Type Type => _expression.Type;
-
-        /// <summary>
-        ///     Gets or sets the source expression.
-        /// </summary>
-        /// <value>
-        ///     The source expression.
-        /// </value>
-        public virtual Expression SourceExpression
-        {
-            get { return _sourceExpression; }
-            [param: NotNull]
-            set
-            {
-                Check.NotNull(value, nameof(value));
-
-                _sourceExpression = value;
-            }
-        }
-
-        /// <summary>
-        ///     Gets or sets the source member.
-        /// </summary>
-        /// <value>
-        ///     The source member.
-        /// </value>
-        public virtual MemberInfo SourceMember { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Dispatches to the specific visit method for this node type.
@@ -156,13 +94,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
-        /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
-        public override string ToString()
-            => Alias != null ? "(" + _expression + ") AS " + Alias : _expression.ToString();
-
-        /// <summary>
         ///     Tests if this object is considered equal to another.
         /// </summary>
         /// <param name="obj"> The object to compare with the current object. </param>
@@ -186,8 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         private bool Equals(AliasExpression other)
-            => Equals(_expression, other._expression)
-               && string.Equals(_alias, other._alias);
+            => string.Equals(_alias, other._alias)
+               && Equals(_expression, other._expression);
 
         /// <summary>
         ///     Returns a hash code for this object.
@@ -199,9 +130,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             unchecked
             {
-                // ReSharper disable once NonReadonlyMemberInGetHashCode
-                return (_expression.GetHashCode() * 397) ^ (_alias?.GetHashCode() ?? 0);
+                return (_expression.GetHashCode() * 397) ^ _alias.GetHashCode();
             }
         }
+
+        /// <summary>
+        ///     Creates a <see cref="String" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        public override string ToString()
+            => Alias != null ? "(" + _expression + ") AS " + Alias : _expression.ToString();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/ColumnReferenceExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnReferenceExpression.cs
@@ -4,37 +4,68 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
 {
     /// <summary>
-    ///     A column expression.
+    ///     A column reference expression.
     /// </summary>
-    public class ColumnExpression : Expression
+    public class ColumnReferenceExpression : Expression
     {
-        private readonly IProperty _property;
+        private readonly Expression _expression;
         private readonly TableExpressionBase _tableExpression;
 
         /// <summary>
-        ///     Creates a new instance of a ColumnExpression.
+        ///     Creates a new instance of a ColumnReferenceExpression.
         /// </summary>
-        /// <param name="name"> The column name. </param>
-        /// <param name="property"> The corresponding property. </param>
+        /// <param name="aliasExpression"> The referenced AliasExpression. </param>
         /// <param name="tableExpression"> The target table expression. </param>
-        public ColumnExpression(
-            [NotNull] string name,
-            [NotNull] IProperty property,
+        public ColumnReferenceExpression(
+            [NotNull] AliasExpression aliasExpression,
             [NotNull] TableExpressionBase tableExpression)
+            : this(
+                  Check.NotNull(aliasExpression, nameof(aliasExpression)).Alias,
+                  aliasExpression,
+                  Check.NotNull(tableExpression, nameof(tableExpression)))
         {
-            Check.NotEmpty(name, nameof(name));
-            Check.NotNull(property, nameof(property));
-            Check.NotNull(tableExpression, nameof(tableExpression));
+        }
 
+        /// <summary>
+        ///     Creates a new instance of a ColumnReferenceExpression.
+        /// </summary>
+        /// <param name="columnExpression"> The referenced ColumnExpression. </param>
+        /// <param name="tableExpression"> The target table expression. </param>
+        public ColumnReferenceExpression(
+            [NotNull] ColumnExpression columnExpression,
+            [NotNull] TableExpressionBase tableExpression)
+            : this(
+                  Check.NotNull(columnExpression, nameof(columnExpression)).Name,
+                  columnExpression,
+                  Check.NotNull(tableExpression, nameof(tableExpression)))
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of a ColumnReferenceExpression.
+        /// </summary>
+        /// <param name="columnReferenceExpression"> The referenced ColumnReferenceExpression. </param>
+        /// <param name="tableExpression"> The target table expression. </param>
+        public ColumnReferenceExpression(
+            [NotNull] ColumnReferenceExpression columnReferenceExpression,
+            [NotNull] TableExpressionBase tableExpression)
+            : this(
+                  Check.NotNull(columnReferenceExpression, nameof(columnReferenceExpression)).Name,
+                  columnReferenceExpression,
+                  Check.NotNull(tableExpression, nameof(tableExpression)))
+        {
+        }
+
+        private ColumnReferenceExpression(string name, Expression expression, TableExpressionBase tableExpression)
+        {
             Name = name;
-            _property = property;
+            _expression = expression;
             _tableExpression = tableExpression;
         }
 
@@ -43,13 +74,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         public virtual TableExpressionBase Table => _tableExpression;
 
-#pragma warning disable 108
-
         /// <summary>
-        ///     The corresponding property.
+        ///     The referenced expression.
         /// </summary>
-        public virtual IProperty Property => _property;
-#pragma warning restore 108
+        public virtual Expression Expression => _expression;
 
         /// <summary>
         ///     Gets the column name.
@@ -60,16 +88,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public virtual string Name { get; }
 
         /// <summary>
+        ///     Gets the static type of the expression that this <see cref="Expression" /> represents. (Inherited from <see cref="Expression" />.)
+        /// </summary>
+        /// <returns> The <see cref="Type" /> that represents the static type of the expression. </returns>
+        public override Type Type => _expression.Type;
+
+        /// <summary>
         ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
         /// </summary>
         /// <returns> The <see cref="ExpressionType" /> that represents this expression. </returns>
         public override ExpressionType NodeType => ExpressionType.Extension;
-
-        /// <summary>
-        ///     Gets the static type of the expression that this <see cref="Expression" /> represents. (Inherited from <see cref="Expression" />.)
-        /// </summary>
-        /// <returns> The <see cref="Type" /> that represents the static type of the expression. </returns>
-        public override Type Type => _property.ClrType;
 
         /// <summary>
         ///     Dispatches to the specific visit method for this node type.
@@ -81,12 +109,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             var specificVisitor = visitor as ISqlExpressionVisitor;
 
             return specificVisitor != null
-                ? specificVisitor.VisitColumn(this)
+                ? specificVisitor.VisitColumnReference(this)
                 : base.Accept(visitor);
         }
 
         /// <summary>
-        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(Expression)" /> method passing the
+        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(System.Linq.Expressions.Expression)" /> method passing the
         ///     reduced expression.
         ///     Throws an exception if the node isn't reducible.
         /// </summary>
@@ -119,15 +147,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 return true;
             }
 
-            return obj.GetType() == GetType()
-                   && Equals((ColumnExpression)obj);
+            return obj.GetType() == GetType() && Equals((ColumnReferenceExpression)obj);
         }
 
-        private bool Equals([NotNull] ColumnExpression other)
-            // Compare on names only because multiple properties can map to same column in inheritance scenario
-            => string.Equals(Name, other.Name)
-               && Type == other.Type
-               && Equals(Table, other.Table);
+        private bool Equals([NotNull] ColumnReferenceExpression other)
+            => Equals(_expression, other._expression)
+               && Equals(_tableExpression, other._tableExpression);
 
         /// <summary>
         ///     Returns a hash code for this object.
@@ -139,9 +164,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             unchecked
             {
-                var hashCode = Type.GetHashCode();
+                var hashCode = _expression.GetHashCode();
                 hashCode = (hashCode * 397) ^ _tableExpression.GetHashCode();
-                hashCode = (hashCode * 397) ^ Name.GetHashCode();
 
                 return hashCode;
             }

--- a/src/EFCore.Relational/Query/Expressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/CrossJoinExpression.cs
@@ -37,6 +37,49 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((CrossJoinExpression)obj);
+        }
+
+        private bool Equals(CrossJoinExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/CrossJoinLateralExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/CrossJoinLateralExpression.cs
@@ -37,6 +37,49 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((CrossJoinLateralExpression)obj);
+        }
+
+        private bool Equals(CrossJoinLateralExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
@@ -66,12 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public override Expression Reduce() => _predicate;
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
-        /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
-        public override string ToString() => _predicate.ToString();
-
-        /// <summary>
         ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(System.Linq.Expressions.Expression)" /> method passing the
         ///     reduced expression.
         ///     Throws an exception if the node isn't reducible.
@@ -92,5 +86,52 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 ? new DiscriminatorPredicateExpression(newPredicate, QuerySource)
                 : this;
         }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((DiscriminatorPredicateExpression)obj);
+        }
+
+        private bool Equals(DiscriminatorPredicateExpression other)
+        {
+            return Equals(_predicate, other._predicate) && Equals(QuerySource, other.QuerySource);
+        }
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (_predicate.GetHashCode() * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+            }
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="String" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        public override string ToString() => _predicate.ToString();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ExistsExpression.cs
@@ -17,12 +17,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// <summary>
         ///     Creates a new instance of a ExistsExpression..
         /// </summary>
-        /// <param name="expression"> The subquery operand of the EXISTS expression. </param>
-        public ExistsExpression([NotNull] Expression expression)
+        /// <param name="subquery"> The subquery operand of the EXISTS expression. </param>
+        public ExistsExpression([NotNull] SelectExpression subquery)
         {
-            Check.NotNull(expression, nameof(expression));
+            Check.NotNull(subquery, nameof(subquery));
 
-            Expression = expression;
+            Subquery = subquery;
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// <value>
         ///     The subquery operand of the EXISTS expression.
         /// </value>
-        public virtual Expression Expression { get; }
+        public virtual SelectExpression Subquery { get; }
 
         /// <summary>
         ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
@@ -74,11 +74,43 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </remarks>
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            var expression = visitor.Visit(Expression);
+            var subquery = (SelectExpression)visitor.Visit(Subquery);
 
-            return expression != Expression
-                ? new ExistsExpression(expression)
+            return subquery != Subquery
+                ? new ExistsExpression(subquery)
                 : this;
         }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((ExistsExpression)obj);
+        }
+
+        private bool Equals(ExistsExpression other) => Equals(Subquery, other.Subquery);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode() => Subquery.GetHashCode();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
@@ -87,6 +87,44 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((ExplicitCastExpression)obj);
+        }
+
+        private bool Equals(ExplicitCastExpression other) => _type == other._type && Equals(Operand, other.Operand);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (_type.GetHashCode() * 397) ^ Operand.GetHashCode();
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="String" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="String" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/FromSqlExpression.cs
@@ -68,6 +68,53 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((FromSqlExpression)obj);
+        }
+
+        private bool Equals(FromSqlExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource)
+               && string.Equals(Sql, other.Sql)
+               && Equals(Arguments, other.Arguments);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Sql.GetHashCode();
+                hashCode = (hashCode * 397) ^ Arguments.GetHashCode();
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/InnerJoinExpression.cs
@@ -37,6 +37,51 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((InnerJoinExpression)obj);
+        }
+
+        private bool Equals(InnerJoinExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource)
+               && Equals(Predicate, other.Predicate);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (Predicate?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
@@ -79,6 +79,38 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((IsNullExpression)obj);
+        }
+
+        private bool Equals(IsNullExpression other) => Equals(_operand, other._operand);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode() => _operand.GetHashCode();
+
+        /// <summary>
         ///     Creates a <see cref="String" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="String" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/LeftOuterJoinExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/LeftOuterJoinExpression.cs
@@ -1,14 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Remotion.Linq.Clauses;
-using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
 {
@@ -38,6 +34,51 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return specificVisitor != null
                 ? specificVisitor.VisitLeftOuterJoin(this)
                 : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((LeftOuterJoinExpression)obj);
+        }
+
+        private bool Equals(LeftOuterJoinExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource)
+               && Equals(Predicate, other.Predicate);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (Predicate?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
@@ -114,11 +114,56 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             var newPatternExpression = visitor.Visit(Pattern);
             var newEscapeCharExpression = EscapeChar == null ? null : visitor.Visit(EscapeChar);
 
-            return (newMatchExpression != Match)
-                   || (newPatternExpression != Pattern)
-                   || (newEscapeCharExpression != EscapeChar)
+            return newMatchExpression != Match
+                   || newPatternExpression != Pattern
+                   || newEscapeCharExpression != EscapeChar
                 ? new LikeExpression(newMatchExpression, newPatternExpression, newEscapeCharExpression)
                 : this;
+        }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((LikeExpression)obj);
+        }
+
+        private bool Equals(LikeExpression other)
+            => Equals(Match, other.Match)
+               && Equals(Pattern, other.Pattern)
+               && Equals(EscapeChar, other.EscapeChar);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Match.GetHashCode();
+                hashCode = (hashCode * 397) ^ Pattern.GetHashCode();
+                hashCode = (hashCode * 397) ^ (EscapeChar?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Expressions/NotNullableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NotNullableExpression.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             Check.NotNull(operand, nameof(operand));
 
             _operand = operand;
-            Type = _operand.Type?.UnwrapNullableType();
+            Type = _operand.Type.UnwrapNullableType();
         }
 
         /// <summary>
@@ -70,5 +70,37 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce() => _operand;
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((NotNullableExpression)obj);
+        }
+
+        private bool Equals([NotNull] NotNullableExpression other) => Equals(_operand, other._operand);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode() => _operand.GetHashCode();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             Check.NotNull(operand, nameof(operand));
 
             _operand = operand;
-            Type = _operand.Type?.MakeNullable();
+            Type = _operand.Type.MakeNullable();
         }
 
         /// <summary>
@@ -70,5 +70,37 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         /// <returns>The reduced expression.</returns>
         public override Expression Reduce() => _operand;
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((NullableExpression)obj);
+        }
+
+        private bool Equals([NotNull] NullableExpression other) => Equals(_operand, other._operand);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode() => _operand.GetHashCode();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/PropertyParameterExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/PropertyParameterExpression.cs
@@ -99,5 +99,44 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 ? specificVisitor.VisitPropertyParameter(this)
                 : base.Accept(visitor);
         }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((PropertyParameterExpression)obj);
+        }
+
+        private bool Equals(PropertyParameterExpression other)
+            => string.Equals(Name, other.Name) && Equals(Property, other.Property);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Name.GetHashCode() * 397) ^ Property.GetHashCode();
+            }
+        }
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SelectExpressionDependencies.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpressionDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -40,11 +41,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     </para>
         /// </summary>
         /// <param name="querySqlGeneratorFactory"> The query SQL generator factory. </param>
-        public SelectExpressionDependencies([NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory)
+        /// <param name="relationalAnnotationProvider"></param>
+        public SelectExpressionDependencies([NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory,
+            [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
         {
             Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory));
+            Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
 
             QuerySqlGeneratorFactory = querySqlGeneratorFactory;
+            RelationalAnnotationProvider = relationalAnnotationProvider;
         }
 
         /// <summary>
@@ -53,11 +58,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public IQuerySqlGeneratorFactory QuerySqlGeneratorFactory { get; }
 
         /// <summary>
+        ///     The relational annotation provider.
+        /// </summary>
+        public IRelationalAnnotationProvider RelationalAnnotationProvider { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="querySqlGeneratorFactory"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public SelectExpressionDependencies With([NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory)
-            => new SelectExpressionDependencies(Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory)));
+            => new SelectExpressionDependencies(Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory)), RelationalAnnotationProvider);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="relationalAnnotationProvider"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public SelectExpressionDependencies With([NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
+            => new SelectExpressionDependencies(QuerySqlGeneratorFactory, Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider)));
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFragmentExpression.cs
@@ -70,5 +70,37 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     itself with the modified children.
         /// </remarks>
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((SqlFragmentExpression)obj);
+        }
+
+        private bool Equals(SqlFragmentExpression other) => string.Equals(Sql, other.Sql);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode() => Sql.GetHashCode();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
@@ -110,5 +110,49 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 ? new SqlFunctionExpression(FunctionName, Type, newArguments)
                 : this;
         }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((SqlFunctionExpression)obj);
+        }
+
+        private bool Equals(SqlFunctionExpression other)
+            => Type == other.Type
+               && string.Equals(FunctionName, other.FunctionName)
+               && _arguments.SequenceEqual(other._arguments);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = _arguments.Aggregate(0, (current, argument) => current + ((current * 397) ^ argument.GetHashCode()));
+                hashCode = (hashCode * 397) ^ FunctionName.GetHashCode();
+                hashCode = (hashCode * 397) ^ Type.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/StringCompareExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/StringCompareExpression.cs
@@ -95,9 +95,53 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             var newLeft = visitor.Visit(Left);
             var newRight = visitor.Visit(Right);
 
-            return (newLeft != Left) || (newRight != Right)
+            return newLeft != Left || newRight != Right
                 ? new StringCompareExpression(Operator, newLeft, newRight)
                 : this;
+        }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((StringCompareExpression)obj);
+        }
+
+        private bool Equals(StringCompareExpression other)
+            => Operator == other.Operator
+               && Equals(Left, other.Left)
+               && Equals(Right, other.Right);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)Operator;
+                hashCode = (hashCode * 397) ^ Left.GetHashCode();
+                hashCode = (hashCode * 397) ^ Right.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/TableExpression.cs
@@ -67,6 +67,53 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((TableExpression)obj);
+        }
+
+        private bool Equals(TableExpression other)
+            => string.Equals(Table, other.Table)
+               && string.Equals(Schema, other.Schema)
+               && string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Table.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Schema?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
         ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
         /// <returns>A <see cref="string" /> representation of the Expression.</returns>

--- a/src/EFCore.Relational/Query/Expressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Expressions/TableExpressionBase.cs
@@ -2,13 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Clauses.ResultOperators;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         private IReadOnlyDictionary<string, object> _parametersValues;
         private ParameterNameGenerator _parameterNameGenerator;
         private RelationalTypeMapping _typeMapping;
+        private NullComparisonTransformingVisitor _nullComparisonTransformingVisitor;
         private RelationalNullsExpandingVisitor _relationalNullsExpandingVisitor;
         private PredicateReductionExpressionOptimizer _predicateReductionExpressionOptimizer;
         private PredicateNegationExpressionOptimizer _predicateNegationExpressionOptimizer;
@@ -123,6 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _parameterNameGenerator = Dependencies.ParameterNameGeneratorFactory.Create();
 
             _parametersValues = parameterValues;
+            _nullComparisonTransformingVisitor = new NullComparisonTransformingVisitor(parameterValues);
             IsCacheable = true;
 
             Visit(SelectExpression);
@@ -262,9 +264,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
         private Expression ApplyOptimizations(Expression expression, bool searchCondition, bool joinCondition = false)
         {
-            var newExpression
-                = new NullComparisonTransformingVisitor(_parametersValues)
-                    .Visit(expression);
+            var newExpression = _nullComparisonTransformingVisitor.Visit(expression);
 
             if (_relationalNullsExpandingVisitor == null)
             {
@@ -365,27 +365,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             Check.NotNull(ordering, nameof(ordering));
 
             var orderingExpression = ordering.Expression;
-            var aliasExpression = orderingExpression as AliasExpression;
 
-            if (aliasExpression != null)
+            if (orderingExpression is AliasExpression aliasExpression)
             {
-                if (aliasExpression.Alias != null)
-                {
-                    var columnExpression = aliasExpression.TryGetColumnExpression();
-
-                    if (columnExpression != null)
-                    {
-                        _relationalCommandBuilder
-                            .Append(SqlGenerator.DelimitIdentifier(columnExpression.TableAlias))
-                            .Append(".");
-                    }
-
-                    _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(aliasExpression.Alias));
-                }
-                else
-                {
-                    Visit(aliasExpression.Expression);
-                }
+                _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(aliasExpression.Alias));
             }
             else if (orderingExpression is ConstantExpression
                      || orderingExpression is ParameterExpression)
@@ -471,8 +454,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 {
                     var parameterExpression = (ParameterExpression)arguments;
 
-                    object parameterValue;
-                    if (parameters.TryGetValue(parameterExpression.Name, out parameterValue))
+                    if (parameters.TryGetValue(parameterExpression.Name, out object parameterValue))
                     {
                         var argumentValues = (object[])parameterValue;
 
@@ -791,20 +773,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             foreach (var inValue in inExpressionValues)
             {
-                var inConstant = inValue as ConstantExpression;
-
-                if (inConstant != null)
+                if (inValue is ConstantExpression inConstant)
                 {
                     AddInExpressionValues(inConstant.Value, inConstants, inConstant);
                 }
                 else
                 {
-                    var inParameter = inValue as ParameterExpression;
-
-                    if (inParameter != null)
+                    if (inValue is ParameterExpression inParameter)
                     {
-                        object parameterValue;
-                        if (_parametersValues.TryGetValue(inParameter.Name, out parameterValue))
+                        if (_parametersValues.TryGetValue(inParameter.Name, out object parameterValue))
                         {
                             AddInExpressionValues(parameterValue, inConstants, inParameter);
 
@@ -813,18 +790,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     }
                     else
                     {
-                        var inListInit = inValue as ListInitExpression;
-
-                        if (inListInit != null)
+                        if (inValue is ListInitExpression inListInit)
                         {
                             inConstants.AddRange(ProcessInExpressionValues(
                                 inListInit.Initializers.SelectMany(i => i.Arguments)));
                         }
                         else
                         {
-                            var newArray = inValue as NewArrayExpression;
-
-                            if (newArray != null)
+                            if (inValue is NewArrayExpression newArray)
                             {
                                 inConstants.AddRange(ProcessInExpressionValues(newArray.Expressions));
                             }
@@ -839,10 +812,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         private static void AddInExpressionValues(
             object value, List<Expression> inConstants, Expression expression)
         {
-            var valuesEnumerable = value as IEnumerable;
-
-            if (valuesEnumerable != null
-                && value.GetType() != typeof(string)
+            if (value is IEnumerable valuesEnumerable && value.GetType() != typeof(string)
                 && value.GetType() != typeof(byte[]))
             {
                 inConstants.AddRange(valuesEnumerable.Cast<object>().Select(Expression.Constant));
@@ -876,13 +846,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     continue;
                 }
 
-                var inParameter = inValue as ParameterExpression;
-
-                if (inParameter != null)
+                if (inValue is ParameterExpression inParameter)
                 {
-                    object parameterValue;
-
-                    if (_parametersValues.TryGetValue(inParameter.Name, out parameterValue))
+                    if (_parametersValues.TryGetValue(inParameter.Name, out object parameterValue))
                     {
                         if (parameterValue != null)
                         {
@@ -1008,10 +974,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 _relationalCommandBuilder.AppendLine();
                 _relationalCommandBuilder.Append("THEN ");
 
-                var constantIfTrue = conditionalExpression.IfTrue as ConstantExpression;
-
-                if (constantIfTrue != null
-                    && constantIfTrue.Type == typeof(bool))
+                if (conditionalExpression.IfTrue is ConstantExpression constantIfTrue && constantIfTrue.Type == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfTrue.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }
@@ -1022,10 +985,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 _relationalCommandBuilder.Append(" ELSE ");
 
-                var constantIfFalse = conditionalExpression.IfFalse as ConstantExpression;
-
-                if (constantIfFalse != null
-                    && constantIfFalse.Type == typeof(bool))
+                if (conditionalExpression.IfFalse is ConstantExpression constantIfFalse && constantIfFalse.Type == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfFalse.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }
@@ -1057,7 +1017,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             using (_relationalCommandBuilder.Indent())
             {
-                Visit(existsExpression.Expression);
+                Visit(existsExpression.Subquery);
             }
 
             _relationalCommandBuilder.Append(")");
@@ -1097,11 +1057,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     {
                         _typeMapping
                             = InferTypeMappingFromColumn(binaryExpression.Left)
-                              ?? InferTypeMappingFromColumn(binaryExpression.Right)
-                              ?? parentTypeMapping;
+                                ?? InferTypeMappingFromColumn(binaryExpression.Right)
+                                ?? parentTypeMapping;
                     }
 
-                    var needParens = binaryExpression.Left.RemoveConvert() is BinaryExpression;
+                    var needParens = binaryExpression.Left.RemoveConvert() is BinaryExpression leftBinaryExpression
+                                     && leftBinaryExpression.NodeType != ExpressionType.Coalesce;
 
                     if (needParens)
                     {
@@ -1117,7 +1078,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                     _relationalCommandBuilder.Append(GenerateOperator(binaryExpression));
 
-                    needParens = binaryExpression.Right.RemoveConvert() is BinaryExpression;
+                    needParens = binaryExpression.Right.RemoveConvert() is BinaryExpression rightBinaryExpression
+                                 && rightBinaryExpression.NodeType != ExpressionType.Coalesce;
 
                     if (needParens)
                     {
@@ -1151,11 +1113,29 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             Check.NotNull(columnExpression, nameof(columnExpression));
 
-            _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(columnExpression.TableAlias))
+            _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(columnExpression.Table.Alias))
                 .Append(".")
                 .Append(SqlGenerator.DelimitIdentifier(columnExpression.Name));
 
             return columnExpression;
+        }
+
+        /// <summary>
+        ///     Visits a ColumnReferenceExpression.
+        /// </summary>
+        /// <param name="columnReferenceExpression"> The column reference expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public virtual Expression VisitColumnReference(ColumnReferenceExpression columnReferenceExpression)
+        {
+            Check.NotNull(columnReferenceExpression, nameof(columnReferenceExpression));
+
+            _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(columnReferenceExpression.Table.Alias))
+                .Append(".")
+                .Append(SqlGenerator.DelimitIdentifier(columnReferenceExpression.Name));
+
+            return columnReferenceExpression;
         }
 
         /// <summary>
@@ -1169,14 +1149,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             Check.NotNull(aliasExpression, nameof(aliasExpression));
 
-            if (!aliasExpression.IsProjected)
-            {
-                Visit(aliasExpression.Expression);
+            Visit(aliasExpression.Expression);
 
-                if (aliasExpression.Alias != null)
-                {
-                    _relationalCommandBuilder.Append(" AS ");
-                }
+            if (aliasExpression.Alias != null)
+            {
+                _relationalCommandBuilder.Append(" AS ");
             }
 
             if (aliasExpression.Alias != null)
@@ -1337,16 +1314,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             {
                 case ExpressionType.Not:
                 {
-                    var inExpression = expression.Operand as InExpression;
-
-                    if (inExpression != null)
+                    if (expression.Operand is InExpression inExpression)
                     {
                         return GenerateNotIn(inExpression);
                     }
 
-                    var isNullExpression = expression.Operand as IsNullExpression;
-
-                    if (isNullExpression != null)
+                    if (expression.Operand is IsNullExpression isNullExpression)
                     {
                         return GenerateIsNotNull(isNullExpression);
                     }
@@ -1470,10 +1443,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// </returns>
         protected virtual RelationalTypeMapping InferTypeMappingFromColumn([NotNull] Expression expression)
         {
-            var column = expression.TryGetColumnExpression();
-            return column?.Property != null
-                ? Dependencies.RelationalTypeMapper.FindMapping(column.Property)
-                : null;
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    return Dependencies.RelationalTypeMapper.FindMapping(columnExpression.Property);
+                case ColumnReferenceExpression columnReferenceExpression:
+                    return InferTypeMappingFromColumn(columnReferenceExpression.Expression);
+                case AliasExpression aliasExpression:
+                    return InferTypeMappingFromColumn(aliasExpression.Expression);
+                default:
+                    return null;
+            }
         }
 
         /// <summary>
@@ -1509,8 +1489,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             {
                 case ExpressionType.Extension:
                 {
-                    var asStringCompareExpression = expression as StringCompareExpression;
-                    if (asStringCompareExpression != null)
+                    if (expression is StringCompareExpression asStringCompareExpression)
                     {
                         return GenerateBinaryOperator(asStringCompareExpression.Operator);
                     }
@@ -1565,34 +1544,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     var leftExpression = expression.Left.RemoveConvert();
                     var rightExpression = expression.Right.RemoveConvert();
 
-                    var parameter
-                        = rightExpression as ParameterExpression
-                          ?? leftExpression as ParameterExpression;
+                    var parameterExpression = leftExpression as ParameterExpression
+                                              ?? rightExpression as ParameterExpression;
 
-                    object parameterValue;
-                    if (parameter != null
-                        && _parameterValues.TryGetValue(parameter.Name, out parameterValue))
+                    if (parameterExpression != null
+                        && _parameterValues.TryGetValue(parameterExpression.Name, out object parameterValue))
                     {
-                        if (parameterValue == null)
-                        {
-                            var columnExpression
-                                = leftExpression.TryGetColumnExpression()
-                                  ?? rightExpression.TryGetColumnExpression();
+                        var nonParameterExpression = leftExpression is ParameterExpression ? rightExpression : leftExpression;
 
-                            if (columnExpression != null)
-                            {
-                                return
-                                    expression.NodeType == ExpressionType.Equal
-                                        ? (Expression)new IsNullExpression(columnExpression)
-                                        : Expression.Not(new IsNullExpression(columnExpression));
-                            }
-                        }
-
-                        var constantExpression
-                            = leftExpression as ConstantExpression
-                              ?? rightExpression as ConstantExpression;
-
-                        if (constantExpression != null)
+                        if (nonParameterExpression is ConstantExpression constantExpression)
                         {
                             if (parameterValue == null
                                 && constantExpression.Value == null)
@@ -1611,6 +1571,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                                         ? Expression.Constant(false)
                                         : Expression.Constant(true);
                             }
+                        }
+
+                        if (parameterValue == null)
+                        {
+                            return
+                                expression.NodeType == ExpressionType.Equal
+                                    ? (Expression)new IsNullExpression(nonParameterExpression)
+                                    : Expression.Not(new IsNullExpression(nonParameterExpression));
                         }
                     }
                 }
@@ -1644,10 +1612,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 // Top-level check for condition/value
                 if (_isSearchCondition && !IsSearchCondition(newExpression))
                 {
-                    var constantExpression = newExpression as ConstantExpression;
-
-                    if (constantExpression != null
-                        && (bool)constantExpression.Value)
+                    if (newExpression is ConstantExpression constantExpression && (bool)constantExpression.Value)
                     {
                         // Absorb top level True node
                         return null;

--- a/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -173,5 +173,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         ///     An Expression.
         /// </returns>
         Expression VisitSqlFragment([NotNull] SqlFragmentExpression sqlFragmentExpression);
+
+        /// <summary>
+        ///     Visit a ColumnReferenceExpression.
+        /// </summary>
+        /// <param name="columnReferenceExpression"> The ColumnReferenceExpression expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        Expression VisitColumnReference([NotNull] ColumnReferenceExpression columnReferenceExpression);
     }
 }

--- a/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
@@ -72,13 +72,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
             for (var i = 0; i < SelectExpression.Projection.Count; i++)
             {
-                var aliasExpression = SelectExpression.Projection[i] as AliasExpression;
-
-                if (aliasExpression != null)
+                if (SelectExpression.Projection[i] is ColumnExpression columnExpression)
                 {
-                    var columnName
-                        = aliasExpression.Alias
-                          ?? aliasExpression.TryGetColumnExpression()?.Name;
+                    var columnName = columnExpression.Name;
 
                     if (columnName != null)
                     {

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -6113,7 +6113,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(5));
         }
 
-        [ConditionalFact(Skip = "The order by inside subquery needs to be aliased to be copied outside. Invalid query generated otherwise.")]
+        [ConditionalFact]
         public virtual void Select_take_skip_null_coalesce_operator()
         {
             AssertQuery<Customer>(
@@ -7217,6 +7217,65 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             join o in os on c.CustomerID equals o.CustomerID into lo
                             from o in lo.Where(x => x.OrderID > 5).OrderBy(x => x.OrderDate).DefaultIfEmpty()
                             select new { c.ContactName, o });
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_member_distinct_where()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID }).Distinct().Where(n => n.CustomerID == "ALFKI"));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_member_distinct_orderby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID }).Distinct().OrderBy(n => n.CustomerID));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_member_distinct_result()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID }).Distinct().Count(n => n.CustomerID.StartsWith("A")));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_complex_distinct_where()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { A = c.CustomerID + c.City }).Distinct().Where(n => n.A == "ALFKIBerlin"));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_complex_distinct_orderby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { A = c.CustomerID + c.City }).Distinct().OrderBy(n => n.A));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_complex_distinct_result()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { A = c.CustomerID + c.City }).Distinct().Count(n => n.A.StartsWith("A")));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_complex_orderby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { A = c.CustomerID + c.City }).OrderBy(n => n.A));
+        }
+
+        [ConditionalFact]
+        public virtual void Anonymous_subquery_orderby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.Orders.Count > 1).Select(c => new
+                {
+                    A = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate
+                }).OrderBy(n => n.A));
         }
 
         private static IEnumerable<TElement> ClientDefaultIfEmpty<TElement>(IEnumerable<TElement> source)

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
@@ -541,7 +541,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             {
                 var dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory") as string;
                 if (string.IsNullOrEmpty(dataDirectory))
+                {
                     dataDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                }
+
                 fileName = Path.Combine(dataDirectory, fileName.Substring("|DataDirectory|".Length));
             }
 #elif NETSTANDARD1_3

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -50,11 +50,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
         /// </summary>
         protected override void GenerateLimitOffset(SelectExpression selectExpression)
         {
-            if (selectExpression.Projection.OfType<RowNumberExpression>().Any())
-            {
-                return;
-            }
-
             if (selectExpression.Offset != null
                 && !selectExpression.OrderBy.Any())
             {
@@ -74,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
             Sql.Append("ROW_NUMBER() OVER(");
             GenerateOrderBy(rowNumberExpression.Orderings);
-            Sql.Append(") AS ").Append(SqlGenerator.DelimitIdentifier(rowNumberExpression.ColumnExpression.Name));
+            Sql.Append(")");
 
             return rowNumberExpression;
         }
@@ -103,9 +98,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
             return base.VisitSqlFunction(sqlFunctionExpression);
         }
 
-        protected override void GenerateProjection([NotNull] Expression projection)
+        protected override void GenerateProjection(Expression projection)
         {
-            var newProjection = (projection as AliasExpression)?.Expression?.NodeType == ExpressionType.Coalesce
+            var newProjection = (projection as BinaryExpression)?.NodeType == ExpressionType.Coalesce
                 && projection.Type.UnwrapNullableType() == typeof(bool)
                     ? new ExplicitCastExpression(projection, projection.Type)
                     : projection;

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -253,14 +253,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
                     case ExpressionType.Extension:
                     {
-                        var nullConditionalExpression = obj as NullConditionalExpression;
-
-                        if (nullConditionalExpression == null)
-                        {
-                            goto default;
-                        }
-
-                        hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalExpression.AccessOperation);
+                        hashCode += (hashCode * 397) ^ obj.GetHashCode();
 
                         break;
                     }
@@ -380,6 +373,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         return CompareMemberInit((MemberInitExpression)a, (MemberInitExpression)b);
                     case ExpressionType.ListInit:
                         return CompareListInit((ListInitExpression)a, (ListInitExpression)b);
+                    case ExpressionType.Extension:
+                        return CompareExtension(a, b);
                     default:
                         throw new NotImplementedException();
                 }
@@ -440,8 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (_parameterScope != null)
                 {
-                    ParameterExpression mapped;
-                    if (_parameterScope.TryGetValue(a, out mapped))
+                    if (_parameterScope.TryGetValue(a, out ParameterExpression mapped))
                     {
                         return mapped.Name == b.Name
                                && mapped.Type == b.Type;
@@ -563,6 +557,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             private bool CompareNewArray(NewArrayExpression a, NewArrayExpression b)
                 => CompareExpressionList(a.Expressions, b.Expressions);
+
+            private bool CompareExtension(Expression a, Expression b)
+                => a.Equals(b);
 
             private bool CompareInvocation(InvocationExpression a, InvocationExpression b)
                 => Compare(a.Expression, b.Expression)

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2494,7 +2494,7 @@ ORDER BY [l1.OneToOne_Optional_FK].[Name], [l1].[Id]",
             AssertSql(
                 @"@__p_0: 2
 
-SELECT [l2].[Id], [t].[Name], [t].[Id]
+SELECT [l2].[Id], [t].[Name]
 FROM [Level2] AS [l2]
 LEFT JOIN (
     SELECT TOP(@__p_0) [x].*

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -956,7 +956,6 @@ FROM [Weapon] AS [w]",
 
         public override void Select_ternary_operation_with_has_value_not_null()
         {
-            // TODO: Optimize this query (See #4267)
             base.Select_ternary_operation_with_has_value_not_null();
 
             AssertSql(
@@ -2360,7 +2359,8 @@ LEFT JOIN (
     SELECT [g].*
     FROM [Gear] AS [g]
     WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])",
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
+ORDER BY [t].[GearNickName], [t].[GearSquadId]",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -366,15 +366,15 @@ ORDER BY (
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
-    SELECT TOP(1) [c0].*
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c0].[CustomerID]) = 1)
-    ORDER BY (
+    SELECT TOP(1) [c0].*, (
         SELECT TOP(1) [oo0].[OrderDate]
         FROM [Orders] AS [oo0]
         WHERE [c0].[CustomerID] = [oo0].[CustomerID]
         ORDER BY [oo0].[OrderDate] DESC
-    ) DESC, [c0].[CustomerID]
+    ) AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c0].[CustomerID]) = 1)
+    ORDER BY [c] DESC, [c0].[CustomerID]
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
 ORDER BY (
     SELECT TOP(1) [oo1].[OrderDate]
@@ -508,15 +508,15 @@ ORDER BY (
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
-    SELECT TOP(1) [c0].*
-    FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] = N'ALFKI'
-    ORDER BY (
+    SELECT TOP(1) [c0].*, (
         SELECT TOP(1) [o0].[OrderDate]
         FROM [Orders] AS [o0]
         WHERE [c0].[CustomerID] = [o0].[CustomerID]
         ORDER BY [o0].[EmployeeID]
-    ), [c0].[CustomerID]
+    ) AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+    ORDER BY [c], [c0].[CustomerID]
 ) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
 ORDER BY (
     SELECT TOP(1) [o1].[OrderDate]
@@ -524,7 +524,7 @@ ORDER BY (
     WHERE [t].[CustomerID] = [o1].[CustomerID]
     ORDER BY [o1].[EmployeeID]
 ), [t].[CustomerID]",
-                Sql);
+                    Sql);
         }
 
         public override void Include_collection_as_no_tracking(bool useString)
@@ -1376,17 +1376,17 @@ INNER JOIN (
         FROM [Orders] AS [oo]
         WHERE [c].[CustomerID] = [oo].[CustomerID]
         ORDER BY [oo].[OrderDate] DESC
-    ) AS [c0_0], [c].[CustomerID]
+    ) AS [c], [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
-    ORDER BY [c0_0] DESC, [c].[CustomerID]
+    ORDER BY [c] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
-ORDER BY [c0].[c0_0] DESC, [c0].[CustomerID], [o].[OrderID]
+ORDER BY [c0].[c] DESC, [c0].[CustomerID], [o].[OrderID]
 
 SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
 FROM [Order Details] AS [o0]
 INNER JOIN (
-    SELECT DISTINCT [c0].[c0_0], [c0].[CustomerID], [o].[OrderID]
+    SELECT DISTINCT [c0].[c], [c0].[CustomerID], [o].[OrderID]
     FROM [Orders] AS [o]
     INNER JOIN (
         SELECT DISTINCT TOP(1) (
@@ -1394,13 +1394,13 @@ INNER JOIN (
             FROM [Orders] AS [oo]
             WHERE [c].[CustomerID] = [oo].[CustomerID]
             ORDER BY [oo].[OrderDate] DESC
-        ) AS [c0_0], [c].[CustomerID]
+        ) AS [c], [c].[CustomerID]
         FROM [Customers] AS [c]
         WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
-        ORDER BY [c0_0] DESC, [c].[CustomerID]
+        ORDER BY [c] DESC, [c].[CustomerID]
     ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
-ORDER BY [o1].[c0_0] DESC, [o1].[CustomerID], [o1].[OrderID]",
+ORDER BY [o1].[c] DESC, [o1].[CustomerID], [o1].[OrderID]",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -1089,12 +1089,17 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]",
             base.Where_comparison_null_constant_and_null_parameter();
 
             Assert.Equal(
-                @"SELECT [e].[Id]
-FROM [NullSemanticsEntity1] AS [e]
+                @"@__prm_0:  (Size = 4000) (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 0 = 1",
+WHERE @__prm_0 IS NULL
+
+@__prm_0:  (Size = 4000) (DbType = String)
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE @__prm_0 IS NOT NULL",
                 Sql);
         }
 
@@ -1103,12 +1108,17 @@ WHERE 0 = 1",
             base.Where_comparison_null_constant_and_nonnull_parameter();
 
             Assert.Equal(
-                @"SELECT [e].[Id]
-FROM [NullSemanticsEntity1] AS [e]
-WHERE 0 = 1
+                @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
-FROM [NullSemanticsEntity1] AS [e]",
+FROM [NullSemanticsEntity1] AS [e]
+WHERE @__prm_0 IS NULL
+
+@__prm_0: Foo (Size = 4000)
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE @__prm_0 IS NOT NULL",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1121,15 +1121,6 @@ FROM [Orders] AS [o2]
 WHERE @_outer_CustomerID = [o2].[CustomerID]
 
 SELECT [o4].[OrderID]
-FROM [Orders] AS [o4]
-
-@_outer_CustomerID: ANATR (Size = 450)
-
-SELECT [o2].[OrderID]
-FROM [Orders] AS [o2]
-WHERE @_outer_CustomerID = [o2].[CustomerID]
-
-SELECT [o4].[OrderID]
 FROM [Orders] AS [o4]",
                 Sql);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -6011,9 +6011,9 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
             base.Select_null_coalesce_operator();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ')
+                @"SELECT [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [c]
 FROM [Customers] AS [c]
-ORDER BY COALESCE([c].[Region], N'ZZ')",
+ORDER BY [c]",
                 Sql);
         }
 
@@ -6445,7 +6445,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE COALESCE([c].[CompanyName], [c].[ContactName]) = N'The Big Cheese'",
+WHERE (COALESCE([c].[CompanyName], [c].[ContactName])) = N'The Big Cheese'",
                 Sql);
         }
 
@@ -6461,11 +6461,11 @@ SELECT DISTINCT [t0].*
 FROM (
     SELECT [t].*
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
         FROM [Customers] AS [c]
-        ORDER BY COALESCE([c].[Region], N'ZZ')
+        ORDER BY [c]
     ) AS [t]
-    ORDER BY COALESCE([t].[Region], N'ZZ')
+    ORDER BY [t].[c]
     OFFSET @__p_1 ROWS
 ) AS [t0]",
                 Sql);
@@ -6477,13 +6477,12 @@ FROM (
 
             Assert.Equal(@"@__p_0: 5
 
-SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ')
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [c]
 FROM [Customers] AS [c]
-ORDER BY COALESCE([c].[Region], N'ZZ')",
+ORDER BY [c]",
                 Sql);
         }
 
-        // TODO: See issue#6703
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Select_take_skip_null_coalesce_operator()
         {
@@ -6495,11 +6494,11 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
 
 SELECT [t].*
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Coalesce]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
-    ORDER BY [Coalesce]
+    ORDER BY [c]
 ) AS [t]
-ORDER BY [t].[Coalesce]
+ORDER BY [t].[c]
 OFFSET @__p_1 ROWS",
                 Sql);
         }
@@ -6515,11 +6514,11 @@ OFFSET @__p_1 ROWS",
 
 SELECT [t].*
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
-    ORDER BY COALESCE([c].[Region], N'ZZ')
+    ORDER BY [c]
 ) AS [t]
-ORDER BY COALESCE([t].[Region], N'ZZ')
+ORDER BY [t].[c]
 OFFSET @__p_1 ROWS",
                 Sql);
         }
@@ -6535,11 +6534,11 @@ OFFSET @__p_1 ROWS",
 
 SELECT [t].*
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
     FROM [Customers] AS [c]
-    ORDER BY COALESCE([c].[Region], N'ZZ')
+    ORDER BY [c]
 ) AS [t]
-ORDER BY COALESCE([t].[Region], N'ZZ')
+ORDER BY [t].[c]
 OFFSET @__p_1 ROWS",
                 Sql);
         }
@@ -7095,13 +7094,13 @@ WHERE [o].[OrderDate] IS NOT NULL",
             Assert.Equal(
                 @"@__nextYear_0: 2017
 
-SELECT [t].[c0]
+SELECT [t].[c]
 FROM (
-    SELECT DISTINCT DATEPART(year, [o].[OrderDate]) AS [c0]
+    SELECT DISTINCT DATEPART(year, [o].[OrderDate]) AS [c]
     FROM [Orders] AS [o]
     WHERE [o].[OrderDate] IS NOT NULL
 ) AS [t]
-WHERE [t].[c0] < @__nextYear_0",
+WHERE [t].[c] < @__nextYear_0",
                 Sql);
         }
 
@@ -7519,6 +7518,127 @@ SELECT CASE
                 FROM [Customers] AS [inner1])))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
+                Sql);
+        }
+
+        public override void Anonymous_member_distinct_where()
+        {
+            base.Anonymous_member_distinct_where();
+
+            Assert.Equal(
+                @"SELECT [t].[CustomerID]
+FROM (
+    SELECT DISTINCT [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE [t].[CustomerID] = N'ALFKI'",
+                Sql);
+        }
+
+        public override void Anonymous_member_distinct_orderby()
+        {
+            base.Anonymous_member_distinct_orderby();
+
+            Assert.Equal(
+                @"SELECT [t].[CustomerID]
+FROM (
+    SELECT DISTINCT [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+ORDER BY [t].[CustomerID]",
+                Sql);
+        }
+
+        public override void Anonymous_member_distinct_result()
+        {
+            base.Anonymous_member_distinct_result();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT [c].[CustomerID]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE [t].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [t].[CustomerID]) = 1)",
+                Sql);
+        }
+
+        public override void Anonymous_complex_distinct_where()
+        {
+            base.Anonymous_complex_distinct_where();
+
+            Assert.Equal(
+                @"SELECT [t].[c]
+FROM (
+    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE [t].[c] = N'ALFKIBerlin'",
+                Sql);
+        }
+
+        public override void Anonymous_complex_distinct_orderby()
+        {
+            base.Anonymous_complex_distinct_orderby();
+
+            Assert.Equal(
+                @"SELECT [t].[c]
+FROM (
+    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    FROM [Customers] AS [c]
+) AS [t]
+ORDER BY [t].[c]",
+                Sql);
+        }
+
+        public override void Anonymous_complex_distinct_result()
+        {
+            base.Anonymous_complex_distinct_result();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE [t].[c] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [t].[c]) = 1)",
+                Sql);
+        }
+
+        public override void Anonymous_complex_orderby()
+        {
+            base.Anonymous_complex_orderby();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID] + [c].[City] AS [c]
+FROM [Customers] AS [c]
+ORDER BY [c]",
+                Sql);
+        }
+
+        public override void Anonymous_subquery_orderby()
+        {
+            base.Anonymous_subquery_orderby();
+
+            Assert.Equal(
+                @"SELECT (
+    SELECT TOP(1) [o2].[OrderDate]
+    FROM [Orders] AS [o2]
+    WHERE [c].[CustomerID] = [o2].[CustomerID]
+    ORDER BY [o2].[OrderID] DESC
+)
+FROM [Customers] AS [c]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) > 1
+ORDER BY (
+    SELECT TOP(1) [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    ORDER BY [o0].[OrderID] DESC
+)",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -103,9 +103,9 @@ ORDER BY [t].[OrderID]",
                 @"@__p_0: 10
 @__p_1: 5
 
-SELECT [t].[c0], [t].[OrderID]
+SELECT [t].[c], [t].[OrderID]
 FROM (
-    SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [c0], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [c], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
@@ -122,7 +122,7 @@ ORDER BY [t].[OrderID]",
                 @"@__p_0: 10
 @__p_1: 5
 
-SELECT [t].[OrderID], [t].[CustomerID], [t].[c0] AS [c0], [t].[ContactName], [t].[c1] AS [c1]
+SELECT [t].[OrderID], [t].[CustomerID], [t].[c0], [t].[ContactName], [t].[c1]
 FROM (
     SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [c0], [ca].[ContactName], [cb].[ContactName] AS [c1], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
     FROM [Orders] AS [o]
@@ -190,11 +190,11 @@ SELECT DISTINCT [t0].*
 FROM (
     SELECT [t1].*
     FROM (
-        SELECT [t].*, ROW_NUMBER() OVER(ORDER BY COALESCE([t].[Region], N'ZZ')) AS [__RowNumber__]
+        SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[c]) AS [__RowNumber__]
         FROM (
-            SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], COALESCE([c].[Region], N'ZZ') AS [c]
             FROM [Customers] AS [c]
-            ORDER BY COALESCE([c].[Region], N'ZZ')
+            ORDER BY [c]
         ) AS [t]
     ) AS [t1]
     WHERE [t1].[__RowNumber__] > @__p_1
@@ -211,15 +211,15 @@ FROM (
 
 SELECT [t0].*
 FROM (
-    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[Coalesce]) AS [__RowNumber__]
+    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[c]) AS [__RowNumber__]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Coalesce]
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [c]
         FROM [Customers] AS [c]
-        ORDER BY [Coalesce]
+        ORDER BY [c]
     ) AS [t]
 ) AS [t0]
 WHERE [t0].[__RowNumber__] > @__p_1
-ORDER BY [t0].[Coalesce]",
+ORDER BY [t0].[c]",
                 Sql);
         }
 
@@ -355,9 +355,9 @@ ORDER BY [t1].[ContactTitle], [t1].[ContactName]",
 
 SELECT CASE
     WHEN EXISTS (
-        SELECT [t].[c0]
+        SELECT [t].[c]
         FROM (
-            SELECT 1 AS [c0], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+            SELECT 1 AS [c], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
             FROM [Customers] AS [c]
         ) AS [t]
         WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1)))
@@ -376,9 +376,9 @@ END",
 
 SELECT CASE
     WHEN NOT EXISTS (
-        SELECT [t].[c0]
+        SELECT [t].[c]
         FROM (
-            SELECT 1 AS [c0], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+            SELECT 1 AS [c], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
             FROM [Customers] AS [c]
             WHERE LEN([c].[CustomerID]) <> 5
         ) AS [t]


### PR DESCRIPTION
In current query pipeline, we create various column/alias expressions in ad-hoc manner and add them to SelectExpression, which create lack of detailed metadata info. e.g. In nested SelectExpression, we don't know which column from inner subqueries is being projected out in outer projection. That is a likely cause to create invalid SQL since it creates disconnect between the sql expressions and selectexpression. This also gives rise to various assumptions which goes viral across the stack like `TryGetColumnExpression`.
Above issue is huge blocker for immutable SelectExpression. This PR is first step in that direction.

Changes involved:
Overall design:
Every sql expression added to SelectExpression knows its source metadata. It is either a column expression backing property on an entity type or it is a .net expression built by combining column expressions. In nested queries, expressions on outer queries have reference to inner expression from where they are getting values. All parts of SelectExpression can be any kind of expression (which was previously restricted to AliasExpression).

Changes:
- No ad-hoc creation of ColumnExpression. When binding a property to SelectExpression, SelectExpression will generate appropriate expression for it. (`BindPropertyToSelectExpression` method which binds property even if it is not added to projection)
- Removal of non-property ColumnExpression - ColumnExpression represent a column which is directly backed by EntityType.Property. For any other case, different kind of expression should be used.
- AliasExpression requires alias to be defined always. Hence unless column needs to aliased, it will not be made AliasExpression.
- Implementation of `Equals` method of various expression which can appear in SelectExpression. And using `ExpressionEqualityComparer` to compare expressions in Projection/OrderBy to avoid duplicates. This removes the complex logic in AddToProjection.
- Removal of `TryGetColumnExpression` - All the places, which relied on assumption of having a column backed expression are changed to work with any kind of expression.
- Introduction of `ColumnReferenceExpression` which can store reference to inner projection expression so that each expression knows its root from subqueries.
~~- Introduction of `ProjectStarExpression` which stores all the projection which are actually being used by outer SelectExpression. (Though they are not printed in SQL. Just * will be printed)~~
- SelectExpression._starProjection stores list of expressions being used by outer SelectExpression.
- Simplification of `AddToProjection` method - Method adds expression straight to projection. Bind method will create the expression to be added from property. Method also unique-fy alias if it is inside subquery. This method also update OrderBy list if a complex expression is getting added to projection and present in order by by alias-ing it.
- Removal of SourceMember/SourceExpression from AliasExpression, (which brought requirement of having every columnexpression as aliasExpression in projection). While visiting `NewExpression` in `RelationalProjectionExpressionVisitor`, we record SourceExpression to sqlExpression mapping and then we write MemberInfo to sqlExpression mapping in SelectExpression. Which is appropriately lifted during Subquery Pushdown. This makes it possible for us to bind operators after projecting into anonymous types.
- Moved RelationalAnnotationsProvider to SelectExpression to find column name so that all the visitors trying to bind property with select expression does not need it to generate column name.

Pending tasks in this PR:
- ~~XML doc comments are pending. (I will write them tomorrow, created PR so that code review can start)~~
- More tests? Suggestions?

Future tasks:
- Investigate visiting `NewExpression` in `RelationalProjectionExpressionVisitor`. At present we visit it twice. The only info we get out of first visit is about client projection. We throw away translated expression. (this would fix #7844 )
- Removal of IncludeExpressionVisitor and associated helper methods from SelectExpression which are just to support current Include pipeline.
- More robust way to deal with Anonymous expressions in projection which helps us identify an anonymous projection from an actual client eval method.
- Implement `Equals` method on all custom expression. Uniform or need based?
- Investigate and consolidate the handling of star projection. Currently we have IsProjectStar, ProjectStarExpression, ProjectStarTable.

This PR is part of #7520 
Partially fix #6703 
