### PR TITLE
Changes for #8007: RelationalDataReader instance ID

### DIFF
--- a/src/EFCore.Relational/Internal/RelationalDiagnosticSourceDataReaderDisposingMessage.cs
+++ b/src/EFCore.Relational/Internal/RelationalDiagnosticSourceDataReaderDisposingMessage.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    // TODO revert to anonymous types when https://github.com/dotnet/corefx/issues/4672 is fixed
+    internal class RelationalDiagnosticSourceDataReaderDisposingMessage
+    {
+        public DbConnection Connection { get; set; }
+        public Guid ConnectionId { get; set; }
+        public DbCommand Command { get; set; }
+        public DbDataReader DataReader { get; set; }
+        public Guid InstanceId { get; set; }
+        public int RecordsAffected { get; set; }
+        public long Timestamp { get; set; }
+        public long Duration { get; set; }
+    }
+}

--- a/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
+++ b/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
@@ -348,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             if (diagnosticSource.IsEnabled(DataReaderDisposing))
             {
                 diagnosticSource.Write(DataReaderDisposing,
-                    new
+                    new RelationalDiagnosticSourceDataReaderDisposingMessage
                     {
                         Connection = connection,
                         ConnectionId = connectionId,

--- a/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
+++ b/src/EFCore.Relational/Internal/RelationalDiagnostics.cs
@@ -341,6 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             Guid connectionId,
             DbDataReader dataReader,
             int recordsAffected,
+            Guid instanceId,
             long startTimestamp,
             long currentTimestamp)
         {
@@ -352,6 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         Connection = connection,
                         ConnectionId = connectionId,
                         DataReader = dataReader,
+                        InstanceId = instanceId,
                         RecordsAffected = recordsAffected,
                         Timestamp = currentTimestamp,
                         Duration = currentTimestamp - startTimestamp

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -228,7 +228,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                                     connection,
                                     dbCommand,
                                     dbCommand.ExecuteReader(),
-                                    DiagnosticSource);
+                                    DiagnosticSource,
+                                    instanceId);
                         }
                         catch
                         {
@@ -351,7 +352,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                                 connection,
                                 dbCommand,
                                 await dbCommand.ExecuteReaderAsync(cancellationToken), 
-                                DiagnosticSource);
+                                DiagnosticSource,
+                                instanceId);
                         }
                         catch
                         {

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private readonly DbCommand _command;
         private readonly DbDataReader _reader;
         private readonly DiagnosticSource _diagnosticSource;
+        private readonly Guid _instanceId;
         private readonly long _startTimestamp;
 
         private bool _disposed;
@@ -36,11 +37,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="command"> The command that was executed. </param>
         /// <param name="reader"> The underlying reader for the result set. </param>
         /// <param name="diagnosticSource"> The diagnostic source. </param>
+        /// <param name="instanceId"> The instance ID for diagnostic logging. </param>
         public RelationalDataReader(
             [CanBeNull] IRelationalConnection connection,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
-            [NotNull] DiagnosticSource diagnosticSource)
+            [NotNull] DiagnosticSource diagnosticSource,
+            [NotNull] Guid instanceId)
         {
             Check.NotNull(command, nameof(command));
             Check.NotNull(reader, nameof(reader));
@@ -50,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             _command = command;
             _reader = reader;
             _diagnosticSource = diagnosticSource;
+            _instanceId = instanceId;
             _startTimestamp = Stopwatch.GetTimestamp();
         }
 
@@ -81,6 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     _connection.ConnectionId,
                     _reader,
                     _reader.RecordsAffected,
+                    _instanceId,
                     _startTimestamp,
                     currentTimestamp);
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -1129,7 +1129,7 @@ Logged Command",
             // And a third after the dispose of the reader
             Assert.Equal(3, diagnostic.Count);
             Assert.Equal(RelationalDiagnostics.DataReaderDisposing, diagnostic[2].Item1);
-            dynamic disposeData = diagnostic[2].Item2;
+            var disposeData = (RelationalDiagnosticSourceDataReaderDisposingMessage)diagnostic[2].Item2;
             Assert.Equal(beforeData.InstanceId, disposeData.InstanceId);
         }
 


### PR DESCRIPTION
Changes for the proposal discussed in #8007

This tracks the already-existing instanceId for diagnostics from the command to the reader, so one can associate the data reader disposal (which happens upon the completion of results reading, not when the command does) with the place it opened. This is needed for consistency in correlation of relational diagnostics.

Note: I was able to test this easily against a slightly out of date dev, but on latest rebase I'm getting all sorts of issues with the InMemory (and other) packages wanting 2.0.0.0. I don't see how this would be related at all, so not spending the time to fight the current tooling...I bet the CI handles this just fine.