### PR TITLE
Test: Change RelationalQueryTestBase not to derive from QueryTestBase…

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/RelationalEfFunctionsTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/RelationalEfFunctionsTestBase.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
@@ -13,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Specification.Tests
 {
-    public abstract class RelationalQueryTestBase<TFixture> : QueryTestBase<TFixture>
+    public abstract class RelationalEfFunctionsTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
         [ConditionalFact]
@@ -45,7 +41,14 @@ namespace Microsoft.EntityFrameworkCore.Relational.Specification.Tests
                 Assert.Equal(0, count);
             }
         }
+        
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
-        protected RelationalQueryTestBase(TFixture fixture) : base(fixture) {}
+        protected RelationalEfFunctionsTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/EfFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EfFunctionsSqlServerTest.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Relational.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class EfFunctionsSqlServerTest : RelationalEfFunctionsTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public EfFunctionsSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        public override void String_Like_Literal()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
+                Assert.Equal(34, count);  // case-insensitive
+            }
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE N'%M%'",
+                Sql);
+        }
+
+        public override void String_Like_Identity()
+        {
+            base.String_Like_Identity();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE [c].[ContactName]",
+                Sql);
+        }
+
+        public override void String_Like_Literal_With_Escape()
+        {
+            base.String_Like_Literal_With_Escape();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE N'!%' ESCAPE '!'",
+                Sql);
+        }
+
+
+        private const string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
-using Microsoft.EntityFrameworkCore.Relational.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,7 +22,7 @@ using System.Threading;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
-    public class QuerySqlServerTest : RelationalQueryTestBase<NorthwindQuerySqlServerFixture>
+    public class QuerySqlServerTest : QueryTestBase<NorthwindQuerySqlServerFixture>
     {
         public QuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -4845,43 +4844,6 @@ WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_
                 Sql);
         }
 
-        public override void String_Like_Literal()
-        {
-            using (var context = CreateContext())
-            {
-                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
-                Assert.Equal(34, count);  // case-insensitive
-            }
-
-            Assert.Equal(
-                @"SELECT COUNT(*)
-FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'%M%'",
-                Sql);
-        }
-
-        public override void String_Like_Identity()
-        {
-            base.String_Like_Identity();
-
-            Assert.Equal(
-                @"SELECT COUNT(*)
-FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE [c].[ContactName]",
-                Sql);
-        }
-
-        public override void String_Like_Literal_With_Escape()
-        {
-            base.String_Like_Literal_With_Escape();
-
-            Assert.Equal(
-                @"SELECT COUNT(*)
-FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'!%' ESCAPE '!'",
-                Sql);
-        }
-
         public override void String_Compare_simple_zero()
         {
             base.String_Compare_simple_zero();
@@ -5815,17 +5777,33 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
+@_outer_CustomerID1: ALFKI (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID1 = [o2].[CustomerID]
+ORDER BY [o2].[OrderID]
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
+@_outer_CustomerID1: ANATR (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]",
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID1 = [o2].[CustomerID]
+ORDER BY [o2].[OrderID]
+
+@_outer_CustomerID1: ANTON (Size = 450)
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID1 = [o2].[CustomerID]
+ORDER BY [o2].[OrderID]
+
+@_outer_CustomerID1: AROUT (Size = 450)
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID1 = [o2].[CustomerID]
+ORDER BY [o2].[OrderID]",
                 Sql);
         }
 
@@ -6445,7 +6423,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (COALESCE([c].[CompanyName], [c].[ContactName])) = N'The Big Cheese'",
+WHERE COALESCE([c].[CompanyName], [c].[ContactName]) = N'The Big Cheese'",
                 Sql);
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/EfFunctionsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/EfFunctionsSqliteTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Relational.Specification.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+#if NETCOREAPP1_1
+using System.Threading;
+#endif
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class EfFunctionsSqliteTest : RelationalEfFunctionsTestBase<NorthwindQuerySqliteFixture>
+    {
+        public EfFunctionsSqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        public override void String_Like_Literal()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
+                Assert.Equal(34, count);
+            }
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Relational.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +11,7 @@ using System.Threading;
 #endif
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
-    public class QuerySqliteTest : RelationalQueryTestBase<NorthwindQuerySqliteFixture>
+    public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
     {
         public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -125,16 +123,6 @@ FROM ""Products"" AS ""p""
 WHERE ""p"".""ProductID"" < 40",
                 Sql);
         }
-
-        public override void String_Like_Literal()
-        {
-            using (var context = CreateContext())
-            {
-                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "%M%"));
-                Assert.Equal(34, count);
-            }
-        }
-
 
         private const string FileLineEnding = @"
 ";


### PR DESCRIPTION
… due to xunit bug

This enables running all QueryTests again. Filed #8050 