### PR TITLE
Query: Update the resolution of string.Replace overload

### DIFF
--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     {
         private static readonly MethodInfo _methodInfo = typeof(string).GetTypeInfo()
             .GetDeclaredMethods(nameof(string.Replace))
-            .Single(m => m.GetParameters()[0].ParameterType == typeof(string));
+            .Single(m => m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(string));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
Resolves #8021 

Reference to correct overload: https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/String.Manipulation.cs#L1146

There are 4 overloads for string.Replace now.
`string Replace(string oldValue, string newValue, bool ignoreCase, CultureInfo culture)`
`string Replace(string oldValue, string newValue, StringComparison comparisonType)`
`String Replace(char oldChar, char newChar)`
`String Replace(String oldValue, String newValue)`