### PR TITLE
[TINY] Fix to #8053 - Query: QuerySourceTracingExpressionVisitor doesn't always prune EF.Property expressions

### DIFF
--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -2328,6 +2328,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Unnecessary_include_doesnt_get_added_complex_when_projecting_EF_Property()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = ctx.Gears
+                    .OrderBy(g => g.Rank)
+                    .Include(g => g.Tag)
+                    .Where(g => g.HasSoulPatch)
+                    .Select(g => new { FullName = EF.Property<string>(g, "FullName") });
+
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+
+                var names = result.Select(r => r.FullName).ToList();
+
+                Assert.True(names.Contains("Damon Baird"));
+                Assert.True(names.Contains("Marcus Fenix"));
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -149,16 +149,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression node)
-        {
-            var referenceSource = node.Arguments.FirstOrDefault() as QuerySourceReferenceExpression;
-
-            if (EntityQueryModelVisitor.IsPropertyMethod(node.Method)
-                && referenceSource?.ReferencedQuerySource.Equals(_targetQuerySource) == true)
-            {
-                return node;
-            }
-
-            return base.VisitMethodCall(node);
-        }
+            => EntityQueryModelVisitor.IsPropertyMethod(node.Method)
+                ? node
+                : base.VisitMethodCall(node);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2387,6 +2387,18 @@ WHERE [e].[Id] IN ('d2c26679-562b-44d1-ab96-23d1775e0926', '23cbcf9b-ce14-45cf-a
                 Sql);
         }
 
+        public override void Unnecessary_include_doesnt_get_added_complex_when_projecting_EF_Property()
+        {
+            base.Unnecessary_include_doesnt_get_added_complex_when_projecting_EF_Property();
+
+            Assert.Equal(
+                @"SELECT [g0].[HasSoulPatch], [g0].[FullName]
+FROM [Gear] AS [g0]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g0].[Rank]",
+                Sql);
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private const string FileLineEnding = @"

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
 SELECT DISTINCT [t0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t0]
@@ -66,7 +66,7 @@ FROM [Orders] AS [c1_Orders]",
 
 SELECT DISTINCT [t0].[CustomerID]
 FROM (
-    SELECT TOP(@__p_0) [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    SELECT TOP(@__p_0) [c0].*
     FROM [Customers] AS [c0]
     ORDER BY [c0].[CustomerID]
 ) AS [t0]


### PR DESCRIPTION
Problem was that we were adding unnecessary condition when pruning EF.Property from the QuerySourceTracingExpressionVisitor.

Fix is to remove the check so that all the EF.Property calls will correctly be pruned.