### PR TITLE
Fix minor grammatical error

### DIFF
--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         exist then the database is deleted.
         ///     </para>
         ///     <para>
-        ///         Warning: The entire database is deleted an no effort is made to remove just the database objects that are used by
+        ///         Warning: The entire database is deleted, and no effort is made to remove just the database objects that are used by
         ///         the model for this context.
         ///     </para>
         /// </summary>
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         exist then the database is deleted.
         ///     </para>
         ///     <para>
-        ///         Warning: The entire database is deleted an no effort is made to remove just the database objects that are used by
+        ///         Warning: The entire database is deleted, and no effort is made to remove just the database objects that are used by
         ///         the model for this context.
         ///     </para>
         /// </summary>


### PR DESCRIPTION
While working on a project on VS, I noticed that the comments had a slight typo.

    Summary of the changes
    - Added missing **_d_**
    - Added comma, to break sentence up