### PR TITLE
[tools/1.0.1] PMC Tools: Use project's runtime framework version

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psd1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psd1
@@ -3,7 +3,7 @@
     ModuleToProcess = 'EntityFrameworkCore.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '2.0.0'
 
     # ID used to uniquely identify this module
     GUID = 'c126fb40-c0f1-43ae-8dd0-06bb50512eb2'

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -783,6 +783,7 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
         $depsFile = Join-Path $targetDir ($startupTargetName + '.deps.json')
         $projectAssetsFile = GetCsproj2Property $startupProject 'ProjectAssetsFile'
         $runtimeConfig = Join-Path $targetDir ($startupTargetName + '.runtimeconfig.json')
+        $runtimeFrameworkVersion = GetCsproj2Property $startupProject 'RuntimeFrameworkVersion'
         $efPath = Join-Path $PSScriptRoot 'netcoreapp1.0\ef.dll'
 
         $dotnetParams = 'exec', '--depsfile', $depsFile
@@ -799,6 +800,10 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
         if (Test-Path $runtimeConfig)
         {
             $dotnetParams += '--runtimeconfig', $runtimeConfig
+        }
+        elseif ($runtimeFrameworkVersion)
+        {
+            $dotnetParams += '--fx-version', $runtimeFrameworkVersion
         }
 
         $dotnetParams += $efPath


### PR DESCRIPTION
This is the PowerShell version of #7948

Fixes #7889