### PR TITLE
Query: Update materialization marking for set operations

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -6749,6 +6749,21 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 19);
         }
 
+        [ConditionalFact(Skip = "Unable to bind group by. See Issue#6658")]
+        public virtual void Union_simple_groupby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(s => s.ContactTitle == "Owner")
+                    .Union(cs.Where(c => c.City == "México D.F."))
+                    .GroupBy(c => c.City)
+                    .Select(g => new
+                    {
+                        g.Key,
+                        Total = g.Count()
+                    }),
+                entryCount: 19);
+        }
+
         [ConditionalFact]
         public virtual void Union_nested()
         {


### PR DESCRIPTION
Add test for set operation followed group by not translating correctly Issue #6658

**This PR does not fix the issue**

We were checking for type matching when marking set operations for materialization. That should not be required as compiler would make sure that types are compatible.