### PR TITLE
Fix to #8060 - Query: Make our reflection info selection logic deterministic

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionTranslators/ParameterlessInstanceMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/ParameterlessInstanceMethodCallTranslator.cs
@@ -28,8 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         protected ParameterlessInstanceMethodCallTranslator(
             [NotNull] Type declaringType, [NotNull] string clrMethodName, [NotNull] string sqlFunctionName)
         {
-            _methodInfo = declaringType.GetTypeInfo()
-                .GetDeclaredMethods(clrMethodName).Single(m => !m.GetParameters().Any());
+            _methodInfo = declaringType.GetRuntimeMethod(clrMethodName, new Type[] { });
 
             _sqlFunctionName = sqlFunctionName;
         }

--- a/src/EFCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/SingleOverloadStaticMethodCallTranslator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -30,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
             [NotNull] string clrMethodName,
             [NotNull] string sqlFunctionName)
         {
-            _methodInfo = declaringType.GetTypeInfo().GetDeclaredMethods(clrMethodName).Single();
+            _methodInfo = declaringType.GetRuntimeMethod(clrMethodName, new Type[] { });
+
             _sqlFunctionName = sqlFunctionName;
         }
 

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -5191,6 +5191,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Where_math_log_new_base()
+        {
+            AssertQuery<OrderDetail>(
+                ods => ods.Where(od => od.OrderID == 11077 && od.Discount > 0).Where(od => Math.Log(od.Discount, 7) < 0),
+                entryCount: 13);
+        }
+
+        [ConditionalFact]
         public virtual void Where_math_sqrt()
         {
             AssertQuery<OrderDetail>(

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerMathTranslator.cs
@@ -17,62 +17,84 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerMathTranslator : IMethodCallTranslator
     {
-        private static readonly Dictionary<string, string> _supportedMethodTranslations = new Dictionary<string, string>
+        private static readonly Dictionary<MethodInfo, string> _supportedMethodTranslations = new Dictionary<MethodInfo, string>
         {
-            { nameof(Math.Abs), "ABS" },
-            { nameof(Math.Ceiling), "CEILING" },
-            { nameof(Math.Floor), "FLOOR" },
-            { nameof(Math.Pow), "POWER" },
-            { nameof(Math.Exp), "EXP" },
-            { nameof(Math.Log10), "LOG10" },
-            { nameof(Math.Log), "LOG" },
-            { nameof(Math.Sqrt), "SQRT" },
-            { nameof(Math.Acos), "ACOS" },
-            { nameof(Math.Asin), "ASIN" },
-            { nameof(Math.Atan), "ATAN" },
-            { nameof(Math.Atan2), "ATN2" },
-            { nameof(Math.Cos), "COS" },
-            { nameof(Math.Sin), "SIN" },
-            { nameof(Math.Tan), "TAN" },
-            { nameof(Math.Sign), "SIGN" }
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(decimal) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(double) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(float) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(int) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(long) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(sbyte) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Abs), new[] { typeof(short) }), "ABS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(decimal) }), "CEILING" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(double) }), "CEILING" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(decimal) }), "FLOOR" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Floor), new[] { typeof(double) }), "FLOOR" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }), "POWER" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Exp), new[] { typeof(double) }), "EXP" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log10), new[] { typeof(double) }), "LOG10" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double) }), "LOG" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) }), "LOG" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sqrt), new[] { typeof(double) }), "SQRT" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Acos), new[] { typeof(double) }), "ACOS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Asin), new[] { typeof(double) }), "ASIN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan), new[] { typeof(double) }), "ATAN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) }), "ATN2" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Cos), new[] { typeof(double) }), "COS" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sin), new[] { typeof(double) }), "SIN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Tan), new[] { typeof(double) }), "TAN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(decimal) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(double) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(float) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(int) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(long) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(sbyte) }), "SIGN" },
+            { typeof(Math).GetRuntimeMethod(nameof(Math.Sign), new[] { typeof(short) }), "SIGN" },
         };
 
-        private static readonly IEnumerable<MethodInfo> _roundMethodInfos = typeof(Math).GetTypeInfo().GetDeclaredMethods(nameof(Math.Round))
-            .Where(m => m.GetParameters().Length == 1
-                        || m.GetParameters().Length == 2 && m.GetParameters()[1].ParameterType == typeof(int));
+        private static readonly IEnumerable<MethodInfo> _truncateMethodInfos = new[]
+        {
+            typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }),
+            typeof(Math).GetRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) })
+        };
+
+        private static readonly IEnumerable<MethodInfo> _roundMethodInfos = new[]
+        {
+            typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }),
+            typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }),
+            typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal), typeof(int) }),
+            typeof(Math).GetRuntimeMethod(nameof(Math.Round), new[] { typeof(double), typeof(int) })
+        };
 
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
             var method = methodCallExpression.Method;
-            if (method.DeclaringType == typeof(Math))
+            if (_supportedMethodTranslations.TryGetValue(method, out string sqlFunctionName))
             {
-                if (_supportedMethodTranslations.TryGetValue(method.Name, out string sqlFunctionName))
-                {
-                    return new SqlFunctionExpression(
-                        sqlFunctionName,
-                        methodCallExpression.Type,
-                        methodCallExpression.Arguments);
-                }
+                return new SqlFunctionExpression(
+                    sqlFunctionName,
+                    methodCallExpression.Type,
+                    methodCallExpression.Arguments);
+            }
 
-                if (method.Name == nameof(Math.Truncate))
-                {
-                    return new SqlFunctionExpression(
-                        "ROUND",
-                        methodCallExpression.Type,
-                        new[] { methodCallExpression.Arguments[0], Expression.Constant(0), Expression.Constant(1) });
-                }
+            if (_truncateMethodInfos.Contains(method))
+            {
+                return new SqlFunctionExpression(
+                    "ROUND",
+                    methodCallExpression.Type,
+                    new[] { methodCallExpression.Arguments[0], Expression.Constant(0), Expression.Constant(1) });
+            }
 
-                if (_roundMethodInfos.Contains(method))
-                {
-                    return new SqlFunctionExpression(
-                        "ROUND",
-                        methodCallExpression.Type,
-                        methodCallExpression.Arguments.Count == 1
-                            ? new[] { methodCallExpression.Arguments[0], Expression.Constant(0) }
-                            : new[] { methodCallExpression.Arguments[0], methodCallExpression.Arguments[1] });
-                }
+            if (_roundMethodInfos.Contains(method))
+            {
+                return new SqlFunctionExpression(
+                    "ROUND",
+                    methodCallExpression.Type,
+                    methodCallExpression.Arguments.Count == 1
+                        ? new[] { methodCallExpression.Arguments[0], Expression.Constant(0) }
+                        : new[] { methodCallExpression.Arguments[0], methodCallExpression.Arguments[1] });
             }
 
             return null;

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringReplaceTranslator.cs
@@ -14,9 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringReplaceTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _methodInfo = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.Replace))
-            .Single(m => m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(string));
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Replace), new[] { typeof(string), typeof(string) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringSubstringTranslator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -14,9 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringSubstringTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _methodInfo = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.Substring))
-            .Single(m => m.GetParameters().Length == 2);
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,9 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringTrimEndTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _trimEnd = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.TrimEnd))
-            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char[]) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trimEnd.Equals(methodCallExpression.Method)
+            if (_methodInfo.Equals(methodCallExpression.Method)
                 // SqlServer RTRIM does not take arguments
                 && ((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0)
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,9 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringTrimStartTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.TrimStart))
-            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new[] { typeof(char[]) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trimStart.Equals(methodCallExpression.Method)
+            if (_methodInfo.Equals(methodCallExpression.Method)
                 // SqlServer LTRIM does not take arguments
                 && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
             {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimTranslator.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -14,9 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringTrimTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _trim = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.Trim))
-            .Single(m => !m.GetParameters().Any());
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new Type[] { });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -24,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trim.Equals(methodCallExpression.Method))
+            if (_methodInfo.Equals(methodCallExpression.Method))
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
                 return new SqlFunctionExpression(

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,10 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqliteStringTrimStartTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _trimStart = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.TrimStart))
-            .Single(m => m.GetParameters().Count() == 1 && m.GetParameters()[0].ParameterType == typeof(char[]));
-
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new[] { typeof(char[]) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -26,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trimStart.Equals(methodCallExpression.Method))
+            if (_methodInfo.Equals(methodCallExpression.Method))
             {
                 var sqlArguments = new List<Expression> { methodCallExpression.Object };
                 var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -15,8 +15,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqliteStringTrimTranslator : IMethodCallTranslator
     {
-        private static readonly IEnumerable<MethodInfo> _trims = typeof(string).GetTypeInfo()
-            .GetDeclaredMethods(nameof(string.Trim));
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new Type[] { });
+
+        private static readonly MethodInfo _methodInfoWithParams
+            = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -24,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_trims.Contains(methodCallExpression.Method))
+            if (methodCallExpression.Method.Equals(_methodInfo) || methodCallExpression.Method.Equals(_methodInfoWithParams))
             {
                 var sqlArguments = new List<Expression> { methodCallExpression.Object };
                 var charactersToTrim = methodCallExpression.Arguments.Count == 1

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5047,6 +5047,16 @@ FROM [Order Details] AS [od]
 WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG([od].[Discount]) < 0E0)");
         }
 
+        public override void Where_math_log_new_base()
+        {
+            base.Where_math_log_new_base();
+
+            AssertSql(
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
+FROM [Order Details] AS [od]
+WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG([od].[Discount], 7E0) < 0E0)");
+        }
+        
         public override void Where_math_sqrt()
         {
             base.Where_math_sqrt();


### PR DESCRIPTION
Problem was that the way we extract MethodInfos for translators was always deterministic and could lead to errors if the new overloads of those methods were to be added.

Fix is to use pattern in which we fully specify the name and types of all arguments to the method - this is guaranteed to be unique.