### PR TITLE
Add query support for delegated identity entity types

### DIFF
--- a/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
@@ -51,7 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Check.NotNull(elementType, nameof(elementType));
 
-            var entityType = _model.FindEntityType(elementType);
+            var entityType = QueryModelVisitor.QueryCompilationContext.FindEntityType(_querySource)
+                             ?? _model.FindEntityType(elementType);
 
             if (QueryModelVisitor.QueryCompilationContext
                 .QuerySourceRequiresMaterialization(_querySource))

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -145,7 +145,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             Check.NotNull(elementType, nameof(elementType));
 
             var relationalQueryCompilationContext = QueryModelVisitor.QueryCompilationContext;
-            var entityType = _model.FindEntityType(elementType);
+
+            var entityType = relationalQueryCompilationContext.FindEntityType(_querySource)
+                             ?? _model.FindEntityType(elementType);
 
             var selectExpression = _selectExpressionFactory.Create(relationalQueryCompilationContext);
 

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1582,8 +1582,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             foreach (var mapping in previousMapping)
             {
-                QueryCompilationContext.QuerySourceMapping
-                    .ReplaceMapping(mapping.Key, mapping.Value);
+                QueryCompilationContext.AddOrUpdateMapping(mapping.Key, mapping.Value);
             }
 
             var innerItemParameter
@@ -1591,7 +1590,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     innerShaper.Type,
                     joinClause.ItemName);
 
-            AddOrUpdateMapping(joinClause, innerItemParameter);
+            QueryCompilationContext.AddOrUpdateMapping(joinClause, innerItemParameter);
 
             var transparentIdentifierType
                 = CreateTransparentIdentifierType(

--- a/src/EFCore/Extensions/NavigationExtensions.cs
+++ b/src/EFCore/Extensions/NavigationExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -22,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     True if the given navigation property is the navigation property on the dependent entity
         ///     type that points to the principal entity, otherwise false.
         /// </returns>
+        [DebuggerStepThrough]
         public static bool IsDependentToPrincipal([NotNull] this INavigation navigation)
             => Check.NotNull(navigation, nameof(navigation)).ForeignKey.DependentToPrincipal == navigation;
 
@@ -32,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     True if this is a collection property, false if it is a reference property.
         /// </returns>
+        [DebuggerStepThrough]
         public static bool IsCollection([NotNull] this INavigation navigation)
         {
             Check.NotNull(navigation, nameof(navigation));
@@ -47,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The inverse navigation, or null if none is defined.
         /// </returns>
+        [DebuggerStepThrough]
         public static INavigation FindInverse([NotNull] this INavigation navigation)
         {
             Check.NotNull(navigation, nameof(navigation));
@@ -62,6 +66,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="navigation"> The navigation property to find the target entity type of. </param>
         /// <returns> The target entity type. </returns>
+        [DebuggerStepThrough]
         public static IEntityType GetTargetType([NotNull] this INavigation navigation)
         {
             Check.NotNull(navigation, nameof(navigation));

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <c>blog => blog.Url</c>).
         /// </param>
         /// <returns> An object that can be used to configure the property. </returns>
-        public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
+        public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TRelatedEntity, TProperty>> propertyExpression)
             => new PropertyBuilder<TProperty>(RelatedEntityType.Builder.Property(
                 Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(),
                 ConfigurationSource.Explicit));
@@ -357,11 +357,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}
+        /// .WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}})" />
         ///         or
-        ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}
+        /// .WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -396,8 +396,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see
-        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
+        ///         <see cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}
+        /// .WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -455,7 +455,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         for all properties of this entity type as described in the <see cref="PropertyAccessMode" /> enum.
         ///     </para>
         ///     <para>
-        ///         Calling this method overrrides for all properties of this entity type any access mode that was
+        ///         Calling this method overrides for all properties of this entity type any access mode that was
         ///         set on the model.
         ///     </para>
         /// </summary>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityResultFindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityResultFindingExpressionVisitor.cs
@@ -57,12 +57,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         protected override Expression VisitQuerySourceReference(
             QuerySourceReferenceExpression expression)
         {
-            var maybeEntityType
-                = expression.Type.TryGetSequenceType() ?? expression.Type;
+            var sequenceType = expression.Type.TryGetSequenceType();
 
             var entityType
-                = _model.FindEntityType(maybeEntityType)
-                  ?? _model.FindEntityType(expression.Type);
+                = ((sequenceType != null
+                    ? _model.FindEntityType(sequenceType)
+                    : null)
+                   ?? _model.FindEntityType(expression.Type))
+                  ?? _queryCompilationContext.FindEntityType(expression.ReferencedQuerySource);
 
             if (entityType != null)
             {

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -393,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             if (qs != null)
                             {
                                 return RewriteNavigationProperties(
-                                    ps.ToList(),
+                                    ps,
                                     qs,
                                     node,
                                     node.Expression,
@@ -482,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             if (qs != null)
                             {
                                 return RewriteNavigationProperties(
-                                    ps.ToList(),
+                                    ps,
                                     qs,
                                     node,
                                     node.Arguments[0],
@@ -526,7 +526,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         }
 
         private Expression RewriteNavigationProperties(
-            List<IPropertyBase> properties,
+            IReadOnlyList<IPropertyBase> properties,
             IQuerySource querySource,
             Expression expression,
             Expression declaringExpression,
@@ -537,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var navigations = properties.OfType<INavigation>().ToList();
 
-            if (navigations.Any())
+            if (navigations.Count > 0)
             {
                 var outerQuerySourceReferenceExpression = new QuerySourceReferenceExpression(querySource);
 
@@ -549,9 +549,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     if (fromSubqueryExpression != null)
                     {
                         return RewriteSelectManyInsideSubqueryIntoJoins(
-                            fromSubqueryExpression, 
-                            outerQuerySourceReferenceExpression, 
-                            navigations, 
+                            fromSubqueryExpression,
+                            outerQuerySourceReferenceExpression,
+                            navigations,
                             additionalFromClauseBeingProcessed);
                     }
 
@@ -594,8 +594,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         .OfType<IncludeResultOperator>()
                         .Where(o => o.PathFromQuerySource == expression))
                     {
-                        includeResultOperator.QuerySource = resultQsre.ReferencedQuerySource;
                         includeResultOperator.PathFromQuerySource = resultQsre;
+                        includeResultOperator.QuerySource = resultQsre.ReferencedQuerySource;
                     }
                 }
 
@@ -748,6 +748,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     targetEntityType.ClrType,
                     NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(targetEntityType.ClrType));
 
+            _queryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(mainFromClause, targetEntityType);
             var querySourceReference = new QuerySourceReferenceExpression(mainFromClause);
             var subQueryModel = new QueryModel(mainFromClause, new SelectClause(querySourceReference));
 
@@ -786,9 +787,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 subQueryVisitor.Rewrite(subQueryModel, parentQueryModel: null);
             }
 
-            var subQuery = new SubQueryExpression(subQueryModel);
-
-            return subQuery;
+            return new SubQueryExpression(subQueryModel);
         }
 
         /// <summary>
@@ -849,7 +848,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (navigation.IsCollection())
                 {
-                    _queryModel.MainFromClause.FromExpression 
+                    _queryModel.MainFromClause.FromExpression
                         = NullAsyncQueryProvider.Instance.CreateEntityQueryableExpression(targetEntityType.ClrType);
 
                     var innerQuerySourceReferenceExpression
@@ -937,7 +936,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 : propertyCreator(querySourceReferenceExpression);
         }
 
-        private static void RewriteNavigationIntoGroupJoin(
+        private void RewriteNavigationIntoGroupJoin(
             JoinClause joinClause,
             INavigation navigation,
             IEntityType targetEntityType,
@@ -991,6 +990,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 new[] { defaultIfEmptyAdditionalFromClause },
                 navigation.IsDependentToPrincipal(),
                 new QuerySourceReferenceExpression(defaultIfEmptyAdditionalFromClause));
+
+            _queryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(defaultIfEmptyAdditionalFromClause, targetEntityType);
         }
 
         private Expression RewriteSelectManyNavigationsIntoJoins(
@@ -1006,14 +1007,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 var targetEntityType = navigation.GetTargetType();
 
-                QuerySourceReferenceExpression innerQuerySourceReferenceExpression;
-
                 var joinClause = BuildJoinFromNavigation(
                     querySourceReferenceExpression,
                     navigation,
                     targetEntityType,
                     false,
-                    out innerQuerySourceReferenceExpression);
+                    out var innerQuerySourceReferenceExpression);
 
                 joinClauses.Add(joinClause);
 
@@ -1062,10 +1061,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 QuerySourceReferenceExpression innerQuerySourceReferenceExpression;
                 var joinClause = BuildJoinFromNavigation(
-                    outerQuerySourceReferenceExpression, 
-                    navigation, 
-                    targetEntityType, 
-                    false, 
+                    outerQuerySourceReferenceExpression,
+                    navigation,
+                    targetEntityType,
+                    false,
                     out innerQuerySourceReferenceExpression);
 
                 if (navigation == collectionNavigation)
@@ -1120,7 +1119,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return outerQuerySourceReferenceExpression;
         }
 
-        private static JoinClause BuildJoinFromNavigation(
+        private JoinClause BuildJoinFromNavigation(
             QuerySourceReferenceExpression querySourceReferenceExpression,
             INavigation navigation,
             IEntityType targetEntityType,
@@ -1149,6 +1148,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     Expression.Constant(null));
 
             innerQuerySourceReferenceExpression = new QuerySourceReferenceExpression(joinClause);
+            _queryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(joinClause, targetEntityType);
 
             var innerKeySelector
                 = CreateKeyAccessExpression(
@@ -1193,14 +1193,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             .Cast<Expression>()
                             .ToArray()));
 
-        private static readonly MethodInfo _propertyMethodInfo
-            = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Property));
-
         private static Expression CreatePropertyExpression(Expression target, IProperty property, bool addNullCheck)
         {
             var propertyExpression = (Expression)Expression.Call(
-                null,
-                _propertyMethodInfo.MakeGenericMethod(property.ClrType),
+                EF.PropertyMethod.MakeGenericMethod(property.ClrType),
                 target,
                 Expression.Constant(property.Name));
 
@@ -1383,7 +1379,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var groupResultOperator = resultOperator as GroupResultOperator;
                 if (groupResultOperator != null)
                 {
-                    groupResultOperator.ElementSelector 
+                    groupResultOperator.ElementSelector
                         = _subqueryInjector.Visit(groupResultOperator.ElementSelector);
 
                     var originalKeySelectorType = groupResultOperator.KeySelector.Type;
@@ -1439,8 +1435,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             node,
                             (properties, querySource) =>
                                 {
-                                    var navigations = properties.OfType<INavigation>().ToList();
-                                    var collectionNavigation = navigations.SingleOrDefault(n => n.IsCollection());
+                                    var collectionNavigation = properties.OfType<INavigation>().SingleOrDefault(n => n.IsCollection());
 
                                     return collectionNavigation != null
                                         ? InjectSubquery(node, collectionNavigation)

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -183,7 +183,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (comparison == ExpressionType.Equal
                 || comparison == ExpressionType.NotEqual)
             {
-                var isEntityTypeExpression = _model.FindEntityType(operand.Type) != null;
+                var isEntityTypeExpression = _model.FindEntityType(operand.Type) != null
+                    || _model.IsDelegatedIdentityEntityType(operand.Type);
 
                 if (isEntityTypeExpression)
                 {

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 Navigation.PropertyInfo));
 
                     queryCompilationContext.AddQuerySourceRequiringMaterialization(mainFromClause);
-                    
+
                     var collectionQueryModel
                         = new QueryModel(
                             mainFromClause,

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -67,27 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             foreach (var includeResultOperator in includeResultOperators.ToArray())
             {
-                var entityType
-                    = _queryCompilationContext.Model
-                        .FindEntityType(includeResultOperator.PathFromQuerySource.Type);
-
-                var nextEntityType = entityType;
-
-                var parts = includeResultOperator.NavigationPropertyPaths.ToArray();
-                var navigationPath = new INavigation[parts.Length];
-
-                for (var i = 0; i < parts.Length; i++)
-                {
-                    navigationPath[i] = nextEntityType.FindNavigation(parts[i]);
-
-                    if (navigationPath[i] == null)
-                    {
-                        throw new InvalidOperationException(
-                            CoreStrings.IncludeBadNavigation(parts[i], nextEntityType.DisplayName()));
-                    }
-
-                    nextEntityType = navigationPath[i].GetTargetType();
-                }
+                var navigationPath = includeResultOperator.GetNavigationPath(_queryCompilationContext);
 
                 var querySourceReferenceExpression
                     = querySourceTracingExpressionVisitor
@@ -109,7 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var sequenceType = querySourceReferenceExpression.Type.TryGetSequenceType();
 
                 if (sequenceType != null
-                    && _queryCompilationContext.Model.FindEntityType(sequenceType) != null)
+                    && (_queryCompilationContext.Model.FindEntityType(sequenceType) != null
+                    || _queryCompilationContext.Model.IsDelegatedIdentityEntityType(sequenceType)))
                 {
                     continue;
                 }

--- a/src/EFCore/Query/ResultOperatorHandler.cs
+++ b/src/EFCore/Query/ResultOperatorHandler.cs
@@ -16,7 +16,6 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.ResultOperators;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -82,8 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(resultOperator, nameof(resultOperator));
             Check.NotNull(queryModel, nameof(queryModel));
 
-            ResultHandler handler;
-            if (!_handlers.TryGetValue(resultOperator.GetType(), out handler))
+            if (!_handlers.TryGetValue(resultOperator.GetType(), out ResultHandler handler))
             {
                 throw new NotImplementedException(resultOperator.GetType().ToString());
             }
@@ -218,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.FirstOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.First)
-                .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
+                    .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
                 entityQueryModelVisitor.Expression);
 
         private static Expression HandleGroup(
@@ -268,8 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             entityQueryModelVisitor.CurrentParameter
                 = Expression.Parameter(expression.Type.GetSequenceType(), groupResultOperator.ItemName);
 
-            entityQueryModelVisitor
-                .AddOrUpdateMapping(groupResultOperator, entityQueryModelVisitor.CurrentParameter);
+            entityQueryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(groupResultOperator, entityQueryModelVisitor.CurrentParameter);
 
             return expression;
         }
@@ -286,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<TSource, CancellationToken, Task<TElement>> elementSelector)
             => new AsyncGroupByAsyncEnumerable<TSource, TKey, TElement>(source, keySelector, elementSelector);
 
-        private sealed class AsyncGroupByAsyncEnumerable<TSource, TKey, TElement> 
+        private sealed class AsyncGroupByAsyncEnumerable<TSource, TKey, TElement>
             : IAsyncEnumerable<IGrouping<TKey, TElement>>
         {
             private readonly IAsyncEnumerable<TSource> _source;
@@ -393,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     (choiceResultOperator.ReturnDefaultWhenEmpty
                                         ? entityQueryModelVisitor.LinqOperatorProvider.LastOrDefault
                                         : entityQueryModelVisitor.LinqOperatorProvider.Last)
-                                    .MakeGenericMethod(methodCallExpression.Arguments[0].Type.GetSequenceType()),
+                                        .MakeGenericMethod(methodCallExpression.Arguments[0].Type.GetSequenceType()),
                                     methodCallExpression.Arguments[0])),
                             methodCallExpression.Arguments[1]
                         });
@@ -403,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.LastOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.Last)
-                .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
+                    .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
                 entityQueryModelVisitor.Expression);
         }
 
@@ -433,7 +430,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.SingleOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.Single)
-                .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
+                    .MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
                 entityQueryModelVisitor.Expression);
 
         private static Expression HandleSkip(

--- a/src/EFCore/Query/ResultOperators/Internal/StringIncludeExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/StringIncludeExpressionNode.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
             var navigationPropertyPathValue = (string)_navigationPropertyPath.Value;
 
             return new IncludeResultOperator(
-                navigationPropertyPathValue.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries), 
+                navigationPropertyPathValue.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries),
                 pathFromQuerySource);
         }
 

--- a/test/EFCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -421,7 +421,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName)
                 => new GenericTestPropertyBuilder<TProperty>(ReferenceOwnershipBuilder.Property<TProperty>(propertyName));
 
-            public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
+            public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TRelatedEntity, TProperty>> propertyExpression)
                 => new GenericTestPropertyBuilder<TProperty>(ReferenceOwnershipBuilder.Property(propertyExpression));
 
             public override TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> Ignore(string propertyName)

--- a/test/EFCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -388,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName)
                 => new NonGenericTestPropertyBuilder<TProperty>(ReferenceOwnershipBuilder.Property<TProperty>(propertyName));
 
-            public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
+            public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TRelatedEntity, TProperty>> propertyExpression)
             {
                 var propertyInfo = propertyExpression.GetPropertyAccess();
                 return new NonGenericTestPropertyBuilder<TProperty>(ReferenceOwnershipBuilder.Property(propertyInfo.PropertyType, propertyInfo.Name));

--- a/test/EFCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -354,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public abstract TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasEntityTypeAnnotation(string annotation, object value);
 
             public abstract TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName);
-            public abstract TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression);
+            public abstract TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TRelatedEntity, TProperty>> propertyExpression);
 
             public abstract TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> Ignore(string propertyName);
 

--- a/test/EFCore.Tests/ModelBuilderTest/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/OwnedTypesTestBase.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var model = modelBuilder.Model;
 
                 var entityBuilder = modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
+                entityBuilder.Property(d => d.CustomerId);
 
                 modelBuilder.Validate();
 


### PR DESCRIPTION
* Add QueryCompilationContext.QuerySourceEntityTypeMapping to keep track of the mapping from IQuerySource to IEntityType
* Change EntityQueryModelVisitor.IterateCompositePropertyExpression to propagate the IEntityType through navigations and rename it to MemberAccessBindingExpressionVisitor.GetPropertyPath
