### PR TITLE
[TINY] fix to #6997 - enabling previously disabled test

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3174,12 +3174,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 (e, a) => Assert.Equal(e.Id, a.Id));
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#6997
+        [ConditionalFact]
         public virtual void Complex_query_with_optional_navigations_and_client_side_evaluation()
         {
             AssertQuery<Level1>(
-                l1s => l1s.Where(l1 => !l1.OneToMany_Optional.Select(l2 => l2.OneToOne_Optional_FK.OneToOne_Optional_FK.Id).All(l4 => ClientMethod(l4))),
-                l1s => l1s.Where(l1 => l1.OneToMany_Optional.Select(l2 => MaybeScalar(
+                l1s => l1s.Where(l1 => l1.Id < 3 && !l1.OneToMany_Optional.Select(l2 => l2.OneToOne_Optional_FK.OneToOne_Optional_FK.Id).All(l4 => ClientMethod(l4))),
+                l1s => l1s.Where(l1 => l1.Id < 3 && !l1.OneToMany_Optional.Select(l2 => MaybeScalar(
                     l2.OneToOne_Optional_FK,
                     () => MaybeScalar<int>(
                         l2.OneToOne_Optional_FK.OneToOne_Optional_FK,

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2366,7 +2366,25 @@ WHERE 1 IN (
             base.Complex_query_with_optional_navigations_and_client_side_evaluation();
 
             AssertSql(
-                @"",
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+WHERE [l1].[Id] < 3
+
+@_outer_Id: 1
+
+SELECT [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id], [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id]
+FROM [Level2] AS [l20]
+LEFT JOIN [Level3] AS [l2.OneToOne_Optional_FK0] ON [l20].[Id] = [l2.OneToOne_Optional_FK0].[Level2_Optional_Id]
+LEFT JOIN [Level4] AS [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0] ON [l2.OneToOne_Optional_FK0].[Id] = [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Level3_Optional_Id]
+WHERE @_outer_Id = [l20].[OneToMany_Optional_InverseId]
+
+@_outer_Id: 2
+
+SELECT [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id], [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id]
+FROM [Level2] AS [l20]
+LEFT JOIN [Level3] AS [l2.OneToOne_Optional_FK0] ON [l20].[Id] = [l2.OneToOne_Optional_FK0].[Level2_Optional_Id]
+LEFT JOIN [Level4] AS [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0] ON [l2.OneToOne_Optional_FK0].[Id] = [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Level3_Optional_Id]
+WHERE @_outer_Id = [l20].[OneToMany_Optional_InverseId]",
                 Sql);
         }
 


### PR DESCRIPTION
This scenario is now working. Added additional constraint to make the test faster (since it's client eval) and fixed baseline, which had a typo.