### PR TITLE
[1.1.2] [Tiny] Make SqlServerDatabaseModelFactoryTest use scratch database …

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests
     {
         public SqlServerDatabaseModelFixture()
         {
-            TestStore = SqlServerTestStore.Create("SqlServerDatabaseModelTest");
+            TestStore = SqlServerTestStore.CreateScratch();
         }
 
         public DatabaseModel CreateModel(string createSql, TableSelectionSet selection = null, ILogger logger = null)


### PR DESCRIPTION
…to avoid getting in a dirty state, since `RelationalDatabaseCleaner` uses `SqlServerDatabaseModelFactory`