### PR TITLE
Update Scaffolding to escape a string containing newlines as a verbatim string

### DIFF
--- a/src/EFCore.Relational.Design/Internal/CSharpUtilities.cs
+++ b/src/EFCore.Relational.Design/Internal/CSharpUtilities.cs
@@ -118,7 +118,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(value, nameof(value));
 
-            return "\"" + EscapeString(value) + "\"";
+            return value.Contains(Environment.NewLine)
+                ? "@\"" + EscapeVerbatimString(value) + "\""
+                : "\"" + EscapeString(value) + "\"";
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
@@ -23,5 +23,15 @@ namespace Microsoft.EntityFrameworkCore.Design.Tests.Scaffolding.Internal
         }
 
         struct SomeGenericStruct<T> {}
+
+        [Theory]
+        [InlineData("", "\"\"")]
+        [InlineData("SomeValue", "\"SomeValue\"")]
+        [InlineData("Contains\\Backslash\"QuoteAnd\tTab", "\"Contains\\\\Backslash\\\"QuoteAnd\\tTab\"")]
+        [InlineData("Contains\r\nNewlinesAnd\"Quotes", "@\"Contains\r\nNewlinesAnd\"\"Quotes\"")]
+        public void DelimitString(string input, string expectedOutput)
+        {
+            Assert.Equal(expectedOutput, new CSharpUtilities().DelimitString(input));
+        }
     }
 }


### PR DESCRIPTION
Fix for #8077.
