### PR TITLE
Fix to #7429 - StartsWith() filter slow with use of SQL CHARINDEX()

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/CompositePredicateExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/CompositePredicateExpressionVisitor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (_useRelationalNulls)
                 {
-                    predicate = new NotNullableExpression(predicate);
+                    predicate = new NullCompensatedExpression(predicate);
                 }
 
                 selectExpression.Predicate = predicate;

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
@@ -99,8 +99,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     return Visit(innerUnary.Operand);
                 }
 
-                var notNullableExpression = node.Operand as NotNullableExpression;
-                var innerBinary = (notNullableExpression?.Operand ?? node.Operand) as BinaryExpression;
+                var nullCompensatedExpression = node.Operand as NullCompensatedExpression;
+                var innerBinary = (nullCompensatedExpression?.Operand ?? node.Operand) as BinaryExpression;
                 if (innerBinary != null)
                 {
                     Expression result = null;
@@ -148,8 +148,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     if (result != null)
                     {
-                        return notNullableExpression != null
-                            ? new NotNullableExpression(result)
+                        return nullCompensatedExpression != null
+                            ? new NullCompensatedExpression(result)
                             : result;
                     }
                 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitExtension(Expression node)
-            => node is NotNullableExpression
+            => node is NullCompensatedExpression
                 ? node
                 : base.VisitExtension(node);
 
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | 1 | 0                             | 0 OR 0 = 0       |
         // N | N | 1                             | 0 OR 1 = 1       |
         private static Expression ExpandNullableEqualNullable(Expression left, Expression right, Expression leftIsNull, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.AndAlso(
                         Expression.Equal(left, right),
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | N | 1                             | 0 OR 1 = 1       |
         private static Expression ExpandNegatedNullableEqualNullable(
             Expression left, Expression right, Expression leftIsNull, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.AndAlso(
                         Expression.NotEqual(left, right),
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | 1 | N           | 0                | 0                |
         private static Expression ExpandNullableEqualNonNullable(
             Expression left, Expression right, Expression leftIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.Equal(left, right),
                     Expression.Not(leftIsNull)));
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | 1 | N           | 0                | 0                |
         private static Expression ExpandNegatedNullableEqualNonNullable(
             Expression left, Expression right, Expression leftIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.NotEqual(left, right),
                     Expression.Not(leftIsNull)));
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // 1 | N | N           | 0                | 0                |
         private static Expression ExpandNonNullableEqualNullable(
             Expression left, Expression right, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.Equal(left, right),
                     Expression.Not(rightIsNull)));
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // 1 | N | N           | 0                | 0                |
         private static Expression ExpandNegatedNonNullableEqualNullable(
             Expression left, Expression right, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.NotEqual(left, right),
                     Expression.Not(rightIsNull)));
@@ -305,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | N | 0                             | 1 && 0 = 0       |
         private static Expression ExpandNullableNotEqualNullable(
             Expression left, Expression right, Expression leftIsNull, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.OrElse(
                         Expression.NotEqual(left, right),
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | N | 0                             | 1 && 0 = 0       |
         private static Expression ExpandNegatedNullableNotEqualNullable(
             Expression left, Expression right, Expression leftIsNull, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.AndAlso(
                     Expression.OrElse(
                         Expression.Equal(left, right),
@@ -366,7 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | 1 | N           | 1                | 1                |
         private static Expression ExpandNullableNotEqualNonNullable(
             Expression left, Expression right, Expression leftIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.NotEqual(left, right),
                     leftIsNull));
@@ -383,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // N | 1 | N           | 1                | 1             |
         private static Expression ExpandNegatedNullableNotEqualNonNullable(
             Expression left, Expression right, Expression leftIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.Equal(left, right),
                     leftIsNull));
@@ -400,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // 1 | N | N           | 1                | 1             |
         private static Expression ExpandNonNullableNotEqualNullable(
             Expression left, Expression right, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.NotEqual(left, right),
                     rightIsNull));
@@ -417,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         // 1 | N | N           | 1                | 1             |
         private static Expression ExpandNegatedNonNullableNotEqualNullable(
             Expression left, Expression right, Expression rightIsNull)
-            => new NotNullableExpression(
+            => new NullCompensatedExpression(
                 Expression.OrElse(
                     Expression.Equal(left, right),
                     rightIsNull));

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpressionVisitorBase.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpressionVisitorBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitExtension(Expression node)
-            => node is NotNullableExpression
+            => node is NullCompensatedExpression
                 ? node
                 : base.VisitExtension(node);
     }

--- a/src/EFCore.Relational/Query/Expressions/NullCompensatedExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullCompensatedExpression.cs
@@ -9,9 +9,10 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
 {
     /// <summary>
-    ///     Reducible annotation expression used to affect null expansion logic.
+    ///     Reducible annotation expression indicating that the following expression fragment has been compensated for null semantics.
+    ///     No additional null semantics related processing is needed for this fragment.
     /// </summary>
-    public class NotNullableExpression : Expression
+    public class NullCompensatedExpression : Expression
     {
         private readonly Expression _operand;
 
@@ -19,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     Creates an instance of NotNullableExpression.
         /// </summary>
         /// <param name="operand"> The operand. </param>
-        public NotNullableExpression([NotNull] Expression operand)
+        public NullCompensatedExpression([NotNull] Expression operand)
         {
             Check.NotNull(operand, nameof(operand));
 
@@ -53,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             var newExpression = visitor.Visit(_operand);
 
             return newExpression != _operand
-                ? new NotNullableExpression(newExpression)
+                ? new NullCompensatedExpression(newExpression)
                 : this;
         }
 
@@ -90,10 +91,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 return true;
             }
 
-            return obj.GetType() == GetType() && Equals((NotNullableExpression)obj);
+            return obj.GetType() == GetType() && Equals((NullCompensatedExpression)obj);
         }
 
-        private bool Equals([NotNull] NotNullableExpression other) => Equals(_operand, other._operand);
+        private bool Equals([NotNull] NullCompensatedExpression other) => Equals(_operand, other._operand);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1585,6 +1585,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 return base.VisitBinary(expression);
             }
+
+            protected override Expression VisitExtension(Expression node)
+                => node is NullCompensatedExpression
+                    ? node
+                    : base.VisitExtension(node);
         }
 
         private class BooleanExpressionTranslatingVisitor : RelinqExpressionVisitor

--- a/src/EFCore.Specification.Tests/FunkyDataQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/FunkyDataQueryTestBase.cs
@@ -279,32 +279,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
             using (var ctx = CreateContext())
             {
-                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName).ToList();
-                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("%B"));
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith("%B"));
                 Assert.True(expected1.Count() == result1.Count);
 
-                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("_r")).Select(c => c.FirstName).ToList();
-                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("_r"));
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith("_r")).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith("_r"));
                 Assert.True(expected2.Count() == result2.Count);
 
-                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(null)).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result3.Count);
 
-                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith("")).Select(c => c.FirstName).ToList();
                 Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
 
-                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith("a__r_")).Select(c => c.FirstName).ToList();
-                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith("a__r_"));
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith("a__r_")).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith("a__r_"));
                 Assert.True(expected5.Count() == result5.Count);
 
-                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName).ToList();
-                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith("%B%a%r"));
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith("%B%a%r")).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.EndsWith("%B%a%r"));
                 Assert.True(expected6.Count() == result6.Count);
 
-                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName).ToList();
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith("")).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result7.Count);
 
-                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(null)).Select(c => c.FirstName).ToList();
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith(null)).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result8.Count);
             }
         }
@@ -315,39 +315,39 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var ctx = CreateContext())
             {
                 var prm1 = "%B";
-                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName).ToList();
-                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm1));
+                var result1 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName).ToList();
+                var expected1 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith(prm1));
                 Assert.True(expected1.Count() == result1.Count);
 
                 var prm2 = "_r";
-                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName).ToList();
-                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm2));
+                var result2 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName).ToList();
+                var expected2 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith(prm2));
                 Assert.True(expected2.Count() == result2.Count);
 
                 var prm3 = (string)null;
-                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm3)).Select(c => c.FirstName).ToList();
+                var result3 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(prm3)).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result3.Count);
 
                 var prm4 = "";
-                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm4)).Select(c => c.FirstName).ToList();
+                var result4 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(prm4)).Select(c => c.FirstName).ToList();
                 Assert.True(ctx.FunkyCustomers.Count() == result4.Count);
 
                 var prm5 = "a__r_";
-                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName).ToList();
-                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.StartsWith(prm5));
+                var result5 = ctx.FunkyCustomers.Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName).ToList();
+                var expected5 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && c.EndsWith(prm5));
                 Assert.True(expected5.Count() == result5.Count);
 
                 var prm6 = "%B%a%r";
-                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName).ToList();
-                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.StartsWith(prm6));
+                var result6 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith(prm6)).Select(c => c.FirstName).ToList();
+                var expected6 = ctx.FunkyCustomers.Select(c => c.FirstName).ToList().Where(c => c != null && !c.EndsWith(prm6));
                 Assert.True(expected6.Count() == result6.Count);
 
                 var prm7 = "";
-                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm7)).Select(c => c.FirstName).ToList();
+                var result7 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith(prm7)).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result7.Count);
 
                 var prm8 = (string)null;
-                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.StartsWith(prm8)).Select(c => c.FirstName).ToList();
+                var result8 = ctx.FunkyCustomers.Where(c => !c.FirstName.EndsWith(prm8)).Select(c => c.FirstName).ToList();
                 Assert.True(0 == result8.Count);
             }
         }

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStartsWithOptimizedTranslator.cs
@@ -31,9 +31,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                         // ReSharper disable once AssignNullToNotNullAttribute
                         methodCallExpression.Object,
                         Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat)),
-                    Expression.Equal(
-                        new SqlFunctionExpression("CHARINDEX", typeof(int), new[] { patternExpression, methodCallExpression.Object }),
-                        Expression.Constant(1)));
+                    new NullCompensatedExpression(
+                        Expression.Equal(
+                            new SqlFunctionExpression(
+                                "LEFT",
+                                // ReSharper disable once PossibleNullReferenceException
+                                methodCallExpression.Object.Type,
+                                new[]
+                                {
+                                    methodCallExpression.Object,
+                                    new SqlFunctionExpression("LEN", typeof(int), new[] { patternExpression })
+                                }),
+                            patternExpression)));
 
                 return patternConstantExpression != null
                     ? (string)patternConstantExpression.Value == string.Empty

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
@@ -23,26 +23,26 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                 var patternExpression = methodCallExpression.Arguments[0];
                 var patternConstantExpression = patternExpression as ConstantExpression;
 
-                var endsWithExpression = Expression.Equal(
-                    new SqlFunctionExpression(
-                        "substr",
-                        // ReSharper disable once PossibleNullReferenceException
-                        methodCallExpression.Object.Type,
-                        new[]
-                        {
-                            methodCallExpression.Object,
-                            Expression.Negate(new SqlFunctionExpression("length", typeof(int), new[] { patternExpression }))
-                        }),
-                    patternExpression);
+                var endsWithExpression = new NullCompensatedExpression(
+                    Expression.Equal(
+                        new SqlFunctionExpression(
+                            "substr",
+                            // ReSharper disable once PossibleNullReferenceException
+                            methodCallExpression.Object.Type,
+                            new[]
+                            {
+                                methodCallExpression.Object,
+                                Expression.Negate(new SqlFunctionExpression("length", typeof(int), new[] { patternExpression }))
+                            }),
+                        patternExpression));
 
-                return new NotNullableExpression(
-                    patternConstantExpression != null
-                        ? (string)patternConstantExpression.Value == string.Empty
-                            ? (Expression)Expression.Constant(true)
-                            : endsWithExpression
-                        : Expression.OrElse(
-                            endsWithExpression,
-                            Expression.Equal(patternExpression, Expression.Constant(string.Empty))));
+                return patternConstantExpression != null
+                    ? (string)patternConstantExpression.Value == string.Empty
+                        ? (Expression)Expression.Constant(true)
+                        : endsWithExpression
+                    : Expression.OrElse(
+                        endsWithExpression,
+                        Expression.Equal(patternExpression, Expression.Constant(string.Empty)));
             }
 
             return null;

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
@@ -31,9 +31,19 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                         // ReSharper disable once AssignNullToNotNullAttribute
                         methodCallExpression.Object,
                         Expression.Add(methodCallExpression.Arguments[0], Expression.Constant("%", typeof(string)), _concat)),
-                    Expression.Equal(
-                        new SqlFunctionExpression("instr", typeof(int), new[] { methodCallExpression.Object, patternExpression }),
-                        Expression.Constant(1)));
+                    new NullCompensatedExpression(
+                        Expression.Equal(
+                            new SqlFunctionExpression(
+                                "substr",
+                                // ReSharper disable once PossibleNullReferenceException
+                                methodCallExpression.Object.Type,
+                                new[]
+                                {
+                                    methodCallExpression.Object,
+                                    Expression.Constant(1),
+                                    new SqlFunctionExpression("length", typeof(int), new[] { patternExpression })
+                                }),
+                            patternExpression)));
 
                 return patternConstantExpression != null
                     ? (string)patternConstantExpression.Value == string.Empty

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -338,7 +338,7 @@ WHERE [e2].[Id] > 5", Sql);
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Required_FK] ON [e1].[Id] = [e1.OneToOne_Required_FK].[Level1_Required_Id]
-WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e1.OneToOne_Required_FK].[Name]) = 1)",
+WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%' AND (LEFT([e1.OneToOne_Required_FK].[Name], LEN(N'L')) = N'L')",
                 Sql);
         }
 
@@ -350,7 +350,7 @@ WHERE [e1.OneToOne_Required_FK].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e1
                 @"SELECT [e3].[Id], [e3].[Level2_Optional_Id], [e3].[Level2_Required_Id], [e3].[Name], [e3].[OneToMany_Optional_InverseId], [e3].[OneToMany_Optional_Self_InverseId], [e3].[OneToMany_Required_InverseId], [e3].[OneToMany_Required_Self_InverseId], [e3].[OneToOne_Optional_PK_InverseId], [e3].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e3]
 INNER JOIN [Level2] AS [e3.OneToOne_Required_FK_Inverse] ON [e3].[Level2_Required_Id] = [e3.OneToOne_Required_FK_Inverse].[Id]
-WHERE [e3.OneToOne_Required_FK_Inverse].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e3.OneToOne_Required_FK_Inverse].[Name]) = 1)",
+WHERE [e3.OneToOne_Required_FK_Inverse].[Name] LIKE N'L' + N'%' AND (LEFT([e3.OneToOne_Required_FK_Inverse].[Name], LEN(N'L')) = N'L')",
                 Sql);
         }
 
@@ -362,7 +362,7 @@ WHERE [e3.OneToOne_Required_FK_Inverse].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE [e1.OneToOne_Optional_FK].[Name] LIKE N'L' + N'%' AND (CHARINDEX(N'L', [e1.OneToOne_Optional_FK].[Name]) = 1)",
+WHERE [e1.OneToOne_Optional_FK].[Name] LIKE N'L' + N'%' AND (LEFT([e1.OneToOne_Optional_FK].[Name], LEN(N'L')) = N'L')",
                 Sql);
         }
 
@@ -386,7 +386,7 @@ WHERE [e1.OneToOne_Optional_FK].[Name] = N'L2 01'",
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE UPPER([e1.OneToOne_Optional_FK].[Name]) LIKE N'L' + N'%' AND (CHARINDEX(N'L', UPPER([e1.OneToOne_Optional_FK].[Name])) = 1)",
+WHERE UPPER([e1.OneToOne_Optional_FK].[Name]) LIKE N'L' + N'%' AND (LEFT(UPPER([e1.OneToOne_Optional_FK].[Name]), LEN(N'L')) = N'L')",
                 Sql);
         }
 
@@ -398,7 +398,7 @@ WHERE UPPER([e1.OneToOne_Optional_FK].[Name]) LIKE N'L' + N'%' AND (CHARINDEX(N'
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE ([e1.OneToOne_Optional_FK].[Name] LIKE [e1.OneToOne_Optional_FK].[Name] + N'%' AND (CHARINDEX([e1.OneToOne_Optional_FK].[Name], [e1.OneToOne_Optional_FK].[Name]) = 1)) OR ([e1.OneToOne_Optional_FK].[Name] = N'')",
+WHERE ([e1.OneToOne_Optional_FK].[Name] LIKE [e1.OneToOne_Optional_FK].[Name] + N'%' AND (LEFT([e1.OneToOne_Optional_FK].[Name], LEN([e1.OneToOne_Optional_FK].[Name])) = [e1.OneToOne_Optional_FK].[Name])) OR ([e1.OneToOne_Optional_FK].[Name] = N'')",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -379,7 +379,7 @@ ORDER BY [t].[OrderID]",
             AssertSql(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -397,7 +397,7 @@ INNER JOIN (
         ORDER BY [oo1].[OrderDate] DESC
     ) AS [c]
     FROM [Customers] AS [c0]
-    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c0].[CustomerID]) = 1)
+    WHERE [c0].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'W')) = N'W')
     ORDER BY (
         SELECT TOP(1) [oo0].[OrderDate]
         FROM [Orders] AS [oo0]
@@ -1381,7 +1381,7 @@ ORDER BY [t].[ContactName], [t].[CustomerID]",
             AssertSql(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
 ORDER BY (
     SELECT TOP(1) [oo].[OrderDate]
     FROM [Orders] AS [oo]
@@ -1399,7 +1399,7 @@ INNER JOIN (
         ORDER BY [oo].[OrderDate] DESC
     ) AS [c], [c].[CustomerID]
     FROM [Customers] AS [c]
-    WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
+    WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
     ORDER BY [c] DESC, [c].[CustomerID]
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ORDER BY [c0].[c] DESC, [c0].[CustomerID], [o].[OrderID]
@@ -1417,7 +1417,7 @@ INNER JOIN (
             ORDER BY [oo].[OrderDate] DESC
         ) AS [c], [c].[CustomerID]
         FROM [Customers] AS [c]
-        WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (CHARINDEX(N'W', [c].[CustomerID]) = 1)
+        WHERE [c].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c].[CustomerID], LEN(N'W')) = N'W')
         ORDER BY [c] DESC, [c].[CustomerID]
     ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ) AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
@@ -1433,7 +1433,7 @@ ORDER BY [o1].[c] DESC, [o1].[CustomerID], [o1].[OrderID]",
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY CASE
-    WHEN [c].[CustomerID] LIKE N'S' + N'%' AND (CHARINDEX(N'S', [c].[CustomerID]) = 1)
+    WHEN [c].[CustomerID] LIKE N'S' + N'%' AND (LEFT([c].[CustomerID], LEN(N'S')) = N'S')
     THEN 1 ELSE 2
 END, [c].[CustomerID]
 
@@ -1441,7 +1441,7 @@ SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
     SELECT [c0].[CustomerID], CASE
-        WHEN [c0].[CustomerID] LIKE N'S' + N'%' AND (CHARINDEX(N'S', [c0].[CustomerID]) = 1)
+        WHEN [c0].[CustomerID] LIKE N'S' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'S')) = N'S')
         THEN 1 ELSE 2
     END AS [c]
     FROM [Customers] AS [c0]

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -943,7 +943,7 @@ FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN @__prm_0 = 0
     THEN CAST(1 AS BIT) ELSE CASE
-        WHEN [e].[StringA] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[StringA]) = 1)
+        WHEN [e].[StringA] LIKE N'A' + N'%' AND (LEFT([e].[StringA], LEN(N'A')) = N'A')
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 END = 1",
@@ -967,7 +967,7 @@ WHERE CASE
         THEN CASE
             WHEN [e].[BoolA] = 1
             THEN CASE
-                WHEN [e].[StringA] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[StringA]) = 1)
+                WHEN [e].[StringA] LIKE N'A' + N'%' AND (LEFT([e].[StringA], LEN(N'A')) = N'A')
                 THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
             END ELSE CAST(0 AS BIT)
         END ELSE CAST(1 AS BIT)
@@ -1034,9 +1034,11 @@ WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)",
             base.Where_equal_using_relational_null_semantics_with_parameter();
 
             Assert.Equal(
-                @"SELECT [e].[Id]
+                @"@__prm_0:  (DbType = String)
+
+SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] IS NULL",
+WHERE [e].[NullableBoolA] = @__prm_0",
                 Sql);
         }
 
@@ -1067,9 +1069,11 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]",
             base.Where_not_equal_using_relational_null_semantics_with_parameter();
 
             Assert.Equal(
-                @"SELECT [e].[Id]
+                @"@__prm_0:  (DbType = String)
+
+SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] IS NOT NULL",
+WHERE [e].[NullableBoolA] <> @__prm_0",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -536,7 +536,7 @@ WHERE [e].[ReportsTo] IS NULL",
             Assert.Equal(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
@@ -861,7 +861,7 @@ END, [o].[OrderID], (
     WHERE [o].[OrderID] = [o1].[OrderID]
 )
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)",
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -924,7 +924,7 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
             Assert.StartsWith(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [e].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
@@ -955,7 +955,7 @@ WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_
     WHERE [o].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)",
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -966,7 +966,7 @@ WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) =
             Assert.StartsWith(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
 
 SELECT TOP(2) [o.Customer0].[City]
 FROM [Orders] AS [o0]
@@ -987,7 +987,7 @@ WHERE [o0].[OrderID] = 10643",
     WHERE [oo].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)",
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -1004,7 +1004,7 @@ WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) =
     ORDER BY [o].[CustomerID]
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [e].[CustomerID]) = 1)",
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -1211,7 +1211,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -684,7 +684,7 @@ ORDER BY [o0].[OrderID]",
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]
 
 @_outer_CustomerID: ALFKI (Size = 450)
@@ -1947,7 +1947,7 @@ END",
     WHEN EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE [c].[ContactName] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[ContactName]) = 1))
+        WHERE [c].[ContactName] LIKE N'A' + N'%' AND (LEFT([c].[ContactName], LEN(N'A')) = N'A'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -1963,7 +1963,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))",
                 Sql);
         }
 
@@ -1977,7 +1977,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))",
                 Sql);
         }
 
@@ -1991,7 +1991,7 @@ FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
                 Sql);
         }
 
@@ -2005,7 +2005,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))",
                 Sql);
         }
 
@@ -2019,7 +2019,7 @@ FROM [Customers] AS [c]
 WHERE (([c].[City] <> N'London') OR [c].[City] IS NULL) AND EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1))",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A'))",
                 Sql);
         }
 
@@ -2033,7 +2033,7 @@ FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [o].[CustomerID]) = 1)) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
+    WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')) AND (([c].[City] <> N'London') OR [c].[City] IS NULL)",
                 Sql);
         }
 
@@ -2060,7 +2060,7 @@ WHERE ([c].[City] = N'London') AND EXISTS (
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE NOT ([c].[ContactName] LIKE N'A' + N'%') OR (CHARINDEX(N'A', [c].[ContactName]) <> 1))
+        WHERE NOT ([c].[ContactName] LIKE N'A' + N'%') OR (LEFT([c].[ContactName], LEN(N'A')) <> N'A'))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -2075,7 +2075,7 @@ END",
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE (NOT ([c].[ContactName] LIKE [c].[ContactName] + N'%') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) <> 1)) AND (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL))
+        WHERE (NOT ([c].[ContactName] LIKE [c].[ContactName] + N'%') OR (LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName])) AND (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 Sql);
@@ -4175,7 +4175,7 @@ END",
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY (
     SELECT CASE
         WHEN EXISTS (
@@ -4731,7 +4731,7 @@ FROM [Customers] AS [c]",
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'M' + N'%' AND (CHARINDEX(N'M', [c].[ContactName]) = 1)",
+WHERE [c].[ContactName] LIKE N'M' + N'%' AND (LEFT([c].[ContactName], LEN(N'M')) = N'M')",
                 Sql);
         }
 
@@ -4742,7 +4742,7 @@ WHERE [c].[ContactName] LIKE N'M' + N'%' AND (CHARINDEX(N'M', [c].[ContactName])
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[ContactName], [c].[ContactName]) = 1)) OR ([c].[ContactName] = N'')",
+WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4753,7 +4753,7 @@ WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[Conta
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[ContactName], [c].[ContactName]) = 1)) OR ([c].[ContactName] = N'')",
+WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (LEFT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName])) OR ([c].[ContactName] = N'')",
                 Sql);
         }
 
@@ -4766,7 +4766,7 @@ WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (CHARINDEX([c].[Conta
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] LIKE @__LocalMethod1_0 + N'%' AND (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) = 1)) OR (@__LocalMethod1_0 = N'')",
+WHERE ([c].[ContactName] LIKE @__LocalMethod1_0 + N'%' AND (LEFT([c].[ContactName], LEN(@__LocalMethod1_0)) = @__LocalMethod1_0)) OR (@__LocalMethod1_0 = N'')",
                 Sql);
         }
 
@@ -5677,7 +5677,7 @@ ORDER BY [o].[OrderID]",
             Assert.StartsWith(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 
 @_outer_CustomerID: ALFKI (Size = 450)
 
@@ -5719,7 +5719,7 @@ WHERE EXISTS (
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -5738,7 +5738,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -5761,7 +5761,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -5780,7 +5780,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -5799,7 +5799,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
     END
 ), [c].[CustomerID]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 
 @_outer_CustomerID1: ALFKI (Size = 450)
 
@@ -5842,7 +5842,7 @@ ORDER BY [o2].[OrderID]",
     WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -5857,7 +5857,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) =
     WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [c].[CustomerID]) = 1)",
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -7561,7 +7561,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[CustomerID] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [t].[CustomerID]) = 1)",
+WHERE [t].[CustomerID] LIKE N'A' + N'%' AND (LEFT([t].[CustomerID], LEN(N'A')) = N'A')",
                 Sql);
         }
 
@@ -7603,7 +7603,7 @@ FROM (
     SELECT DISTINCT [c].[CustomerID] + [c].[City] AS [c]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[c] LIKE N'A' + N'%' AND (CHARINDEX(N'A', [t].[c]) = 1)",
+WHERE [t].[c] LIKE N'A' + N'%' AND (LEFT([t].[c], LEN(N'A')) = N'A')",
                 Sql);
         }
 


### PR DESCRIPTION
Fix is to use more permanent translation:

property.StartsWith(pattern) => property LIKE pattern + '%' AND LEFT(property, LEN(pattern)) = pattern

Also fixed minor issue with null semantics where we would apply C# null semantics for comparisons to null-valued parameters