### PR TITLE
Re-enable disabled benchmark tests.

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Shared test suite for Entity Framework Core relational database providers.</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Relational.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Relational.Specification</RootNamespace>

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>Shared test suite for Entity Framework Core database providers.</Description>
     <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Specification</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/test/EFCore.Benchmarks.EF6/InitializationTests.cs
+++ b/test/EFCore.Benchmarks.EF6/InitializationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
     {
         [Benchmark]
         [BenchmarkVariation("Warm (10000 instances)", false, 10000)]
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
         public void CreateAndDisposeUnusedContext(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
         [Benchmark]
         [AdventureWorksDatabaseRequired]
         [BenchmarkVariation("Warm (1000 instances)", false, 1000)]
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
         public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
         [Benchmark]
         [AdventureWorksDatabaseRequired]
         [BenchmarkVariation("Warm (100 instances)", false, 100)]
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
         public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));

--- a/test/EFCore.Benchmarks.EFCore/InitializationTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/InitializationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore
         [Benchmark]
         [BenchmarkVariation("Warm (10000 instances)", false, 10000)]
 #if NET46
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #elif NETCOREAPP1_1
 #else
 #error target frameworks need to be updated.
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore
         [AdventureWorksDatabaseRequired]
         [BenchmarkVariation("Warm (1000 instances)", false, 1000)]
 #if NET46
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #elif NETCOREAPP1_1
 #else
 #error target frameworks need to be updated.
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore
         [AdventureWorksDatabaseRequired]
         [BenchmarkVariation("Warm (100 instances)", false, 100)]
 #if NET46
-        //[BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #elif NETCOREAPP1_1
 #else
 #error target frameworks need to be updated.

--- a/test/EFCore.Benchmarks/ColdStartSandbox.cs
+++ b/test/EFCore.Benchmarks/ColdStartSandbox.cs
@@ -12,7 +12,11 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         private AppDomain _domain = AppDomain.CreateDomain(
             "Cold Start Sandbox",
             null,
-            new AppDomainSetup { ApplicationBase = AppDomain.CurrentDomain.BaseDirectory });
+            new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
+                ConfigurationFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile
+            });
 
         ~ColdStartSandbox()
         {


### PR DESCRIPTION
Add net46 as tfm in test project for test driven

resolves #7998 

Also avoids exception while using testdriven to run tests.
Still cannot get dotnet-ef.Tests to be no-op in testdriven.