### PR TITLE
Add test for subquery null comparison translated correctly

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -7677,6 +7677,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             AssertQuery<Order>(os => os.Where(o => o.OrderID == parameter), entryCount: 1);
         }
 
+        [ConditionalFact]
+        public virtual void Subquery_is_null_translated_correctly()
+        {
+            AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    let lastOrder = c.Orders.OrderByDescending(o => o.OrderID)
+                        .Select(o => o.CustomerID)
+                        .FirstOrDefault()
+                    where lastOrder == null
+                    select c,
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void Subquery_is_not_null_translated_correctly()
+        {
+            AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    let lastOrder = c.Orders.OrderByDescending(o => o.OrderID)
+                        .Select(o => o.CustomerID)
+                        .FirstOrDefault()
+                    where lastOrder != null
+                    select c,
+                entryCount: 89);
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -7644,6 +7644,36 @@ FROM [Orders] AS [o]
 WHERE [o].[OrderID] = 10300");
         }
 
+        public override void Subquery_is_null_translated_correctly()
+        {
+            base.Subquery_is_null_translated_correctly();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT TOP(1) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID] DESC
+) IS NULL");
+        }
+
+        public override void Subquery_is_not_null_translated_correctly()
+        {
+            base.Subquery_is_not_null_translated_correctly();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT TOP(1) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID] DESC
+) IS NOT NULL");
+        }
+
         protected override void ClearLog() => TestSqlLoggerFactory.Reset();
 
         private void AssertSql(params string [] expected)


### PR DESCRIPTION
Resolves #6353 

This is probably fixed by #7950  in which we removed a lot of restrictions on translation of expression. So we can actually build is null for subquery perhaps.