### PR TITLE
A unique index only means an alternate key if it is the principal end of an FK

### DIFF
--- a/src/EFCore.Relational.Design/Infrastructure/RelationalDesignEventId.cs
+++ b/src/EFCore.Relational.Design/Infrastructure/RelationalDesignEventId.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         IndexColumnSkipped,
         FoundForeignKeyColumn,
         FoundSequence,
-        ForeignKeyReferencesMissingTable
+        ForeignKeyReferencesMissingTable,
+        ForeignKeyPrincipalEndContainsNullableColumns
     }
 }

--- a/src/EFCore.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
+++ b/src/EFCore.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
@@ -147,6 +147,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("MissingTable", nameof(table)),
                 table);
 
+        /// <summary>
+        ///     The principal end of the foreign key '{foreignKeyName}' contains the following nullable columns '{columnNames}'. Entity Framework requires the properties representing those columns to be non-nullable.
+        /// </summary>
+        public static string ForeignKeyPrincipalEndContainsNullableColumns([CanBeNull] object foreignKeyName, [CanBeNull] object columnNames)
+            => string.Format(
+                GetString("ForeignKeyPrincipalEndContainsNullableColumns", nameof(foreignKeyName), nameof(columnNames)),
+                foreignKeyName, columnNames);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational.Design/Properties/RelationalDesignStrings.resx
+++ b/src/EFCore.Relational.Design/Properties/RelationalDesignStrings.resx
@@ -168,4 +168,7 @@
   <data name="MissingTable" xml:space="preserve">
     <value>Unable to find a table in the database matching the selected table {table}.</value>
   </data>
+  <data name="ForeignKeyPrincipalEndContainsNullableColumns" xml:space="preserve">
+    <value>The principal end of the foreign key '{foreignKeyName}' contains the following nullable columns '{columnNames}'. Entity Framework requires the properties representing those columns to be non-nullable.</value>
+  </data>
 </root>

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -373,13 +373,9 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.OneToOneFktoUniqueKeyDependentId2).HasColumnName("OneToOneFKToUniqueKeyDependentID2");
 
-                entity.Property(e => e.OneToOneFktoUniqueKeyDependentFk1)
-                    .IsRequired()
-                    .HasColumnName("OneToOneFKToUniqueKeyDependentFK1");
+                entity.Property(e => e.OneToOneFktoUniqueKeyDependentFk1).HasColumnName("OneToOneFKToUniqueKeyDependentFK1");
 
-                entity.Property(e => e.OneToOneFktoUniqueKeyDependentFk2)
-                    .IsRequired()
-                    .HasColumnName("OneToOneFKToUniqueKeyDependentFK2");
+                entity.Property(e => e.OneToOneFktoUniqueKeyDependentFk2).HasColumnName("OneToOneFKToUniqueKeyDependentFK2");
 
                 entity.Property(e => e.SomeColumn)
                     .IsRequired()
@@ -389,7 +385,6 @@ namespace E2ETest.Namespace
                     .WithOne(p => p.OneToOneFktoUniqueKeyDependent)
                     .HasPrincipalKey<OneToOneFktoUniqueKeyPrincipal>(p => new { p.OneToOneFktoUniqueKeyPrincipalUniqueKey1, p.OneToOneFktoUniqueKeyPrincipalUniqueKey2 })
                     .HasForeignKey<OneToOneFktoUniqueKeyDependent>(d => new { d.OneToOneFktoUniqueKeyDependentFk1, d.OneToOneFktoUniqueKeyDependentFk2 })
-                    .OnDelete(DeleteBehavior.Restrict)
                     .HasConstraintName("FK_OneToOneFKToUniqueKeyDependent");
             });
 
@@ -446,13 +441,9 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.OneToOneSeparateFkdependentId2).HasColumnName("OneToOneSeparateFKDependentID2");
 
-                entity.Property(e => e.OneToOneSeparateFkdependentFk1)
-                    .IsRequired()
-                    .HasColumnName("OneToOneSeparateFKDependentFK1");
+                entity.Property(e => e.OneToOneSeparateFkdependentFk1).HasColumnName("OneToOneSeparateFKDependentFK1");
 
-                entity.Property(e => e.OneToOneSeparateFkdependentFk2)
-                    .IsRequired()
-                    .HasColumnName("OneToOneSeparateFKDependentFK2");
+                entity.Property(e => e.OneToOneSeparateFkdependentFk2).HasColumnName("OneToOneSeparateFKDependentFK2");
 
                 entity.Property(e => e.SomeDependentEndColumn)
                     .IsRequired()
@@ -461,7 +452,6 @@ namespace E2ETest.Namespace
                 entity.HasOne(d => d.OneToOneSeparateFkdependentFk)
                     .WithOne(p => p.OneToOneSeparateFkdependent)
                     .HasForeignKey<OneToOneSeparateFkdependent>(d => new { d.OneToOneSeparateFkdependentFk1, d.OneToOneSeparateFkdependentFk2 })
-                    .OnDelete(DeleteBehavior.Restrict)
                     .HasConstraintName("FK_OneToOneSeparateFKDependent");
             });
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.expected
@@ -81,7 +81,6 @@ namespace E2ETest.Namespace
                     .WithOne(p => p.OneToOneFktoUniqueKeyDependent)
                     .HasPrincipalKey<OneToOneFktoUniqueKeyPrincipal>(p => new { p.OneToOneFktoUniqueKeyPrincipalUniqueKey1, p.OneToOneFktoUniqueKeyPrincipalUniqueKey2 })
                     .HasForeignKey<OneToOneFktoUniqueKeyDependent>(d => new { d.OneToOneFktoUniqueKeyDependentFk1, d.OneToOneFktoUniqueKeyDependentFk2 })
-                    .OnDelete(DeleteBehavior.Restrict)
                     .HasConstraintName("FK_OneToOneFKToUniqueKeyDependent");
             });
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOneFKToUniqueKeyDependent.expected
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOneFKToUniqueKeyDependent.expected
@@ -15,10 +15,8 @@ namespace E2ETest.Namespace
         [Required]
         [MaxLength(20)]
         public string SomeColumn { get; set; }
-        [Required]
         [Column("OneToOneFKToUniqueKeyDependentFK1")]
         public int? OneToOneFktoUniqueKeyDependentFk1 { get; set; }
-        [Required]
         [Column("OneToOneFKToUniqueKeyDependentFK2")]
         public int? OneToOneFktoUniqueKeyDependentFk2 { get; set; }
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOneSeparateFKDependent.expected
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOneSeparateFKDependent.expected
@@ -15,10 +15,8 @@ namespace E2ETest.Namespace
         [Required]
         [MaxLength(20)]
         public string SomeDependentEndColumn { get; set; }
-        [Required]
         [Column("OneToOneSeparateFKDependentFK1")]
         public int? OneToOneSeparateFkdependentFk1 { get; set; }
-        [Required]
         [Column("OneToOneSeparateFKDependentFK2")]
         public int? OneToOneSeparateFkdependentFk2 { get; set; }
 

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
@@ -29,19 +29,13 @@ namespace E2E.Sqlite
                     .HasName("sqlite_autoindex_Users_Groups_2")
                     .IsUnique();
 
-                entity.Property(e => e.GroupId).IsRequired();
-
-                entity.Property(e => e.UserId).IsRequired();
-
                 entity.HasOne(d => d.Group)
                     .WithMany(p => p.UsersGroups)
-                    .HasForeignKey(d => d.GroupId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .HasForeignKey(d => d.GroupId);
 
                 entity.HasOne(d => d.User)
                     .WithMany(p => p.UsersGroups)
-                    .HasForeignKey(d => d.UserId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .HasForeignKey(d => d.UserId);
             });
         }
     }

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/ManyToMany/UsersGroups.expected
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/ManyToMany/UsersGroups.expected
@@ -9,9 +9,7 @@ namespace E2E.Sqlite
     public partial class UsersGroups
     {
         public string Id { get; set; }
-        [Required]
         public string UserId { get; set; }
-        [Required]
         public string GroupId { get; set; }
 
         [ForeignKey("GroupId")]


### PR DESCRIPTION
Fixes issue #7956. 

Previously a unique index implied that the properties on which that index is based would be set as required even if the underlying columns were nullable. Now we only do this if the properties are the principal end of a foreign key. This prevents columns which just happen to use a unique index but have nothing to do with a  FK being set to required when this is not necessary.