### PR TITLE
Pushdown subquery when applying distinct in presence of limit

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             get => _isDistinct;
             set
             {
-                if (_offset != null)
+                if (_offset != null || _limit != null)
                 {
                     PushDownSubquery();
                 }

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -7277,7 +7277,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void OrderBy_skip_take_level_1()
+        public virtual void OrderBy_skip_take()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactTitle)
@@ -7289,7 +7289,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void OrderBy_skip_take_level_2()
+        public virtual void OrderBy_skip_take_take()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactTitle)
@@ -7297,6 +7297,36 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     .Skip(5)
                     .Take(8)
                     .Take(3),
+                assertOrder: true,
+                entryCount: 3);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_take_take_take()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(15)
+                    .Take(10)
+                    .Take(8)
+                    .Take(5),
+                assertOrder: true,
+                entryCount: 5);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_skip_take_skip()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactTitle)
+                    .ThenBy(c => c.ContactName)
+                    .Skip(5)
+                    .Take(15)
+                    .Skip(2)
+                    .Take(8)
+                    .Skip(5),
                 assertOrder: true,
                 entryCount: 3);
         }
@@ -7315,20 +7345,56 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void OrderBy_skip_take_level_3()
+        public virtual void OrderBy_coalesce_take_distinct()
+        {
+            AssertQuery<Product>(
+                ps => ps.OrderBy(p => p.UnitPrice ?? 0)
+                    .Take(15)
+                    .Distinct(),
+                assertOrder: false,
+                entryCount: 15);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_coalesce_skip_take_distinct()
+        {
+            AssertQuery<Product>(
+                ps => ps.OrderBy(p => p.UnitPrice ?? 0)
+                    .Skip(5)
+                    .Take(15)
+                    .Distinct(),
+                assertOrder: false,
+                entryCount: 15);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_coalesce_skip_take_distinct_take()
+        {
+            AssertQuery<Product>(
+                ps => ps.OrderBy(p => p.UnitPrice ?? 0)
+                    .Skip(5)
+                    .Take(15)
+                    .Distinct()
+                    .Take(5),
+                assertOrder: false,
+                entryCount: 5);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_skip_take_distinct_orderby_take()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactTitle)
                     .ThenBy(c => c.ContactName)
                     .Skip(5)
                     .Take(15)
-                    .Take(10)
-                    .Take(8)
-                    .Take(5),
-                assertOrder: true,
-                entryCount: 5);
+                    .Distinct()
+                    .OrderBy(c => c.ContactTitle)
+                    .Take(8),
+                assertOrder: false,
+                entryCount: 8);
         }
-
+        
         [ConditionalFact]
         public virtual void No_orderby_added_for_fully_translated_manually_constructed_LOJ()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -282,12 +282,16 @@ ORDER BY [o.Customer].[CustomerID]",
                 @"SELECT [o.Customer.Orders].[OrderID], [o.Customer.Orders].[CustomerID], [o.Customer.Orders].[EmployeeID], [o.Customer.Orders].[OrderDate]
 FROM [Orders] AS [o.Customer.Orders]
 INNER JOIN (
-    SELECT DISTINCT TOP(1) [o.Customer0].[CustomerID]
-    FROM [Orders] AS [o0]
-    LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
-    WHERE [o0].[OrderID] = 10248
-) AS [t] ON [o.Customer.Orders].[CustomerID] = [t].[CustomerID]
-ORDER BY [t].[CustomerID]");
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT TOP(1) [o.Customer0].[CustomerID]
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+        WHERE [o0].[OrderID] = 10248
+        ORDER BY [o.Customer0].[CustomerID]
+    ) AS [t]
+) AS [t0] ON [o.Customer.Orders].[CustomerID] = [t0].[CustomerID]
+ORDER BY [t0].[CustomerID]");
         }
 
         public override void Include_multi_level_collection_and_then_include_reference_predicate(bool useString)
@@ -826,20 +830,24 @@ ORDER BY [t].[CustomerID], [t0].[CustomerID]",
 SELECT [c1.Orders].[OrderID], [c1.Orders].[CustomerID], [c1.Orders].[EmployeeID], [c1.Orders].[OrderDate]
 FROM [Orders] AS [c1.Orders]
 INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t1].[CustomerID]
+    SELECT DISTINCT [t3].*
     FROM (
-        SELECT TOP(@__p_0) [c1].*
-        FROM [Customers] AS [c1]
-        ORDER BY [c1].[CustomerID]
-    ) AS [t1]
-    CROSS JOIN (
-        SELECT [c2].*
-        FROM [Customers] AS [c2]
-        ORDER BY [c2].[CustomerID]
-        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
-    ) AS [t2]
-) AS [t3] ON [c1.Orders].[CustomerID] = [t3].[CustomerID]
-ORDER BY [t3].[CustomerID]",
+        SELECT TOP(@__p_1) [t1].[CustomerID]
+        FROM (
+            SELECT TOP(@__p_0) [c1].*
+            FROM [Customers] AS [c1]
+            ORDER BY [c1].[CustomerID]
+        ) AS [t1]
+        CROSS JOIN (
+            SELECT [c2].*
+            FROM [Customers] AS [c2]
+            ORDER BY [c2].[CustomerID]
+            OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ) AS [t2]
+        ORDER BY [t1].[CustomerID]
+    ) AS [t3]
+) AS [t4] ON [c1.Orders].[CustomerID] = [t4].[CustomerID]
+ORDER BY [t4].[CustomerID]",
                     //
                     @"@__p_1: 1
 @__p_0: 2
@@ -847,20 +855,24 @@ ORDER BY [t3].[CustomerID]",
 SELECT [c2.Orders].[OrderID], [c2.Orders].[CustomerID], [c2.Orders].[EmployeeID], [c2.Orders].[OrderDate]
 FROM [Orders] AS [c2.Orders]
 INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t5].[CustomerID], [t4].[CustomerID] AS [c0]
+    SELECT DISTINCT [t7].*
     FROM (
-        SELECT TOP(@__p_0) [c3].*
-        FROM [Customers] AS [c3]
-        ORDER BY [c3].[CustomerID]
-    ) AS [t4]
-    CROSS JOIN (
-        SELECT [c4].*
-        FROM [Customers] AS [c4]
-        ORDER BY [c4].[CustomerID]
-        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
-    ) AS [t5]
-) AS [t6] ON [c2.Orders].[CustomerID] = [t6].[CustomerID]
-ORDER BY [t6].[c0], [t6].[CustomerID]");
+        SELECT TOP(@__p_1) [t6].[CustomerID], [t5].[CustomerID] AS [c0]
+        FROM (
+            SELECT TOP(@__p_0) [c3].*
+            FROM [Customers] AS [c3]
+            ORDER BY [c3].[CustomerID]
+        ) AS [t5]
+        CROSS JOIN (
+            SELECT [c4].*
+            FROM [Customers] AS [c4]
+            ORDER BY [c4].[CustomerID]
+            OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ) AS [t6]
+        ORDER BY [t5].[CustomerID], [t6].[CustomerID]
+    ) AS [t7]
+) AS [t8] ON [c2.Orders].[CustomerID] = [t8].[CustomerID]
+ORDER BY [t8].[c0], [t8].[CustomerID]");
             }
         }
 
@@ -971,20 +983,24 @@ ORDER BY [t].[CustomerID]",
 SELECT [c1.Orders].[OrderID], [c1.Orders].[CustomerID], [c1.Orders].[EmployeeID], [c1.Orders].[OrderDate]
 FROM [Orders] AS [c1.Orders]
 INNER JOIN (
-    SELECT DISTINCT TOP(@__p_1) [t1].[CustomerID]
+    SELECT DISTINCT [t3].*
     FROM (
-        SELECT TOP(@__p_0) [c1].*
-        FROM [Customers] AS [c1]
-        ORDER BY [c1].[CustomerID]
-    ) AS [t1]
-    CROSS JOIN (
-        SELECT [c2].*
-        FROM [Customers] AS [c2]
-        ORDER BY [c2].[CustomerID]
-        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
-    ) AS [t2]
-) AS [t3] ON [c1.Orders].[CustomerID] = [t3].[CustomerID]
-ORDER BY [t3].[CustomerID]");
+        SELECT TOP(@__p_1) [t1].[CustomerID]
+        FROM (
+            SELECT TOP(@__p_0) [c1].*
+            FROM [Customers] AS [c1]
+            ORDER BY [c1].[CustomerID]
+        ) AS [t1]
+        CROSS JOIN (
+            SELECT [c2].*
+            FROM [Customers] AS [c2]
+            ORDER BY [c2].[CustomerID]
+            OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ) AS [t2]
+        ORDER BY [t1].[CustomerID]
+    ) AS [t3]
+) AS [t4] ON [c1.Orders].[CustomerID] = [t4].[CustomerID]
+ORDER BY [t4].[CustomerID]");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1743,9 +1743,12 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [o].*
-    FROM [Orders] AS [o]
-) AS [t]");
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT TOP(@__p_0) [o].*
+        FROM [Orders] AS [o]
+    ) AS [t]
+) AS [t0]");
         }
 
         public override void Take_Where_Distinct_Count()
@@ -1757,10 +1760,13 @@ FROM (
 
 SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [o].*
-    FROM [Orders] AS [o]
-    WHERE [o].[CustomerID] = N'FRANK'
-) AS [t]");
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT TOP(@__p_0) [o].*
+        FROM [Orders] AS [o]
+        WHERE [o].[CustomerID] = N'FRANK'
+    ) AS [t]
+) AS [t0]");
         }
 
         public override void Null_conditional_simple()
@@ -4000,9 +4006,12 @@ ORDER BY [t].[CustomerID]");
             AssertSql(
                 @"@__p_0: 5
 
-SELECT DISTINCT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-ORDER BY [o].[OrderID]");
+SELECT DISTINCT [t].*
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
         }
 
         public override void OrderBy_shadow()
@@ -7049,9 +7058,9 @@ WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t2].[OrderI
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
-        public override void OrderBy_skip_take_level_1()
+        public override void OrderBy_skip_take()
         {
-            base.OrderBy_skip_take_level_1();
+            base.OrderBy_skip_take();
 
             AssertSql(
                 @"@__p_0: 5
@@ -7064,9 +7073,9 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
-        public override void OrderBy_skip_take_level_2()
+        public override void OrderBy_skip_take_take()
         {
-            base.OrderBy_skip_take_level_2();
+            base.OrderBy_skip_take_take();
 
             AssertSql(
                 @"@__p_2: 3
@@ -7084,27 +7093,9 @@ ORDER BY [t].[ContactTitle], [t].[ContactName]");
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
-        public override void OrderBy_skip_take_distinct()
+        public override void OrderBy_skip_take_take_take_take()
         {
-            base.OrderBy_skip_take_distinct();
-
-            AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
-
-SELECT DISTINCT [t].*
-FROM (
-    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-    FROM [Customers] AS [c]
-    ORDER BY [c].[ContactTitle], [c].[ContactName]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t]");
-        }
-
-        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
-        public override void OrderBy_skip_take_level_3()
-        {
-            base.OrderBy_skip_take_level_3();
+            base.OrderBy_skip_take_take_take_take();
 
             AssertSql(
                 @"@__p_4: 5
@@ -7129,6 +7120,129 @@ FROM (
     ORDER BY [t0].[ContactTitle], [t0].[ContactName]
 ) AS [t1]
 ORDER BY [t1].[ContactTitle], [t1].[ContactName]");
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_skip_take_skip_take_skip()
+        {
+            base.OrderBy_skip_take_skip_take_skip();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+@__p_2: 2
+@__p_3: 8
+@__p_4: 5
+
+SELECT [t0].*
+FROM (
+    SELECT [t].*
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[ContactTitle], [c].[ContactName]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+    ORDER BY [t].[ContactTitle], [t].[ContactName]
+    OFFSET @__p_2 ROWS FETCH NEXT @__p_3 ROWS ONLY
+) AS [t0]
+ORDER BY [t0].[ContactTitle], [t0].[ContactName]
+OFFSET @__p_4 ROWS");
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_skip_take_distinct()
+        {
+            base.OrderBy_skip_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[ContactTitle], [c].[ContactName]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]");
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_coalesce_take_distinct()
+        {
+            base.OrderBy_coalesce_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT TOP(@__p_0) [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+    FROM [Products] AS [p]
+    ORDER BY COALESCE([p].[UnitPrice], 0.0)
+) AS [t]");
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_coalesce_skip_take_distinct()
+        {
+            base.OrderBy_coalesce_skip_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+    FROM [Products] AS [p]
+    ORDER BY COALESCE([p].[UnitPrice], 0.0)
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]");
+
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_coalesce_skip_take_distinct_take()
+        {
+            base.OrderBy_coalesce_skip_take_distinct_take();
+
+            AssertSql(
+                @"@__p_2: 5
+@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT TOP(@__p_2) [t].*
+FROM (
+    SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+    FROM [Products] AS [p]
+    ORDER BY COALESCE([p].[UnitPrice], 0.0)
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+) AS [t]");
+        }
+
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void OrderBy_skip_take_distinct_orderby_take()
+        {
+            base.OrderBy_skip_take_distinct_orderby_take();
+
+            AssertSql(
+                @"@__p_2: 8
+@__p_0: 5
+@__p_1: 15
+
+SELECT TOP(@__p_2) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[ContactTitle], [c].[ContactName]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
+    ) AS [t]
+) AS [t0]
+ORDER BY [t0].[ContactTitle]");
         }
 
         public override void No_orderby_added_for_fully_translated_manually_constructed_LOJ()
@@ -7362,8 +7476,12 @@ WHERE [outer].[CustomerID] = N'ALFKI'",
             SELECT 1
             FROM [Customers] AS [cc1]
             WHERE EXISTS (
-                SELECT DISTINCT TOP(10) 1
-                FROM [Customers] AS [inner1])))
+                SELECT DISTINCT 1
+                FROM (
+                    SELECT TOP(10) [inner1].*
+                    FROM [Customers] AS [inner1]
+                    ORDER BY [inner1].[CustomerID]
+                ) AS [t1])))
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -241,9 +241,9 @@ FROM [Customers] AS [c]
 WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_0 = N'')");
         }
 
-        public override void OrderBy_skip_take_level_1()
+        public override void OrderBy_skip_take()
         {
-            base.OrderBy_skip_take_level_1();
+            base.OrderBy_skip_take();
 
             AssertSql(
                 @"@__p_0: 5
@@ -257,9 +257,9 @@ FROM (
 WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))");
         }
 
-        public override void OrderBy_skip_take_level_2()
+        public override void OrderBy_skip_take_take()
         {
-            base.OrderBy_skip_take_level_2();
+            base.OrderBy_skip_take_take();
 
             AssertSql(
                 @"@__p_2: 3
@@ -278,28 +278,9 @@ FROM (
 ORDER BY [t].[ContactTitle], [t].[ContactName]");
         }
 
-        public override void OrderBy_skip_take_distinct()
+        public override void OrderBy_skip_take_take_take_take()
         {
-            base.OrderBy_skip_take_distinct();
-
-            AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
-
-SELECT DISTINCT [t].*
-FROM (
-    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
-    FROM (
-        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
-        FROM [Customers] AS [c]
-    ) AS [t0]
-    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
-) AS [t]");
-        }
-
-        public override void OrderBy_skip_take_level_3()
-        {
-            base.OrderBy_skip_take_level_3();
+            base.OrderBy_skip_take_take_take_take();
 
             AssertSql(
                 @"@__p_4: 5
@@ -326,6 +307,136 @@ FROM (
     ORDER BY [t0].[ContactTitle], [t0].[ContactName]
 ) AS [t1]
 ORDER BY [t1].[ContactTitle], [t1].[ContactName]");
+        }
+        
+        public override void OrderBy_skip_take_skip_take_skip()
+        {
+            base.OrderBy_skip_take_skip_take_skip();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+@__p_2: 2
+@__p_3: 8
+@__p_4: 5
+
+SELECT [t3].*
+FROM (
+    SELECT [t0].*, ROW_NUMBER() OVER(ORDER BY [t0].[ContactTitle], [t0].[ContactName]) AS [__RowNumber__2]
+    FROM (
+        SELECT [t2].*
+        FROM (
+            SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[ContactTitle], [t].[ContactName]) AS [__RowNumber__1]
+            FROM (
+                SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+                FROM (
+                    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+                    FROM [Customers] AS [c]
+                ) AS [t1]
+                WHERE ([t1].[__RowNumber__] > @__p_0) AND ([t1].[__RowNumber__] <= (@__p_0 + @__p_1))
+            ) AS [t]
+        ) AS [t2]
+        WHERE ([t2].[__RowNumber__1] > @__p_2) AND ([t2].[__RowNumber__1] <= (@__p_2 + @__p_3))
+    ) AS [t0]
+) AS [t3]
+WHERE [t3].[__RowNumber__2] > @__p_4");
+        }
+
+        public override void OrderBy_skip_take_distinct()
+        {
+            base.OrderBy_skip_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+    FROM (
+        SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
+) AS [t]");
+        }
+
+        public override void OrderBy_coalesce_take_distinct()
+        {
+            base.OrderBy_coalesce_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT TOP(@__p_0) [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+    FROM [Products] AS [p]
+    ORDER BY COALESCE([p].[UnitPrice], 0.0)
+) AS [t]");
+        }
+
+        public override void OrderBy_coalesce_skip_take_distinct()
+        {
+            base.OrderBy_coalesce_skip_take_distinct();
+
+            AssertSql(
+                @"@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT [t].*
+FROM (
+    SELECT [t0].[ProductID], [t0].[Discontinued], [t0].[ProductName], [t0].[UnitPrice], [t0].[UnitsInStock]
+    FROM (
+        SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock], ROW_NUMBER() OVER(ORDER BY COALESCE([p].[UnitPrice], 0.0)) AS [__RowNumber__]
+        FROM [Products] AS [p]
+    ) AS [t0]
+    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
+) AS [t]");
+        }
+
+        public override void OrderBy_coalesce_skip_take_distinct_take()
+        {
+            base.OrderBy_coalesce_skip_take_distinct_take();
+
+            AssertSql(
+                @"@__p_2: 5
+@__p_0: 5
+@__p_1: 15
+
+SELECT DISTINCT TOP(@__p_2) [t].*
+FROM (
+    SELECT [t0].[ProductID], [t0].[Discontinued], [t0].[ProductName], [t0].[UnitPrice], [t0].[UnitsInStock]
+    FROM (
+        SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock], ROW_NUMBER() OVER(ORDER BY COALESCE([p].[UnitPrice], 0.0)) AS [__RowNumber__]
+        FROM [Products] AS [p]
+    ) AS [t0]
+    WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))
+) AS [t]");
+        }
+
+        public override void OrderBy_skip_take_distinct_orderby_take()
+        {
+            base.OrderBy_skip_take_distinct_orderby_take();
+
+            AssertSql(
+                @"@__p_2: 8
+@__p_0: 5
+@__p_1: 15
+
+SELECT TOP(@__p_2) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT DISTINCT [t].*
+    FROM (
+        SELECT [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+        FROM (
+            SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactTitle], [c].[ContactName]) AS [__RowNumber__]
+            FROM [Customers] AS [c]
+        ) AS [t1]
+        WHERE ([t1].[__RowNumber__] > @__p_0) AND ([t1].[__RowNumber__] <= (@__p_0 + @__p_1))
+    ) AS [t]
+) AS [t0]
+ORDER BY [t0].[ContactTitle]");
         }
 
         public override void Skip_Take_Any()


### PR DESCRIPTION
Distinct clears ordering and in the presence of limit it can create incorrect results.
Add counter in RowNumberPagingExpressionVisitor because for a multi level nested subquery, inner subquery can provide column with RowNumber while we are adding it on outer level which causes name clash for a subquery
Counter make sure to unique-fy them for given select expression.
Moved the visitor to constructor

Resolves #7525