### PR TITLE
Query: SqlServer: Translate DateTime.Add* to server only if the argum…

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -6940,6 +6940,42 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Select_expression_date_add_milliseconds_above_the_range()
+        {
+            AssertQuery<Order>(
+                 os => os.Where(o => o.OrderDate != null)
+                    .Select(o => new Order
+                    {
+                        OrderDate = o.OrderDate.Value.AddMilliseconds(1000000000000)
+                    }));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_expression_date_add_milliseconds_below_the_range()
+        {
+            AssertQuery<Order>(
+                 os => os.Where(o => o.OrderDate != null)
+                    .Select(o => new Order
+                    {
+                        OrderDate = o.OrderDate.Value.AddMilliseconds(-1000000000000)
+                    }));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_expression_date_add_milliseconds_large_number_divided()
+        {
+            var millisecondsPerDay = 86400000L;
+            AssertQuery<Order>(
+                os => os.Where(o => o.OrderDate != null)
+                    .Select(o => new Order
+                    {
+                        OrderDate = o.OrderDate.Value
+                            .AddDays(o.OrderDate.Value.Millisecond / millisecondsPerDay)
+                            .AddMilliseconds(o.OrderDate.Value.Millisecond % millisecondsPerDay)
+                    }));
+        }
+
+        [ConditionalFact]
         public virtual void Select_expression_references_are_updated_correctly_with_subquery()
         {
             var nextYear = 2017;

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -7052,6 +7052,42 @@ WHERE [o].[OrderDate] IS NOT NULL",
                 Sql);
         }
 
+        public override void Select_expression_date_add_milliseconds_above_the_range()
+        {
+            base.Select_expression_date_add_milliseconds_above_the_range();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] IS NOT NULL",
+                Sql);
+        }
+
+        public override void Select_expression_date_add_milliseconds_below_the_range()
+        {
+            base.Select_expression_date_add_milliseconds_below_the_range();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] IS NOT NULL",
+                Sql);
+        }
+
+        public override void Select_expression_date_add_milliseconds_large_number_divided()
+        {
+            base.Select_expression_date_add_milliseconds_large_number_divided();
+
+            Assert.Equal(
+                @"@__millisecondsPerDay_1: 86400000
+@__millisecondsPerDay_0: 86400000
+
+SELECT DATEADD(millisecond, DATEPART(millisecond, [o].[OrderDate]) % @__millisecondsPerDay_1, DATEADD(day, DATEPART(millisecond, [o].[OrderDate]) / @__millisecondsPerDay_0, [o].[OrderDate]))
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] IS NOT NULL",
+                Sql);
+        }
+
         public override void Select_expression_references_are_updated_correctly_with_subquery()
         {
             base.Select_expression_references_are_updated_correctly_with_subquery();


### PR DESCRIPTION
…ent is in range of int

resolves #7756 