### PR TITLE
Fix to #6383 - The wrong type is being selected when an extension method is used in a subquery

### DIFF
--- a/src/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/src/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Update_read_only_props_with_named_fields()
             => Update<BlogReadOnlyExplicit>("Posts");
 
-        [Fact(Skip = "#8068")]
+        [Fact]
         public virtual void Include_collection_write_only_props()
         {
             using (var context = CreateContext())
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         public virtual void Update_write_only_props()
             => Update<BlogWriteOnly>("Posts");
 
-        [Fact(Skip = "#8068")]
+        [Fact]
         public virtual void Include_collection_write_only_props_with_named_fields()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -315,6 +315,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             includeCompiler.CompileIncludes(queryModel, includeResultOperators, TrackResults(queryModel), asyncQuery);
 
+            queryModel.TransformExpressions(new CollectionNavigationSubqueryInjector(this).Visit);
+
             _navigationRewritingExpressionVisitorFactory
                 .Create(this)
                 .Rewrite(queryModel, parentQueryModel: null);

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class CollectionNavigationSubqueryInjector : RelinqExpressionVisitor
+    {
+        private readonly EntityQueryModelVisitor _queryModelVisitor;
+        private bool _shouldInject;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CollectionNavigationSubqueryInjector([NotNull] EntityQueryModelVisitor queryModelVisitor, bool shouldInject = false)
+        {
+            _queryModelVisitor = queryModelVisitor;
+            _shouldInject = shouldInject;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static readonly MethodInfo MaterializeCollectionNavigationMethodInfo
+            = typeof(CollectionNavigationSubqueryInjector).GetTypeInfo()
+                .GetDeclaredMethod(nameof(MaterializeCollectionNavigation));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMember(MemberExpression memberExpression)
+        {
+            Check.NotNull(memberExpression, nameof(memberExpression));
+
+            var newMemberExpression = default(Expression);
+            if (_shouldInject)
+            {
+                newMemberExpression = _queryModelVisitor.BindNavigationPathPropertyExpression(
+                    memberExpression,
+                    (properties, querySource) =>
+                    {
+                        var collectionNavigation = properties.OfType<INavigation>().SingleOrDefault(n => n.IsCollection());
+
+                        return collectionNavigation != null
+                                ? InjectSubquery(memberExpression, collectionNavigation)
+                                : default(Expression);
+                    });
+            }
+
+            return newMemberExpression ?? base.VisitMember(memberExpression);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            if (!EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+            {
+                _shouldInject = true;
+            }
+
+            var newMethodCallExpression = default(Expression);
+            if (_shouldInject)
+            {
+                newMethodCallExpression = _queryModelVisitor.BindNavigationPathPropertyExpression(
+                    methodCallExpression,
+                    (properties, querySource) =>
+                    {
+                        var collectionNavigation = properties.OfType<INavigation>().SingleOrDefault(n => n.IsCollection());
+
+                        return collectionNavigation != null
+                            ? InjectSubquery(methodCallExpression, collectionNavigation)
+                            : default(Expression);
+                    });
+            }
+
+            return newMethodCallExpression ?? base.VisitMethodCall(methodCallExpression);
+        }
+
+        private static Expression InjectSubquery(Expression expression, INavigation collectionNavigation)
+        {
+            var targetType = collectionNavigation.GetTargetType().ClrType;
+            var mainFromClause = new MainFromClause(targetType.Name.Substring(0, 1).ToLowerInvariant(), targetType, expression);
+            var selector = new QuerySourceReferenceExpression(mainFromClause);
+
+            var subqueryModel = new QueryModel(mainFromClause, new SelectClause(selector));
+            var subqueryExpression = new SubQueryExpression(subqueryModel);
+
+            var resultCollectionType = collectionNavigation.GetCollectionAccessor().CollectionType;
+
+            var result = Expression.Call(
+                MaterializeCollectionNavigationMethodInfo.MakeGenericMethod(targetType),
+                Expression.Constant(collectionNavigation), subqueryExpression);
+
+            return resultCollectionType.GetTypeInfo().IsGenericType && resultCollectionType.GetGenericTypeDefinition() == typeof(ICollection<>)
+                ? (Expression)result
+                : Expression.Convert(result, resultCollectionType);
+        }
+
+        [UsedImplicitly]
+        private static ICollection<TEntity> MaterializeCollectionNavigation<TEntity>(INavigation navigation, IEnumerable<object> elements)
+        {
+            var collection = navigation.GetCollectionAccessor().Create(elements);
+
+            return (ICollection<TEntity>)collection;
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2473,6 +2473,164 @@ ORDER BY [t].[Rank]");
 FROM [Weapon] AS [w]");
         }
 
+        public override void Client_method_on_collection_navigation_in_predicate()
+        {
+            base.Client_method_on_collection_navigation_in_predicate();
+
+            AssertSql(
+                @"SELECT [g].[FullName], [g].[Nickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]");
+        }
+
+        public override void Client_method_on_collection_navigation_in_predicate_accessed_by_ef_property()
+        {
+            base.Client_method_on_collection_navigation_in_predicate_accessed_by_ef_property();
+
+            AssertSql(
+                @"SELECT [g].[FullName], [g].[Nickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 0)",
+                //
+                @"@_outer_FullName: Augustus Cole (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Dominic Santiago (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Garron Paduk (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]");
+        }
+
+        public override void Client_method_on_collection_navigation_in_order_by()
+        {
+            base.Client_method_on_collection_navigation_in_order_by();
+
+            AssertSql(
+                @"SELECT [g].[FullName], [g].[Nickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 0)",
+                //
+                @"@_outer_FullName: Augustus Cole (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Dominic Santiago (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Garron Paduk (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]");
+        }
+
+        public override void Client_method_on_collection_navigation_in_additional_from_clause()
+        {
+            base.Client_method_on_collection_navigation_in_additional_from_clause();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] = N'Officer'",
+                //
+                @"@_outer_Nickname: Baird (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+FROM [Gear] AS [g0]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g0].[LeaderNickname]) AND (@_outer_SquadId = [g0].[LeaderSquadId]))",
+                //
+                @"@_outer_Nickname: Marcus (Size = 4000)
+@_outer_SquadId: 1
+
+SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+FROM [Gear] AS [g0]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g0].[LeaderNickname]) AND (@_outer_SquadId = [g0].[LeaderSquadId]))");
+        }
+
+        public override void Client_method_on_collection_navigation_in_outer_join_key()
+        {
+            base.Client_method_on_collection_navigation_in_outer_join_key();
+
+            AssertContainsSql(
+                @"SELECT [g].[FullName], [g].[Nickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"@_outer_FullName1: Damon Baird (Size = 450)
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
+                //
+                @"@_outer_FullName1: Augustus Cole (Size = 450)
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
+                //
+                @"@_outer_FullName1: Dominic Santiago (Size = 450)
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
+                //
+                @"@_outer_FullName1: Marcus Fenix (Size = 450)
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
+                //
+                @"@_outer_FullName1: Garron Paduk (Size = 450)
+
+SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+FROM [Weapon] AS [w0]
+WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
+                //
+                @"SELECT [o].[FullName], [o].[Nickname]
+FROM [Gear] AS [o]
+WHERE ([o].[Discriminator] = N'Officer') AND ([o].[HasSoulPatch] = 1)",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]");
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was that when translating collection navigation outside projection we assumed it's always going to be wrapped in a subquery.
This is the case for the most part because in order to be useful inside a query, collection needs to have it's cardinality reduced to single element using a result operator (Count, Any, FirstOrDefault etc), which forces subquery on the collection.
However it is also possible to use client method, which takes collection and returns single element. For this case, subquery won't be generated and we were unable to translate such query.

Fix is to inject subqueries where needed, using same mechanism we use in case of projection. Client method forces materialization on the collection, so it's safe to use.