### PR TITLE
Query: Use member name for alias for anonymous/DTO projection

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             if (joinCondition
                 && newExpression is BinaryExpression binaryExpression
-                    && binaryExpression.NodeType == ExpressionType.Equal)
+                && binaryExpression.NodeType == ExpressionType.Equal)
             {
                 newExpression = Expression.MakeBinary(
                     binaryExpression.NodeType,
@@ -319,8 +319,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             var optimizedRightExpression = relationalNullsOptimizedExpandingVisitor.Visit(expression);
 
             return relationalNullsOptimizedExpandingVisitor.IsOptimalExpansion
-                    ? optimizedRightExpression
-                    : _relationalNullsExpandingVisitor.Visit(expression);
+                ? optimizedRightExpression
+                : _relationalNullsExpandingVisitor.Visit(expression);
         }
 
         /// <summary>
@@ -346,8 +346,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                      && leftBooleanConstant == true
                      && rightBooleanConstant == true)
                     || (binaryExpression.NodeType == ExpressionType.NotEqual
-                    && leftBooleanConstant == false
-                    && rightBooleanConstant == false))
+                        && leftBooleanConstant == false
+                        && rightBooleanConstant == false))
                 {
                     return;
                 }
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             Check.NotNull(arguments, nameof(arguments));
             Check.NotNull(parameters, nameof(parameters));
 
-            string[] substitutions = null;
+            string [] substitutions = null;
 
             // ReSharper disable once SwitchStatementMissingSomeCases
             switch (arguments.NodeType)
@@ -476,7 +476,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                     if (parameters.TryGetValue(parameterExpression.Name, out object parameterValue))
                     {
-                        var argumentValues = (object[])parameterValue;
+                        var argumentValues = (object [])parameterValue;
 
                         substitutions = new string[argumentValues.Length];
 
@@ -502,7 +502,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 case ExpressionType.Constant:
                 {
                     var constantExpression = (ConstantExpression)arguments;
-                    var argumentValues = (object[])constantExpression.Value;
+                    var argumentValues = (object [])constantExpression.Value;
 
                     substitutions = new string[argumentValues.Length];
 
@@ -812,8 +812,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     {
                         if (inValue is ListInitExpression inListInit)
                         {
-                            inConstants.AddRange(ProcessInExpressionValues(
-                                inListInit.Initializers.SelectMany(i => i.Arguments)));
+                            inConstants.AddRange(
+                                ProcessInExpressionValues(
+                                    inListInit.Initializers.SelectMany(i => i.Arguments)));
                         }
                         else
                         {
@@ -832,8 +833,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         private static void AddInExpressionValues(
             object value, List<Expression> inConstants, Expression expression)
         {
-            if (value is IEnumerable valuesEnumerable && value.GetType() != typeof(string)
-                && value.GetType() != typeof(byte[]))
+            if (value is IEnumerable valuesEnumerable
+                && value.GetType() != typeof(string)
+                && value.GetType() != typeof(byte []))
             {
                 inConstants.AddRange(valuesEnumerable.Cast<object>().Select(Expression.Constant));
             }
@@ -994,7 +996,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 _relationalCommandBuilder.AppendLine();
                 _relationalCommandBuilder.Append("THEN ");
 
-                if (conditionalExpression.IfTrue is ConstantExpression constantIfTrue && constantIfTrue.Type == typeof(bool))
+                if (conditionalExpression.IfTrue is ConstantExpression constantIfTrue
+                    && constantIfTrue.Type == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfTrue.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }
@@ -1005,7 +1008,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 _relationalCommandBuilder.Append(" ELSE ");
 
-                if (conditionalExpression.IfFalse is ConstantExpression constantIfFalse && constantIfFalse.Type == typeof(bool))
+                if (conditionalExpression.IfFalse is ConstantExpression constantIfFalse
+                    && constantIfFalse.Type == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfFalse.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }
@@ -1077,8 +1081,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     {
                         _typeMapping
                             = InferTypeMappingFromColumn(binaryExpression.Left)
-                                ?? InferTypeMappingFromColumn(binaryExpression.Right)
-                                ?? parentTypeMapping;
+                              ?? InferTypeMappingFromColumn(binaryExpression.Right)
+                              ?? parentTypeMapping;
                     }
 
                     var needParens = binaryExpression.Left.RemoveConvert() is BinaryExpression leftBinaryExpression
@@ -1392,9 +1396,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             Check.NotNull(constantExpression, nameof(constantExpression));
 
             var value = constantExpression.Value;
-            _relationalCommandBuilder.Append(value == null
-                ? "NULL"
-                : SqlGenerator.GenerateLiteral(value, GetTypeMapping(value)));
+            _relationalCommandBuilder.Append(
+                value == null
+                    ? "NULL"
+                    : SqlGenerator.GenerateLiteral(value, GetTypeMapping(value)));
 
             return constantExpression;
         }
@@ -1789,7 +1794,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             private static Expression ConvertToValue(Expression expression)
                 => IsSearchCondition(expression)
-                    ? Expression.Condition(expression,
+                    ? Expression.Condition(
+                        expression,
                         Expression.Constant(true, expression.Type),
                         Expression.Constant(false, expression.Type))
                     : expression;

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -110,12 +110,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
         protected override void GenerateProjection(Expression projection)
         {
-            var newProjection = (projection as BinaryExpression)?.NodeType == ExpressionType.Coalesce
-                && projection.Type.UnwrapNullableType() == typeof(bool)
-                    ? new ExplicitCastExpression(projection, projection.Type)
-                    : projection;
+            var aliasedProjection = projection as AliasExpression;
+            var expressionToProcess = aliasedProjection?.Expression ?? projection;
+            var updatedExperssion = ExplicitCastToBool(expressionToProcess);
 
-            base.GenerateProjection(newProjection);
+            expressionToProcess = aliasedProjection != null
+                ? new AliasExpression(aliasedProjection.Alias, updatedExperssion)
+                : updatedExperssion;
+
+            base.GenerateProjection(expressionToProcess);
+        }
+
+        private Expression ExplicitCastToBool(Expression expression)
+        {
+            return (expression as BinaryExpression)?.NodeType == ExpressionType.Coalesce
+                   && expression.Type.UnwrapNullableType() == typeof(bool)
+                ? new ExplicitCastExpression(expression, expression.Type)
+                : expression;
         }
 
         private class RowNumberPagingExpressionVisitor : ExpressionVisitorBase

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -266,7 +266,7 @@ ORDER BY [t0].[DefaultText0], [t0].[DefaultText]");
             base.Join_navigation_key_access_optional();
 
             AssertSql(
-                @"SELECT [e1].[Id], [e2].[Id]
+                @"SELECT [e1].[Id] AS [Id1], [e2].[Id] AS [Id2]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[Level1_Optional_Id]");
         }
@@ -276,7 +276,7 @@ INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[Level1_Optional_Id]");
             base.Join_navigation_key_access_required();
 
             AssertSql(
-                @"SELECT [e1].[Id], [e2].[Id]
+                @"SELECT [e1].[Id] AS [Id1], [e2].[Id] AS [Id2]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[Level1_Required_Id]");
         }
@@ -405,7 +405,7 @@ WHERE DATEADD(day, [e1.OneToOne_Optional_FK].[Id], DATEADD(day, 15E0, [e1.OneToO
             base.Join_navigation_in_outer_selector_translated_to_extra_join();
 
             AssertSql(
-                @"SELECT [e1].[Id], [e2].[Id]
+                @"SELECT [e1].[Id] AS [Id1], [e2].[Id] AS [Id2]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
 INNER JOIN [Level2] AS [e2] ON [e1.OneToOne_Optional_FK].[Id] = [e2].[Id]");
@@ -416,7 +416,7 @@ INNER JOIN [Level2] AS [e2] ON [e1.OneToOne_Optional_FK].[Id] = [e2].[Id]");
             base.Join_navigation_in_outer_selector_translated_to_extra_join_nested();
 
             AssertSql(
-                @"SELECT [e1].[Id], [e3].[Id]
+                @"SELECT [e1].[Id] AS [Id1], [e3].[Id] AS [Id3]
 FROM [Level1] AS [e1]
 LEFT JOIN [Level2] AS [e1.OneToOne_Required_FK] ON [e1].[Id] = [e1.OneToOne_Required_FK].[Level1_Required_Id]
 LEFT JOIN [Level3] AS [e1.OneToOne_Required_FK.OneToOne_Optional_FK] ON [e1.OneToOne_Required_FK].[Id] = [e1.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Optional_Id]
@@ -428,7 +428,7 @@ INNER JOIN [Level3] AS [e3] ON [e1.OneToOne_Required_FK.OneToOne_Optional_FK].[I
             base.Join_navigation_in_outer_selector_translated_to_extra_join_nested2();
 
             AssertSql(
-                @"SELECT [e3].[Id], [e1].[Id]
+                @"SELECT [e3].[Id] AS [Id3], [e1].[Id] AS [Id1]
 FROM [Level3] AS [e3]
 INNER JOIN [Level2] AS [e3.OneToOne_Required_FK_Inverse] ON [e3].[Level2_Required_Id] = [e3.OneToOne_Required_FK_Inverse].[Id]
 LEFT JOIN [Level1] AS [e3.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK_Inverse] ON [e3.OneToOne_Required_FK_Inverse].[Level1_Optional_Id] = [e3.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK_Inverse].[Id]
@@ -440,7 +440,7 @@ INNER JOIN [Level1] AS [e1] ON [e3.OneToOne_Required_FK_Inverse.OneToOne_Optiona
             base.Join_navigation_in_inner_selector_translated_to_subquery();
 
             AssertSql(
-                @"SELECT [e2].[Id], [e1].[Id]
+                @"SELECT [e2].[Id] AS [Id2], [e1].[Id] AS [Id1]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
     SELECT TOP(1) [subQuery0].[Id]
@@ -454,7 +454,7 @@ INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
             base.Join_navigations_in_inner_selector_translated_to_multiple_subquery_without_collision();
 
             AssertSql(
-                @"SELECT [e2].[Id], [e1].[Id], [e3].[Id]
+                @"SELECT [e2].[Id] AS [Id2], [e1].[Id] AS [Id1], [e3].[Id] AS [Id3]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
     SELECT TOP(1) [subQuery0].[Id]
@@ -469,7 +469,7 @@ INNER JOIN [Level3] AS [e3] ON [e2].[Id] = [e3].[Level2_Optional_Id]");
             base.Join_navigation_translated_to_subquery_non_key_join();
 
             AssertSql(
-                @"SELECT [e2].[Id], [e2].[Name], [e1].[Id], [e1].[Name]
+                @"SELECT [e2].[Id] AS [Id2], [e2].[Name] AS [Name2], [e1].[Id] AS [Id1], [e1].[Name] AS [Name1]
 FROM [Level2] AS [e2]
 INNER JOIN [Level1] AS [e1] ON [e2].[Name] = (
     SELECT TOP(1) [subQuery0].[Name]
@@ -483,7 +483,7 @@ INNER JOIN [Level1] AS [e1] ON [e2].[Name] = (
             base.Join_navigation_translated_to_subquery_self_ref();
 
             AssertSql(
-                @"SELECT [e1].[Id], [e2].[Id]
+                @"SELECT [e1].[Id] AS [Id1], [e2].[Id] AS [Id2]
 FROM [Level1] AS [e1]
 INNER JOIN [Level1] AS [e2] ON [e1].[Id] = [e2].[OneToMany_Optional_Self_InverseId]");
         }
@@ -493,7 +493,7 @@ INNER JOIN [Level1] AS [e2] ON [e1].[Id] = [e2].[OneToMany_Optional_Self_Inverse
             base.Join_navigation_translated_to_subquery_nested();
 
             AssertSql(
-                @"SELECT [e3].[Id], [e1].[Id]
+                @"SELECT [e3].[Id] AS [Id3], [e1].[Id] AS [Id1]
 FROM [Level3] AS [e3]
 INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
     SELECT TOP(1) [subQuery.OneToOne_Optional_FK0].[Id]
@@ -508,7 +508,7 @@ INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
             base.Join_navigation_translated_to_subquery_deeply_nested_non_key_join();
 
             AssertSql(
-                @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
+                @"SELECT [e4].[Id] AS [Id4], [e4].[Name] AS [Name4], [e1].[Id] AS [Id1], [e1].[Name] AS [Name1]
 FROM [Level4] AS [e4]
 INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
     SELECT TOP(1) [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK0].[Name]
@@ -524,7 +524,7 @@ INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
             base.Join_navigation_translated_to_subquery_deeply_nested_required();
 
             AssertSql(
-                @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
+                @"SELECT [e4].[Id] AS [Id4], [e4].[Name] AS [Name4], [e1].[Id] AS [Id1], [e1].[Name] AS [Name1]
 FROM [Level1] AS [e1]
 INNER JOIN [Level4] AS [e4] ON [e1].[Name] = (
     SELECT TOP(1) [subQuery.OneToOne_Required_FK_Inverse.OneToOne_Required_PK_Inverse0].[Name]
@@ -865,7 +865,7 @@ WHERE ([l1.OneToOne_Optional_FK.OneToOne_Required_FK].[Name] <> N'L3 05') OR [l1
             base.SelectMany_navigation_comparison1();
 
             AssertSql(
-                @"SELECT [l11].[Id], [l12].[Id]
+                @"SELECT [l11].[Id] AS [Id1], [l12].[Id] AS [Id2]
 FROM [Level1] AS [l11]
 CROSS JOIN [Level1] AS [l12]
 WHERE [l11].[Id] = [l12].[Id]");
@@ -876,7 +876,7 @@ WHERE [l11].[Id] = [l12].[Id]");
             base.SelectMany_navigation_comparison2();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l2].[Id]
+                @"SELECT [l1].[Id] AS [Id1], [l2].[Id] AS [Id2]
 FROM [Level1] AS [l1]
 CROSS JOIN [Level2] AS [l2]
 WHERE [l1].[Id] = [l2].[Level1_Optional_Id]");
@@ -887,7 +887,7 @@ WHERE [l1].[Id] = [l2].[Level1_Optional_Id]");
             base.SelectMany_navigation_comparison3();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l2].[Id]
+                @"SELECT [l1].[Id] AS [Id1], [l2].[Id] AS [Id2]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 CROSS JOIN [Level2] AS [l2]
@@ -899,7 +899,7 @@ WHERE [l1.OneToOne_Optional_FK].[Id] = [l2].[Id]");
             base.Where_complex_predicate_with_with_nav_prop_and_OrElse1();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l2].[Id]
+                @"SELECT [l1].[Id] AS [Id1], [l2].[Id] AS [Id2]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 CROSS JOIN [Level2] AS [l2]
@@ -979,7 +979,7 @@ WHERE ([e.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[Id] = [e.O
                 @"SELECT [e].[Id], [e].[Name], CASE
     WHEN [e.OneToOne_Optional_FK].[Id] IS NOT NULL
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END, [e.OneToOne_Optional_FK].[Id], [e.OneToOne_Optional_FK].[Name]
+END, [e.OneToOne_Optional_FK].[Id] AS [Id0], [e.OneToOne_Optional_FK].[Name] AS [Name0]
 FROM [Level1] AS [e]
 LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK] ON [e].[Id] = [e.OneToOne_Optional_FK].[Level1_Optional_Id]");
         }
@@ -1515,7 +1515,7 @@ WHERE EXISTS (
             base.Correlated_subquery_doesnt_project_unnecessary_columns_in_top_level_join();
 
             AssertSql(
-                @"SELECT [e1].[Name], [e2].[Id]
+                @"SELECT [e1].[Name] AS [Name1], [e2].[Id] AS [Id2]
 FROM [Level1] AS [e1]
 INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[Level1_Optional_Id]
 WHERE EXISTS (
@@ -1710,7 +1710,7 @@ ORDER BY [l3].[Level2_Required_Id]");
             AssertSql(
                 @"@__p_0: 10
 
-SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse].[Id], [l3.OneToOne_Required_FK_Inverse].[Date], [l3.OneToOne_Required_FK_Inverse].[Level1_Optional_Id], [l3.OneToOne_Required_FK_Inverse].[Level1_Required_Id], [l3.OneToOne_Required_FK_Inverse].[Name], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_PK_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId], [l3].[Name]
+SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse].[Id], [l3.OneToOne_Required_FK_Inverse].[Date], [l3.OneToOne_Required_FK_Inverse].[Level1_Optional_Id], [l3.OneToOne_Required_FK_Inverse].[Level1_Required_Id], [l3.OneToOne_Required_FK_Inverse].[Name], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_PK_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId], [l3].[Name] AS [Name0]
 FROM [Level3] AS [l3]
 INNER JOIN [Level2] AS [l3.OneToOne_Required_FK_Inverse] ON [l3].[Level2_Required_Id] = [l3.OneToOne_Required_FK_Inverse].[Id]
 ORDER BY [l3].[Level2_Required_Id]");
@@ -2325,7 +2325,7 @@ ORDER BY [l1_outer].[Id]");
             AssertSql(
                 @"@__p_0: 2
 
-SELECT TOP(@__p_0) [l1].[Id], [l1.OneToOne_Optional_FK].[Name]
+SELECT TOP(@__p_0) [l1].[Id], [l1.OneToOne_Optional_FK].[Name] AS [Brand]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 ORDER BY [l1.OneToOne_Optional_FK].[Name], [l1].[Id]");

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -703,10 +703,10 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] | 1) > 0)");
                 @"SELECT TOP(1) CASE
     WHEN ([g].[Rank] & 1) = 1
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END, CASE
+END AS [BitwiseTrue], CASE
     WHEN ([g].[Rank] & 1) = 2
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END, [g].[Rank] & 1
+END AS [BitwiseFalse], [g].[Rank] & 1 AS [BitwiseValue]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & 1) = 1)");
         }
@@ -803,10 +803,10 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & @__paramet
                 @"SELECT TOP(1) CASE
     WHEN ([g].[Rank] & 1) = 1
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END, CASE
+END AS [hasFlagTrue], CASE
     WHEN ([g].[Rank] & 2) = 2
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+END AS [hasFlagFalse]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & 1) = 1)");
         }
@@ -846,7 +846,7 @@ WHERE [w].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
                 @"SELECT [w].[Id], CASE
     WHEN [w].[IsAutomatic] = 0
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+END AS [Manual]
 FROM [Weapon] AS [w]
 WHERE [w].[IsAutomatic] = 1");
         }
@@ -862,14 +862,14 @@ WHERE [w].[IsAutomatic] = 1");
 SELECT [w].[Id], CASE
     WHEN [w].[AmmunitionType] = @__ammunitionType_1
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+END AS [Cartidge]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] = @__ammunitionType_0",
                 //
                 @"SELECT [w].[Id], CASE
     WHEN [w].[AmmunitionType] IS NULL
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+END AS [Cartidge]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] IS NULL");
         }
@@ -882,7 +882,7 @@ WHERE [w].[AmmunitionType] IS NULL");
                 @"SELECT [w].[Id], CASE
     WHEN [w].[IsAutomatic] = 1
     THEN 1 ELSE 0
-END
+END AS [Num]
 FROM [Weapon] AS [w]");
         }
 
@@ -894,7 +894,7 @@ FROM [Weapon] AS [w]");
                 @"SELECT [w].[Id], CASE
     WHEN [w].[IsAutomatic] = 0
     THEN 1 ELSE 0
-END
+END AS [Num]
 FROM [Weapon] AS [w]");
         }
 
@@ -906,7 +906,7 @@ FROM [Weapon] AS [w]");
                 @"SELECT [w].[Id], CASE
     WHEN [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1)
     THEN N'Yes' ELSE N'No'
-END
+END AS [IsCartidge]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1)");
         }
@@ -919,7 +919,7 @@ WHERE [w].[AmmunitionType] IS NOT NULL AND ([w].[AmmunitionType] = 1)");
                 @"SELECT [w].[Id], CASE
     WHEN ([w].[AmmunitionType] = 2) AND ([w].[SynergyWithId] = 1)
     THEN N'Yes' ELSE N'No'
-END
+END AS [IsCartidge]
 FROM [Weapon] AS [w]");
         }
 
@@ -931,7 +931,7 @@ FROM [Weapon] AS [w]");
                 @"SELECT [w].[Id], CASE
     WHEN ([w].[IsAutomatic] = 0) AND ([w].[SynergyWithId] = 1)
     THEN N'Yes' ELSE N'No'
-END
+END AS [IsCartidge]
 FROM [Weapon] AS [w]");
         }
 
@@ -943,7 +943,7 @@ FROM [Weapon] AS [w]");
                 @"SELECT [w].[Id], CASE
     WHEN ([w].[IsAutomatic] = 0) AND ([w].[SynergyWithId] = 1)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
+END AS [IsCartidge]
 FROM [Weapon] AS [w]");
         }
 
@@ -958,7 +958,7 @@ FROM [Weapon] AS [w]");
         WHEN [w].[AmmunitionType] = 1
         THEN N'ManualCartridge' ELSE N'Manual'
     END ELSE N'Auto'
-END
+END AS [IsManualCartidge]
 FROM [Weapon] AS [w]");
         }
 
@@ -1078,7 +1078,7 @@ WHERE ([t].[Nickname] = [t0].[Nickname]) OR ([t].[Nickname] IS NULL AND [t0].[Ni
             base.Select_Singleton_Navigation_With_Member_Access();
 
             AssertSql(
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName] AS [B], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [CogTag] AS [ct]
 LEFT JOIN (
     SELECT [ct.Gear].*
@@ -1164,7 +1164,7 @@ WHERE [ct].[GearNickName] IS NULL AND [ct].[GearSquadId] IS NULL");
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected();
 
             AssertSql(
-                @"SELECT [ct1].[Id], [ct2].[Id]
+                @"SELECT [ct1].[Id] AS [Id1], [ct2].[Id] AS [Id2]
 FROM [CogTag] AS [ct1]
 LEFT JOIN (
     SELECT [ct1.Gear].*
@@ -1185,7 +1185,7 @@ WHERE ([t].[Nickname] = [t0].[Nickname]) OR ([t].[Nickname] IS NULL AND [t0].[Ni
             base.Optional_Navigation_Null_Coalesce_To_Clr_Type();
 
             AssertSql(
-                @"SELECT TOP(1) CAST(COALESCE([w.SynergyWith].[IsAutomatic], 0) AS bit)
+                @"SELECT TOP(1) CAST(COALESCE([w.SynergyWith].[IsAutomatic], 0) AS bit) AS [IsAutomatic]
 FROM [Weapon] AS [w]
 LEFT JOIN [Weapon] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]");
         }
@@ -1209,7 +1209,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((
             base.Singleton_Navigation_With_Member_Access();
 
             AssertSql(
-                @"SELECT [t].[CityOrBirthName]
+                @"SELECT [t].[CityOrBirthName] AS [B]
 FROM [CogTag] AS [ct]
 LEFT JOIN (
     SELECT [ct.Gear].*
@@ -1758,7 +1758,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
             base.Optional_navigation_type_compensation_works_with_projection_into_anonymous_type();
 
             AssertSql(
-                @"SELECT [t0].[SquadId]
+                @"SELECT [t0].[SquadId] AS [SquadId]
 FROM [CogTag] AS [t]
 LEFT JOIN (
     SELECT [t.Gear].*
@@ -1773,7 +1773,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
             base.Optional_navigation_type_compensation_works_with_DTOs();
 
             AssertSql(
-                @"SELECT [t0].[SquadId]
+                @"SELECT [t0].[SquadId] AS [Id]
 FROM [CogTag] AS [t]
 LEFT JOIN (
     SELECT [t.Gear].*
@@ -2352,11 +2352,11 @@ ORDER BY [g].[FullName], [g].[Rank]");
             base.Subquery_is_lifted_from_main_from_clause_of_SelectMany();
 
             AssertSql(
-                @"SELECT [g].[FullName], [g2].[FullName]
+                @"SELECT [g].[FullName] AS [Name1], [g2].[FullName] AS [Name2]
 FROM [Gear] AS [g]
 CROSS JOIN [Gear] AS [g2]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = 1) AND ([g2].[HasSoulPatch] = 0))
-ORDER BY [g].[FullName], [g].[Rank]");
+ORDER BY [Name1], [g].[Rank]");
         }
 
         public override void Subquery_containing_SelectMany_projecting_main_from_clause_gets_lifted()
@@ -2428,10 +2428,10 @@ ORDER BY [g].[Nickname], [g].[Rank]");
             base.Subquery_is_not_lifted_from_additional_from_clause();
 
             AssertSql(
-                @"SELECT [g1].[FullName]
+                @"SELECT [g1].[FullName] AS [Name1]
 FROM [Gear] AS [g1]
 WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND ([g1].[HasSoulPatch] = 1)
-ORDER BY [g1].[FullName]",
+ORDER BY [Name1]",
                 //
                 @"SELECT [g0].[HasSoulPatch], [g0].[FullName]
 FROM [Gear] AS [g0]
@@ -2466,7 +2466,7 @@ ORDER BY [t].[Rank]");
             base.Select_length_of_string_property();
 
             AssertSql(
-                @"SELECT [w].[Name], CAST(LEN([w].[Name]) AS int)
+                @"SELECT [w].[Name], CAST(LEN([w].[Name]) AS int) AS [Length]
 FROM [Weapon] AS [w]");
         }
 
@@ -2553,7 +2553,7 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
             base.Client_method_on_collection_navigation_in_additional_from_clause();
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId]
+                @"SELECT [g].[Nickname] AS [g], [g].[SquadId]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] = N'Officer'",
                 //
@@ -2611,7 +2611,7 @@ SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[
 FROM [Weapon] AS [w0]
 WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
                 //
-                @"SELECT [o].[FullName], [o].[Nickname]
+                @"SELECT [o].[FullName], [o].[Nickname] AS [o]
 FROM [Gear] AS [o]
 WHERE ([o].[Discriminator] = N'Officer') AND ([o].[HasSoulPatch] = 1)",
                 //

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -1230,7 +1230,7 @@ ORDER BY [t].[CustomerID]");
             base.Include_with_complex_projection(useString);
 
             AssertSql(
-                @"SELECT [o].[CustomerID]
+                @"SELECT [o].[CustomerID] AS [Id]
 FROM [Orders] AS [o]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
@@ -21,421 +19,403 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             base.Compare_bool_with_bool_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[NullableBoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[NullableBoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[NullableBoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_negated_bool_with_bool_equal()
         {
             base.Compare_negated_bool_with_bool_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_bool_with_negated_bool_equal()
         {
             base.Compare_bool_with_negated_bool_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_negated_bool_with_negated_bool_equal()
         {
             base.Compare_negated_bool_with_negated_bool_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_bool_with_bool_equal_negated()
         {
             base.Compare_bool_with_bool_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_negated_bool_with_bool_equal_negated()
         {
             base.Compare_negated_bool_with_bool_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_bool_with_negated_bool_equal_negated()
         {
             base.Compare_bool_with_negated_bool_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_negated_bool_with_negated_bool_equal_negated()
         {
             base.Compare_negated_bool_with_negated_bool_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_bool_with_bool_not_equal()
         {
             base.Compare_bool_with_bool_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_negated_bool_with_bool_not_equal()
         {
             base.Compare_negated_bool_with_bool_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_bool_with_negated_bool_not_equal()
         {
             base.Compare_bool_with_negated_bool_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_negated_bool_with_negated_bool_not_equal()
         {
             base.Compare_negated_bool_with_negated_bool_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_bool_with_bool_not_equal_negated()
         {
             base.Compare_bool_with_bool_not_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[NullableBoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[NullableBoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[NullableBoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_negated_bool_with_bool_not_equal_negated()
         {
             base.Compare_negated_bool_with_bool_not_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_bool_with_negated_bool_not_equal_negated()
         {
             base.Compare_bool_with_negated_bool_not_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_negated_bool_with_negated_bool_not_equal_negated()
         {
             base.Compare_negated_bool_with_negated_bool_not_equal_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND ([e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL)) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_equals_method()
         {
             base.Compare_equals_method();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] = [e].[NullableBoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] = [e].[NullableBoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[NullableBoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
-                Sql);
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
         public override void Compare_equals_method_negated()
         {
             base.Compare_equals_method_negated();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[BoolA] <> [e].[BoolB]
-
-SELECT [e].[Id]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
-                Sql);
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
         }
 
         public override void Compare_complex_equal_equal_equal()
         {
             base.Compare_complex_equal_equal_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -444,9 +424,9 @@ WHERE CASE
 END = CASE
     WHEN [e].[IntA] = [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN [e].[NullableBoolA] = [e].[BoolB]
@@ -454,9 +434,9 @@ WHERE CASE
 END = CASE
     WHEN [e].[IntA] = [e].[NullableIntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)
@@ -464,15 +444,14 @@ WHERE CASE
 END = CASE
     WHEN ([e].[NullableIntA] = [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_complex_equal_not_equal_equal()
         {
             base.Compare_complex_equal_not_equal_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -481,9 +460,9 @@ WHERE CASE
 END <> CASE
     WHEN [e].[IntA] = [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN [e].[NullableBoolA] = [e].[BoolB]
@@ -491,9 +470,9 @@ WHERE CASE
 END <> CASE
     WHEN [e].[IntA] = [e].[NullableIntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)
@@ -501,15 +480,14 @@ WHERE CASE
 END <> CASE
     WHEN ([e].[NullableIntA] = [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_complex_not_equal_equal_equal()
         {
             base.Compare_complex_not_equal_equal_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -518,9 +496,9 @@ WHERE CASE
 END = CASE
     WHEN [e].[IntA] = [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
@@ -528,9 +506,9 @@ WHERE CASE
 END = CASE
     WHEN [e].[IntA] = [e].[NullableIntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)
@@ -538,15 +516,14 @@ WHERE CASE
 END = CASE
     WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_complex_not_equal_not_equal_equal()
         {
             base.Compare_complex_not_equal_not_equal_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -555,9 +532,9 @@ WHERE CASE
 END <> CASE
     WHEN [e].[IntA] = [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
@@ -565,9 +542,9 @@ WHERE CASE
 END <> CASE
     WHEN [e].[IntA] = [e].[NullableIntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)
@@ -575,15 +552,14 @@ WHERE CASE
 END <> CASE
     WHEN (([e].[NullableIntA] = [e].[NullableIntB]) AND ([e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL)) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_complex_not_equal_equal_not_equal()
         {
             base.Compare_complex_not_equal_equal_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -592,9 +568,9 @@ WHERE CASE
 END = CASE
     WHEN [e].[IntA] <> [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
@@ -602,9 +578,9 @@ WHERE CASE
 END = CASE
     WHEN ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)
@@ -612,15 +588,14 @@ WHERE CASE
 END = CASE
     WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL)) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_complex_not_equal_not_equal_not_equal()
         {
             base.Compare_complex_not_equal_not_equal_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
@@ -629,9 +604,9 @@ WHERE CASE
 END <> CASE
     WHEN [e].[IntA] <> [e].[IntB]
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
@@ -639,9 +614,9 @@ WHERE CASE
 END <> CASE
     WHEN ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END
-
-SELECT [e].[Id]
+END",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE CASE
     WHEN (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)
@@ -649,219 +624,200 @@ WHERE CASE
 END <> CASE
     WHEN (([e].[NullableIntA] <> [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL)) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END",
-                Sql);
+END");
         }
 
         public override void Compare_nullable_with_null_parameter_equal()
         {
             base.Compare_nullable_with_null_parameter_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Compare_nullable_with_non_null_parameter_not_equal()
         {
             base.Compare_nullable_with_non_null_parameter_not_equal();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] = @__prm_0",
-                Sql);
+WHERE [e].[NullableStringA] = @__prm_0");
         }
 
         public override void Join_uses_database_semantics()
         {
             base.Join_uses_database_semantics();
 
-            Assert.Equal(
-                @"SELECT [e1].[Id], [e2].[Id], [e1].[NullableIntA], [e2].[NullableIntB]
+            AssertSql(
+                @"SELECT [e1].[Id] AS [Id1], [e2].[Id] AS [Id2], [e1].[NullableIntA], [e2].[NullableIntB]
 FROM [NullSemanticsEntity1] AS [e1]
-INNER JOIN [NullSemanticsEntity2] AS [e2] ON [e1].[NullableIntA] = [e2].[NullableIntB]",
-                Sql);
+INNER JOIN [NullSemanticsEntity2] AS [e2] ON [e1].[NullableIntA] = [e2].[NullableIntB]");
         }
 
         public override void Contains_with_local_array_closure_with_null()
         {
             base.Contains_with_local_array_closure_with_null();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Contains_with_local_array_closure_false_with_null()
         {
             base.Contains_with_local_array_closure_false_with_null();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] NOT IN (N'Foo') AND [e].[NullableStringA] IS NOT NULL",
-                Sql);
+WHERE [e].[NullableStringA] NOT IN (N'Foo') AND [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Contains_with_local_array_closure_with_multiple_nulls()
         {
             base.Contains_with_local_array_closure_with_multiple_nulls();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ors_with_null()
         {
             base.Where_multiple_ors_with_null();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo', N'Blah') OR [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IN (N'Foo', N'Blah') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ands_with_null()
         {
             base.Where_multiple_ands_with_null();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] IS NOT NULL",
-                Sql);
+WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Where_multiple_ors_with_nullable_parameter()
         {
             base.Where_multiple_ors_with_nullable_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant()
         {
             base.Where_multiple_ands_with_nullable_parameter_and_constant();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm3_2: Blah (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] NOT IN (N'Foo', @__prm3_2) AND [e].[NullableStringA] IS NOT NULL",
-                Sql);
+WHERE [e].[NullableStringA] NOT IN (N'Foo', @__prm3_2) AND [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized()
         {
             base.Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm3_2: Blah (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ((([e].[NullableStringB] IS NOT NULL AND (([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL)) AND [e].[NullableStringA] IS NOT NULL) AND [e].[NullableStringA] IS NOT NULL) AND (([e].[NullableStringA] <> @__prm3_2) OR [e].[NullableStringA] IS NULL)",
-                Sql);
+WHERE ((([e].[NullableStringB] IS NOT NULL AND (([e].[NullableStringA] <> N'Foo') OR [e].[NullableStringA] IS NULL)) AND [e].[NullableStringA] IS NOT NULL) AND [e].[NullableStringA] IS NOT NULL) AND (([e].[NullableStringA] <> @__prm3_2) OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Where_coalesce()
         {
             base.Where_coalesce();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE COALESCE([e].[NullableBoolA], 1) = 1",
-                Sql);
+WHERE COALESCE([e].[NullableBoolA], 1) = 1");
         }
 
         public override void Where_equal_nullable_with_null_value_parameter()
         {
             base.Where_equal_nullable_with_null_value_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_not_equal_nullable_with_null_value_parameter()
         {
             base.Where_not_equal_nullable_with_null_value_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IS NOT NULL",
-                Sql);
+WHERE [e].[NullableStringA] IS NOT NULL");
         }
 
         public override void Where_equal_with_coalesce()
         {
             base.Where_equal_with_coalesce();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE (COALESCE([e].[NullableStringA], [e].[NullableStringB]) = [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) AND [e].[NullableStringC] IS NULL)",
-                Sql);
+WHERE (COALESCE([e].[NullableStringA], [e].[NullableStringB]) = [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) AND [e].[NullableStringC] IS NULL)");
         }
 
         public override void Where_not_equal_with_coalesce()
         {
             base.Where_not_equal_with_coalesce();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ((COALESCE([e].[NullableStringA], [e].[NullableStringB]) <> [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL)) AND (([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) OR [e].[NullableStringC] IS NOT NULL)",
-                Sql);
+WHERE ((COALESCE([e].[NullableStringA], [e].[NullableStringB]) <> [e].[NullableStringC]) OR (([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL)) AND (([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) OR [e].[NullableStringC] IS NOT NULL)");
         }
 
         public override void Where_equal_with_coalesce_both_sides()
         {
             base.Where_equal_with_coalesce_both_sides();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE COALESCE([e].[NullableStringA], [e].[NullableStringB]) = COALESCE([e].[StringA], [e].[StringB])",
-                Sql);
+WHERE COALESCE([e].[NullableStringA], [e].[NullableStringB]) = COALESCE([e].[StringA], [e].[StringB])");
         }
 
         public override void Where_not_equal_with_coalesce_both_sides()
         {
             base.Where_not_equal_with_coalesce_both_sides();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ((COALESCE([e].[NullableIntA], [e].[NullableIntB]) <> COALESCE([e].[NullableIntC], [e].[NullableIntB])) OR (([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) OR ([e].[NullableIntC] IS NULL AND [e].[NullableIntB] IS NULL))) AND (([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) OR ([e].[NullableIntC] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL))",
-                Sql);
+WHERE ((COALESCE([e].[NullableIntA], [e].[NullableIntB]) <> COALESCE([e].[NullableIntC], [e].[NullableIntB])) OR (([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL) OR ([e].[NullableIntC] IS NULL AND [e].[NullableIntB] IS NULL))) AND (([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL) OR ([e].[NullableIntC] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL))");
         }
 
         public override void Where_equal_with_conditional()
         {
             base.Where_equal_with_conditional();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE (CASE
@@ -870,15 +826,14 @@ WHERE (CASE
 END = [e].[NullableStringC]) OR (CASE
     WHEN ([e].[NullableStringA] = [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)
     THEN [e].[NullableStringA] ELSE [e].[NullableStringB]
-END IS NULL AND [e].[NullableStringC] IS NULL)",
-                Sql);
+END IS NULL AND [e].[NullableStringC] IS NULL)");
         }
 
         public override void Where_not_equal_with_conditional()
         {
             base.Where_not_equal_with_conditional();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE (([e].[NullableStringC] <> CASE
@@ -890,40 +845,37 @@ END) OR ([e].[NullableStringC] IS NULL OR CASE
 END IS NULL)) AND ([e].[NullableStringC] IS NOT NULL OR CASE
     WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)
     THEN [e].[NullableStringA] ELSE [e].[NullableStringB]
-END IS NOT NULL)",
-                Sql);
+END IS NOT NULL)");
         }
 
         public override void Where_equal_with_conditional_non_nullable()
         {
             base.Where_equal_with_conditional_non_nullable();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE ([e].[NullableStringC] <> CASE
     WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL)
     THEN [e].[StringA] ELSE [e].[StringB]
-END) OR [e].[NullableStringC] IS NULL",
-                Sql);
+END) OR [e].[NullableStringC] IS NULL");
         }
 
         public override void Where_equal_with_and_and_contains()
         {
             base.Where_equal_with_and_and_contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ((CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) OR ([e].[NullableStringB] = N'')) AND ([e].[BoolA] = 1)",
-                Sql);
+WHERE ((CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) OR ([e].[NullableStringB] = N'')) AND ([e].[BoolA] = 1)");
         }
 
         public override void Where_conditional_search_condition_in_result()
         {
             base.Where_conditional_search_condition_in_result();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0: True
 
 SELECT [e].[Id]
@@ -934,9 +886,9 @@ WHERE CASE
         WHEN [e].[StringA] IN (N'Foo', N'Bar')
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END ELSE CAST(0 AS BIT)
-END = 1
-
-@__prm_0: True
+END = 1",
+                //
+                @"@__prm_0: True
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -946,15 +898,14 @@ WHERE CASE
         WHEN [e].[StringA] LIKE N'A' + N'%' AND (LEFT([e].[StringA], LEN(N'A')) = N'A')
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
-END = 1",
-                Sql);
+END = 1");
         }
 
         public override void Where_nested_conditional_search_condition_in_result()
         {
             base.Where_nested_conditional_search_condition_in_result();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm1_0: True
 @__prm2_1: False
 
@@ -981,246 +932,226 @@ WHERE CASE
             THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
         END
     END
-END = 1",
-                Sql);
+END = 1");
         }
 
         public override void Where_equal_using_relational_null_semantics()
         {
             base.Where_equal_using_relational_null_semantics();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
-                Sql);
+WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
         }
 
         public override void Where_nullable_bool()
         {
             base.Where_nullable_bool();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = 1",
-                Sql);
+WHERE [e].[NullableBoolA] = 1");
         }
 
         public override void Where_nullable_bool_equal_with_constant()
         {
             base.Where_nullable_bool_equal_with_constant();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = 1",
-                Sql);
+WHERE [e].[NullableBoolA] = 1");
         }
 
         public override void Where_nullable_bool_with_null_check()
         {
             base.Where_nullable_bool_with_null_check();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)",
-                Sql);
+WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)");
         }
 
         public override void Where_equal_using_relational_null_semantics_with_parameter()
         {
             base.Where_equal_using_relational_null_semantics_with_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0:  (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = @__prm_0",
-                Sql);
+WHERE [e].[NullableBoolA] = @__prm_0");
         }
 
         public override void Where_equal_using_relational_null_semantics_complex_with_parameter()
         {
             base.Where_equal_using_relational_null_semantics_complex_with_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
-                Sql);
+WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
         }
 
         public override void Where_not_equal_using_relational_null_semantics()
         {
             base.Where_not_equal_using_relational_null_semantics();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]",
-                Sql);
+WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
         }
 
         public override void Where_not_equal_using_relational_null_semantics_with_parameter()
         {
             base.Where_not_equal_using_relational_null_semantics_with_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0:  (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] <> @__prm_0",
-                Sql);
+WHERE [e].[NullableBoolA] <> @__prm_0");
         }
 
         public override void Where_not_equal_using_relational_null_semantics_complex_with_parameter()
         {
             base.Where_not_equal_using_relational_null_semantics_complex_with_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]",
-                Sql);
+WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
         }
 
         public override void Where_comparison_null_constant_and_null_parameter()
         {
             base.Where_comparison_null_constant_and_null_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0:  (Size = 4000) (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE @__prm_0 IS NULL
-
-@__prm_0:  (Size = 4000) (DbType = String)
+WHERE @__prm_0 IS NULL",
+                //
+                @"@__prm_0:  (Size = 4000) (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE @__prm_0 IS NOT NULL",
-                Sql);
+WHERE @__prm_0 IS NOT NULL");
         }
 
         public override void Where_comparison_null_constant_and_nonnull_parameter()
         {
             base.Where_comparison_null_constant_and_nonnull_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE @__prm_0 IS NULL
-
-@__prm_0: Foo (Size = 4000)
+WHERE @__prm_0 IS NULL",
+                //
+                @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE @__prm_0 IS NOT NULL",
-                Sql);
+WHERE @__prm_0 IS NOT NULL");
         }
 
         public override void Where_comparison_nonnull_constant_and_null_parameter()
         {
             base.Where_comparison_nonnull_constant_and_null_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 0 = 1
-
-SELECT [e].[Id]
-FROM [NullSemanticsEntity1] AS [e]",
-                Sql);
+WHERE 0 = 1",
+                //
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]");
         }
 
         public override void Where_comparison_null_semantics_optimization_works_with_complex_predicates()
         {
             base.Where_comparison_null_semantics_optimization_works_with_complex_predicates();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IS NULL",
-                Sql);
+WHERE [e].[NullableStringA] IS NULL");
         }
 
         public override void Switching_null_semantics_produces_different_cache_entry()
         {
             base.Switching_null_semantics_produces_different_cache_entry();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)
-
-SELECT [e].[Id]
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
-                Sql);
+WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
         }
 
         public override void Switching_parameter_value_to_null_produces_different_cache_entry()
         {
             base.Switching_parameter_value_to_null_produces_different_cache_entry();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__prm_0: Foo (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE @__prm_0 = N'Foo'
-
-SELECT [e].[Id]
+WHERE @__prm_0 = N'Foo'",
+                //
+                @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE 0 = 1",
-                Sql);
+WHERE 0 = 1");
         }
 
         public override void From_sql_composed_with_relational_null_comparison()
         {
             base.From_sql_composed_with_relational_null_comparison();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[Id], [c].[BoolA], [c].[BoolB], [c].[BoolC], [c].[IntA], [c].[IntB], [c].[IntC], [c].[NullableBoolA], [c].[NullableBoolB], [c].[NullableBoolC], [c].[NullableIntA], [c].[NullableIntB], [c].[NullableIntC], [c].[NullableStringA], [c].[NullableStringB], [c].[NullableStringC], [c].[StringA], [c].[StringB], [c].[StringC]
 FROM (
     SELECT * FROM ""NullSemanticsEntity1""
 ) AS [c]
-WHERE [c].[StringA] = [c].[StringB]",
-                Sql);
+WHERE [c].[StringA] = [c].[StringB]");
         }
 
         public override void Projecting_nullable_bool_with_coalesce()
         {
             base.Projecting_nullable_bool_with_coalesce();
 
-            Assert.Equal(
-                @"SELECT [e].[Id], CAST(COALESCE([e].[NullableBoolA], 0) AS bit)
-FROM [NullSemanticsEntity1] AS [e]",
-                Sql);
+            AssertSql(
+                @"SELECT [e].[Id], CAST(COALESCE([e].[NullableBoolA], 0) AS bit) AS [Coalesce]
+FROM [NullSemanticsEntity1] AS [e]");
         }
 
         public override void Projecting_nullable_bool_with_coalesce_nested()
         {
             base.Projecting_nullable_bool_with_coalesce_nested();
 
-            Assert.Equal(
-                @"SELECT [e].[Id], CAST(COALESCE([e].[NullableBoolA], COALESCE([e].[NullableBoolB], 0)) AS bit)
-FROM [NullSemanticsEntity1] AS [e]",
-                Sql);
+            AssertSql(
+                @"SELECT [e].[Id], CAST(COALESCE([e].[NullableBoolA], COALESCE([e].[NullableBoolB], 0)) AS bit) AS [Coalesce]
+FROM [NullSemanticsEntity1] AS [e]");
         }
-        
-        protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
-        private const string FileLineEnding = @"
-";
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        protected override void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -22,163 +22,131 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             base.Join_with_nav_projected_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void GroupJoin_with_nav_projected_in_subquery_when_client_eval()
         {
             base.GroupJoin_with_nav_projected_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void Join_with_nav_in_predicate_in_subquery_when_client_eval()
         {
             base.Join_with_nav_in_predicate_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void GroupJoin_with_nav_in_predicate_in_subquery_when_client_eval()
         {
             base.GroupJoin_with_nav_in_predicate_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void Join_with_nav_in_orderby_in_subquery_when_client_eval()
         {
             base.Join_with_nav_in_orderby_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void GroupJoin_with_nav_in_orderby_in_subquery_when_client_eval()
         {
             base.GroupJoin_with_nav_in_orderby_in_subquery_when_client_eval();
 
-            Assert.Contains(
+            AssertContainsSql(
                 @"SELECT [od0].[OrderID], [od0].[ProductID], [od0].[Discount], [od0].[Quantity], [od0].[UnitPrice], [od.Product0].[ProductID], [od.Product0].[Discontinued], [od.Product0].[ProductName], [od.Product0].[UnitPrice], [od.Product0].[UnitsInStock]
 FROM [Order Details] AS [od0]
 INNER JOIN [Products] AS [od.Product0] ON [od0].[ProductID] = [od.Product0].[ProductID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [o.Customer0].[CustomerID], [o.Customer0].[Address], [o.Customer0].[City], [o.Customer0].[CompanyName], [o.Customer0].[ContactName], [o.Customer0].[ContactTitle], [o.Customer0].[Country], [o.Customer0].[Fax], [o.Customer0].[Phone], [o.Customer0].[PostalCode], [o.Customer0].[Region]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]",
-                Sql);
-
-            Assert.Contains(
+                //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void Select_Where_Navigation()
         {
             base.Select_Where_Navigation();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o.Customer].[City] = N'Seattle'",
-                Sql);
+WHERE [o.Customer].[City] = N'Seattle'");
         }
 
         public override void Select_Where_Navigation_Contains()
         {
             base.Select_Where_Navigation_Contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE CHARINDEX(N'Sea', [o.Customer].[City]) > 0",
-            Sql);
+WHERE CHARINDEX(N'Sea', [o.Customer].[City]) > 0");
         }
 
         public override void Select_Where_Navigation_Deep()
         {
             base.Select_Where_Navigation_Deep();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 1
 
 SELECT TOP(@__p_0) [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
@@ -186,40 +154,38 @@ FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
 WHERE [od.Order.Customer].[City] = N'Seattle'
-ORDER BY [od].[OrderID], [od].[ProductID]",
-                Sql);
+ORDER BY [od].[OrderID], [od].[ProductID]");
         }
 
         public override void Take_Select_Navigation()
         {
             base.Take_Select_Navigation();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 2
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Select_collection_FirstOrDefault_project_single_column1()
         {
             base.Select_collection_FirstOrDefault_project_single_column1();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 2
 
 SELECT TOP(@__p_0) (
@@ -228,15 +194,14 @@ SELECT TOP(@__p_0) (
     WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]",
-                Sql);
+ORDER BY [c].[CustomerID]");
         }
 
         public override void Select_collection_FirstOrDefault_project_single_column2()
         {
             base.Select_collection_FirstOrDefault_project_single_column2();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 2
 
 SELECT TOP(@__p_0) (
@@ -245,58 +210,55 @@ SELECT TOP(@__p_0) (
     WHERE [c].[CustomerID] = [o].[CustomerID]
 )
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]",
-                Sql);
+ORDER BY [c].[CustomerID]");
         }
 
         public override void Select_collection_FirstOrDefault_project_anonymous_type()
         {
             base.Select_collection_FirstOrDefault_project_anonymous_type();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 2
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Select_collection_FirstOrDefault_project_entity()
         {
             base.Select_collection_FirstOrDefault_project_entity();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 2
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Skip_Select_Navigation()
@@ -305,28 +267,27 @@ WHERE @_outer_CustomerID = [o].[CustomerID]",
 
             if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
             {
-                Assert.StartsWith(
+                AssertSql(
                     @"@__p_0: 20
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
-OFFSET @__p_0 ROWS
-
-@_outer_CustomerID: FAMIA (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-ORDER BY [o].[OrderID]
-
-@_outer_CustomerID: FISSA (Size = 450)
+OFFSET @__p_0 ROWS",
+                    //
+                    @"@_outer_CustomerID: FAMIA (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
-                    Sql);
+                    //
+                    @"@_outer_CustomerID: FISSA (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]");
             }
         }
 
@@ -334,101 +295,93 @@ ORDER BY [o].[OrderID]",
         {
             base.Select_Where_Navigation_Included();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o.Customer].[City] = N'Seattle'",
-                Sql);
+WHERE [o.Customer].[City] = N'Seattle'");
         }
 
         public override void Include_with_multiple_optional_navigations()
         {
             base.Include_with_multiple_optional_navigations();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[OrderID], [od.Order].[CustomerID], [od.Order].[EmployeeID], [od.Order].[OrderDate], [od.Order.Customer].[CustomerID], [od.Order.Customer].[Address], [od.Order.Customer].[City], [od.Order.Customer].[CompanyName], [od.Order.Customer].[ContactName], [od.Order.Customer].[ContactTitle], [od.Order.Customer].[Country], [od.Order.Customer].[Fax], [od.Order.Customer].[Phone], [od.Order.Customer].[PostalCode], [od.Order.Customer].[Region]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
-WHERE [od.Order.Customer].[City] = N'London'",
-                Sql);
+WHERE [od.Order.Customer].[City] = N'London'");
         }
 
         public override void Select_Navigation()
         {
             base.Select_Navigation();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                Sql);
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]");
         }
 
         public override void Select_Navigations()
         {
             base.Select_Navigations();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                Sql);
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]");
         }
 
         public override void Select_Where_Navigation_Multiple_Access()
         {
             base.Select_Where_Navigation_Multiple_Access();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)",
-                Sql);
+WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)");
         }
 
         public override void Select_Navigations_Where_Navigations()
         {
             base.Select_Navigations_Where_Navigations();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)",
-                Sql);
+WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)");
         }
 
         public override void Select_Where_Navigation_Client()
         {
             base.Select_Where_Navigation_Client();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
-                Sql);
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]");
         }
 
         public override void Select_Singleton_Navigation_With_Member_Access()
         {
             base.Select_Singleton_Navigation_With_Member_Access();
 
-            Assert.Equal(
-                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+            AssertSql(
+                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City] AS [B], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)",
-                Sql);
+WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)");
         }
 
         public override void Select_count_plus_sum()
         {
             base.Select_count_plus_sum();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT SUM([od].[Quantity])
     FROM [Order Details] AS [od]
@@ -437,186 +390,176 @@ WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]
-)
-FROM [Orders] AS [o]",
-                Sql);
+) AS [Total]
+FROM [Orders] AS [o]");
         }
 
         public override void Singleton_Navigation_With_Member_Access()
         {
             base.Singleton_Navigation_With_Member_Access();
 
-            Assert.Equal(
-                @"SELECT [o.Customer].[City]
+            AssertSql(
+                @"SELECT [o.Customer].[City] AS [B]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)",
-                Sql);
+WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555 5555') OR [o.Customer].[Phone] IS NULL)");
         }
 
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
-WHERE (([o].[OrderID] < 10300) AND ([o0].[OrderID] < 10400)) AND (([o.Customer].[City] = [o.Customer0].[City]) OR ([o.Customer].[City] IS NULL AND [o.Customer0].[City] IS NULL))",
-                Sql);
+WHERE (([o].[OrderID] < 10300) AND ([o0].[OrderID] < 10400)) AND (([o.Customer].[City] = [o.Customer0].[City]) OR ([o.Customer].[City] IS NULL AND [o.Customer0].[City] IS NULL))");
         }
 
         public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
         {
             base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected();
 
-            Assert.Equal(
-                @"SELECT [o].[CustomerID], [o0].[CustomerID]
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [CustomerID0], [o0].[CustomerID] AS [C2]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 CROSS JOIN [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
-WHERE (([o].[OrderID] < 10300) AND ([o0].[OrderID] < 10400)) AND (([o.Customer].[City] = [o.Customer0].[City]) OR ([o.Customer].[City] IS NULL AND [o.Customer0].[City] IS NULL))",
-                Sql);
+WHERE (([o].[OrderID] < 10300) AND ([o0].[OrderID] < 10400)) AND (([o.Customer].[City] = [o.Customer0].[City]) OR ([o.Customer].[City] IS NULL AND [o.Customer0].[City] IS NULL))");
         }
 
         public override void Select_Where_Navigation_Equals_Navigation()
         {
             base.Select_Where_Navigation_Equals_Navigation();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o1]
 CROSS JOIN [Orders] AS [o2]
-WHERE ([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL)",
-                Sql);
+WHERE ([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL)");
         }
 
         public override void Select_Where_Navigation_Null()
         {
             base.Select_Where_Navigation_Null();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[ReportsTo] IS NULL",
-                Sql);
+WHERE [e].[ReportsTo] IS NULL");
         }
 
         public override void Select_Where_Navigation_Null_Deep()
         {
             base.Select_Where_Navigation_Null_Deep();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 LEFT JOIN [Employees] AS [e.Manager] ON [e].[ReportsTo] = [e.Manager].[EmployeeID]
-WHERE [e.Manager].[ReportsTo] IS NULL",
-                Sql);
+WHERE [e.Manager].[ReportsTo] IS NULL");
         }
 
         public override void Select_Where_Navigation_Null_Reverse()
         {
             base.Select_Where_Navigation_Null_Reverse();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE [e].[ReportsTo] IS NULL",
-                Sql);
+WHERE [e].[ReportsTo] IS NULL");
         }
 
         public override void Select_collection_navigation_simple()
         {
             base.Select_collection_navigation_simple();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANTON (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: AROUT (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Select_collection_navigation_multi_part()
         {
             base.Select_collection_navigation_multi_part();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region], [o].[OrderID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o].[CustomerID] = N'ALFKI'
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
+WHERE [o].[CustomerID] = N'ALFKI'",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_any()
         {
             base.Collection_select_nav_prop_any();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT CASE
         WHEN EXISTS (
@@ -625,16 +568,15 @@ WHERE @_outer_CustomerID = [o0].[CustomerID]",
             WHERE [c].[CustomerID] = [o].[CustomerID])
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [Any]
+FROM [Customers] AS [c]");
         }
 
         public override void Collection_select_nav_prop_predicate()
         {
             base.Collection_select_nav_prop_predicate();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT CASE
     WHEN (
         SELECT COUNT(*)
@@ -643,43 +585,40 @@ FROM [Customers] AS [c]",
     ) > 0
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END
-FROM [Customers] AS [c]",
-                Sql);
+FROM [Customers] AS [c]");
         }
 
         public override void Collection_where_nav_prop_any()
         {
             base.Collection_where_nav_prop_any();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID])",
-                Sql);
+    WHERE [c].[CustomerID] = [o].[CustomerID])");
         }
 
         public override void Collection_where_nav_prop_any_predicate()
         {
             base.Collection_where_nav_prop_any_predicate();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ([o].[OrderID] > 0) AND ([c].[CustomerID] = [o].[CustomerID]))",
-                Sql);
+    WHERE ([o].[OrderID] > 0) AND ([c].[CustomerID] = [o].[CustomerID]))");
         }
 
         public override void Collection_select_nav_prop_all()
         {
             base.Collection_select_nav_prop_all();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT CASE
         WHEN NOT EXISTS (
@@ -688,154 +627,145 @@ WHERE EXISTS (
             WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [All]
+FROM [Customers] AS [c]");
         }
 
         public override void Collection_select_nav_prop_all_client()
         {
             base.Collection_select_nav_prop_all_client();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+WHERE @_outer_CustomerID = [o0].[CustomerID]");
         }
 
         public override void Collection_where_nav_prop_all()
         {
             base.Collection_where_nav_prop_all();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE NOT EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
-    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))",
-                Sql);
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND (([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL))");
         }
 
         public override void Collection_where_nav_prop_all_client()
         {
             base.Collection_where_nav_prop_all_client();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_count()
         {
             base.Collection_select_nav_prop_count();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [Count]
+FROM [Customers] AS [c]");
         }
 
         public override void Collection_where_nav_prop_count()
         {
             base.Collection_where_nav_prop_count();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-) > 5",
-                Sql);
+) > 5");
         }
 
         public override void Collection_where_nav_prop_count_reverse()
         {
             base.Collection_where_nav_prop_count_reverse();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE 5 < (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)",
-                Sql);
+)");
         }
 
         public override void Collection_orderby_nav_prop_count()
         {
             base.Collection_orderby_nav_prop_count();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)",
-                Sql);
+)");
         }
 
         public override void Collection_select_nav_prop_long_count()
         {
             base.Collection_select_nav_prop_long_count();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT COUNT_BIG(*)
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [C]
+FROM [Customers] AS [c]");
         }
 
         public override void Select_multiple_complex_projections()
         {
             base.Select_multiple_complex_projections();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]
-), [o].[OrderDate], (
+) AS [collection1], [o].[OrderDate] AS [scalar1], (
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
@@ -843,10 +773,10 @@ FROM [Customers] AS [c]",
             WHERE ([od].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od].[OrderID]))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
-), CASE
+) AS [any], CASE
     WHEN [o].[CustomerID] = N'ALFKI'
     THEN N'50' ELSE N'10'
-END, [o].[OrderID], (
+END AS [conditional], [o].[OrderID] AS [scalar2], (
     SELECT CASE
         WHEN NOT EXISTS (
             SELECT 1
@@ -854,99 +784,108 @@ END, [o].[OrderID], (
             WHERE ([o].[OrderID] = [od0].[OrderID]) AND ([od0].[OrderID] <> 42))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
-), (
+) AS [all], (
     SELECT COUNT_BIG(*)
     FROM [Order Details] AS [o1]
     WHERE [o].[OrderID] = [o1].[OrderID]
-)
+) AS [collection2]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')",
-                Sql);
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
         }
 
         public override void Collection_select_nav_prop_sum()
         {
             base.Collection_select_nav_prop_sum();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT SUM([o].[OrderID])
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [Sum]
+FROM [Customers] AS [c]");
         }
 
         public override void Collection_where_nav_prop_sum()
         {
             base.Collection_where_nav_prop_sum();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE (
     SELECT SUM([o].[OrderID])
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-) > 1000",
-                Sql);
+) > 1000");
         }
 
         public override void Collection_select_nav_prop_first_or_default()
         {
             base.Collection_select_nav_prop_first_or_default();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_first_or_default_then_nav_prop()
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
 WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
-ORDER BY [e].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
-FROM [Orders] AS [e0]
-LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
-WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])
-
-@_outer_CustomerID: ANATR (Size = 450)
+ORDER BY [e].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
 WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
+                //
+                @"@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
+                //
+                @"@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
+FROM [Orders] AS [e0]
+LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
+WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])");
         }
 
         public override void Collection_select_nav_prop_first_or_default_then_nav_prop_nested()
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop_nested();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT TOP(1) [o.Customer].[City]
     FROM [Orders] AS [o]
@@ -954,31 +893,44 @@ WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_
     WHERE [o].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
-                Sql);
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
         }
 
         public override void Collection_select_nav_prop_single_or_default_then_nav_prop_nested()
         {
             base.Collection_select_nav_prop_single_or_default_then_nav_prop_nested();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT 1
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
-
-SELECT TOP(2) [o.Customer0].[City]
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
+                //
+                @"SELECT TOP(2) [o.Customer0].[City]
 FROM [Orders] AS [o0]
 LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
 WHERE [o0].[OrderID] = 10643",
-                Sql);
+                //
+                @"SELECT TOP(2) [o.Customer0].[City]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+WHERE [o0].[OrderID] = 10643",
+                //
+                @"SELECT TOP(2) [o.Customer0].[City]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+WHERE [o0].[OrderID] = 10643",
+                //
+                @"SELECT TOP(2) [o.Customer0].[City]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+WHERE [o0].[OrderID] = 10643");
         }
 
         public override void Collection_select_nav_prop_first_or_default_then_nav_prop_nested_using_property_method()
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop_nested_using_property_method();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT TOP(1) [oo.Customer].[City]
     FROM [Orders] AS [oo]
@@ -986,15 +938,14 @@ WHERE [o0].[OrderID] = 10643",
     WHERE [oo].[CustomerID] = N'ALFKI'
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
-                Sql);
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
         }
 
         public override void Collection_select_nav_prop_first_or_default_then_nav_prop_nested_with_orderby()
         {
             base.Collection_select_nav_prop_first_or_default_then_nav_prop_nested_with_orderby();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT (
     SELECT TOP(1) [o.Customer].[City]
     FROM [Orders] AS [o]
@@ -1003,64 +954,59 @@ WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) =
     ORDER BY [o].[CustomerID]
 )
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')",
-                Sql);
+WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')");
         }
 
         public override void Navigation_fk_based_inside_contains()
         {
             base.Navigation_fk_based_inside_contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] IN (N'ALFKI')",
-                Sql);
+WHERE [o].[CustomerID] IN (N'ALFKI')");
         }
 
         public override void Navigation_inside_contains()
         {
             base.Navigation_inside_contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o.Customer].[City] IN (N'Novigrad', N'Seattle')",
-                Sql);
+WHERE [o.Customer].[City] IN (N'Novigrad', N'Seattle')");
         }
 
         public override void Navigation_inside_contains_nested()
         {
             base.Navigation_inside_contains_nested();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
-WHERE [od.Order.Customer].[City] IN (N'Novigrad', N'Seattle')",
-                Sql);
+WHERE [od.Order.Customer].[City] IN (N'Novigrad', N'Seattle')");
         }
 
         public override void Navigation_from_join_clause_inside_contains()
         {
             base.Navigation_from_join_clause_inside_contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o.Customer].[Country] IN (N'USA', N'Redania')",
-                Sql);
+WHERE [o.Customer].[Country] IN (N'USA', N'Redania')");
         }
 
         public override void Where_subquery_on_navigation()
         {
             base.Where_subquery_on_navigation();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE EXISTS (
@@ -1075,15 +1021,14 @@ WHERE EXISTS (
         FROM [Order Details] AS [o0]
         WHERE [o0].[Quantity] = 1
         ORDER BY [o0].[OrderID] DESC, [o0].[ProductID]
-    ) AS [t1] ON ([t0].[OrderID] = [t1].[OrderID]) AND ([t0].[ProductID] = [t1].[ProductID]))",
-                Sql);
+    ) AS [t1] ON ([t0].[OrderID] = [t1].[OrderID]) AND ([t0].[ProductID] = [t1].[ProductID]))");
         }
 
         public override void Where_subquery_on_navigation2()
         {
             base.Where_subquery_on_navigation2();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE EXISTS (
@@ -1097,38 +1042,45 @@ WHERE EXISTS (
         SELECT TOP(1) [o0].[OrderID], [o0].[ProductID]
         FROM [Order Details] AS [o0]
         ORDER BY [o0].[OrderID] DESC, [o0].[ProductID]
-    ) AS [t1] ON ([t0].[OrderID] = [t1].[OrderID]) AND ([t0].[ProductID] = [t1].[ProductID]))",
-                Sql);
+    ) AS [t1] ON ([t0].[OrderID] = [t1].[OrderID]) AND ([t0].[ProductID] = [t1].[ProductID]))");
         }
 
         public override void Where_subquery_on_navigation_client_eval()
         {
             base.Where_subquery_on_navigation_client_eval();
 
-            Assert.StartsWith(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
-
-SELECT [o4].[OrderID]
-FROM [Orders] AS [o4]
-
-@_outer_CustomerID: ALFKI (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT [o2].[OrderID]
 FROM [Orders] AS [o2]
-WHERE @_outer_CustomerID = [o2].[CustomerID]
-
-SELECT [o4].[OrderID]
+WHERE @_outer_CustomerID = [o2].[CustomerID]",
+                //
+                @"SELECT [o4].[OrderID]
 FROM [Orders] AS [o4]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o2].[OrderID]
+FROM [Orders] AS [o2]
+WHERE @_outer_CustomerID = [o2].[CustomerID]",
+                //
+                @"SELECT [o4].[OrderID]
+FROM [Orders] AS [o4]");
         }
 
         public override void Navigation_in_subquery_referencing_outer_query()
         {
             base.Navigation_in_subquery_referencing_outer_query();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
@@ -1138,116 +1090,109 @@ WHERE ((
     INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
     LEFT JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
     WHERE ([o.Customer].[Country] = [od.Order.Customer].[Country]) OR ([o.Customer].[Country] IS NULL AND [od.Order.Customer].[Country] IS NULL)
-) > 0) AND [o].[OrderID] IN (10643, 10692)",
-                Sql);
+) > 0) AND [o].[OrderID] IN (10643, 10692)");
         }
 
         public override void GroupBy_on_nav_prop()
         {
             base.GroupBy_on_nav_prop();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[City]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-ORDER BY [o.Customer].[City]",
-                Sql);
+ORDER BY [o.Customer].[City]");
         }
 
         public override void Where_nav_prop_group_by()
         {
             base.Where_nav_prop_group_by();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
 WHERE [od.Order].[CustomerID] = N'ALFKI'
-ORDER BY [od].[Quantity]",
-                Sql);
+ORDER BY [od].[Quantity]");
         }
 
         public override void Let_group_by_nav_prop()
         {
             base.Let_group_by_nav_prop();
 
-            Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[CustomerID]
+            AssertSql(
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[CustomerID] AS [customer]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
-ORDER BY [od.Order].[CustomerID]",
-                Sql);
+ORDER BY [od.Order].[CustomerID]");
         }
 
         public override void Project_first_or_default_on_empty_collection_of_value_types_returns_proper_default()
         {
             base.Project_first_or_default_on_empty_collection_of_value_types_returns_proper_default();
 
-            Assert.Equal(
-                "",
-                Sql);
+            AssertSql(
+                "");
         }
 
         public override void Project_single_scalar_value_subquery_is_properly_inlined()
         {
             base.Project_single_scalar_value_subquery_is_properly_inlined();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], (
     SELECT TOP(1) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
     ORDER BY [o].[OrderID]
-)
-FROM [Customers] AS [c]",
-                Sql);
+) AS [OrderId]
+FROM [Customers] AS [c]");
         }
 
         public override void Project_single_entity_value_subquery_works()
         {
             base.Project_single_entity_value_subquery_works();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
-ORDER BY [c].[CustomerID]
-
-@_outer_CustomerID: ALFKI (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-ORDER BY [o].[OrderID]
-
-@_outer_CustomerID: ANATR (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-ORDER BY [o].[OrderID]
-
-@_outer_CustomerID: ANTON (Size = 450)
-
-SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]
-ORDER BY [o].[OrderID]
-
-@_outer_CustomerID: AROUT (Size = 450)
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
-                Sql);
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                //
+                @"@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                //
+                @"@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]");
         }
 
         public override void Project_single_scalar_value_subquery_in_query_with_optional_navigation_works()
         {
             base.Project_single_scalar_value_subquery_in_query_with_optional_navigation_works();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__p_0: 3
 
 SELECT TOP(@__p_0) [o].[OrderID], (
@@ -1255,18 +1200,17 @@ SELECT TOP(@__p_0) [o].[OrderID], (
     FROM [Order Details] AS [od]
     WHERE [o].[OrderID] = [od].[OrderID]
     ORDER BY [od].[OrderID], [od].[ProductID]
-), [o.Customer].[City]
+) AS [OrderDetail], [o.Customer].[City]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-ORDER BY [o].[OrderID]",
-                Sql);
+ORDER BY [o].[OrderID]");
         }
 
         public override void GroupJoin_with_complex_subquery_and_LOJ_gets_flattened()
         {
             base.GroupJoin_with_complex_subquery_and_LOJ_gets_flattened();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 LEFT JOIN (
@@ -1274,15 +1218,14 @@ LEFT JOIN (
     FROM [Order Details] AS [od]
     INNER JOIN [Orders] AS [o] ON [od].[OrderID] = 10260
     INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]",
-                Sql);
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
         }
 
         public override void GroupJoin_with_complex_subquery_and_LOJ_gets_flattened2()
         {
             base.GroupJoin_with_complex_subquery_and_LOJ_gets_flattened2();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 LEFT JOIN (
@@ -1290,15 +1233,16 @@ LEFT JOIN (
     FROM [Order Details] AS [od]
     INNER JOIN [Orders] AS [o] ON [od].[OrderID] = 10260
     INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]",
-                Sql);
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
         }
 
-        protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        private const string FileLineEnding = @"
-";
+        private void AssertContainsSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        protected override void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -97,9 +97,9 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
                 @"@__p_0: 10
 @__p_1: 5
 
-SELECT [t].[c], [t].[OrderID]
+SELECT [t].[Contact], [t].[OrderID]
 FROM (
-    SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [c], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [Contact], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
@@ -114,9 +114,9 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
                 @"@__p_0: 10
 @__p_1: 5
 
-SELECT [t].[OrderID], [t].[CustomerID], [t].[CustomerID0], [t].[ContactName], [t].[ContactName0]
+SELECT [t].[OrderID], [t].[CustomerIDA], [t].[CustomerIDB], [t].[ContactNameA], [t].[ContactNameB]
 FROM (
-    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [CustomerID0], [ca].[ContactName], [cb].[ContactName] AS [ContactName0], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    SELECT [o].[OrderID], [ca].[CustomerID] AS [CustomerIDA], [cb].[CustomerID] AS [CustomerIDB], [ca].[ContactName] AS [ContactNameA], [cb].[ContactName] AS [ContactNameB], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
     FROM [Orders] AS [o]
     INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
     INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]
@@ -200,11 +200,11 @@ FROM (
 
 SELECT [t0].*
 FROM (
-    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[c]) AS [__RowNumber__]
+    SELECT [t].*, ROW_NUMBER() OVER(ORDER BY [t].[Region]) AS [__RowNumber__]
     FROM (
-        SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [c]
+        SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Region]
         FROM [Customers] AS [c]
-        ORDER BY [c]
+        ORDER BY [Region]
     ) AS [t]
 ) AS [t0]
 WHERE [t0].[__RowNumber__] > @__p_1");


### PR DESCRIPTION
Resolves #8204 

This introduces aliases when they are not needed therefore, other parts of SelectExpression should use alias only and inner expression of alias should only be visited during projection.

Changes to baseline are submitted in separate in commit for read-ability.  (and coming soon)
