### PR TITLE
Add change tracking support for delegated identity entity types

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -203,7 +203,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     stateManager.Notify.NavigationCollectionChanged(entry, navigation, added, removed);
                 }
             }
-            else if (!ReferenceEquals(currentValue, snapshotValue))
+            else if (!ReferenceEquals(currentValue, snapshotValue)
+                && (!navigation.ForeignKey.IsOwnership
+                || !navigation.IsDependentToPrincipal()))
             {
                 stateManager.Notify.NavigationReferenceChanged(entry, navigation, snapshotValue, currentValue);
             }

--- a/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -48,9 +48,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                     else
                     {
-                        TraverseGraph(
-                            node.CreateNode(node, stateManager.GetOrCreateEntry(navigationValue), navigation),
-                            handleNode);
+                        var targetEntityType = navigation.GetTargetType();
+                        var targetEntry = targetEntityType.HasDelegatedIdentity()
+                            ? stateManager.GetOrCreateEntry(navigationValue, targetEntityType)
+                            : stateManager.GetOrCreateEntry(navigationValue);
+                        TraverseGraph(node.CreateNode(node, targetEntry, navigation), handleNode);
                     }
                 }
             }
@@ -92,8 +94,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                     else
                     {
+                        var targetType = navigation.GetTargetType();
+                        var entry = targetType.HasDelegatedIdentity()
+                            ? stateManager.GetOrCreateEntry(navigationValue, targetType)
+                            : stateManager.GetOrCreateEntry(navigationValue);
                         await TraverseGraphAsync(
-                            node.CreateNode(node, stateManager.GetOrCreateEntry(navigationValue), navigation),
+                            node.CreateNode(node, entry, navigation),
                             handleNode,
                             cancellationToken);
                     }

--- a/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -62,7 +62,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             internalEntityEntry.SetEntityState(
-                internalEntityEntry.IsKeySet ? (EntityState)node.NodeState : EntityState.Added,
+                internalEntityEntry.IsKeySet || internalEntityEntry.EntityType.IsOwned()
+                    ? (EntityState)node.NodeState : EntityState.Added,
                 acceptChanges: true);
 
             return true;
@@ -77,7 +78,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             await internalEntityEntry.SetEntityStateAsync(
-                internalEntityEntry.IsKeySet ? (EntityState)node.NodeState : EntityState.Added,
+                internalEntityEntry.IsKeySet || internalEntityEntry.EntityType.IsOwned()
+                    ? (EntityState)node.NodeState : EntityState.Added,
                 acceptChanges: true,
                 cancellationToken: cancellationToken);
 

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -24,6 +23,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         InternalEntityEntry GetOrCreateEntry([NotNull] object entity);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalEntityEntry GetOrCreateEntry([NotNull] object entity, [NotNull] IEntityType entityType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -58,6 +63,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         InternalEntityEntry TryGetEntry([NotNull] object entity);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalEntityEntry TryGetEntry([NotNull] object entity, [NotNull] IEntityType type);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/IValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IValueGenerationManager.cs
@@ -19,6 +19,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         void Generate([NotNull] InternalEntityEntry entry);
+        
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void Propagate([NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -70,7 +70,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (PrepareForAdd(entityState))
             {
+                StateManager.ValueGeneration.Propagate(this);
                 StateManager.ValueGeneration.Generate(this);
+            }
+            else if (EntityType.IsOwned()
+                     && oldState == EntityState.Detached)
+            {
+                StateManager.ValueGeneration.Propagate(this);
             }
 
             SetEntityState(oldState, entityState, acceptChanges);
@@ -89,7 +95,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (PrepareForAdd(entityState))
             {
+                StateManager.ValueGeneration.Propagate(this);
                 await StateManager.ValueGeneration.GenerateAsync(this, cancellationToken);
+            }
+            else if (EntityType.IsOwned()
+                     && oldState == EntityState.Detached)
+            {
+                StateManager.ValueGeneration.Propagate(this);
             }
 
             SetEntityState(oldState, entityState, acceptChanges);
@@ -299,8 +311,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
 
-            if (currentState == EntityState.Added
-                || currentState == EntityState.Deleted)
+            if (currentState == EntityState.Added)
             {
                 return;
             }
@@ -311,6 +322,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 && property.IsKey())
             {
                 throw new InvalidOperationException(CoreStrings.KeyReadOnly(property.Name, EntityType.DisplayName()));
+            }
+
+            if (currentState == EntityState.Deleted)
+            {
+                return;
             }
 
             if (changeState)

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         private bool AnyFkPropertiesModified(object relatedEntity)
         {
-            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity);
+            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity, Metadata.GetTargetType());
 
             return relatedEntry != null
                    && Metadata.ForeignKey.Properties.Any(relatedEntry.IsModified);
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         private void SetFkPropertiesModified(object relatedEntity, bool modified)
         {
-            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity);
+            var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity, Metadata.GetTargetType());
             if (relatedEntry != null)
             {
                 SetFkPropertiesModified(relatedEntry, modified);

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -36,5 +36,27 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             : base(internalEntry, navigation)
         {
         }
+
+        /// <summary>
+        ///     The <see cref="EntityEntry" /> of the entity this navigation targets.
+        /// </summary>
+        /// <value> An entry for the entity that owns this navigation targets. </value>
+        public virtual EntityEntry TargetEntry
+        {
+            get
+            {
+                var target = GetTargetEntry();
+                return target == null ? null : new EntityEntry(target);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual InternalEntityEntry GetTargetEntry()
+            => CurrentValue == null
+                ? null
+                : InternalEntry.StateManager.GetOrCreateEntry(CurrentValue, Metadata.GetTargetType());
     }
 }

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -51,6 +51,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public new virtual EntityEntry<TEntity> EntityEntry => new EntityEntry<TEntity>(InternalEntry);
 
         /// <summary>
+        ///     The <see cref="EntityEntry{TEntity}" /> of the entity this navigation targets.
+        /// </summary>
+        /// <value> An entry for the entity that owns this navigation targets. </value>
+        public new virtual EntityEntry<TProperty> TargetEntry
+        {
+            get
+            {
+                var target = GetTargetEntry();
+                return target == null ? null : new EntityEntry<TProperty>(target);
+            }
+        }
+
+        /// <summary>
         ///     Gets or sets the value currently assigned to this property. If the current value is set using this property,
         ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
         ///     for the context to detect the change.

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -160,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore
                 contextServices.Initialize(scopedServiceProvider, options, this);
 
                 _logger = scopedServiceProvider.GetRequiredService<ILogger<DbContext>>();
-                
+
                 return contextServices;
             }
             finally
@@ -1067,7 +1067,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entities, nameof(entities));
             CheckDisposed();
-            
+
             var stateManager = StateManager;
 
             // An Added entity does not yet exist in the database. If it is then marked as deleted there is

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -608,7 +608,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, entityType, foundType);
 
         /// <summary>
-        ///     The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified.
+        ///     The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified. To change the principal of an existing entity with an identifying foreign key first delete the dependent and invoke 'SaveChanges' then associate the dependent with the new principal.
         /// </summary>
         public static string KeyReadOnly([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -1636,6 +1636,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("NonDefiningOwnership", nameof(ownershipNavigation), nameof(definingNavigation), nameof(entityType)),
                 ownershipNavigation, definingNavigation, entityType);
+
+        /// <summary>
+        ///     The entity type '{entityType}' has delegated identity and the given entity is currently referenced from several owner entities. To access the entry for a particular reference to this entity call '{targetEntryCall}' on the owner entry.
+        /// </summary>
+        public static string AmbiguousDelegatedIdentityEntity([CanBeNull] object entityType, [CanBeNull] object targetEntryCall)
+            => string.Format(
+                GetString("AmbiguousDelegatedIdentityEntity", nameof(entityType), nameof(targetEntryCall)),
+                entityType, targetEntryCall);
+
+        /// <summary>
+        ///     The entity type '{entityType}' has delegated identity and the given entity is currently not being tracked. To start tracking this entity call '{targetEntryCall}' on the owner entry.
+        /// </summary>
+        public static string UntrackedDelegatedIdentityEntity([CanBeNull] object entityType, [CanBeNull] object targetEntryCall)
+            => string.Format(
+                GetString("UntrackedDelegatedIdentityEntity", nameof(entityType), nameof(targetEntryCall)),
+                entityType, targetEntryCall);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -346,7 +346,7 @@
     <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
   </data>
   <data name="KeyReadOnly" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified.</value>
+    <value>The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified. To change the principal of an existing entity with an identifying foreign key first delete the dependent and invoke 'SaveChanges' then associate the dependent with the new principal.</value>
   </data>
   <data name="PropertyReadOnlyAfterSave" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is defined to be read-only after it has been saved, but its value has been modified or marked as modified.</value>
@@ -743,5 +743,11 @@
   </data>
   <data name="NonDefiningOwnership" xml:space="preserve">
     <value>The ownership navigation '{ownershipNavigation}' should be the same as the defining navigation '{definingNavigation}' for entity type '{entityType}'</value>
+  </data>
+  <data name="AmbiguousDelegatedIdentityEntity" xml:space="preserve">
+    <value>The entity type '{entityType}' has delegated identity and the given entity is currently referenced from several owner entities. To access the entry for a particular reference to this entity call '{targetEntryCall}' on the owner entry.</value>
+  </data>
+  <data name="UntrackedDelegatedIdentityEntity" xml:space="preserve">
+    <value>The entity type '{entityType}' has delegated identity and the given entity is currently not being tracked. To start tracking this entity call '{targetEntryCall}' on the owner entry.</value>
   </data>
 </root>

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -1,0 +1,901 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
+{
+    public class OwnedFixupTest
+    {
+        [Fact]
+        public void Can_get_owned_entity_entry()
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new ParentPN { Id = 77 };
+                var dependent = new ChildPN { Name = "1" };
+                principal.Child1 = dependent;
+                principal.Child2 = dependent;
+
+                Assert.Equal(CoreStrings.UntrackedDelegatedIdentityEntity(
+                    typeof(ChildPN).ShortDisplayName(),
+                    "." + nameof(EntityEntry.Reference) + "()." + nameof(ReferenceEntry.TargetEntry)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(dependent)).Message);
+
+                var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+
+                Assert.Same(dependentEntry1.GetInfrastructure(), context.Entry(dependent).GetInfrastructure());
+
+                var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+
+                Assert.Equal(CoreStrings.AmbiguousDelegatedIdentityEntity(
+                    typeof(ChildPN).ShortDisplayName(),
+                    "." + nameof(EntityEntry.Reference) + "()." + nameof(ReferenceEntry.TargetEntry)),
+                    Assert.Throws<InvalidOperationException>(() => context.Entry(dependent)).Message);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Principal_nav_set_unidirectional(EntityState entityState)
+        {
+            Principal_nav_set_unidirectional_impl(entityState, true);
+            Principal_nav_set_unidirectional_impl(entityState, false);
+            Principal_nav_set_unidirectional_impl(entityState, null);
+        }
+
+        private void Principal_nav_set_unidirectional_impl(EntityState entityState, bool? graph)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new ParentPN { Id = 77 };
+                if (graph == null)
+                {
+                    context.Entry(principal).State = entityState;
+                }
+                var dependent = new ChildPN { Name = "1" };
+                principal.Child1 = dependent;
+                var subDependent = new SubChildPN { Name = "1S" };
+                dependent.SubChild = subDependent;
+
+                if (graph == null)
+                {
+                    context.ChangeTracker.DetectChanges();
+                }
+                else if (graph == true)
+                {
+                    context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+                }
+                else
+                {
+                    switch (entityState)
+                    {
+                        case EntityState.Added:
+                            context.Add(principal);
+                            break;
+                        case EntityState.Unchanged:
+                            context.Attach(principal);
+                            break;
+                        case EntityState.Modified:
+                            context.Update(principal);
+                            break;
+                    }
+                }
+
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(entityState, context.Entry(principal).State);
+
+                            Assert.Same(dependent, principal.Child1);
+                            Assert.Null(principal.Child2);
+                            var dependentEntry = context.Entry(dependent);
+                            Assert.Equal(principal.Id, dependentEntry.Property("ParentId").CurrentValue);
+                            Assert.Equal(graph == null ? EntityState.Added : entityState, dependentEntry.State);
+                            Assert.Equal(nameof(ParentPN.Child1), dependentEntry.Metadata.DefiningNavigationName);
+
+                            Assert.Same(subDependent, dependent.SubChild);
+                            var subDependentEntry = context.Entry(subDependent);
+                            Assert.Equal(principal.Id, subDependentEntry.Property("ChildId").CurrentValue);
+                            Assert.Equal(graph == null ? EntityState.Added : entityState, subDependentEntry.State);
+                            Assert.Equal(nameof(ChildPN.SubChild), subDependentEntry.Metadata.DefiningNavigationName);
+                        });
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Both_navs_set(EntityState entityState)
+        {
+            Both_navs_set_impl(entityState, true);
+            Both_navs_set_impl(entityState, false);
+            Both_navs_set_impl(entityState, null);
+        }
+
+        private void Both_navs_set_impl(EntityState entityState, bool? graph)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new Parent { Id = 77 };
+                if (graph == null)
+                {
+                    context.Entry(principal).State = entityState;
+                }
+                var dependent = new Child { Name = "1", Parent = principal };
+                principal.Child1 = dependent;
+
+                if (graph == null)
+                {
+                    context.ChangeTracker.DetectChanges();
+                }
+                else if (graph == true)
+                {
+                    context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+                }
+                else
+                {
+                    switch (entityState)
+                    {
+                        case EntityState.Added:
+                            context.Add(principal);
+                            break;
+                        case EntityState.Unchanged:
+                            context.Attach(principal);
+                            break;
+                        case EntityState.Modified:
+                            context.Update(principal);
+                            break;
+                    }
+                }
+
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Same(dependent, principal.Child1);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(graph == null ? EntityState.Added : entityState, context.Entry(dependent).State);
+                        });
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Principal_nav_set_bidirectional(EntityState entityState)
+        {
+            Principal_nav_set_bidirectional_impl(entityState, true);
+            Principal_nav_set_bidirectional_impl(entityState, false);
+            Principal_nav_set_bidirectional_impl(entityState, null);
+        }
+
+        private void Principal_nav_set_bidirectional_impl(EntityState entityState, bool? graph)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new Parent { Id = 77 };
+                if (graph == null)
+                {
+                    context.Entry(principal).State = entityState;
+                }
+                var dependent = new Child { Name = "1" };
+                principal.Child1 = dependent;
+
+                if (graph == null)
+                {
+                    context.ChangeTracker.DetectChanges();
+                }
+                else if (graph == true)
+                {
+                    context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+                }
+                else
+                {
+                    switch (entityState)
+                    {
+                        case EntityState.Added:
+                            context.Add(principal);
+                            break;
+                        case EntityState.Unchanged:
+                            context.Attach(principal);
+                            break;
+                        case EntityState.Modified:
+                            context.Update(principal);
+                            break;
+                    }
+                }
+
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child1);
+                            Assert.Same(principal, dependent.Parent);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(graph == null ? EntityState.Added : entityState, context.Entry(dependent).State);
+                        });
+            }
+        }
+
+        [Fact]
+        public async Task Principal_nav_set_unidirectional_AddAsync()
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new ParentPN { Id = 77 };
+                var dependent = new ChildPN { Name = "1" };
+                principal.Child1 = dependent;
+
+                await context.AddAsync(principal);
+                var entityState = EntityState.Added;
+
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                AssertFixup(
+                    context,
+                    () =>
+                        {
+                            Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
+                            Assert.Same(dependent, principal.Child1);
+                            Assert.Equal(entityState, context.Entry(principal).State);
+                            Assert.Equal(entityState, context.Entry(dependent).State);
+                        });
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Identity_changed_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new ParentPN { Id = 77 };
+                var dependent = new ChildPN { Name = "1" };
+                principal.Child1 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+
+                principal.Child1 = null;
+                principal.Child2 = dependent;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(entityState == EntityState.Added ? 2 : 3, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal.Child1);
+                Assert.Same(dependent, principal.Child2);
+                Assert.Equal(entityState, context.Entry(principal).State);
+                Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
+                var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+                Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Added, dependentEntry2.State);
+                Assert.Equal(nameof(ParentPN.Child2), dependentEntry2.Metadata.DefiningNavigationName);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Identity_changed_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new Parent { Id = 77 };
+                var dependent = new Child { Name = "1", Parent = principal };
+                principal.Child2 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+
+                principal.Child1 = dependent;
+                principal.Child2 = null;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(entityState == EntityState.Added ? 2 : 3, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal.Child2);
+                Assert.Same(principal, dependent.Parent);
+                Assert.Same(dependent, principal.Child1);
+                Assert.Equal(entityState, context.Entry(principal).State);
+                Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
+                var dependentEntry = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+                Assert.Equal(principal.Id, dependentEntry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Added, dependentEntry.State);
+                Assert.Equal(nameof(Parent.Child1), dependentEntry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Identity_swapped_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new ParentPN { Id = 77 };
+                var dependent1 = new ChildPN { Name = "1" };
+                principal.Child1 = dependent1;
+                var dependent2 = new ChildPN { Name = "2" };
+                principal.Child2 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+                var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+
+                principal.Child2 = dependent1;
+                principal.Child1 = dependent2;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                Assert.Same(dependent1, principal.Child2);
+                Assert.Same(dependent2, principal.Child1);
+                Assert.Equal(entityState, context.Entry(principal).State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal).Reference(p => p.Child2).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child2), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Identity_swapped_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal = new Parent { Id = 77 };
+                var dependent1 = new Child { Name = "1", Parent = principal };
+                principal.Child1 = dependent1;
+                var dependent2 = new Child { Name = "2", Parent = principal };
+                principal.Child2 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+                var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+
+                principal.Child2 = dependent1;
+                principal.Child1 = dependent2;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                Assert.Same(principal, dependent1.Parent);
+                Assert.Same(dependent1, principal.Child2);
+                Assert.Same(principal, dependent2.Parent);
+                Assert.Same(dependent2, principal.Child1);
+                Assert.Equal(entityState, context.Entry(principal).State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal).Reference(p => p.Child2).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child2), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_changed_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new ParentPN { Id = 77 };
+                var principal2 = new ParentPN { Id = 78 };
+                var dependent = new ChildPN { Name = "1" };
+                principal1.Child1 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+
+                principal2.Child1 = dependent;
+                principal1.Child1 = null;
+
+                if (entityState != EntityState.Added)
+                {
+                    Assert.Equal(CoreStrings.KeyReadOnly("ParentId", dependentEntry1.Metadata.DisplayName()),
+                        Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                }
+                else
+                {
+                    context.ChangeTracker.DetectChanges();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                    Assert.Null(principal1.Child1);
+                    Assert.Null(principal1.Child2);
+                    Assert.Same(dependent, principal2.Child1);
+                    Assert.Null(principal2.Child2);
+                    Assert.Equal(entityState, context.Entry(principal1).State);
+                    Assert.Equal(entityState, context.Entry(principal2).State);
+                    Assert.Equal(EntityState.Detached, dependentEntry1.State);
+                    var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+                    Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
+                    Assert.Equal(EntityState.Added, dependentEntry2.State);
+                    Assert.Equal(nameof(Parent.Child1), dependentEntry2.Metadata.DefiningNavigationName);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_changed_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new Parent { Id = 77 };
+                var principal2 = new Parent { Id = 78 };
+                var dependent = new Child { Name = "1" };
+                principal1.Child1 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+
+                principal2.Child1 = dependent;
+                principal1.Child1 = null;
+
+                if (entityState != EntityState.Added)
+                {
+                    Assert.Equal(CoreStrings.KeyReadOnly("ParentId", dependentEntry1.Metadata.DisplayName()),
+                        Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                }
+                else
+                {
+                    context.ChangeTracker.DetectChanges();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                    Assert.Null(principal1.Child1);
+                    Assert.Null(principal1.Child2);
+                    Assert.Same(dependent, principal2.Child1);
+                    Assert.Null(principal2.Child2);
+                    Assert.Same(principal2, dependent.Parent);
+                    Assert.Equal(entityState, context.Entry(principal1).State);
+                    Assert.Equal(entityState, context.Entry(principal2).State);
+                    Assert.Equal(EntityState.Detached, dependentEntry1.State);
+                    var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+                    Assert.Equal(EntityState.Added, dependentEntry2.State);
+                    Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
+                    Assert.Equal(nameof(Parent.Child1), dependentEntry2.Metadata.DefiningNavigationName);
+                }
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_swapped_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new ParentPN { Id = 77 };
+                var principal2 = new ParentPN { Id = 78 };
+                var dependent1 = new ChildPN { Name = "1" };
+                principal1.Child1 = dependent1;
+                var dependent2 = new ChildPN { Name = "2" };
+                principal2.Child1 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+                var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+
+                principal1.Child1 = dependent2;
+                principal2.Child1 = dependent1;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(4, context.ChangeTracker.Entries().Count());
+                Assert.Same(dependent2, principal1.Child1);
+                Assert.Null(principal1.Child2);
+                Assert.Same(dependent1, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Equal(EntityState.Detached, dependent1Entry.State);
+                Assert.Equal(EntityState.Detached, dependent2Entry.State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal2).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal2.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal1).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal1.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_swapped_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new Parent { Id = 77 };
+                var principal2 = new Parent { Id = 78 };
+                var dependent1 = new Child { Name = "1" };
+                principal1.Child1 = dependent1;
+                var dependent2 = new Child { Name = "2" };
+                principal2.Child1 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+                var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+
+                principal1.Child1 = dependent2;
+                principal2.Child1 = dependent1;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(4, context.ChangeTracker.Entries().Count());
+                Assert.Same(dependent2, principal1.Child1);
+                Assert.Null(principal1.Child2);
+                Assert.Same(dependent1, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Same(principal2, dependent1.Parent);
+                Assert.Same(principal1, dependent2.Parent);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal2).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(principal2.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(nameof(Parent.Child1), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal1).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal1.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_and_identity_changed_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new ParentPN { Id = 77 };
+                var principal2 = new ParentPN { Id = 78 };
+                var dependent = new ChildPN { Name = "1" };
+                principal1.Child2 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+
+                principal2.Child1 = dependent;
+                principal1.Child2 = null;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(entityState == EntityState.Added ? 3 : 4, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal1.Child1);
+                Assert.Null(principal1.Child2);
+                Assert.Same(dependent, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
+                var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+                Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Added, dependentEntry2.State);
+                Assert.Equal(nameof(Parent.Child1), dependentEntry2.Metadata.DefiningNavigationName);
+            }
+        }
+
+        [Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_and_identity_changed_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new Parent { Id = 77 };
+                var principal2 = new Parent { Id = 78 };
+                var dependent = new Child { Name = "1", Parent = principal1 };
+                principal1.Child2 = dependent;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+
+                principal2.Child1 = dependent;
+                principal1.Child2 = null;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(entityState == EntityState.Added ? 3 : 4, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal1.Child1);
+                Assert.Null(principal1.Child2);
+                Assert.Same(dependent, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Same(principal2, dependent.Parent);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
+                var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+                Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Added, dependentEntry2.State);
+                Assert.Equal(nameof(Parent.Child1), dependentEntry2.Metadata.DefiningNavigationName);
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_and_identity_swapped_unidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new ParentPN { Id = 77 };
+                var principal2 = new ParentPN { Id = 78 };
+                var dependent1 = new ChildPN { Name = "1" };
+                principal1.Child2 = dependent1;
+                var dependent2 = new ChildPN { Name = "2" };
+                principal2.Child1 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+                var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+
+                principal2.Child1 = dependent1;
+                principal1.Child2 = dependent2;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(4, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal1.Child1);
+                Assert.Same(dependent2, principal1.Child2);
+                Assert.Same(dependent1, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal1).Reference(p => p.Child2).TargetEntry.GetInfrastructure());
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(nameof(Parent.Child2), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal2).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        // TODO: #7340
+        //[Theory]
+        [InlineData(EntityState.Added)]
+        [InlineData(EntityState.Modified)]
+        [InlineData(EntityState.Unchanged)]
+        public void Parent_and_identity_swapped_bidirectional(EntityState entityState)
+        {
+            using (var context = new FixupContext())
+            {
+                var principal1 = new Parent { Id = 77 };
+                var principal2 = new Parent { Id = 78 };
+                var dependent1 = new Child { Name = "1", Parent = principal1 };
+                principal1.Child2 = dependent1;
+                var dependent2 = new Child { Name = "2" };
+                principal2.Child1 = dependent2;
+
+                context.ChangeTracker.TrackGraph(principal1, e => e.Entry.State = entityState);
+                context.ChangeTracker.TrackGraph(principal2, e => e.Entry.State = entityState);
+
+                var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+                var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+
+                principal2.Child1 = dependent1;
+                principal1.Child2 = dependent2;
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal(4, context.ChangeTracker.Entries().Count());
+                Assert.Null(principal1.Child1);
+                Assert.Same(dependent2, principal1.Child2);
+                Assert.Same(dependent1, principal2.Child1);
+                Assert.Null(principal2.Child2);
+                Assert.Same(principal2, dependent1.Parent);
+                Assert.Same(principal1, dependent2.Parent);
+                Assert.Equal(entityState, context.Entry(principal1).State);
+                Assert.Equal(entityState, context.Entry(principal2).State);
+                Assert.Same(dependent1Entry.GetInfrastructure(),
+                    context.Entry(principal1).Reference(p => p.Child2).TargetEntry.GetInfrastructure());
+                Assert.Equal(EntityState.Modified, dependent1Entry.State);
+                Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(nameof(Parent.Child2), dependent1Entry.Metadata.DefiningNavigationName);
+                Assert.Same(dependent2Entry.GetInfrastructure(),
+                    context.Entry(principal2).Reference(p => p.Child1).TargetEntry.GetInfrastructure());
+                Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
+                Assert.Equal(EntityState.Modified, dependent2Entry.State);
+                Assert.Equal(nameof(Parent.Child1), dependent2Entry.Metadata.DefiningNavigationName);
+            }
+        }
+
+        private class Parent
+        {
+            public int Id { get; set; }
+
+            public Child Child1 { get; set; }
+            public Child Child2 { get; set; }
+        }
+
+        private class Child
+        {
+            public string Name { get; set; }
+
+            public Parent Parent { get; set; }
+            public SubChild SubChild { get; set; }
+        }
+
+        private class SubChild
+        {
+            public string Name { get; set; }
+
+            public Child Child { get; set; }
+        }
+
+        private class ParentPN
+        {
+            public int Id { get; set; }
+
+            public ChildPN Child1 { get; set; }
+            public ChildPN Child2 { get; set; }
+        }
+
+        private class ChildPN
+        {
+            public string Name { get; set; }
+
+            public SubChildPN SubChild { get; set; }
+        }
+
+        private class SubChildPN
+        {
+            public string Name { get; set; }
+        }
+
+        private class FixupContext : DbContext
+        {
+            public FixupContext()
+            {
+                ChangeTracker.AutoDetectChangesEnabled = false;
+            }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Parent>(pb =>
+                    {
+                        pb.Property(p => p.Id).ValueGeneratedNever();
+                        pb.OwnsOne(p => p.Child1, cb =>
+                            {
+                                cb.Property<int?>("ParentId");
+                                cb.HasForeignKey("ParentId");
+                                cb.HasOne(c => c.Parent)
+                                    .WithOne(p => p.Child1);
+                                cb.OwnsOne(c => c.SubChild, scb =>
+                                    {
+                                        scb.HasForeignKey("ChildId");
+                                        scb.HasOne(sc => sc.Child)
+                                            .WithOne(c => c.SubChild);
+                                    });
+                            });
+                        pb.OwnsOne(p => p.Child2, cb =>
+                            {
+                                cb.Property<int?>("ParentId");
+                                cb.HasForeignKey("ParentId");
+                                cb.HasOne(c => c.Parent)
+                                    .WithOne(p => p.Child2);
+                                cb.OwnsOne(c => c.SubChild, scb =>
+                                    {
+                                        scb.HasForeignKey("ChildId");
+                                        scb.HasOne(sc => sc.Child)
+                                            .WithOne(c => c.SubChild);
+                                    });
+                            });
+                    });
+
+                modelBuilder.Entity<ParentPN>(pb =>
+                    {
+                        pb.Property(p => p.Id).ValueGeneratedNever();
+                        pb.OwnsOne(p => p.Child1, cb =>
+                            {
+                                cb.Property<int?>("ParentId");
+                                cb.HasForeignKey("ParentId");
+                                cb.OwnsOne(c => c.SubChild, scb => { scb.HasForeignKey("ChildId"); });
+                            });
+                        pb.OwnsOne(p => p.Child2, cb =>
+                            {
+                                cb.Property<int?>("ParentId");
+                                cb.HasForeignKey("ParentId");
+                                cb.OwnsOne(c => c.SubChild, scb => { scb.HasForeignKey("ChildId"); });
+                            });
+                    });
+            }
+
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(nameof(FixupContext));
+        }
+
+        private void AssertFixup(DbContext context, Action asserts)
+        {
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+            context.ChangeTracker.DetectChanges();
+            asserts();
+        }
+    }
+}

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -1462,9 +1462,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = new ParentDN { Id = 77 };
                 var dependent = new ChildDN { Id = 78 };
 
-                context.Entry(dependent).Property("ParentId").CurrentValue = principal.Id;
-
                 context.Entry(principal).State = entityState;
+                context.Entry(dependent).Property("ParentId").CurrentValue = principal.Id;
                 context.Entry(dependent).State = entityState;
 
                 AssertFixup(
@@ -1490,9 +1489,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 var principal = new ParentDN { Id = 77 };
                 var dependent = new ChildDN { Id = 78, Parent = principal };
 
-                context.Entry(dependent).Property("ParentId").CurrentValue = principal.Id;
-
                 context.Entry(principal).State = entityState;
+                context.Entry(dependent).Property("ParentId").CurrentValue = principal.Id;
                 context.Entry(dependent).State = entityState;
 
                 AssertFixup(

--- a/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
@@ -78,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Same(chunky, cherry.Monkeys.Single());
                 Assert.Equal(cherry.Id, chunky.GarciaId);
                 Assert.Same(cherry, reference.CurrentValue);
+                Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
 
                 reference.CurrentValue = null;
 
@@ -85,6 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Empty(cherry.Monkeys);
                 Assert.Null(chunky.GarciaId);
                 Assert.Null(reference.CurrentValue);
+                Assert.Null(reference.TargetEntry);
             }
         }
 
@@ -107,6 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Same(chunky, cherry.Monkeys.Single());
                 Assert.Equal(cherry.Id, chunky.GarciaId);
                 Assert.Same(cherry, reference.CurrentValue);
+                Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
 
                 reference.CurrentValue = null;
 
@@ -114,6 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Empty(cherry.Monkeys);
                 Assert.Null(chunky.GarciaId);
                 Assert.Null(reference.CurrentValue);
+                Assert.Null(reference.TargetEntry);
             }
         }
 
@@ -193,6 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Equal(cherry.Id, chunky.GarciaId);
                 Assert.Same(cherry, reference.CurrentValue);
 
+                Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
                 Assert.Equal(EntityState.Added, context.Entry(cherry).State);
                 Assert.Equal(EntityState.Added, context.Entry(chunky).State);
 
@@ -203,6 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Null(chunky.GarciaId);
                 Assert.Null(reference.CurrentValue);
 
+                Assert.Null(reference.TargetEntry);
                 Assert.Equal(EntityState.Added, context.Entry(cherry).State);
                 Assert.Equal(EntityState.Added, context.Entry(chunky).State);
             }
@@ -228,6 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Equal(cherry.Id, chunky.GarciaId);
                 Assert.Same(cherry, reference.CurrentValue);
 
+                Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
                 Assert.Equal(EntityState.Added, context.Entry(cherry).State);
                 Assert.Equal(EntityState.Added, context.Entry(chunky).State);
 
@@ -238,6 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
                 Assert.Null(chunky.GarciaId);
                 Assert.Null(reference.CurrentValue);
 
+                Assert.Null(reference.TargetEntry);
                 Assert.Equal(EntityState.Added, context.Entry(cherry).State);
                 Assert.Equal(EntityState.Added, context.Entry(chunky).State);
             }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -214,6 +214,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 throw new NotImplementedException();
             }
 
+            public InternalEntityEntry GetOrCreateEntry(object entity, IEntityType entityType)
+            {
+                throw new NotImplementedException();
+            }
+
             public InternalEntityEntry StartTrackingFromQuery(
                 IEntityType baseEntityType,
                 object entity,
@@ -239,6 +244,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             public InternalEntityEntry TryGetEntry(object entity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public InternalEntityEntry TryGetEntry(object entity, IEntityType type)
             {
                 throw new NotImplementedException();
             }
@@ -4278,8 +4288,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 Assert.Equal(
                     CoreStrings.InvalidUseService(
-                        nameof(DbContextOptionsBuilder.UseLoggerFactory), 
-                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider), 
+                        nameof(DbContextOptionsBuilder.UseLoggerFactory),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider),
                         nameof(ILoggerFactory)),
                     Assert.Throws<InvalidOperationException>(() => context.Model).Message);
             }
@@ -4437,7 +4447,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 var _ = context.Model;
             }
-            
+
             using (var context = new ChangeSdlCacheContext(true))
             {
                 Assert.Equal(
@@ -4485,7 +4495,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             {
                 var _ = context.Model;
             }
-            
+
             using (var context = new ConstructorTestContextWithOC3A(
                 new DbContextOptionsBuilder<ConstructorTestContextWithOC3A>()
                     .UseTransientInMemoryDatabase()
@@ -4540,7 +4550,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     Assert.Throws<InvalidOperationException>(() => context.Model).Message);
             }
         }
-        
+
         [Fact]
         public void Throws_changing_warnings_default_in_OnConfiguring_when_UseInternalServiceProvider()
         {


### PR DESCRIPTION
Add ReferenceEntry.TargetEntry as a way to get entries for the delegated identity entities
If the navigation to owned entity is set to null the owned entity will be deleted
Changes in the inverse navigation from an owned type will be ignored as its meaning is ambiguous