### PR TITLE
Query: Avoid revisiting NewExpression in RelationalProjectionExpressi…

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -52,62 +52,62 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <summary>
         ///     Visit a method call expression.
         /// </summary>
-        /// <param name="node"> The expression to visit. </param>
+        /// <param name="methodCallExpression"> The expression to visit. </param>
         /// <returns>
         ///     An Expression corresponding to the translated method call.
         /// </returns>
-        protected override Expression VisitMethodCall(MethodCallExpression node)
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
-            Check.NotNull(node, nameof(node));
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (IncludeCompiler.IsIncludeMethod(node))
+            if (IncludeCompiler.IsIncludeMethod(methodCallExpression))
             {
-                return node;
+                return methodCallExpression;
             }
 
-            if (EntityQueryModelVisitor.IsPropertyMethod(node.Method))
+            if (EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
             {
-                var newArg0 = Visit(node.Arguments[0]);
+                var newArg0 = Visit(methodCallExpression.Arguments[0]);
 
-                if (newArg0 != node.Arguments[0])
+                if (newArg0 != methodCallExpression.Arguments[0])
                 {
                     return Expression.Call(
-                        node.Method,
+                        methodCallExpression.Method,
                         newArg0,
-                        node.Arguments[1]);
+                        methodCallExpression.Arguments[1]);
                 }
 
-                return node;
+                return methodCallExpression;
             }
 
-            return base.VisitMethodCall(node);
+            return base.VisitMethodCall(methodCallExpression);
         }
 
         /// <summary>
         ///     Visit a new expression.
         /// </summary>
-        /// <param name="expression"> The expression to visit. </param>
+        /// <param name="newExpression"> The expression to visit. </param>
         /// <returns>
         ///     An Expression corresponding to the translated new expression.
         /// </returns>
-        protected override Expression VisitNew(NewExpression expression)
+        protected override Expression VisitNew(NewExpression newExpression)
         {
-            Check.NotNull(expression, nameof(expression));
+            Check.NotNull(newExpression, nameof(newExpression));
 
-            var newNewExpression = base.VisitNew(expression);
+            var newNewExpression = base.VisitNew(newExpression);
 
             var selectExpression = QueryModelVisitor.TryGetQuery(_querySource);
 
             if (selectExpression != null)
             {
-                for (var i = 0; i < expression.Arguments.Count; i++)
+                for (var i = 0; i < newExpression.Arguments.Count; i++)
                 {
-                    var sourceExpression = expression.Arguments[i];
+                    var sourceExpression = newExpression.Arguments[i];
 
                     if (_sourceExpressionProjectionMapping.ContainsKey(sourceExpression))
                     {
-                        var memberInfo = expression.Members?[i]
-                            ?? (expression.Arguments[i] as MemberExpression)?.Member;
+                        var memberInfo = newExpression.Members?[i]
+                                         ?? (newExpression.Arguments[i] as MemberExpression)?.Member;
 
                         if (memberInfo != null)
                         {
@@ -125,16 +125,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <summary>
         ///     Visits the given node.
         /// </summary>
-        /// <param name="node"> The expression to visit. </param>
+        /// <param name="expression"> The expression to visit. </param>
         /// <returns>
         ///     An Expression to the translated input expression.
         /// </returns>
-        public override Expression Visit(Expression node)
+        public override Expression Visit(Expression expression)
         {
             var selectExpression = QueryModelVisitor.TryGetQuery(_querySource);
 
-            if (node != null
-                && !(node is ConstantExpression)
+            if (expression != null
+                && !(expression is ConstantExpression)
+                && !(expression is NewExpression)
                 && selectExpression != null)
             {
                 var existingProjectionsCount = selectExpression.Projection.Count;
@@ -142,16 +143,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 var sqlExpression
                     = _sqlTranslatingExpressionVisitorFactory
                         .Create(QueryModelVisitor, selectExpression, inProjection: true)
-                        .Visit(node);
+                        .Visit(expression);
 
                 if (sqlExpression == null)
                 {
-                    var qsre = node as QuerySourceReferenceExpression;
-                    if (qsre == null)
-                    {
-                        QueryModelVisitor.RequiresClientProjection = true;
-                    }
-                    else
+                    if (expression is QuerySourceReferenceExpression qsre)
                     {
                         if (QueryModelVisitor.ParentQueryModelVisitor != null
                             && selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
@@ -159,69 +155,70 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                             selectExpression.ProjectStarTable = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
                         }
                     }
+                    else
+                    {
+                        QueryModelVisitor.RequiresClientProjection = true;
+                    }
                 }
                 else
                 {
                     selectExpression.RemoveRangeFromProjection(existingProjectionsCount);
 
-                    if (!(node is NewExpression))
+                    if (!(expression is QuerySourceReferenceExpression))
                     {
-                        if (!(node is QuerySourceReferenceExpression))
+                        if (sqlExpression is NullableExpression nullableExpression)
                         {
-                            if (sqlExpression is NullableExpression nullableExpression)
-                            {
-                                sqlExpression = nullableExpression.Operand;
-                            }
-
-                            if (sqlExpression is ColumnExpression)
-                            {
-                                selectExpression.AddToProjection(sqlExpression);
-
-                                _sourceExpressionProjectionMapping[node] = sqlExpression;
-
-                                return node;
-                            }
+                            sqlExpression = nullableExpression.Operand;
                         }
 
-                        if (!(sqlExpression is ConstantExpression))
+                        if (sqlExpression is ColumnExpression)
                         {
-                            var targetExpression
-                                = QueryModelVisitor.QueryCompilationContext.QuerySourceMapping
-                                    .GetExpression(_querySource);
+                            selectExpression.AddToProjection(sqlExpression);
 
-                            if (targetExpression.Type == typeof(ValueBuffer))
+                            _sourceExpressionProjectionMapping[expression] = sqlExpression;
+
+                            return expression;
+                        }
+                    }
+
+                    if (!(sqlExpression is ConstantExpression))
+                    {
+                        var targetExpression
+                            = QueryModelVisitor.QueryCompilationContext.QuerySourceMapping
+                                .GetExpression(_querySource);
+
+                        if (targetExpression.Type == typeof(ValueBuffer))
+                        {
+                            var index = selectExpression.AddToProjection(sqlExpression);
+
+                            _sourceExpressionProjectionMapping[expression] = sqlExpression;
+
+                            var readValueExpression
+                                = _entityMaterializerSource
+                                    .CreateReadValueCallExpression(targetExpression, index);
+
+                            var outputDataInfo
+                                = (expression as SubQueryExpression)?.QueryModel
+                                .GetOutputDataInfo();
+
+                            if (outputDataInfo is StreamedScalarValueInfo)
                             {
-                                var index = selectExpression.AddToProjection(sqlExpression);
-
-                                _sourceExpressionProjectionMapping[node] = sqlExpression;
-
-                                var readValueExpression
-                                    = _entityMaterializerSource
-                                        .CreateReadValueCallExpression(targetExpression, index);
-
-                                var outputDataInfo
-                                    = (node as SubQueryExpression)?.QueryModel
-                                    .GetOutputDataInfo();
-
-                                if (outputDataInfo is StreamedScalarValueInfo)
-                                {
-                                    // Compensate for possible nulls
-                                    readValueExpression
-                                        = Expression.Coalesce(
-                                            readValueExpression,
-                                            Expression.Default(node.Type));
-                                }
-
-                                return Expression.Convert(readValueExpression, node.Type);
+                                // Compensate for possible nulls
+                                readValueExpression
+                                    = Expression.Coalesce(
+                                        readValueExpression,
+                                        Expression.Default(expression.Type));
                             }
 
-                            return node;
+                            return Expression.Convert(readValueExpression, expression.Type);
                         }
+
+                        return expression;
                     }
                 }
             }
 
-            return base.Visit(node);
+            return base.Visit(expression);
         }
     }
 }

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -1678,10 +1678,23 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Where_subquery_anon()
         {
             AssertQuery<Employee, Order>((es, os) =>
-                from e in es.Take(9).Select(e => new { e })
-                from o in os.Take(1000).Select(o => new { o })
+                from e in es.Take(3).Select(e => new { e })
+                from o in os.Take(5).Select(o => new { o })
                 where e.e.EmployeeID == o.o.EmployeeID
                 select new { e, o });
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_anon_nested()
+        {
+            AssertQuery<Employee, Order, Customer>(
+                (es, os, cs) =>
+                    from t in (
+                        from e in es.Take(3).Select(e => new { e }).Where(e => e.e.City == "London")
+                        from o in os.Take(5).Select(o => new { o })
+                        select new { e, o })
+                    from c in cs.Take(2).Select(c => new { c })
+                    select new { t.e, t.o, c });
         }
 
         [ConditionalFact]

--- a/src/EFCore/Query/Internal/QuerySourceExtensions.cs
+++ b/src/EFCore/Query/Internal/QuerySourceExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
-using Remotion.Linq;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ResultOperators;
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -431,13 +431,13 @@ WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555
 
             Assert.Equal(
                 @"SELECT (
-    SELECT SUM([od0].[Quantity])
-    FROM [Order Details] AS [od0]
-    WHERE [o].[OrderID] = [od0].[OrderID]
+    SELECT SUM([od].[Quantity])
+    FROM [Order Details] AS [od]
+    WHERE [o].[OrderID] = [od].[OrderID]
 ) + (
     SELECT COUNT(*)
-    FROM [Order Details] AS [o1]
-    WHERE [o].[OrderID] = [o1].[OrderID]
+    FROM [Order Details] AS [o0]
+    WHERE [o].[OrderID] = [o0].[OrderID]
 )
 FROM [Orders] AS [o]",
                 Sql);
@@ -622,8 +622,8 @@ WHERE @_outer_CustomerID = [o0].[CustomerID]",
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
-            FROM [Orders] AS [o0]
-            WHERE [c].[CustomerID] = [o0].[CustomerID])
+            FROM [Orders] AS [o]
+            WHERE [c].[CustomerID] = [o].[CustomerID])
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 )
@@ -685,8 +685,8 @@ WHERE EXISTS (
     SELECT CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM [Orders] AS [o0]
-            WHERE ([c].[CustomerID] = [o0].[CustomerID]) AND (([o0].[CustomerID] <> N'ALFKI') OR [o0].[CustomerID] IS NULL))
+            FROM [Orders] AS [o]
+            WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 )
@@ -705,15 +705,15 @@ ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID = [o1].[CustomerID]
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]
 
 @_outer_CustomerID: ANATR (Size = 450)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
-FROM [Orders] AS [o1]
-WHERE @_outer_CustomerID = [o1].[CustomerID]",
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 Sql);
         }
 
@@ -761,8 +761,8 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT(*)
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -820,8 +820,8 @@ ORDER BY (
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT_BIG(*)
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -834,14 +834,14 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT (
     SELECT COUNT(*)
-    FROM [Order Details] AS [o2]
-    WHERE [o].[OrderID] = [o2].[OrderID]
+    FROM [Order Details] AS [o0]
+    WHERE [o].[OrderID] = [o0].[OrderID]
 ), [o].[OrderDate], (
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
-            FROM [Order Details] AS [od1]
-            WHERE ([od1].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od1].[OrderID]))
+            FROM [Order Details] AS [od]
+            WHERE ([od].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od].[OrderID]))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 ), CASE
@@ -851,14 +851,14 @@ END, [o].[OrderID], (
     SELECT CASE
         WHEN NOT EXISTS (
             SELECT 1
-            FROM [Order Details] AS [od2]
-            WHERE ([o].[OrderID] = [od2].[OrderID]) AND ([od2].[OrderID] <> 42))
+            FROM [Order Details] AS [od0]
+            WHERE ([o].[OrderID] = [od0].[OrderID]) AND ([od0].[OrderID] <> 42))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 ), (
     SELECT COUNT_BIG(*)
-    FROM [Order Details] AS [o3]
-    WHERE [o].[OrderID] = [o3].[OrderID]
+    FROM [Order Details] AS [o1]
+    WHERE [o].[OrderID] = [o1].[OrderID]
 )
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)",
@@ -871,9 +871,9 @@ WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) =
 
             Assert.Equal(
                 @"SELECT (
-    SELECT SUM([o0].[OrderID])
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
+    SELECT SUM([o].[OrderID])
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -1185,7 +1185,7 @@ ORDER BY [od.Order].[CustomerID]",
             base.Project_first_or_default_on_empty_collection_of_value_types_returns_proper_default();
 
             Assert.Equal(
-                @"",
+                "",
                 Sql);
         }
 
@@ -1195,10 +1195,10 @@ ORDER BY [od.Order].[CustomerID]",
 
             Assert.Equal(
                 @"SELECT [c].[CustomerID], (
-    SELECT TOP(1) [o0].[OrderID]
-    FROM [Orders] AS [o0]
-    WHERE [c].[CustomerID] = [o0].[CustomerID]
-    ORDER BY [o0].[OrderID]
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
 )
 FROM [Customers] AS [c]",
                 Sql);
@@ -1252,10 +1252,10 @@ ORDER BY [o].[OrderID]",
                 @"@__p_0: 3
 
 SELECT TOP(@__p_0) [o].[OrderID], (
-    SELECT TOP(1) [od0].[OrderID]
-    FROM [Order Details] AS [od0]
-    WHERE [o].[OrderID] = [od0].[OrderID]
-    ORDER BY [od0].[OrderID], [od0].[ProductID]
+    SELECT TOP(1) [od].[OrderID]
+    FROM [Order Details] AS [od]
+    WHERE [o].[OrderID] = [od].[OrderID]
+    ORDER BY [od].[OrderID], [od].[ProductID]
 ), [o.Customer].[City]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]


### PR DESCRIPTION
…onVisitor

Do not set RequireClientProjection true for anonymous type projection

Minor follow up from #7950 
Resolves #7844 