### PR TITLE
Query: Allow set operations to work after casting

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -856,13 +856,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     return null;
                 }
 
-                var querySourceReferenceExpression
-                    = subQueryModel.SelectClause.Selector as QuerySourceReferenceExpression;
+                var referencedQuerySource = subQueryModel.SelectClause.Selector.TryGetReferencedQuerySource();
 
-                if (querySourceReferenceExpression == null
+                if (referencedQuerySource == null
                     || _inProjection
                     || !_queryModelVisitor.QueryCompilationContext
-                        .QuerySourceRequiresMaterialization(querySourceReferenceExpression.ReferencedQuerySource))
+                        .QuerySourceRequiresMaterialization(referencedQuerySource))
                 {
                     var subQueryModelVisitor
                         = (RelationalQueryModelVisitor)_queryModelVisitor.QueryCompilationContext

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1556,8 +1556,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ?.QueryModel;
 
             var referencedQuerySource
-                = (subQueryModel?.MainFromClause.FromExpression as QuerySourceReferenceExpression)
-                    ?.ReferencedQuerySource;
+                = subQueryModel?.MainFromClause.FromExpression.TryGetReferencedQuerySource();
 
             if (referencedQuerySource != groupJoinClause
                 || queryModel.CountQuerySourceReferences(groupJoinClause) != 1

--- a/src/EFCore.Specification.Tests/InheritanceTestBase.cs
+++ b/src/EFCore.Specification.Tests/InheritanceTestBase.cs
@@ -439,6 +439,66 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [Fact]
+        public virtual void Can_concat_kiwis_and_eagles_as_birds()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis = context.Set<Kiwi>();
+
+                var eagles = context.Set<Eagle>();
+
+                var concat = kiwis.Cast<Bird>().Concat(eagles).ToList();
+
+                Assert.Equal(2, concat.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_except_kiwis_and_eagles_as_birds()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis = context.Set<Kiwi>();
+
+                var eagles = context.Set<Eagle>();
+
+                var concat = kiwis.Cast<Bird>().Except(eagles).ToList();
+
+                Assert.Equal(1, concat.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_intersect_kiwis_and_eagles_as_birds()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis = context.Set<Kiwi>();
+
+                var eagles = context.Set<Eagle>();
+
+                var concat = kiwis.Cast<Bird>().Intersect(eagles).ToList();
+
+                Assert.Equal(0, concat.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_union_kiwis_and_eagles_as_birds()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis = context.Set<Kiwi>();
+
+                var eagles = context.Set<Eagle>();
+
+                var concat = kiwis.Cast<Bird>().Union(eagles).ToList();
+
+                Assert.Equal(2, concat.Count);
+            }
+        }
+
         protected InheritanceContext CreateContext() => Fixture.CreateContext();
 
         protected TFixture Fixture { get; }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -10,6 +10,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -256,6 +258,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             return constantExpression.Type.GetTypeInfo().IsGenericType
                    && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IQuerySource TryGetReferencedQuerySource([NotNull] this Expression expression)
+        {
+            return (expression as QuerySourceReferenceExpression)?.ReferencedQuerySource;
         }
     }
 }

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -544,8 +544,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
                 else
                 {
-                    var subqueryExpression = ((queryModel.SelectClause.Selector as QuerySourceReferenceExpression)
-                        ?.ReferencedQuerySource as MainFromClause)?.FromExpression as SubQueryExpression;
+                    var subqueryExpression
+                        = (queryModel.SelectClause.Selector
+                            .TryGetReferencedQuerySource() as MainFromClause)?.FromExpression as SubQueryExpression;
 
                     var nestedGroupResultOperator
                         = subqueryExpression?.QueryModel?.ResultOperators

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -587,8 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     propertyCreator,
                     conditionalAccessPropertyCreator);
 
-                var resultQsre = navigationResultExpression as QuerySourceReferenceExpression;
-                if (resultQsre != null)
+                if (navigationResultExpression is QuerySourceReferenceExpression resultQsre)
                 {
                     foreach (var includeResultOperator in _queryModelVisitor.QueryCompilationContext.QueryAnnotations
                         .OfType<IncludeResultOperator>()
@@ -674,8 +673,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var qsre = (declaringExpression as MemberExpression)?.Expression as QuerySourceReferenceExpression;
                 if (qsre == null)
                 {
-                    var methodCallExpression = declaringExpression as MethodCallExpression;
-                    if (methodCallExpression != null && EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+                    if (declaringExpression is MethodCallExpression methodCallExpression
+                        && EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
                     {
                         qsre = methodCallExpression.Arguments[0] as QuerySourceReferenceExpression;
                     }
@@ -1035,7 +1034,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             foreach (var includeResultOperator in _queryModelVisitor.QueryCompilationContext.QueryAnnotations.OfType<IncludeResultOperator>())
             {
-                if ((includeResultOperator.PathFromQuerySource as QuerySourceReferenceExpression)?.ReferencedQuerySource
+                if (includeResultOperator.PathFromQuerySource.TryGetReferencedQuerySource()
                     == additionalFromClauseBeingProcessed)
                 {
                     includeResultOperator.PathFromQuerySource = querySourceReferenceExpression;
@@ -1100,7 +1099,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     foreach (var includeResultOperator in _queryModelVisitor.QueryCompilationContext.QueryAnnotations.OfType<IncludeResultOperator>())
                     {
-                        if ((includeResultOperator.PathFromQuerySource as QuerySourceReferenceExpression)?.ReferencedQuerySource
+                        if (includeResultOperator.PathFromQuerySource.TryGetReferencedQuerySource()
                             == additionalFromClauseBeingProcessed)
                         {
                             includeResultOperator.PathFromQuerySource = navigationJoin.QuerySourceReferenceExpression;

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -231,18 +233,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var parentQueryModel = _queryModelStack.Peek();
 
-            var referencedQuerySource
-                = (expression.QueryModel.SelectClause.Selector
-                    as QuerySourceReferenceExpression)?
-                .ReferencedQuerySource;
+            var referencedQuerySource = expression.QueryModel.SelectClause.Selector.TryGetReferencedQuerySource();
 
             if (referencedQuerySource != null)
             {
-                var parentQuerySource =
-                    (parentQueryModel.SelectClause.Selector as QuerySourceReferenceExpression)
-                    ?.ReferencedQuerySource;
+                var parentQuerySource = parentQueryModel.SelectClause.Selector.TryGetReferencedQuerySource();
 
-                if (referencedQuerySource.ItemType == parentQuerySource?.ItemType)
+                var parentQueryModelResultType
+                    = parentQueryModel.ResultTypeOverride?.TryGetSequenceType()
+                      ?? ((CastResultOperator)parentQueryModel.ResultOperators.LastOrDefault(r => r is CastResultOperator))?.CastItemType
+                      ?? parentQuerySource?.ItemType;
+
+                if (parentQueryModelResultType?.GetTypeInfo().IsAssignableFrom(referencedQuerySource.ItemType.GetTypeInfo()) == true)
                 {
                     var resultSetOperators = GetSetResultOperatorSourceExpressions(parentQueryModel);
 
@@ -345,8 +347,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private void AdjustForResultOperators(QueryModel queryModel)
         {
             var referencedQuerySource
-                = (queryModel.SelectClause.Selector as QuerySourceReferenceExpression)?.ReferencedQuerySource
-                  ?? (queryModel.MainFromClause.FromExpression as QuerySourceReferenceExpression)?.ReferencedQuerySource;
+                = queryModel.SelectClause.Selector.TryGetReferencedQuerySource()
+                  ?? queryModel.MainFromClause.FromExpression.TryGetReferencedQuerySource();
 
             // The selector may not have been a QSRE but this query model may still have something that needs adjusted.
             // Example:
@@ -435,9 +437,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             DemoteQuerySource(querySource);
 
             var underlyingQuerySource
-                = ((querySource as FromClauseBase)
-                    ?.FromExpression as QuerySourceReferenceExpression)
-                ?.ReferencedQuerySource;
+                = (querySource as FromClauseBase)?.FromExpression.TryGetReferencedQuerySource();
 
             if (underlyingQuerySource != null)
             {

--- a/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
@@ -48,9 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
             {
                 var subQueryExpression = newMethodCallExpression.Arguments[0] as SubQueryExpression;
-                var subSelector = subQueryExpression?.QueryModel.SelectClause.Selector as QuerySourceReferenceExpression;
-
-                if (subSelector != null)
+                if (subQueryExpression?.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression subSelector)
                 {
                     var subQueryModel = subQueryExpression.QueryModel;
 

--- a/src/EFCore/Query/ResultOperatorHandler.cs
+++ b/src/EFCore/Query/ResultOperatorHandler.cs
@@ -521,8 +521,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             var source2 = entityQueryModelVisitor
                 .ReplaceClauseReferences(secondSource);
 
+            var resultType = entityQueryModelVisitor.Expression.Type.GetSequenceType();
+            var sourceType = source2.Type.GetSequenceType();
+            while (!resultType.GetTypeInfo().IsAssignableFrom(sourceType.GetTypeInfo()))
+            {
+                resultType = resultType.GetTypeInfo().BaseType;
+            }
+
             return Expression.Call(
-                setMethodInfo.MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
+                setMethodInfo.MakeGenericMethod(resultType),
                 entityQueryModelVisitor.Expression,
                 source2);
         }

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -50,22 +50,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         }
 
         private static IQuerySource GetQuerySource(Expression expression)
-        {
-            while (true)
-            {
-                if (expression is QuerySourceReferenceExpression querySourceReferenceExpression)
-                {
-                    return querySourceReferenceExpression.ReferencedQuerySource;
-                }
-
-                if (!(expression is MemberExpression memberExpression))
-                {
-                    return null;
-                }
-
-                expression = memberExpression.Expression.RemoveConvert();
-            }
-        }
+            => expression.TryGetReferencedQuerySource()
+               ?? (expression is MemberExpression memberExpression
+                   ? GetQuerySource(memberExpression.Expression.RemoveConvert())
+                   : null);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
Resolves #7280

There were mainly 2 issues here
1. When marking source2 in set operation for materialization, we had exact type match. Which is not correct because `Concat<T>` can take parameter of derived type of `T`.
2. Since our shaped queries are transparent to cast result operator which are directly assignable, while forming `Concat<T>` we need to find the right type to use for `T` since we had swallowed it earlier.