### PR TITLE
Query: Process ConstantExpression in BooleanExpressionTranslatingVisitor

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -3140,6 +3140,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Join_complex_condition()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs.Where(c => c.CustomerID == "ALFKI")
+                join o in os.Where(o => o.OrderID < 10250) on true equals true
+                select c.CustomerID);
+        }
+
+        [ConditionalFact]
         public virtual void Join_client_new_expression()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -6142,6 +6151,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertQuery<Customer>(customer => customer
                     // ReSharper disable once ConvertConditionalTernaryToNullCoalescing
                     .OrderBy(c => c.Region == null ? "ZZ" : c.Region),
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_conditional_operator_where_condition_null()
+        {
+            var fakeCustomer = new Customer();
+            AssertQuery<Customer>(customer => customer
+                    .OrderBy(c => fakeCustomer.City == "London" ? "ZZ" : c.City),
                 entryCount: 91);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3166,6 +3166,22 @@ INNER JOIN [Orders] AS [o] ON ([c].[CustomerID] = [o].[CustomerID]) AND ([c].[Cu
                 Sql);
         }
 
+        public override void Join_complex_condition()
+        {
+            base.Join_complex_condition();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o].*
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10250
+) AS [t] ON 1 = 1
+WHERE [c].[CustomerID] = N'ALFKI'",
+                Sql);
+        }
+
         public override void Join_client_new_expression()
         {
             base.Join_client_new_expression();
@@ -6029,6 +6045,20 @@ FROM [Customers] AS [c]
 ORDER BY CASE
     WHEN [c].[Region] IS NULL
     THEN N'ZZ' ELSE [c].[Region]
+END",
+                Sql);
+        }
+
+        public override void OrderBy_conditional_operator_where_condition_null()
+        {
+            base.OrderBy_conditional_operator_where_condition_null();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY CASE
+    WHEN 0 = 1
+    THEN N'ZZ' ELSE [c].[City]
 END",
                 Sql);
         }


### PR DESCRIPTION
Resolves #8092 

The issue here was, the condition `_parameter == "code"` has parameter value as null, thus `NullComparisonTransformingVisitor` converted the condition to `false`. This condition was part of conditional expression in the order by clause, which produced incorrect SQL as 0.
The fix is to convert constantExpression in `BooleanExpressionTranslatingVisitor` to appropriate expression based on search condition. Since this change will convert `true` to `true == true` for search condition, which we don't want to print specifically for Where clause, moved that processing to `GeneratePredicate` (we need it for join conditions where join conditions are also search conditions.

Also kept the `Translate` method in visitor so we can easily pass the flag and reuse the same visitor.