### PR TITLE
Fix diagnostic name for RelationalDiagnostics.ConnectionError

### DIFF
--- a/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
+++ b/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public const string ConnectionOpened = NamePrefix + nameof(ConnectionOpened);
         public const string ConnectionClosing = NamePrefix + nameof(ConnectionClosing);
         public const string ConnectionClosed = NamePrefix + nameof(ConnectionClosed);
-        public const string ConnectionError = NamePrefix + nameof(ConnectionClosed);
+        public const string ConnectionError = NamePrefix + nameof(ConnectionError);
 
         public const string TransactionStarted = NamePrefix + nameof(TransactionStarted);
         public const string TransactionCommitted = NamePrefix + nameof(TransactionCommitted);


### PR DESCRIPTION
Looks like a copy/paste oops here - the diagnostic name was incorrect.

I was trying to write an adapter per #7939 and wondered why this wasn't working. Turns out I wasn't the crazy one, *this time*...

Fixes item 1 in #8001.