### PR TITLE
[1.1.2/TINY] making fix for issue 7714 thread safe

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         private readonly bool _bindParentQueries;
         private readonly bool _inProjection;
 
-        internal static IStreamedDataInfo CurrentQueryModelStreamedDataInfo;
+        internal IStreamedDataInfo CurrentQueryModelStreamedDataInfo;
 
         /// <summary>
         ///     Creates a new instance of <see cref="SqlTranslatingExpressionVisitor" />.
@@ -724,7 +724,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                    ?? _queryModelVisitor.BindMemberToOuterQueryParameter(expression);
         }
 
-        private static AliasExpression TryBindParentExpression(
+        private AliasExpression TryBindParentExpression(
             RelationalQueryModelVisitor queryModelVisitor,
             Func<RelationalQueryModelVisitor, AliasExpression> binder)
         {


### PR DESCRIPTION
Previous fix was using static field and therefore was not thread safe - multiple queries could be compiled simultaneously which could result in corrupted translations.