### PR TITLE
Query: Include: Refactor to use tree data structure inside IncludeCompiler.

### DIFF
--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -698,18 +698,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Lambda<Func<QueryContext, TResults>>(
                         _expression, QueryContextParameter);
 
-            var queryExecutor = queryExecutorExpression.Compile();
+            try
+            {
+                return queryExecutorExpression.Compile();
+            }
+            finally
+            {
+                QueryCompilationContext.Logger.LogDebug(
+                    CoreEventId.QueryPlan,
+                    () =>
+                        {
+                            var queryPlan = _expressionPrinter.Print(queryExecutorExpression);
 
-            QueryCompilationContext.Logger.LogDebug(
-                CoreEventId.QueryPlan,
-                () =>
-                    {
-                        var queryPlan = _expressionPrinter.Print(queryExecutorExpression);
-
-                        return queryPlan;
-                    });
-
-            return queryExecutor;
+                            return queryPlan;
+                        });
+            }
         }
 
         /// <summary>

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -140,39 +140,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
         }
 
         /// <summary>
-        ///     Tests if this object is considered equal to another.
-        /// </summary>
-        /// <param name="obj"> The object to compare with the current object. </param>
-        /// <returns>
-        ///     true if the objects are considered equal, false if they are not.
-        /// </returns>
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            return obj.GetType() == GetType() && Equals((NullConditionalExpression)obj);
-        }
-
-        private bool Equals(NullConditionalExpression other)
-            => Equals(AccessOperation, other.AccessOperation);
-
-        /// <summary>
-        ///     Returns a hash code for this object.
-        /// </summary>
-        /// <returns>
-        ///     A hash code for this object.
-        /// </returns>
-        public override int GetHashCode() => AccessOperation.GetHashCode();
-
-        /// <summary>
         ///     Returns a textual representation of the <see cref="T:System.Linq.Expressions.Expression" />.
         /// </summary>
         /// <returns>

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -253,8 +253,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
                     case ExpressionType.Extension:
                     {
-                        hashCode += (hashCode * 397) ^ obj.GetHashCode();
-
+                        if (obj is NullConditionalExpression nullConditionalExpression)
+                        {
+                            hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalExpression.AccessOperation);
+                        }
+                        else
+                        {
+                            hashCode += (hashCode * 397) ^ obj.GetHashCode();
+                        }
+                        
                         break;
                     }
                     default:
@@ -559,7 +566,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 => CompareExpressionList(a.Expressions, b.Expressions);
 
             private bool CompareExtension(Expression a, Expression b)
-                => a.Equals(b);
+            {
+                if (a is NullConditionalExpression nullConditionalExpressionA
+                    && b is NullConditionalExpression nullConditionalExpressionB)
+                {
+                    return Compare(
+                        nullConditionalExpressionA.AccessOperation,
+                        nullConditionalExpressionB.AccessOperation);
+                }
+
+                return a.Equals(b);
+            }
 
             private bool CompareInvocation(InvocationExpression a, InvocationExpression b)
                 => Compare(a.Expression, b.Expression)

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -1,0 +1,576 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ExpressionVisitors;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public partial class IncludeCompiler
+    {
+        private sealed class CollectionQueryModelRewritingExpressionVisitor : RelinqExpressionVisitor
+        {
+            private static readonly ExpressionEqualityComparer _expressionEqualityComparer
+                = new ExpressionEqualityComparer();
+
+            private readonly QueryCompilationContext _queryCompilationContext;
+            private readonly QueryModel _parentQueryModel;
+
+            public CollectionQueryModelRewritingExpressionVisitor(
+                QueryCompilationContext queryCompilationContext,
+                QueryModel parentQueryModel)
+            {
+                _queryCompilationContext = queryCompilationContext;
+                _parentQueryModel = parentQueryModel;
+            }
+
+            public List<Ordering> ParentOrderings { get; } = new List<Ordering>();
+
+            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+            {
+                if (typeof(IQueryBuffer).GetTypeInfo()
+                        .IsAssignableFrom(methodCallExpression.Object?.Type.GetTypeInfo())
+                    && methodCallExpression.Method.Name
+                        .StartsWith(nameof(IQueryBuffer.IncludeCollection), StringComparison.Ordinal))
+                {
+                    var lambaArgument = methodCallExpression.Arguments[8];
+                    var convertExpression = lambaArgument as UnaryExpression;
+
+                    var subQueryExpression
+                        = (SubQueryExpression)
+                            ((LambdaExpression)(convertExpression?.Operand ?? lambaArgument))
+                             .Body.RemoveConvert();
+
+                    var navigation
+                        = (INavigation)
+                            ((ConstantExpression)methodCallExpression.Arguments[1])
+                            .Value;
+
+                    Rewrite(subQueryExpression.QueryModel, navigation);
+
+                    var newArguments = methodCallExpression.Arguments.ToArray();
+
+                    Expression newLambdaExpression
+                        = Expression.Lambda<Func<IEnumerable<object>>>(subQueryExpression);
+
+                    if (convertExpression != null)
+                    {
+                        newLambdaExpression = convertExpression.Update(newLambdaExpression);
+                    }
+
+                    newArguments[8] = newLambdaExpression;
+
+                    return methodCallExpression.Update(methodCallExpression.Object, newArguments);
+                }
+
+                return base.VisitMethodCall(methodCallExpression);
+            }
+
+            private void Rewrite(QueryModel collectionQueryModel, INavigation navigation)
+            {
+                var querySourceReferenceFindingExpressionTreeVisitor
+                    = new QuerySourceReferenceFindingExpressionTreeVisitor();
+
+                collectionQueryModel.BodyClauses.Single()
+                    .TransformExpressions(querySourceReferenceFindingExpressionTreeVisitor.Visit);
+
+                collectionQueryModel.BodyClauses.Clear();
+
+                var parentQuerySourceReferenceExpression
+                    = querySourceReferenceFindingExpressionTreeVisitor.QuerySourceReferenceExpression;
+
+                var parentQuerySource = parentQuerySourceReferenceExpression.ReferencedQuerySource;
+
+                BuildParentOrderings(
+                    _parentQueryModel,
+                    navigation,
+                    parentQuerySourceReferenceExpression,
+                    ParentOrderings);
+
+                var querySourceMapping = new QuerySourceMapping();
+                var clonedParentQueryModel = _parentQueryModel.Clone(querySourceMapping);
+
+                _queryCompilationContext.CloneAnnotations(querySourceMapping, clonedParentQueryModel);
+
+                var clonedParentQuerySourceReferenceExpression
+                    = (QuerySourceReferenceExpression)querySourceMapping.GetExpression(parentQuerySource);
+
+                var clonedParentQuerySource
+                    = clonedParentQuerySourceReferenceExpression.ReferencedQuerySource;
+
+                AdjustPredicate(
+                    clonedParentQueryModel,
+                    clonedParentQuerySource,
+                    clonedParentQuerySourceReferenceExpression);
+
+                clonedParentQueryModel.SelectClause
+                    = new SelectClause(Expression.Default(typeof(AnonymousObject)));
+
+                var subQueryProjection = new List<Expression>();
+
+                var lastResultOperator = ProcessResultOperators(clonedParentQueryModel);
+
+                clonedParentQueryModel.ResultTypeOverride
+                    = typeof(IQueryable<>).MakeGenericType(clonedParentQueryModel.SelectClause.Selector.Type);
+
+                var parentItemName
+                    = parentQuerySource.HasGeneratedItemName()
+                        ? navigation.DeclaringEntityType.DisplayName()[0].ToString().ToLowerInvariant()
+                        : parentQuerySource.ItemName;
+
+                collectionQueryModel.MainFromClause.ItemName = $"{parentItemName}.{navigation.Name}";
+
+                var collectionQuerySourceReferenceExpression
+                    = new QuerySourceReferenceExpression(collectionQueryModel.MainFromClause);
+
+                var joinQuerySourceReferenceExpression
+                    = CreateJoinToParentQuery(
+                        clonedParentQueryModel,
+                        clonedParentQuerySourceReferenceExpression,
+                        collectionQuerySourceReferenceExpression,
+                        navigation.ForeignKey,
+                        collectionQueryModel,
+                        subQueryProjection);
+
+                ApplyParentOrderings(
+                    ParentOrderings,
+                    clonedParentQueryModel,
+                    querySourceMapping,
+                    lastResultOperator);
+
+                LiftOrderBy(
+                    clonedParentQuerySource,
+                    joinQuerySourceReferenceExpression,
+                    clonedParentQueryModel,
+                    collectionQueryModel,
+                    subQueryProjection);
+
+                clonedParentQueryModel.SelectClause.Selector
+                    = Expression.New(
+                        AnonymousObject.AnonymousObjectCtor,
+                        Expression.NewArrayInit(
+                            typeof(object),
+                            subQueryProjection));
+            }
+
+            private static void BuildParentOrderings(
+                QueryModel queryModel,
+                INavigation navigation,
+                QuerySourceReferenceExpression querySourceReferenceExpression,
+                ICollection<Ordering> parentOrderings)
+            {
+                var orderings = parentOrderings;
+
+                var orderByClause
+                    = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
+
+                if (orderByClause != null)
+                {
+                    orderings = orderings.Concat(orderByClause.Orderings).ToArray();
+                }
+
+                foreach (var property in navigation.ForeignKey.PrincipalKey.Properties)
+                {
+                    var propertyExpression
+                        = EntityQueryModelVisitor
+                            .CreatePropertyExpression(querySourceReferenceExpression, property);
+
+                    if (!orderings.Any(
+                        o =>
+                            _expressionEqualityComparer.Equals(o.Expression, propertyExpression)
+                            || o.Expression is MemberExpression memberExpression
+                            && memberExpression.Expression is QuerySourceReferenceExpression memberQuerySourceReferenceExpression
+                            && ReferenceEquals(memberQuerySourceReferenceExpression.ReferencedQuerySource, querySourceReferenceExpression.ReferencedQuerySource)
+                            && memberExpression.Member.Equals(property.PropertyInfo)))
+                    {
+                        parentOrderings.Add(new Ordering(propertyExpression, OrderingDirection.Asc));
+                    }
+                }
+            }
+
+            private static void AdjustPredicate(
+                QueryModel queryModel,
+                IQuerySource parentQuerySource,
+                Expression targetParentExpression)
+            {
+                var querySourcePriorityAnalyzer
+                    = new QuerySourcePriorityAnalyzer(queryModel.SelectClause.Selector);
+
+                Expression predicate = null;
+
+                if (querySourcePriorityAnalyzer.AreLowerPriorityQuerySources(parentQuerySource))
+                {
+                    predicate
+                        = Expression.NotEqual(
+                            targetParentExpression,
+                            Expression.Constant(null, targetParentExpression.Type));
+                }
+
+                predicate
+                    = querySourcePriorityAnalyzer.GetHigherPriorityQuerySources(parentQuerySource)
+                        .Select(qs => new QuerySourceReferenceExpression(qs))
+                        .Select(qsre => Expression.Equal(qsre, Expression.Constant(null, qsre.Type)))
+                        .Aggregate(
+                            predicate,
+                            (current, nullCheck)
+                                => current == null
+                                    ? nullCheck
+                                    : Expression.AndAlso(current, nullCheck));
+
+                if (predicate != null)
+                {
+                    var whereClause = queryModel.BodyClauses.OfType<WhereClause>().LastOrDefault();
+
+                    if (whereClause == null)
+                    {
+                        queryModel.BodyClauses.Add(new WhereClause(predicate));
+                    }
+                    else
+                    {
+                        whereClause.Predicate = Expression.AndAlso(whereClause.Predicate, predicate);
+                    }
+                }
+            }
+
+            private sealed class QuerySourcePriorityAnalyzer : RelinqExpressionVisitor
+            {
+                private readonly List<IQuerySource> _querySources = new List<IQuerySource>();
+
+                public QuerySourcePriorityAnalyzer(Expression expression)
+                {
+                    Visit(expression);
+                }
+
+                public bool AreLowerPriorityQuerySources(IQuerySource querySource)
+                {
+                    var index = _querySources.IndexOf(querySource);
+
+                    return index != -1 && index < _querySources.Count - 1;
+                }
+
+                public IEnumerable<IQuerySource> GetHigherPriorityQuerySources(IQuerySource querySource)
+                {
+                    var index = _querySources.IndexOf(querySource);
+
+                    if (index != -1)
+                    {
+                        for (var i = 0; i < index; i++)
+                        {
+                            yield return _querySources[i];
+                        }
+                    }
+                }
+
+                protected override Expression VisitBinary(BinaryExpression node)
+                {
+                    IQuerySource querySource;
+
+                    if (node.NodeType == ExpressionType.Coalesce
+                        && (querySource = ExtractQuerySource(node.Left)) != null)
+                    {
+                        _querySources.Add(querySource);
+
+                        if ((querySource = ExtractQuerySource(node.Right)) != null)
+                        {
+                            _querySources.Add(querySource);
+                        }
+                        else
+                        {
+                            Visit(node.Right);
+
+                            return node;
+                        }
+                    }
+
+                    return base.VisitBinary(node);
+                }
+
+                private static IQuerySource ExtractQuerySource(Expression expression)
+                {
+                    switch (expression)
+                    {
+                        case QuerySourceReferenceExpression querySourceReferenceExpression:
+                            return querySourceReferenceExpression.ReferencedQuerySource;
+                        case MethodCallExpression methodCallExpression
+                        when IsIncludeMethod(methodCallExpression):
+                            return ((QuerySourceReferenceExpression)methodCallExpression.Arguments[1]).ReferencedQuerySource;
+                    }
+
+                    return null;
+                }
+            }
+
+            private static bool ProcessResultOperators(QueryModel queryModel)
+            {
+                var choiceResultOperator
+                    = queryModel.ResultOperators.LastOrDefault() as ChoiceResultOperatorBase;
+
+                var lastResultOperator = false;
+
+                if (choiceResultOperator != null)
+                {
+                    queryModel.ResultOperators.Remove(choiceResultOperator);
+                    queryModel.ResultOperators.Add(new TakeResultOperator(Expression.Constant(1)));
+
+                    lastResultOperator = choiceResultOperator is LastResultOperator;
+                }
+
+                foreach (var groupResultOperator
+                    in queryModel.ResultOperators.OfType<GroupResultOperator>()
+                        .ToArray())
+                {
+                    queryModel.ResultOperators.Remove(groupResultOperator);
+
+                    var orderByClause = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
+
+                    if (orderByClause == null)
+                    {
+                        queryModel.BodyClauses.Add(orderByClause = new OrderByClause());
+                    }
+
+                    orderByClause.Orderings.Add(new Ordering(groupResultOperator.KeySelector, OrderingDirection.Asc));
+                }
+
+                if (queryModel.BodyClauses
+                        .Count(
+                            bc => bc is AdditionalFromClause
+                                  || bc is JoinClause
+                                  || bc is GroupJoinClause) > 0)
+                {
+                    queryModel.ResultOperators.Add(new DistinctResultOperator());
+                }
+
+                return lastResultOperator;
+            }
+
+            private static QuerySourceReferenceExpression CreateJoinToParentQuery(
+                QueryModel parentQueryModel,
+                QuerySourceReferenceExpression parentQuerySourceReferenceExpression,
+                Expression outerTargetExpression,
+                IForeignKey foreignKey,
+                QueryModel targetQueryModel,
+                ICollection<Expression> subQueryProjection)
+            {
+                var subQueryExpression = new SubQueryExpression(parentQueryModel);
+                var parentQuerySource = parentQuerySourceReferenceExpression.ReferencedQuerySource;
+
+                var joinClause
+                    = new JoinClause(
+                        "_" + parentQuerySource.ItemName,
+                        typeof(AnonymousObject),
+                        subQueryExpression,
+                        CreateKeyAccessExpression(
+                            outerTargetExpression,
+                            foreignKey.Properties),
+                        Expression.Constant(null));
+
+                var joinQuerySourceReferenceExpression = new QuerySourceReferenceExpression(joinClause);
+                var innerKeyExpressions = new List<Expression>();
+
+                foreach (var principalKeyProperty in foreignKey.PrincipalKey.Properties)
+                {
+                    innerKeyExpressions.Add(
+                        Expression.Convert(
+                            Expression.Call(
+                                joinQuerySourceReferenceExpression,
+                                AnonymousObject.GetValueMethodInfo,
+                                Expression.Constant(subQueryProjection.Count)),
+                            principalKeyProperty.ClrType.MakeNullable()));
+
+                    var propertyExpression
+                        = EntityQueryModelVisitor
+                            .CreatePropertyExpression(parentQuerySourceReferenceExpression, principalKeyProperty);
+
+                    subQueryProjection.Add(
+                        Expression.Convert(
+                            new NullConditionalExpression(
+                                parentQuerySourceReferenceExpression,
+                                parentQuerySourceReferenceExpression,
+                                propertyExpression),
+                            typeof(object)));
+                }
+
+                joinClause.InnerKeySelector
+                    = innerKeyExpressions.Count == 1
+                        ? innerKeyExpressions[0]
+                        : Expression.New(
+                            AnonymousObject.AnonymousObjectCtor,
+                            Expression.NewArrayInit(
+                                typeof(object),
+                                innerKeyExpressions.Select(e => Expression.Convert(e, typeof(object)))));
+
+                targetQueryModel.BodyClauses.Add(joinClause);
+
+                return joinQuerySourceReferenceExpression;
+            }
+
+            // TODO: Unify this with other versions
+            private static Expression CreateKeyAccessExpression(Expression target, IReadOnlyList<IProperty> properties)
+                => properties.Count == 1
+                    ? EntityQueryModelVisitor
+                        .CreatePropertyExpression(target, properties[0])
+                    : Expression.New(
+                        AnonymousObject.AnonymousObjectCtor,
+                        Expression.NewArrayInit(
+                            typeof(object),
+                            properties
+                                .Select(
+                                    p =>
+                                        Expression.Convert(
+                                            EntityQueryModelVisitor.CreatePropertyExpression(target, p),
+                                            typeof(object)))
+                                .Cast<Expression>()
+                                .ToArray()));
+
+            private static void ApplyParentOrderings(
+                IEnumerable<Ordering> parentOrderings,
+                QueryModel queryModel,
+                QuerySourceMapping querySourceMapping,
+                bool reverseOrdering)
+            {
+                var orderByClause = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
+
+                if (orderByClause == null)
+                {
+                    queryModel.BodyClauses.Add(orderByClause = new OrderByClause());
+                }
+
+                foreach (var ordering in parentOrderings)
+                {
+                    var newExpression
+                        = CloningExpressionVisitor
+                            .AdjustExpressionAfterCloning(ordering.Expression, querySourceMapping);
+
+                    if (newExpression is MethodCallExpression methodCallExpression
+                        && EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+                    {
+                        newExpression
+                            = new NullConditionalExpression(
+                                methodCallExpression.Arguments[0],
+                                methodCallExpression.Arguments[0],
+                                methodCallExpression);
+                    }
+
+                    orderByClause.Orderings
+                        .Add(new Ordering(newExpression, ordering.OrderingDirection));
+                }
+
+                if (reverseOrdering)
+                {
+                    foreach (var ordering in orderByClause.Orderings)
+                    {
+                        ordering.OrderingDirection
+                            = ordering.OrderingDirection == OrderingDirection.Asc
+                                ? OrderingDirection.Desc
+                                : OrderingDirection.Asc;
+                    }
+                }
+            }
+
+            private static void LiftOrderBy(
+                IQuerySource querySource,
+                Expression targetExpression,
+                QueryModel fromQueryModel,
+                QueryModel toQueryModel,
+                List<Expression> subQueryProjection)
+            {
+                var canRemove
+                    = !fromQueryModel.ResultOperators
+                        .Any(r => r is SkipResultOperator || r is TakeResultOperator);
+
+                foreach (var orderByClause
+                    in fromQueryModel.BodyClauses.OfType<OrderByClause>().ToArray())
+                {
+                    var outerOrderByClause = new OrderByClause();
+
+                    foreach (var ordering in orderByClause.Orderings)
+                    {
+                        int projectionIndex;
+
+                        if (ordering.Expression is MemberExpression memberExpression
+                            && memberExpression.Expression is QuerySourceReferenceExpression memberQsre
+                            && memberQsre.ReferencedQuerySource == querySource)
+                        {
+                            projectionIndex
+                                = subQueryProjection
+                                    .FindIndex(
+                                        e =>
+                                            {
+                                                var propertyExpression = (MethodCallExpression)((NullConditionalExpression)e.RemoveConvert()).AccessOperation;
+                                                var properyQsre = (QuerySourceReferenceExpression)propertyExpression.Arguments[0];
+                                                var propertyName = (string)((ConstantExpression)propertyExpression.Arguments[1]).Value;
+
+                                                return properyQsre.ReferencedQuerySource == memberQsre.ReferencedQuerySource
+                                                       && propertyName == memberExpression.Member.Name;
+                                            });
+                        }
+                        else
+                        {
+                            projectionIndex
+                                = subQueryProjection
+                                    .FindIndex(e => _expressionEqualityComparer.Equals(e.RemoveConvert(), ordering.Expression));
+                        }
+
+                        if (projectionIndex == -1)
+                        {
+                            projectionIndex = subQueryProjection.Count;
+
+                            subQueryProjection.Add(Expression.Convert(ordering.Expression, typeof(object)));
+                        }
+
+                        var newExpression
+                            = Expression.Call(
+                                targetExpression,
+                                AnonymousObject.GetValueMethodInfo,
+                                Expression.Constant(projectionIndex));
+
+                        outerOrderByClause.Orderings
+                            .Add(new Ordering(newExpression, ordering.OrderingDirection));
+                    }
+
+                    toQueryModel.BodyClauses.Add(outerOrderByClause);
+
+                    if (canRemove)
+                    {
+                        fromQueryModel.BodyClauses.Remove(orderByClause);
+                    }
+                }
+            }
+
+            private class QuerySourceReferenceFindingExpressionTreeVisitor : RelinqExpressionVisitor
+            {
+                public QuerySourceReferenceExpression QuerySourceReferenceExpression { get; private set; }
+
+                protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression querySourceReferenceExpression)
+                {
+                    if (QuerySourceReferenceExpression == null)
+                    {
+                        QuerySourceReferenceExpression = querySourceReferenceExpression;
+                    }
+
+                    return querySourceReferenceExpression;
+                }
+            }
+
+            protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+            {
+                subQueryExpression.QueryModel.TransformExpressions(Visit);
+
+                return subQueryExpression;
+            }
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTree.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTree.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public partial class IncludeCompiler
+    {
+        private sealed class IncludeLoadTree : IncludeLoadTreeNodeBase
+        {
+            public IncludeLoadTree(QuerySourceReferenceExpression querySourceReferenceExpression)
+                => QuerySourceReferenceExpression = querySourceReferenceExpression;
+
+            public QuerySourceReferenceExpression QuerySourceReferenceExpression { get; }
+
+            public void AddLoadPath(IReadOnlyList<INavigation> navigationPath)
+            {
+                AddLoadPath(this, navigationPath, index: 0);
+            }
+
+            public void Compile(
+                QueryCompilationContext queryCompilationContext,
+                QueryModel queryModel,
+                bool trackingQuery,
+                bool asyncQuery,
+                ref int collectionIncludeId)
+            {
+                var entityParameter
+                    = Expression.Parameter(QuerySourceReferenceExpression.Type, name: "entity");
+
+                var propertyExpressions = new List<Expression>();
+                var blockExpressions = new List<Expression>();
+
+                if (trackingQuery)
+                {
+                    blockExpressions.Add(
+                        Expression.Call(
+                            Expression.Property(
+                                EntityQueryModelVisitor.QueryContextParameter,
+                                nameof(QueryContext.QueryBuffer)),
+                            _queryBufferStartTrackingMethodInfo,
+                            entityParameter,
+                            Expression.Constant(
+                                queryCompilationContext.Model
+                                    .FindEntityType(entityParameter.Type))));
+                }
+
+                var includedIndex = 0;
+
+                foreach (var includeLoadTreeNode in Children)
+                {
+                    includeLoadTreeNode.Compile(
+                        queryCompilationContext,
+                        QuerySourceReferenceExpression,
+                        entityParameter,
+                        propertyExpressions,
+                        blockExpressions,
+                        trackingQuery,
+                        asyncQuery,
+                        ref includedIndex,
+                        ref collectionIncludeId);
+                }
+
+                Expression includeExpression = null;
+
+                if (asyncQuery)
+                {
+                    var taskExpression = new List<Expression>();
+
+                    foreach (var expression in blockExpressions.ToArray())
+                    {
+                        if (expression.Type == typeof(Task))
+                        {
+                            blockExpressions.Remove(expression);
+                            taskExpression.Add(expression);
+                        }
+                    }
+
+                    if (taskExpression.Count > 0)
+                    {
+                        blockExpressions.Add(
+                            Expression.Call(
+                                _awaitIncludesMethodInfo,
+                                Expression.NewArrayInit(
+                                    typeof(Func<Task>),
+                                    taskExpression.Select(e => Expression.Lambda(e)))));
+
+                        includeExpression
+                            = Expression.Property(
+                                Expression.Call(
+                                    _includeAsyncMethodInfo.MakeGenericMethod(QuerySourceReferenceExpression.Type),
+                                    EntityQueryModelVisitor.QueryContextParameter,
+                                    QuerySourceReferenceExpression,
+                                    Expression.NewArrayInit(typeof(object), propertyExpressions),
+                                    Expression.Lambda(
+                                        Expression.Block(blockExpressions),
+                                        EntityQueryModelVisitor.QueryContextParameter,
+                                        entityParameter,
+                                        _includedParameter,
+                                        _cancellationTokenParameter),
+                                    _cancellationTokenParameter),
+                                nameof(Task<object>.Result));
+                    }
+                }
+
+                if (includeExpression == null)
+                {
+                    includeExpression
+                        = Expression.Call(
+                            _includeMethodInfo.MakeGenericMethod(QuerySourceReferenceExpression.Type),
+                            EntityQueryModelVisitor.QueryContextParameter,
+                            QuerySourceReferenceExpression,
+                            Expression.NewArrayInit(typeof(object), propertyExpressions),
+                            Expression.Lambda(
+                                Expression.Block(typeof(void), blockExpressions),
+                                EntityQueryModelVisitor.QueryContextParameter,
+                                entityParameter,
+                                _includedParameter));
+                }
+
+                ApplyIncludeExpressionsToQueryModel(queryModel, QuerySourceReferenceExpression, includeExpression);
+            }
+
+            private static void ApplyIncludeExpressionsToQueryModel(
+                QueryModel queryModel,
+                QuerySourceReferenceExpression querySourceReferenceExpression,
+                Expression expression)
+            {
+                var includeReplacingExpressionVisitor = new IncludeReplacingExpressionVisitor();
+
+                foreach (var groupResultOperator
+                    in queryModel.ResultOperators.OfType<GroupResultOperator>())
+                {
+                    var newElementSelector
+                        = includeReplacingExpressionVisitor.Replace(
+                            querySourceReferenceExpression,
+                            expression,
+                            groupResultOperator.ElementSelector);
+
+                    if (!ReferenceEquals(newElementSelector, groupResultOperator.ElementSelector))
+                    {
+                        groupResultOperator.ElementSelector = newElementSelector;
+
+                        return;
+                    }
+                }
+
+                queryModel.SelectClause.TransformExpressions(
+                    e => includeReplacingExpressionVisitor.Replace(
+                        querySourceReferenceExpression,
+                        expression,
+                        e));
+            }
+
+            private static readonly MethodInfo _awaitIncludesMethodInfo
+                = typeof(IncludeLoadTree).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(_AwaitIncludes));
+
+            // ReSharper disable once InconsistentNaming
+            private static async Task _AwaitIncludes(IReadOnlyList<Func<Task>> taskFactories)
+            {
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (var i = 0; i < taskFactories.Count; i++)
+                {
+                    await taskFactories[i]();
+                }
+            }
+
+            private class IncludeReplacingExpressionVisitor : RelinqExpressionVisitor
+            {
+                private QuerySourceReferenceExpression _querySourceReferenceExpression;
+                private Expression _includeExpression;
+
+                public Expression Replace(
+                    QuerySourceReferenceExpression querySourceReferenceExpression,
+                    Expression includeExpression,
+                    Expression searchedExpression)
+                {
+                    _querySourceReferenceExpression = querySourceReferenceExpression;
+                    _includeExpression = includeExpression;
+
+                    return Visit(searchedExpression);
+                }
+
+                protected override Expression VisitQuerySourceReference(
+                    QuerySourceReferenceExpression querySourceReferenceExpression)
+                {
+                    if (ReferenceEquals(querySourceReferenceExpression, _querySourceReferenceExpression))
+                    {
+                        _querySourceReferenceExpression = null;
+
+                        return _includeExpression;
+                    }
+
+                    return querySourceReferenceExpression;
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public partial class IncludeCompiler
+    {
+        private sealed class IncludeLoadTreeNode : IncludeLoadTreeNodeBase
+        {
+            private static readonly MethodInfo _referenceEqualsMethodInfo
+                = typeof(object).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(ReferenceEquals));
+
+            private static readonly MethodInfo _collectionAccessorAddMethodInfo
+                = typeof(IClrCollectionAccessor).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(IClrCollectionAccessor.Add));
+
+            private static readonly MethodInfo _queryBufferIncludeCollectionMethodInfo
+                = typeof(IQueryBuffer).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(IQueryBuffer.IncludeCollection));
+
+            private static readonly MethodInfo _queryBufferIncludeCollectionAsyncMethodInfo
+                = typeof(IQueryBuffer).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(IQueryBuffer.IncludeCollectionAsync));
+
+            public IncludeLoadTreeNode(INavigation navigation) => Navigation = navigation;
+
+            public INavigation Navigation { get; }
+
+            public void Compile(
+                QueryCompilationContext queryCompilationContext,
+                Expression targetQuerySourceReferenceExpression,
+                Expression entityParameter,
+                ICollection<Expression> propertyExpressions,
+                ICollection<Expression> blockExpressions,
+                bool trackingQuery,
+                bool asyncQuery,
+                ref int includedIndex,
+                ref int collectionIncludeId)
+            {
+                if (Navigation.IsCollection())
+                {
+                    var targetType = Navigation.GetTargetType().ClrType;
+
+                    var mainFromClause
+                        = new MainFromClause(
+                            targetType.Name.Substring(0, 1).ToLowerInvariant(),
+                            targetType,
+                            Expression.Property(
+                                targetQuerySourceReferenceExpression,
+                                Navigation.PropertyInfo));
+
+                    queryCompilationContext.AddQuerySourceRequiringMaterialization(mainFromClause);
+                    
+                    var collectionQueryModel
+                        = new QueryModel(
+                            mainFromClause,
+                            new SelectClause(new QuerySourceReferenceExpression(mainFromClause)));
+
+                    Expression collectionLambdaExpression
+                        = Expression.Lambda<Func<IEnumerable<object>>>(
+                            new SubQueryExpression(collectionQueryModel));
+
+                    var includeCollectionMethodInfo = _queryBufferIncludeCollectionMethodInfo;
+
+                    Expression cancellationTokenExpression = null;
+
+                    if (asyncQuery)
+                    {
+                        collectionLambdaExpression
+                            = Expression.Convert(
+                                collectionLambdaExpression,
+                                typeof(Func<IAsyncEnumerable<object>>));
+
+                        includeCollectionMethodInfo = _queryBufferIncludeCollectionAsyncMethodInfo;
+                        cancellationTokenExpression = _cancellationTokenParameter;
+                    }
+
+                    blockExpressions.Add(
+                        BuildCollectionIncludeExpressions(
+                            Navigation,
+                            entityParameter,
+                            trackingQuery,
+                            collectionLambdaExpression,
+                            includeCollectionMethodInfo,
+                            cancellationTokenExpression,
+                            ref collectionIncludeId));
+                }
+                else
+                {
+                    blockExpressions.Add(
+                        Compile(
+                            propertyExpressions,
+                            entityParameter,
+                            trackingQuery,
+                            ref includedIndex,
+                            targetQuerySourceReferenceExpression));
+                }
+            }
+
+            private Expression Compile(
+                ICollection<Expression> propertyExpressions,
+                Expression targetEntityExpression,
+                bool trackingQuery,
+                ref int includedIndex,
+                Expression lastPropertyExpression)
+            {
+                propertyExpressions.Add(
+                    lastPropertyExpression
+                        = EntityQueryModelVisitor.CreatePropertyExpression(
+                            lastPropertyExpression, Navigation));
+
+                var relatedArrayAccessExpression
+                    = Expression.ArrayAccess(_includedParameter, Expression.Constant(includedIndex++));
+
+                var relatedEntityExpression
+                    = Expression.Convert(relatedArrayAccessExpression, Navigation.ClrType);
+
+                var stateManagerProperty
+                    = Expression.Property(
+                        Expression.Property(
+                            EntityQueryModelVisitor.QueryContextParameter,
+                            nameof(QueryContext.StateManager)),
+                        nameof(Lazy<object>.Value));
+
+                var blockExpressions = new List<Expression>();
+
+                if (trackingQuery)
+                {
+                    blockExpressions.Add(
+                        Expression.Call(
+                            Expression.Property(
+                                EntityQueryModelVisitor.QueryContextParameter,
+                                nameof(QueryContext.QueryBuffer)),
+                            _queryBufferStartTrackingMethodInfo,
+                            relatedArrayAccessExpression,
+                            Expression.Constant(Navigation.GetTargetType())));
+
+                    blockExpressions.Add(
+                        Expression.Call(
+                            _setRelationshipSnapshotValueMethodInfo,
+                            stateManagerProperty,
+                            Expression.Constant(Navigation),
+                            targetEntityExpression,
+                            relatedArrayAccessExpression));
+                }
+                else
+                {
+                    blockExpressions.Add(
+                        Expression.Assign(
+                            Expression.MakeMemberAccess(
+                                targetEntityExpression,
+                                Navigation.GetMemberInfo(false, true)),
+                            relatedEntityExpression));
+                }
+
+                var inverseNavigation = Navigation.FindInverse();
+
+                if (inverseNavigation != null)
+                {
+                    var collection = inverseNavigation.IsCollection();
+
+                    if (trackingQuery)
+                    {
+                        blockExpressions.Add(
+                            Expression.Call(
+                                collection
+                                    ? _addToCollectionSnapshotMethodInfo
+                                    : _setRelationshipSnapshotValueMethodInfo,
+                                stateManagerProperty,
+                                Expression.Constant(inverseNavigation),
+                                relatedArrayAccessExpression,
+                                targetEntityExpression));
+                    }
+                    else
+                    {
+                        blockExpressions.Add(
+                            collection
+                                ? (Expression)Expression.Call(
+                                    Expression.Constant(inverseNavigation.GetCollectionAccessor()),
+                                    _collectionAccessorAddMethodInfo,
+                                    relatedArrayAccessExpression,
+                                    targetEntityExpression)
+                                : Expression.Assign(
+                                    Expression.MakeMemberAccess(
+                                        relatedEntityExpression,
+                                        inverseNavigation
+                                            .GetMemberInfo(forConstruction: false, forSet: true)),
+                                    targetEntityExpression));
+                    }
+                }
+
+                // ReSharper disable once LoopCanBeConvertedToQuery
+                foreach (var includeLoadTreeNode in Children)
+                {
+                    blockExpressions.Add(
+                        includeLoadTreeNode.Compile(
+                            propertyExpressions,
+                            relatedEntityExpression,
+                            trackingQuery,
+                            ref includedIndex,
+                            lastPropertyExpression));
+                }
+
+                return
+                    Expression.IfThen(
+                        Expression.Not(
+                            Expression.Call(
+                                _referenceEqualsMethodInfo,
+                                relatedArrayAccessExpression,
+                                Expression.Constant(null, typeof(object)))),
+                        Expression.Block(typeof(void), blockExpressions));
+            }
+
+            private static Expression BuildCollectionIncludeExpressions(
+                INavigation navigation,
+                Expression targetEntityExpression,
+                bool trackingQuery,
+                Expression relatedCollectionFuncExpression,
+                MethodInfo includeCollectionMethodInfo,
+                Expression cancellationTokenExpression,
+                ref int collectionIncludeId)
+            {
+                var inverseNavigation = navigation.FindInverse();
+
+                var arguments = new List<Expression>
+                {
+                    Expression.Constant(collectionIncludeId++),
+                    Expression.Constant(navigation),
+                    Expression.Constant(inverseNavigation, typeof(INavigation)),
+                    Expression.Constant(navigation.GetTargetType()),
+                    Expression.Constant(navigation.GetCollectionAccessor()),
+                    Expression.Constant(inverseNavigation?.GetSetter(), typeof(IClrPropertySetter)),
+                    Expression.Constant(trackingQuery),
+                    targetEntityExpression,
+                    relatedCollectionFuncExpression
+                };
+
+                if (cancellationTokenExpression != null)
+                {
+                    arguments.Add(cancellationTokenExpression);
+                }
+
+                return Expression.Call(
+                    Expression.Property(
+                        EntityQueryModelVisitor.QueryContextParameter,
+                        nameof(QueryContext.QueryBuffer)),
+                    includeCollectionMethodInfo,
+                    arguments);
+            }
+
+            private static readonly MethodInfo _setRelationshipSnapshotValueMethodInfo
+                = typeof(IncludeLoadTreeNode).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(SetRelationshipSnapshotValue));
+
+            private static void SetRelationshipSnapshotValue(
+                IStateManager stateManager,
+                IPropertyBase navigation,
+                object entity,
+                object value)
+            {
+                var internalEntityEntry = stateManager.TryGetEntry(entity);
+
+                Debug.Assert(internalEntityEntry != null);
+
+                internalEntityEntry.SetRelationshipSnapshotValue(navigation, value);
+            }
+
+            private static readonly MethodInfo _addToCollectionSnapshotMethodInfo
+                = typeof(IncludeLoadTreeNode).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(AddToCollectionSnapshot));
+
+            private static void AddToCollectionSnapshot(
+                IStateManager stateManager,
+                IPropertyBase navigation,
+                object entity,
+                object value)
+            {
+                var internalEntityEntry = stateManager.TryGetEntry(entity);
+
+                Debug.Assert(internalEntityEntry != null);
+
+                internalEntityEntry.AddToCollectionSnapshot(navigation, value);
+            }
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNodeBase.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNodeBase.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public partial class IncludeCompiler
+    {
+        private abstract class IncludeLoadTreeNodeBase
+        {
+            protected static void AddLoadPath(
+                IncludeLoadTreeNodeBase node,
+                IReadOnlyList<INavigation> navigationPath,
+                int index)
+            {
+                while (index < navigationPath.Count)
+                {
+                    var navigation = navigationPath[index];
+                    var childNode = node.Children.SingleOrDefault(n => n.Navigation == navigation);
+
+                    if (childNode == null)
+                    {
+                        node.Children.Add(childNode = new IncludeLoadTreeNode(navigation));
+                    }
+
+                    node = childNode;
+                    index = index + 1;
+                }
+            }
+
+            protected ICollection<IncludeLoadTreeNode> Children { get; } = new List<IncludeLoadTreeNode>();
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -3,30 +3,22 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
-using Microsoft.EntityFrameworkCore.Query.ResultOperators;
 using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Clauses.ExpressionVisitors;
-using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Clauses.StreamedData;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -34,39 +26,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class IncludeCompiler
+    public partial class IncludeCompiler
     {
-        private static readonly ExpressionEqualityComparer _expressionEqualityComparer
-            = new ExpressionEqualityComparer();
-
-        private static readonly MethodInfo _referenceEqualsMethodInfo
-            = typeof(object).GetTypeInfo()
-                .GetDeclaredMethod(nameof(ReferenceEquals));
-
-        private static readonly MethodInfo _collectionAccessorAddMethodInfo
-            = typeof(IClrCollectionAccessor).GetTypeInfo()
-                .GetDeclaredMethod(nameof(IClrCollectionAccessor.Add));
-
         private static readonly MethodInfo _queryBufferStartTrackingMethodInfo
             = typeof(IQueryBuffer).GetTypeInfo()
                 .GetDeclaredMethods(nameof(IQueryBuffer.StartTracking))
                 .Single(mi => mi.GetParameters()[1].ParameterType == typeof(IEntityType));
 
-        private static readonly MethodInfo _queryBufferIncludeCollectionMethodInfo
-            = typeof(IQueryBuffer).GetTypeInfo()
-                .GetDeclaredMethod(nameof(IQueryBuffer.IncludeCollection));
-
-        private static readonly MethodInfo _queryBufferIncludeCollectionAsyncMethodInfo
-            = typeof(IQueryBuffer).GetTypeInfo()
-                .GetDeclaredMethod(nameof(IQueryBuffer.IncludeCollectionAsync));
-
         private static readonly ParameterExpression _includedParameter
             = Expression.Parameter(typeof(object[]), name: "included");
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         private static readonly ParameterExpression _cancellationTokenParameter
             = Expression.Parameter(typeof(CancellationToken), name: "ct");
 
@@ -87,21 +56,94 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _querySourceTracingExpressionVisitorFactory = querySourceTracingExpressionVisitorFactory;
         }
 
-        private struct IncludeSpecification
+        private IEnumerable<IncludeLoadTree> CreateIncludeLoadTrees(
+            ICollection<IncludeResultOperator> includeResultOperators,
+            Expression targetExpression)
         {
-            public IncludeSpecification(
-                IncludeResultOperator includeResultOperator,
-                QuerySourceReferenceExpression querySourceReferenceExpression,
-                INavigation[] navigationPath)
+            var querySourceTracingExpressionVisitor
+                = _querySourceTracingExpressionVisitorFactory.Create();
+
+            var includeLoadTrees = new List<IncludeLoadTree>();
+
+            foreach (var includeResultOperator in includeResultOperators.ToArray())
             {
-                IncludeResultOperator = includeResultOperator;
-                QuerySourceReferenceExpression = querySourceReferenceExpression;
-                NavigationPath = navigationPath;
+                var entityType
+                    = _queryCompilationContext.Model
+                        .FindEntityType(includeResultOperator.PathFromQuerySource.Type);
+
+                var nextEntityType = entityType;
+
+                var parts = includeResultOperator.NavigationPropertyPaths.ToArray();
+                var navigationPath = new INavigation[parts.Length];
+
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    navigationPath[i] = nextEntityType.FindNavigation(parts[i]);
+
+                    if (navigationPath[i] == null)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.IncludeBadNavigation(parts[i], nextEntityType.DisplayName()));
+                    }
+
+                    nextEntityType = navigationPath[i].GetTargetType();
+                }
+
+                var querySourceReferenceExpression
+                    = querySourceTracingExpressionVisitor
+                        .FindResultQuerySourceReferenceExpression(
+                            targetExpression,
+                            includeResultOperator.QuerySource);
+
+                if (querySourceReferenceExpression == null)
+                {
+                    _queryCompilationContext.Logger
+                        .LogWarning(
+                            CoreEventId.IncludeIgnoredWarning,
+                            () => CoreStrings.LogIgnoredInclude(
+                                $"{includeResultOperator.QuerySource.ItemName}.{navigationPath.Select(n => n.Name).Join(".")}"));
+
+                    continue;
+                }
+
+                var sequenceType = querySourceReferenceExpression.Type.TryGetSequenceType();
+
+                if (sequenceType != null
+                    && _queryCompilationContext.Model.FindEntityType(sequenceType) != null)
+                {
+                    continue;
+                }
+
+                if (!(!navigationPath.Any(n => n.IsCollection())
+                      || navigationPath.Length == 1))
+                {
+                    continue;
+                }
+
+                var includeLoadTree
+                    = includeLoadTrees
+                        .SingleOrDefault(
+                            t => ReferenceEquals(
+                                t.QuerySourceReferenceExpression, querySourceReferenceExpression));
+
+                if (includeLoadTree == null)
+                {
+                    includeLoadTrees.Add(includeLoadTree = new IncludeLoadTree(querySourceReferenceExpression));
+                }
+
+                includeLoadTree.AddLoadPath(navigationPath);
+
+                _queryCompilationContext.Logger
+                    .LogDebug(
+                        CoreEventId.IncludingNavigation,
+                        () => CoreStrings.LogIncludingNavigation(
+                            $"{includeResultOperator.PathFromQuerySource}.{includeResultOperator.NavigationPropertyPaths.Join(".")}"));
+
+                // TODO: Hack until new Include fully implemented
+                includeResultOperators.Remove(includeResultOperator);
             }
 
-            public IncludeResultOperator IncludeResultOperator { get; }
-            public QuerySourceReferenceExpression QuerySourceReferenceExpression { get; }
-            public INavigation[] NavigationPath { get; }
+            return includeLoadTrees;
         }
 
         /// <summary>
@@ -119,164 +161,30 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return;
             }
 
-            var includeGroupings
-                = CreateIncludeSpecifications(queryModel, includeResultOperators)
-                    .GroupBy(a => a.QuerySourceReferenceExpression);
-
-            var compiledIncludes
-                = new List<(
-                    QuerySourceReferenceExpression querySourceReferenceExpression,
-                    Expression expression)>();
-
-            foreach (var includeGrouping in includeGroupings)
+            foreach (var includeLoadTree
+                in CreateIncludeLoadTrees(includeResultOperators, queryModel.SelectClause.Selector))
             {
-                var entityParameter = Expression.Parameter(includeGrouping.Key.Type, name: "entity");
-
-                var propertyExpressions = new List<Expression>();
-                var blockExpressions = new List<Expression>();
-
-                if (trackingQuery)
-                {
-                    blockExpressions.Add(
-                        Expression.Call(
-                            Expression.Property(
-                                EntityQueryModelVisitor.QueryContextParameter,
-                                nameof(QueryContext.QueryBuffer)),
-                            _queryBufferStartTrackingMethodInfo,
-                            entityParameter,
-                            Expression.Constant(
-                                _queryCompilationContext.Model
-                                    .FindEntityType(entityParameter.Type))));
-                }
-
-                var includedIndex = 0;
-
-                foreach (var includeSpecification in includeGrouping)
-                {
-                    _queryCompilationContext.Logger
-                        .LogDebug(
-                            CoreEventId.IncludingNavigation,
-                            () => CoreStrings.LogIncludingNavigation(
-                                $"{includeSpecification.IncludeResultOperator.PathFromQuerySource}.{includeSpecification.IncludeResultOperator.NavigationPropertyPaths.Join(".")}"));
-
-                    var navigation = includeSpecification.NavigationPath[0];
-
-                    if (navigation.IsCollection())
-                    {
-                        Expression collectionLambdaExpression
-                            = Expression.Lambda<Func<IEnumerable<object>>>(
-                                Expression.Property(includeSpecification.QuerySourceReferenceExpression, navigation.PropertyInfo));
-
-                        var includeCollectionMethodInfo = _queryBufferIncludeCollectionMethodInfo;
-
-                        Expression cancellationTokenExpression = null;
-
-                        if (asyncQuery)
-                        {
-                            collectionLambdaExpression
-                                = Expression.Convert(
-                                    collectionLambdaExpression,
-                                    typeof(Func<IAsyncEnumerable<object>>));
-
-                            includeCollectionMethodInfo = _queryBufferIncludeCollectionAsyncMethodInfo;
-                            cancellationTokenExpression = _cancellationTokenParameter;
-                        }
-
-                        blockExpressions.Add(
-                            BuildCollectionIncludeExpressions(
-                                navigation,
-                                entityParameter,
-                                trackingQuery,
-                                collectionLambdaExpression,
-                                includeCollectionMethodInfo,
-                                cancellationTokenExpression));
-                    }
-                    else
-                    {
-                        propertyExpressions.AddRange(
-                            includeSpecification.NavigationPath
-                                .Select(
-                                    (t, i) =>
-                                        includeSpecification.NavigationPath
-                                            .Take(i + 1)
-                                            .Aggregate(
-                                                (Expression)includeSpecification.QuerySourceReferenceExpression,
-                                                EntityQueryModelVisitor.CreatePropertyExpression)));
-
-                        blockExpressions.Add(
-                            BuildReferenceIncludeExpressions(
-                                includeSpecification.NavigationPath,
-                                entityParameter,
-                                trackingQuery,
-                                ref includedIndex,
-                                navigationIndex: 0));
-                    }
-
-                    // TODO: Hack until new Include fully implemented
-                    includeResultOperators.Remove(includeSpecification.IncludeResultOperator);
-                }
-
-                Expression includeExpression = null;
-
-                if (asyncQuery)
-                {
-                    var taskExpression = new List<Expression>();
-
-                    foreach (var expression in blockExpressions.ToArray())
-                    {
-                        if (expression.Type == typeof(Task))
-                        {
-                            blockExpressions.Remove(expression);
-                            taskExpression.Add(expression);
-                        }
-                    }
-
-                    if (taskExpression.Count > 0)
-                    {
-                        blockExpressions.Add(
-                            Expression.Call(
-                                _awaitIncludesMethodInfo,
-                                Expression.NewArrayInit(
-                                    typeof(Func<Task>),
-                                    taskExpression.Select(e => Expression.Lambda(e)))));
-
-                        includeExpression
-                            = Expression.Property(
-                                Expression.Call(
-                                    _includeAsyncMethodInfo.MakeGenericMethod(includeGrouping.Key.Type),
-                                    EntityQueryModelVisitor.QueryContextParameter,
-                                    includeGrouping.Key,
-                                    Expression.NewArrayInit(typeof(object), propertyExpressions),
-                                    Expression.Lambda(
-                                        Expression.Block(blockExpressions),
-                                        EntityQueryModelVisitor.QueryContextParameter,
-                                        entityParameter,
-                                        _includedParameter,
-                                        _cancellationTokenParameter),
-                                    _cancellationTokenParameter),
-                                nameof(Task<object>.Result));
-                    }
-                }
-
-                if (includeExpression == null)
-                {
-                    includeExpression
-                        = Expression.Call(
-                            _includeMethodInfo.MakeGenericMethod(includeGrouping.Key.Type),
-                            EntityQueryModelVisitor.QueryContextParameter,
-                            includeGrouping.Key,
-                            Expression.NewArrayInit(typeof(object), propertyExpressions),
-                            Expression.Lambda(
-                                Expression.Block(typeof(void), blockExpressions),
-                                EntityQueryModelVisitor.QueryContextParameter,
-                                entityParameter,
-                                _includedParameter));
-                }
-
-                compiledIncludes.Add((includeGrouping.Key, includeExpression));
+                includeLoadTree.Compile(
+                    _queryCompilationContext,
+                    queryModel,
+                    trackingQuery,
+                    asyncQuery,
+                    ref _collectionIncludeId);
             }
+        }
 
-            ApplyIncludeExpressionsToQueryModel(queryModel, compiledIncludes);
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void RewriteCollectionQueries([NotNull] QueryModel queryModel)
+        {
+            var collectionQueryModelRewritingExpressionVisitor
+                = new CollectionQueryModelRewritingExpressionVisitor(_queryCompilationContext, queryModel);
+
+            queryModel.TransformExpressions(collectionQueryModelRewritingExpressionVisitor.Visit);
+
+            ApplyParentOrderings(queryModel, collectionQueryModelRewritingExpressionVisitor.ParentOrderings);
         }
 
         private static void ApplyParentOrderings(
@@ -301,892 +209,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     orderByClause.Orderings.Add(ordering);
                 }
             }
-        }
-
-        private static void ApplyIncludeExpressionsToQueryModel(
-            QueryModel queryModel,
-            IEnumerable<(
-                QuerySourceReferenceExpression querySourceReferenceExpression,
-                Expression expression)> compiledIncludes)
-        {
-            var includeReplacingExpressionVisitor = new IncludeReplacingExpressionVisitor();
-
-            foreach (var include in compiledIncludes)
-            {
-                queryModel.SelectClause.TransformExpressions(
-                    e => includeReplacingExpressionVisitor.Replace(
-                        include.querySourceReferenceExpression,
-                        include.expression,
-                        e));
-
-                foreach (var groupResultOperator
-                    in queryModel.ResultOperators.OfType<GroupResultOperator>())
-                {
-                    groupResultOperator.ElementSelector
-                        = includeReplacingExpressionVisitor.Replace(
-                            include.querySourceReferenceExpression,
-                            include.expression,
-                            groupResultOperator.ElementSelector);
-                }
-            }
-        }
-
-        private static readonly MethodInfo _awaitIncludesMethodInfo
-            = typeof(IncludeCompiler).GetTypeInfo()
-                .GetDeclaredMethod(nameof(_AwaitIncludes));
-
-        // ReSharper disable once InconsistentNaming
-        private static async Task _AwaitIncludes(IReadOnlyList<Func<Task>> taskFactories)
-        {
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (var i = 0; i < taskFactories.Count; i++)
-            {
-                await taskFactories[i]();
-            }
-        }
-
-        private class IncludeReplacingExpressionVisitor : RelinqExpressionVisitor
-        {
-            private QuerySourceReferenceExpression _querySourceReferenceExpression;
-            private Expression _includeExpression;
-
-            public Expression Replace(
-                QuerySourceReferenceExpression querySourceReferenceExpression,
-                Expression includeExpression,
-                Expression searchedExpression)
-            {
-                _querySourceReferenceExpression = querySourceReferenceExpression;
-                _includeExpression = includeExpression;
-
-                return Visit(searchedExpression);
-            }
-
-            protected override Expression VisitQuerySourceReference(
-                QuerySourceReferenceExpression querySourceReferenceExpression)
-            {
-                if (ReferenceEquals(querySourceReferenceExpression, _querySourceReferenceExpression))
-                {
-                    _querySourceReferenceExpression = null;
-
-                    return _includeExpression;
-                }
-
-                return querySourceReferenceExpression;
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual void RewriteCollectionQueries([NotNull] QueryModel queryModel)
-        {
-            var collectionQueryModelRewritingExpressionVisitor
-                = new CollectionQueryModelRewritingExpressionVisitor(_queryCompilationContext, queryModel);
-
-            queryModel.TransformExpressions(collectionQueryModelRewritingExpressionVisitor.Visit);
-
-            ApplyParentOrderings(queryModel, collectionQueryModelRewritingExpressionVisitor.ParentOrderings);
-        }
-
-        private sealed class CollectionQueryModelRewritingExpressionVisitor : RelinqExpressionVisitor
-        {
-            private readonly QueryCompilationContext _queryCompilationContext;
-            private readonly QueryModel _parentQueryModel;
-
-            public CollectionQueryModelRewritingExpressionVisitor(
-                QueryCompilationContext queryCompilationContext,
-                QueryModel parentQueryModel)
-            {
-                _queryCompilationContext = queryCompilationContext;
-                _parentQueryModel = parentQueryModel;
-            }
-
-            public List<Ordering> ParentOrderings { get; } = new List<Ordering>();
-
-            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
-            {
-                if (typeof(IQueryBuffer).GetTypeInfo()
-                        .IsAssignableFrom(methodCallExpression.Object?.Type.GetTypeInfo())
-                    && methodCallExpression.Method.Name
-                        .StartsWith(nameof(IQueryBuffer.IncludeCollection), StringComparison.Ordinal))
-                {
-                    var lambaArgument = methodCallExpression.Arguments[8];
-                    var convertExpression = lambaArgument as UnaryExpression;
-
-                    var materializeCollectionNavigationMethodCallExpression
-                        = (MethodCallExpression)((LambdaExpression)(convertExpression?.Operand ?? lambaArgument)).Body.RemoveConvert();
-
-                    var navigation
-                        = (INavigation)
-                        ((ConstantExpression)
-                            materializeCollectionNavigationMethodCallExpression.Arguments[0])
-                        .Value;
-
-                    var subQueryExpression
-                        = (SubQueryExpression)materializeCollectionNavigationMethodCallExpression
-                            .Arguments[1];
-
-                    Rewrite(subQueryExpression.QueryModel, navigation);
-
-                    var newArguments = methodCallExpression.Arguments.ToArray();
-
-                    Expression newLambdaExpression
-                        = Expression.Lambda<Func<IEnumerable<object>>>(subQueryExpression);
-
-                    if (convertExpression != null)
-                    {
-                        newLambdaExpression = convertExpression.Update(newLambdaExpression);
-                    }
-
-                    newArguments[8] = newLambdaExpression;
-
-                    return methodCallExpression.Update(methodCallExpression.Object, newArguments);
-                }
-
-                return base.VisitMethodCall(methodCallExpression);
-            }
-
-            private void Rewrite(QueryModel collectionQueryModel, INavigation navigation)
-            {
-                var querySourceReferenceFindingExpressionTreeVisitor
-                    = new QuerySourceReferenceFindingExpressionTreeVisitor();
-
-                collectionQueryModel.BodyClauses.Single()
-                    .TransformExpressions(querySourceReferenceFindingExpressionTreeVisitor.Visit);
-
-                collectionQueryModel.BodyClauses.Clear();
-
-                _queryCompilationContext.AddQuerySourceRequiringMaterialization(
-                    ((QuerySourceReferenceExpression)collectionQueryModel.SelectClause.Selector).ReferencedQuerySource);
-
-                var parentQuerySourceReferenceExpression
-                    = querySourceReferenceFindingExpressionTreeVisitor.QuerySourceReferenceExpression;
-
-                var parentQuerySource = parentQuerySourceReferenceExpression.ReferencedQuerySource;
-
-                BuildParentOrderings(
-                    _parentQueryModel,
-                    navigation,
-                    parentQuerySourceReferenceExpression,
-                    ParentOrderings);
-
-                var querySourceMapping = new QuerySourceMapping();
-                var clonedParentQueryModel = _parentQueryModel.Clone(querySourceMapping);
-
-                CloneAnnotations(querySourceMapping, clonedParentQueryModel);
-
-                var clonedParentQuerySourceReferenceExpression
-                    = (QuerySourceReferenceExpression)querySourceMapping.GetExpression(parentQuerySource);
-
-                var clonedParentQuerySource
-                    = clonedParentQuerySourceReferenceExpression.ReferencedQuerySource;
-
-                AdjustPredicate(
-                    clonedParentQueryModel,
-                    clonedParentQuerySource,
-                    clonedParentQuerySourceReferenceExpression);
-
-                clonedParentQueryModel.SelectClause
-                    = new SelectClause(Expression.Default(typeof(AnonymousObject)));
-
-                var subQueryProjection = new List<Expression>();
-
-                var lastResultOperator = ProcessResultOperators(clonedParentQueryModel);
-
-                clonedParentQueryModel.ResultTypeOverride
-                    = typeof(IQueryable<>).MakeGenericType(clonedParentQueryModel.SelectClause.Selector.Type);
-
-                var parentItemName
-                    = parentQuerySource.HasGeneratedItemName()
-                        ? navigation.DeclaringEntityType.DisplayName()[0].ToString().ToLowerInvariant()
-                        : parentQuerySource.ItemName;
-
-                collectionQueryModel.MainFromClause.ItemName = $"{parentItemName}.{navigation.Name}";
-
-                var collectionQuerySourceReferenceExpression
-                    = new QuerySourceReferenceExpression(collectionQueryModel.MainFromClause);
-
-                var joinQuerySourceReferenceExpression
-                    = CreateJoinToParentQuery(
-                        clonedParentQueryModel,
-                        clonedParentQuerySourceReferenceExpression,
-                        collectionQuerySourceReferenceExpression,
-                        navigation.ForeignKey,
-                        collectionQueryModel,
-                        subQueryProjection);
-
-                ApplyParentOrderings(
-                    ParentOrderings,
-                    clonedParentQueryModel,
-                    querySourceMapping,
-                    lastResultOperator);
-
-                LiftOrderBy(
-                    clonedParentQuerySource,
-                    joinQuerySourceReferenceExpression,
-                    clonedParentQueryModel,
-                    collectionQueryModel,
-                    subQueryProjection);
-
-                for (var i = 0; i < subQueryProjection.Count; i++)
-                {
-                    var unaryExpression = (UnaryExpression)subQueryProjection[i];
-
-                    if (unaryExpression.Operand is MethodCallExpression methodCallExpression
-                        && EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
-                    {
-                        subQueryProjection[i]
-                            = unaryExpression.Update(
-                                new NullConditionalExpression(
-                                    methodCallExpression.Arguments[0],
-                                    methodCallExpression.Arguments[0],
-                                    methodCallExpression));
-                    }
-                }
-
-                clonedParentQueryModel.SelectClause.Selector
-                    = Expression.New(
-                        AnonymousObject.AnonymousObjectCtor,
-                        Expression.NewArrayInit(
-                            typeof(object),
-                            subQueryProjection));
-            }
-
-            private static void BuildParentOrderings(
-                QueryModel queryModel,
-                INavigation navigation,
-                QuerySourceReferenceExpression querySourceReferenceExpression,
-                ICollection<Ordering> parentOrderings)
-            {
-                var orderings = parentOrderings;
-
-                var orderByClause
-                    = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
-
-                if (orderByClause != null)
-                {
-                    orderings = orderings.Concat(orderByClause.Orderings).ToArray();
-                }
-
-                foreach (var property in navigation.ForeignKey.PrincipalKey.Properties)
-                {
-                    var propertyExpression
-                        = EntityQueryModelVisitor
-                            .CreatePropertyExpression(querySourceReferenceExpression, property);
-
-                    if (!orderings.Any(
-                        o =>
-                            _expressionEqualityComparer.Equals(o.Expression, propertyExpression)
-                            || o.Expression is MemberExpression memberExpression
-                            && memberExpression.Expression is QuerySourceReferenceExpression memberQuerySourceReferenceExpression
-                            && ReferenceEquals(memberQuerySourceReferenceExpression.ReferencedQuerySource, querySourceReferenceExpression.ReferencedQuerySource)
-                            && memberExpression.Member.Equals(property.PropertyInfo)))
-                    {
-                        parentOrderings.Add(new Ordering(propertyExpression, OrderingDirection.Asc));
-                    }
-                }
-            }
-
-            private void CloneAnnotations(QuerySourceMapping querySourceMapping, QueryModel queryModel)
-            {
-                var clonedAnnotations = new List<IQueryAnnotation>();
-
-                // ReSharper disable once LoopCanBeConvertedToQuery
-                foreach (var annotation
-                    in _queryCompilationContext.QueryAnnotations.OfType<ICloneableQueryAnnotation>())
-                {
-                    if (querySourceMapping.GetExpression(annotation.QuerySource)
-                        is QuerySourceReferenceExpression querySourceReferenceExpression)
-                    {
-                        clonedAnnotations.Add(
-                            annotation.Clone(
-                                querySourceReferenceExpression.ReferencedQuerySource, queryModel));
-                    }
-                }
-
-                var newAnnotations = _queryCompilationContext.QueryAnnotations.ToList();
-
-                newAnnotations.AddRange(clonedAnnotations);
-
-                _queryCompilationContext.QueryAnnotations = newAnnotations;
-            }
-
-            private static void AdjustPredicate(
-                QueryModel queryModel,
-                IQuerySource parentQuerySource,
-                Expression targetParentExpression)
-            {
-                var querySourcePriorityAnalyzer
-                    = new QuerySourcePriorityAnalyzer(queryModel.SelectClause.Selector);
-
-                Expression predicate = null;
-
-                if (querySourcePriorityAnalyzer.AreLowerPriorityQuerySources(parentQuerySource))
-                {
-                    predicate
-                        = Expression.NotEqual(
-                            targetParentExpression,
-                            Expression.Constant(null, targetParentExpression.Type));
-                }
-
-                predicate
-                    = querySourcePriorityAnalyzer.GetHigherPriorityQuerySources(parentQuerySource)
-                        .Select(qs => new QuerySourceReferenceExpression(qs))
-                        .Select(qsre => Expression.Equal(qsre, Expression.Constant(null, qsre.Type)))
-                        .Aggregate(
-                            predicate,
-                            (current, nullCheck)
-                                => current == null
-                                    ? nullCheck
-                                    : Expression.AndAlso(current, nullCheck));
-
-                if (predicate != null)
-                {
-                    var whereClause = queryModel.BodyClauses.OfType<WhereClause>().LastOrDefault();
-
-                    if (whereClause == null)
-                    {
-                        queryModel.BodyClauses.Add(new WhereClause(predicate));
-                    }
-                    else
-                    {
-                        whereClause.Predicate = Expression.AndAlso(whereClause.Predicate, predicate);
-                    }
-                }
-            }
-
-            private sealed class QuerySourcePriorityAnalyzer : RelinqExpressionVisitor
-            {
-                private readonly List<IQuerySource> _querySources = new List<IQuerySource>();
-
-                public QuerySourcePriorityAnalyzer(Expression expression)
-                {
-                    Visit(expression);
-                }
-
-                public bool AreLowerPriorityQuerySources(IQuerySource querySource)
-                {
-                    var index = _querySources.IndexOf(querySource);
-
-                    return index != -1 && index < _querySources.Count - 1;
-                }
-
-                public IEnumerable<IQuerySource> GetHigherPriorityQuerySources(IQuerySource querySource)
-                {
-                    var index = _querySources.IndexOf(querySource);
-
-                    if (index != -1)
-                    {
-                        for (var i = 0; i < index; i++)
-                        {
-                            yield return _querySources[i];
-                        }
-                    }
-                }
-
-                protected override Expression VisitBinary(BinaryExpression node)
-                {
-                    IQuerySource querySource;
-
-                    if (node.NodeType == ExpressionType.Coalesce
-                        && (querySource = ExtractQuerySource(node.Left)) != null)
-                    {
-                        _querySources.Add(querySource);
-
-                        if ((querySource = ExtractQuerySource(node.Right)) != null)
-                        {
-                            _querySources.Add(querySource);
-                        }
-                        else
-                        {
-                            Visit(node.Right);
-
-                            return node;
-                        }
-                    }
-
-                    return base.VisitBinary(node);
-                }
-
-                private static IQuerySource ExtractQuerySource(Expression expression)
-                {
-                    switch (expression)
-                    {
-                        case QuerySourceReferenceExpression querySourceReferenceExpression:
-                            return querySourceReferenceExpression.ReferencedQuerySource;
-                        case MethodCallExpression methodCallExpression
-                        when IsIncludeMethod(methodCallExpression):
-                            return ((QuerySourceReferenceExpression)methodCallExpression.Arguments[1]).ReferencedQuerySource;
-                    }
-
-                    return null;
-                }
-            }
-
-            private static bool ProcessResultOperators(QueryModel queryModel)
-            {
-                var choiceResultOperator
-                    = queryModel.ResultOperators.LastOrDefault() as ChoiceResultOperatorBase;
-
-                var lastResultOperator = false;
-
-                if (choiceResultOperator != null)
-                {
-                    queryModel.ResultOperators.Remove(choiceResultOperator);
-                    queryModel.ResultOperators.Add(new TakeResultOperator(Expression.Constant(1)));
-
-                    lastResultOperator = choiceResultOperator is LastResultOperator;
-                }
-
-                foreach (var groupResultOperator
-                    in queryModel.ResultOperators.OfType<GroupResultOperator>()
-                        .ToArray())
-                {
-                    queryModel.ResultOperators.Remove(groupResultOperator);
-
-                    var orderByClause = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
-
-                    if (orderByClause == null)
-                    {
-                        queryModel.BodyClauses.Add(orderByClause = new OrderByClause());
-                    }
-
-                    orderByClause.Orderings.Add(new Ordering(groupResultOperator.KeySelector, OrderingDirection.Asc));
-                }
-
-                if (queryModel.BodyClauses
-                        .Count(
-                            bc => bc is AdditionalFromClause
-                                  || bc is JoinClause
-                                  || bc is GroupJoinClause) > 0)
-                {
-                    queryModel.ResultOperators.Add(new DistinctResultOperator());
-                }
-
-                return lastResultOperator;
-            }
-
-            private static QuerySourceReferenceExpression CreateJoinToParentQuery(
-                QueryModel parentQueryModel,
-                QuerySourceReferenceExpression parentQuerySourceReferenceExpression,
-                Expression outerTargetExpression,
-                IForeignKey foreignKey,
-                QueryModel targetQueryModel,
-                ICollection<Expression> subQueryProjection)
-            {
-                var subQueryExpression = new SubQueryExpression(parentQueryModel);
-                var parentQuerySource = parentQuerySourceReferenceExpression.ReferencedQuerySource;
-
-                var joinClause
-                    = new JoinClause(
-                        "_" + parentQuerySource.ItemName,
-                        typeof(AnonymousObject),
-                        subQueryExpression,
-                        CreateKeyAccessExpression(
-                            outerTargetExpression,
-                            foreignKey.Properties),
-                        Expression.Constant(null));
-
-                var joinQuerySourceReferenceExpression = new QuerySourceReferenceExpression(joinClause);
-                var innerKeyExpressions = new List<Expression>();
-
-                foreach (var principalKeyProperty in foreignKey.PrincipalKey.Properties)
-                {
-                    innerKeyExpressions.Add(
-                        Expression.Convert(
-                            Expression.Call(
-                                joinQuerySourceReferenceExpression,
-                                AnonymousObject.GetValueMethodInfo,
-                                Expression.Constant(subQueryProjection.Count)),
-                            principalKeyProperty.ClrType.MakeNullable()));
-
-                    subQueryProjection.Add(
-                        Expression.Convert(
-                            EntityQueryModelVisitor
-                                .CreatePropertyExpression(
-                                    parentQuerySourceReferenceExpression,
-                                    principalKeyProperty),
-                            typeof(object)));
-                }
-
-                joinClause.InnerKeySelector
-                    = innerKeyExpressions.Count == 1
-                        ? innerKeyExpressions[0]
-                        : Expression.New(
-                            AnonymousObject.AnonymousObjectCtor,
-                            Expression.NewArrayInit(
-                                typeof(object),
-                                innerKeyExpressions.Select(e => Expression.Convert(e, typeof(object)))));
-
-                targetQueryModel.BodyClauses.Add(joinClause);
-
-                return joinQuerySourceReferenceExpression;
-            }
-
-            // TODO: Unify this with other versions
-            private static Expression CreateKeyAccessExpression(Expression target, IReadOnlyList<IProperty> properties)
-                => properties.Count == 1
-                    ? EntityQueryModelVisitor
-                        .CreatePropertyExpression(target, properties[0])
-                    : Expression.New(
-                        AnonymousObject.AnonymousObjectCtor,
-                        Expression.NewArrayInit(
-                            typeof(object),
-                            properties
-                                .Select(
-                                    p =>
-                                        Expression.Convert(
-                                            EntityQueryModelVisitor.CreatePropertyExpression(target, p),
-                                            typeof(object)))
-                                .Cast<Expression>()
-                                .ToArray()));
-
-            private static void ApplyParentOrderings(
-                IEnumerable<Ordering> parentOrderings,
-                QueryModel queryModel,
-                QuerySourceMapping querySourceMapping,
-                bool reverseOrdering)
-            {
-                var orderByClause = queryModel.BodyClauses.OfType<OrderByClause>().LastOrDefault();
-
-                if (orderByClause == null)
-                {
-                    queryModel.BodyClauses.Add(orderByClause = new OrderByClause());
-                }
-
-                foreach (var ordering in parentOrderings)
-                {
-                    var newExpression
-                        = CloningExpressionVisitor
-                            .AdjustExpressionAfterCloning(ordering.Expression, querySourceMapping);
-
-                    orderByClause.Orderings
-                        .Add(new Ordering(newExpression, ordering.OrderingDirection));
-                }
-
-                if (reverseOrdering)
-                {
-                    foreach (var ordering in orderByClause.Orderings)
-                    {
-                        ordering.OrderingDirection
-                            = ordering.OrderingDirection == OrderingDirection.Asc
-                                ? OrderingDirection.Desc
-                                : OrderingDirection.Asc;
-                    }
-                }
-            }
-
-            private static void LiftOrderBy(
-                IQuerySource querySource,
-                Expression targetExpression,
-                QueryModel fromQueryModel,
-                QueryModel toQueryModel,
-                List<Expression> subQueryProjection)
-            {
-                var canRemove
-                    = !fromQueryModel.ResultOperators
-                        .Any(r => r is SkipResultOperator || r is TakeResultOperator);
-
-                foreach (var orderByClause
-                    in fromQueryModel.BodyClauses.OfType<OrderByClause>().ToArray())
-                {
-                    var outerOrderByClause = new OrderByClause();
-
-                    foreach (var ordering in orderByClause.Orderings)
-                    {
-                        int projectionIndex;
-
-                        if (ordering.Expression is MemberExpression memberExpression
-                            && memberExpression.Expression is QuerySourceReferenceExpression memberQsre
-                            && memberQsre.ReferencedQuerySource == querySource)
-                        {
-                            projectionIndex
-                                = subQueryProjection
-                                    .FindIndex(
-                                        e =>
-                                            {
-                                                var propertyExpression = (MethodCallExpression)e.RemoveConvert();
-                                                var properyQsre = (QuerySourceReferenceExpression)propertyExpression.Arguments[0];
-                                                var propertyName = (string)((ConstantExpression)propertyExpression.Arguments[1]).Value;
-
-                                                return properyQsre.ReferencedQuerySource == memberQsre.ReferencedQuerySource
-                                                       && propertyName == memberExpression.Member.Name;
-                                            });
-                        }
-                        else
-                        {
-                            projectionIndex
-                                = subQueryProjection
-                                    .FindIndex(e => _expressionEqualityComparer.Equals(e.RemoveConvert(), ordering.Expression));
-                        }
-
-                        if (projectionIndex == -1)
-                        {
-                            projectionIndex = subQueryProjection.Count;
-
-                            subQueryProjection.Add(Expression.Convert(ordering.Expression, typeof(object)));
-                        }
-
-                        var newExpression
-                            = Expression.Call(
-                                targetExpression,
-                                AnonymousObject.GetValueMethodInfo,
-                                Expression.Constant(projectionIndex));
-
-                        outerOrderByClause.Orderings
-                            .Add(new Ordering(newExpression, ordering.OrderingDirection));
-                    }
-
-                    toQueryModel.BodyClauses.Add(outerOrderByClause);
-
-                    if (canRemove)
-                    {
-                        fromQueryModel.BodyClauses.Remove(orderByClause);
-                    }
-                }
-            }
-
-            private class QuerySourceReferenceFindingExpressionTreeVisitor : RelinqExpressionVisitor
-            {
-                public QuerySourceReferenceExpression QuerySourceReferenceExpression { get; private set; }
-
-                protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression querySourceReferenceExpression)
-                {
-                    if (QuerySourceReferenceExpression == null)
-                    {
-                        QuerySourceReferenceExpression = querySourceReferenceExpression;
-                    }
-
-                    return querySourceReferenceExpression;
-                }
-            }
-
-            protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
-            {
-                subQueryExpression.QueryModel.TransformExpressions(Visit);
-
-                return subQueryExpression;
-            }
-        }
-
-        private Expression BuildCollectionIncludeExpressions(
-            INavigation navigation,
-            Expression targetEntityExpression,
-            bool trackingQuery,
-            Expression relatedCollectionFuncExpression,
-            MethodInfo includeCollectionMethodInfo,
-            Expression cancellationTokenExpression)
-        {
-            var inverseNavigation = navigation.FindInverse();
-
-            var arguments = new List<Expression>
-            {
-                Expression.Constant(_collectionIncludeId++),
-                Expression.Constant(navigation),
-                Expression.Constant(inverseNavigation, typeof(INavigation)),
-                Expression.Constant(navigation.GetTargetType()),
-                Expression.Constant(navigation.GetCollectionAccessor()),
-                Expression.Constant(inverseNavigation?.GetSetter(), typeof(IClrPropertySetter)),
-                Expression.Constant(trackingQuery),
-                targetEntityExpression,
-                relatedCollectionFuncExpression
-            };
-
-            if (cancellationTokenExpression != null)
-            {
-                arguments.Add(cancellationTokenExpression);
-            }
-
-            return Expression.Call(
-                Expression.Property(
-                    EntityQueryModelVisitor.QueryContextParameter,
-                    nameof(QueryContext.QueryBuffer)),
-                includeCollectionMethodInfo,
-                arguments);
-        }
-
-        private IEnumerable<IncludeSpecification> CreateIncludeSpecifications(
-            QueryModel queryModel,
-            IEnumerable<IncludeResultOperator> includeResultOperators)
-        {
-            var querySourceTracingExpressionVisitor
-                = _querySourceTracingExpressionVisitorFactory.Create();
-
-            return includeResultOperators
-                .Select(
-                    includeResultOperator =>
-                        {
-                            var entityType
-                                = _queryCompilationContext.Model
-                                    .FindEntityType(includeResultOperator.PathFromQuerySource.Type);
-
-                            var parts = includeResultOperator.NavigationPropertyPaths.ToArray();
-                            var navigationPath = new INavigation[parts.Length];
-
-                            for (var i = 0; i < parts.Length; i++)
-                            {
-                                navigationPath[i] = entityType.FindNavigation(parts[i]);
-
-                                if (navigationPath[i] == null)
-                                {
-                                    throw new InvalidOperationException(
-                                        CoreStrings.IncludeBadNavigation(parts[i], entityType.DisplayName()));
-                                }
-
-                                entityType = navigationPath[i].GetTargetType();
-                            }
-
-                            var querySourceReferenceExpression
-                                = querySourceTracingExpressionVisitor
-                                    .FindResultQuerySourceReferenceExpression(
-                                        queryModel.SelectClause.Selector,
-                                        includeResultOperator.QuerySource);
-
-                            if (querySourceReferenceExpression == null)
-                            {
-                                _queryCompilationContext.Logger
-                                    .LogWarning(
-                                        CoreEventId.IncludeIgnoredWarning,
-                                        () => CoreStrings.LogIgnoredInclude(
-                                            $"{includeResultOperator.QuerySource.ItemName}.{navigationPath.Select(n => n.Name).Join(".")}"));
-                            }
-
-                            return new IncludeSpecification(
-                                includeResultOperator,
-                                querySourceReferenceExpression,
-                                navigationPath);
-                        })
-                .Where(
-                    a =>
-                        {
-                            if (a.QuerySourceReferenceExpression == null)
-                            {
-                                return false;
-                            }
-
-                            var sequenceType = a.QuerySourceReferenceExpression.Type.TryGetSequenceType();
-
-                            if (sequenceType != null
-                                && _queryCompilationContext.Model.FindEntityType(sequenceType) != null)
-                            {
-                                return false;
-                            }
-
-                            return !a.NavigationPath.Any(n => n.IsCollection())
-                                   || a.NavigationPath.Length == 1;
-                        })
-                .ToArray();
-        }
-
-        private static Expression BuildReferenceIncludeExpressions(
-            IReadOnlyList<INavigation> navigationPath,
-            Expression targetEntityExpression,
-            bool trackingQuery,
-            ref int includedIndex,
-            int navigationIndex)
-        {
-            var navigation = navigationPath[navigationIndex];
-
-            var relatedArrayAccessExpression
-                = Expression.ArrayAccess(_includedParameter, Expression.Constant(includedIndex++));
-
-            var relatedEntityExpression
-                = Expression.Convert(relatedArrayAccessExpression, navigation.ClrType);
-
-            var stateManagerProperty
-                = Expression.Property(
-                    Expression.Property(
-                        EntityQueryModelVisitor.QueryContextParameter,
-                        nameof(QueryContext.StateManager)),
-                    nameof(Lazy<object>.Value));
-
-            var blockExpressions = new List<Expression>();
-
-            if (trackingQuery)
-            {
-                blockExpressions.Add(
-                    Expression.Call(
-                        Expression.Property(
-                            EntityQueryModelVisitor.QueryContextParameter,
-                            nameof(QueryContext.QueryBuffer)),
-                        _queryBufferStartTrackingMethodInfo,
-                        relatedArrayAccessExpression,
-                        Expression.Constant(navigation.GetTargetType())));
-
-                blockExpressions.Add(
-                    Expression.Call(
-                        _setRelationshipSnapshotValueMethodInfo,
-                        stateManagerProperty,
-                        Expression.Constant(navigation),
-                        targetEntityExpression,
-                        relatedArrayAccessExpression));
-            }
-            else
-            {
-                blockExpressions.Add(
-                    Expression.Assign(
-                        Expression.MakeMemberAccess(
-                            targetEntityExpression,
-                            navigation.GetMemberInfo(false, true)),
-                        relatedEntityExpression));
-            }
-
-            var inverseNavigation = navigation.FindInverse();
-
-            if (inverseNavigation != null)
-            {
-                var collection = inverseNavigation.IsCollection();
-
-                if (trackingQuery)
-                {
-                    blockExpressions.Add(
-                        Expression.Call(
-                            collection
-                                ? _addToCollectionSnapshotMethodInfo
-                                : _setRelationshipSnapshotValueMethodInfo,
-                            stateManagerProperty,
-                            Expression.Constant(inverseNavigation),
-                            relatedArrayAccessExpression,
-                            targetEntityExpression));
-                }
-                else
-                {
-                    blockExpressions.Add(
-                        collection
-                            ? (Expression)Expression.Call(
-                                Expression.Constant(inverseNavigation.GetCollectionAccessor()),
-                                _collectionAccessorAddMethodInfo,
-                                relatedArrayAccessExpression,
-                                targetEntityExpression)
-                            : Expression.Assign(
-                                Expression.MakeMemberAccess(
-                                    relatedEntityExpression,
-                                    inverseNavigation
-                                        .GetMemberInfo(forConstruction: false, forSet: true)),
-                                targetEntityExpression));
-                }
-            }
-
-            if (navigationIndex < navigationPath.Count - 1)
-            {
-                blockExpressions.Add(
-                    BuildReferenceIncludeExpressions(
-                        navigationPath,
-                        relatedEntityExpression,
-                        trackingQuery,
-                        ref includedIndex,
-                        navigationIndex + 1));
-            }
-
-            return
-                Expression.IfThen(
-                    Expression.Not(
-                        Expression.Call(
-                            _referenceEqualsMethodInfo,
-                            relatedArrayAccessExpression,
-                            Expression.Constant(null, typeof(object)))),
-                    Expression.Block(typeof(void), blockExpressions));
         }
 
         /// <summary>
@@ -1234,40 +256,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             return entity;
-        }
-
-        private static readonly MethodInfo _setRelationshipSnapshotValueMethodInfo
-            = typeof(IncludeCompiler).GetTypeInfo()
-                .GetDeclaredMethod(nameof(SetRelationshipSnapshotValue));
-
-        private static void SetRelationshipSnapshotValue(
-            IStateManager stateManager,
-            IPropertyBase navigation,
-            object entity,
-            object value)
-        {
-            var internalEntityEntry = stateManager.TryGetEntry(entity);
-
-            Debug.Assert(internalEntityEntry != null);
-
-            internalEntityEntry.SetRelationshipSnapshotValue(navigation, value);
-        }
-
-        private static readonly MethodInfo _addToCollectionSnapshotMethodInfo
-            = typeof(IncludeCompiler).GetTypeInfo()
-                .GetDeclaredMethod(nameof(AddToCollectionSnapshot));
-
-        private static void AddToCollectionSnapshot(
-            IStateManager stateManager,
-            IPropertyBase navigation,
-            object entity,
-            object value)
-        {
-            var internalEntityEntry = stateManager.TryGetEntry(entity);
-
-            Debug.Assert(internalEntityEntry != null);
-
-            internalEntityEntry.AddToCollectionSnapshot(navigation, value);
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -47,14 +47,11 @@ ORDER BY [o].[ProductID]",
         {
             base.Include_reference(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_collection(bool useString)
@@ -207,10 +204,8 @@ ORDER BY [t].[CustomerID]",
         {
             base.Include_reference_and_collection(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 ORDER BY [o].[OrderID]
@@ -223,64 +218,45 @@ INNER JOIN (
     LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
 ) AS [t] ON [o.OrderDetails].[OrderID] = [t].[OrderID]
 ORDER BY [t].[OrderID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_references_multi_level(bool useString)
         {
             base.Include_references_multi_level(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]
 LEFT JOIN [Customers] AS [o.Order.Customer] ON [o.Order].[CustomerID] = [o.Order.Customer].[CustomerID]",
-                    Sql);
-            }
-            else
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Order Details] AS [o]
-INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_multiple_references_multi_level(bool useString)
         {
             base.Include_multiple_references_multi_level(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region]
 FROM [Order Details] AS [o]
 INNER JOIN [Products] AS [o.Product] ON [o].[ProductID] = [o.Product].[ProductID]
 INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]
 LEFT JOIN [Customers] AS [o.Order.Customer] ON [o.Order].[CustomerID] = [o.Order.Customer].[CustomerID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_multiple_references_multi_level_reverse(bool useString)
         {
             base.Include_multiple_references_multi_level_reverse(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate], [o.Order.Customer].[CustomerID], [o.Order.Customer].[Address], [o.Order.Customer].[City], [o.Order.Customer].[CompanyName], [o.Order.Customer].[ContactName], [o.Order.Customer].[ContactTitle], [o.Order.Customer].[Country], [o.Order.Customer].[Fax], [o.Order.Customer].[Phone], [o.Order.Customer].[PostalCode], [o.Order.Customer].[Region], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]
 LEFT JOIN [Customers] AS [o.Order.Customer] ON [o.Order].[CustomerID] = [o.Order.Customer].[CustomerID]
 INNER JOIN [Products] AS [o.Product] ON [o].[ProductID] = [o.Product].[ProductID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_references_and_collection_multi_level(bool useString)
@@ -902,7 +878,6 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t2]
-    ORDER BY [t1].[CustomerID]
 ) AS [t3] ON [c1.Orders].[CustomerID] = [t3].[CustomerID]
 ORDER BY [t3].[CustomerID]
 
@@ -924,7 +899,6 @@ INNER JOIN (
         ORDER BY [c4].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t5]
-    ORDER BY [t4].[CustomerID], [t5].[CustomerID]
 ) AS [t6] ON [c2.Orders].[CustomerID] = [t6].[CustomerID]
 ORDER BY [t6].[c0], [t6].[CustomerID]",
                     Sql);
@@ -964,14 +938,14 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[City], [c].[CustomerID]
 
-SELECT [c.Orders0].[OrderID], [c.Orders0].[CustomerID], [c.Orders0].[EmployeeID], [c.Orders0].[OrderDate]
-FROM [Orders] AS [c.Orders0]
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
 INNER JOIN (
-    SELECT [c1].[CustomerID], [c1].[City]
-    FROM [Customers] AS [c1]
-    WHERE [c1].[CustomerID] = N'ALFKI'
-) AS [t0] ON [c.Orders0].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t0].[City], [t0].[CustomerID]",
+    SELECT [c0].[CustomerID], [c0].[City]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[City], [t].[CustomerID]",
                 Sql);
         }
 
@@ -1054,7 +1028,6 @@ INNER JOIN (
         ORDER BY [c2].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t2]
-    ORDER BY [t1].[CustomerID]
 ) AS [t3] ON [c1.Orders].[CustomerID] = [t3].[CustomerID]
 ORDER BY [t3].[CustomerID]",
                     Sql);
@@ -1065,29 +1038,23 @@ ORDER BY [t3].[CustomerID]",
         {
             base.Include_multiple_references(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate]
 FROM [Order Details] AS [o]
 INNER JOIN [Products] AS [o.Product] ON [o].[ProductID] = [o.Product].[ProductID]
 INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_reference_alias_generation(bool useString)
         {
             base.Include_reference_alias_generation(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o.Order].[OrderID], [o.Order].[CustomerID], [o.Order].[EmployeeID], [o.Order].[OrderDate]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_duplicate_reference(bool useString)
@@ -1259,32 +1226,26 @@ ORDER BY [t].[CustomerID]",
         {
             base.Include_reference_dependent_already_tracked(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_reference_as_no_tracking(bool useString)
         {
             base.Include_reference_as_no_tracking(useString);
 
-            if (!useString)
-            {
-                AssertSql(
-                    @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                    Sql);
-            }
+                Sql);
         }
 
         public override void Include_collection_as_no_tracking2(bool useString)


### PR DESCRIPTION
Move from a list of include paths to a tree representation in preparation for making the compiler fully recursive.