### PR TITLE
[1.1.2] Fix to #7944 - EF Core 1.1.1 has introduced a new ArgumentException for complex queries with with subqueries, if the same subquery is present multiple times in the query model

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/QueryTestBase.cs
@@ -6485,6 +6485,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                  select new { c.CustomerID, o1.OrderID, o2.OrderDate }));
         }
 
+        [ConditionalFact]
+        public virtual void Complex_query_with_repeated_query_model_compiles_correctly()
+        {
+            AssertQuery<Customer>(cs => cs
+                .Where(outer => outer.CustomerID == "ALFKI")
+                .Where(outer =>
+                    (from c in cs
+                     let customers = cs.Select(cc => cc.CustomerID)
+                     where customers.Any()
+                     select customers).Any()),
+                     entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Complex_query_with_repeated_nested_query_model_compiles_correctly()
+        {
+            AssertQuery<Customer>(cs => cs
+                .Where(outer => outer.CustomerID == "ALFKI")
+                .Where(outer =>
+                    (from c in cs
+                     let customers = cs.Where(cc => cs.OrderBy(inner => inner.CustomerID).Take(10).Distinct().Any()).Select(cc => cc.CustomerID)
+                     where customers.Any()
+                     select customers).Any()),
+                     entryCount: 1);
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryModelExtensions.cs
@@ -51,12 +51,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var queryModel = expression.QueryModel;
 
-                var newQueryModel = new QueryModel(queryModel.MainFromClause, queryModel.SelectClause);
-                ShallowCopy(queryModel, newQueryModel);
+                if (!_mapping.ContainsKey(queryModel))
+                {
+                    var newQueryModel = new QueryModel(queryModel.MainFromClause, queryModel.SelectClause);
+                    ShallowCopy(queryModel, newQueryModel);
 
-                _mapping.Add(queryModel, newQueryModel);
-
-                queryModel.TransformExpressions(Visit);
+                    _mapping.Add(queryModel, newQueryModel);
+                    queryModel.TransformExpressions(Visit);
+                }
 
                 return expression;
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -6457,6 +6457,57 @@ WHERE (([c].[City] = N'Seattle') AND [c].[City] IS NOT NULL) AND ([t1].[OrderID]
                 Sql);
         }
 
+        public override void Complex_query_with_repeated_query_model_compiles_correctly()
+        {
+            base.Complex_query_with_repeated_query_model_compiles_correctly();
+
+            Assert.Equal(
+                @"SELECT [outer].[CustomerID], [outer].[Address], [outer].[City], [outer].[CompanyName], [outer].[ContactName], [outer].[ContactTitle], [outer].[Country], [outer].[Fax], [outer].[Phone], [outer].[PostalCode], [outer].[Region]
+FROM [Customers] AS [outer]
+WHERE [outer].[CustomerID] = N'ALFKI'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c0]
+        WHERE EXISTS (
+            SELECT 1
+            FROM (
+                SELECT [cc3].[CustomerID]
+                FROM [Customers] AS [cc3]
+            ) AS [t0]))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
+        public override void Complex_query_with_repeated_nested_query_model_compiles_correctly()
+        {
+            base.Complex_query_with_repeated_nested_query_model_compiles_correctly();
+
+            Assert.Equal(
+                @"SELECT [outer].[CustomerID], [outer].[Address], [outer].[City], [outer].[CompanyName], [outer].[ContactName], [outer].[ContactTitle], [outer].[Country], [outer].[Fax], [outer].[Phone], [outer].[PostalCode], [outer].[Region]
+FROM [Customers] AS [outer]
+WHERE [outer].[CustomerID] = N'ALFKI'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c0]
+        WHERE EXISTS (
+            SELECT 1
+            FROM (
+                SELECT [cc3].[CustomerID]
+                FROM [Customers] AS [cc3]
+                WHERE EXISTS (
+                    SELECT DISTINCT TOP(10) 1
+                    FROM [Customers] AS [inner3])
+            ) AS [t0]))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Problem was that when we fixed #7476 we introduced a mechanism to copy and then restore query models to prevent them from being corrupted during (failed) attempt at translating them to SQL.
However we have not accounted for the case where the same subquery would be present in the query model more than once (same reference).

Fix is to add defensive check to the logic that creates a copy of a query model. If we already copied that particular (sub)query model, we don't need to do it twice. It is safe to do, because all occurrences of the query model that share the same reference are guaranteed to have the same body clauses and therefore can later be re-created from the same copy.