### PR TITLE
Query: Add test when parameter can be losslessly convertible to colum…

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -7670,6 +7670,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 });
         }
 
+        [ConditionalFact]
+        public virtual void Int16_parameter_can_be_used_for_int_column()
+        {
+            const ushort parameter = 10300;
+            AssertQuery<Order>(os => os.Where(o => o.OrderID == parameter), entryCount: 1);
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -7634,6 +7634,16 @@ LEFT JOIN [Order Details] AS [orderDetail0] ON [order0].[OrderID] = [orderDetail
 ORDER BY [order0].[OrderID]");
         }
 
+        public override void Int16_parameter_can_be_used_for_int_column()
+        {
+            base.Int16_parameter_can_be_used_for_int_column();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = 10300");
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private void AssertSql(params string [] expected)


### PR DESCRIPTION
…n type in comparison

This was fixed by #5310
Adding test for #5663 