### PR TITLE
Fixing extensibility blockers in QueryCompiler/ParameterExtractingExpressionVisitor

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -51,10 +51,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private bool _inLambda;
 
-        private ParameterExtractingExpressionVisitor(
-            IEvaluatableExpressionFilter evaluatableExpressionFilter,
-            QueryContext queryContext,
-            ISensitiveDataLogger logger,
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ParameterExtractingExpressionVisitor(
+            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
+            [NotNull] QueryContext queryContext,
+            [NotNull] ISensitiveDataLogger logger,
             bool parameterize)
         {
             _evaluatableExpressionFilter = evaluatableExpressionFilter;
@@ -67,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public Expression ExtractParameters([NotNull] Expression expression)
+        public virtual Expression ExtractParameters([NotNull] Expression expression)
         {
             var oldPartialEvaluationInfo = _partialEvaluationInfo;
 
@@ -375,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public object Evaluate([CanBeNull] Expression expression, [CanBeNull] out string parameterName)
+        public virtual object Evaluate([CanBeNull] Expression expression, [CanBeNull] out string parameterName)
         {
             parameterName = null;
 

--- a/src/EFCore/Query/Internal/EvaluatableExpressionFilter.cs
+++ b/src/EFCore/Query/Internal/EvaluatableExpressionFilter.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EvaluatableExpressionFilter : EvaluatableExpressionFilterBase
+    {
+        private static readonly PropertyInfo _dateTimeNow
+            = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.Now));
+
+        private static readonly PropertyInfo _dateTimeUtcNow
+            = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.UtcNow));
+
+        private static readonly MethodInfo _guidNewGuid
+            = typeof(Guid).GetTypeInfo().GetDeclaredMethod(nameof(Guid.NewGuid));
+
+        private static readonly List<MethodInfo> _randomNext
+            = typeof(Random).GetTypeInfo().GetDeclaredMethods(nameof(Random.Next)).ToList();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (_guidNewGuid.Equals(methodCallExpression.Method)
+                || _randomNext.Contains(methodCallExpression.Method))
+            {
+                return false;
+            }
+
+            return base.IsEvaluatableMethodCall(methodCallExpression);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override bool IsEvaluatableMember(MemberExpression memberExpression)
+        {
+            if (Equals(memberExpression.Member, _dateTimeNow)
+                || Equals(memberExpression.Member, _dateTimeUtcNow))
+            {
+                return false;
+            }
+
+            return base.IsEvaluatableMember(memberExpression);
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -315,36 +315,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         new TransformingExpressionTreeProcessor(ExpressionTransformerRegistry.CreateDefault())
                     })));
 
-        private class EvaluatableExpressionFilter : EvaluatableExpressionFilterBase
-        {
-            private static readonly PropertyInfo _dateTimeNow
-                = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.Now));
-
-            private static readonly PropertyInfo _dateTimeUtcNow
-                = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.UtcNow));
-
-            private static readonly MethodInfo _guidNewGuid
-                = typeof(Guid).GetTypeInfo().GetDeclaredMethod(nameof(Guid.NewGuid));
-
-            private static readonly List<MethodInfo> _randomNext
-                = typeof(Random).GetTypeInfo().GetDeclaredMethods(nameof(Random.Next)).ToList();
-
-            public override bool IsEvaluatableMethodCall(MethodCallExpression methodCallExpression)
-            {
-                if (_guidNewGuid.Equals(methodCallExpression.Method) 
-                    || _randomNext.Contains(methodCallExpression.Method))
-                {
-                    return false;
-                }
-
-                return base.IsEvaluatableMethodCall(methodCallExpression);
-            }
-
-            public override bool IsEvaluatableMember(MemberExpression memberExpression)
-                => !Equals(memberExpression.Member, _dateTimeNow) 
-                    && !Equals(memberExpression.Member, _dateTimeUtcNow);
-        }
-
         private INodeTypeProvider NodeTypeProvider
             => _nodeTypeProvider
                ?? (_nodeTypeProvider = _nodeTypeProviderFactory.Create());


### PR DESCRIPTION
Making ctor public, de-nesting class and making methods virtual.