### PR TITLE
DRY code to unique-fy the projection expression

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -228,9 +228,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         if (sqlExpression is ColumnExpression)
                         {
-                            selectExpression.AddToProjection(sqlExpression);
+                            var index = selectExpression.AddToProjection(sqlExpression);
 
-                            _sourceExpressionProjectionMapping[expression] = sqlExpression;
+                            _sourceExpressionProjectionMapping[expression] = selectExpression.Projection[index];
 
                             return expression;
                         }
@@ -246,7 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         {
                             var index = selectExpression.AddToProjection(sqlExpression);
 
-                            _sourceExpressionProjectionMapping[expression] = sqlExpression;
+                            _sourceExpressionProjectionMapping[expression] = selectExpression.Projection[index];
 
                             var readValueExpression
                                 = _entityMaterializerSource

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -176,14 +176,14 @@ ORDER BY [t].[Id], [e.OneToMany_Optional].[Id]",
                 @"SELECT [e.OneToMany_Optional.OneToMany_Optional].[Id], [e.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [e.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [e.OneToMany_Optional.OneToMany_Optional].[Name], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToMany_Optional.OneToMany_Optional]
 INNER JOIN (
-    SELECT DISTINCT [e.OneToMany_Optional0].[Id], [t0].[Id] AS [c0]
+    SELECT DISTINCT [e.OneToMany_Optional0].[Id], [t0].[Id] AS [Id0]
     FROM [Level2] AS [e.OneToMany_Optional0]
     INNER JOIN (
         SELECT [e1].[Id]
         FROM [Level1] AS [e1]
     ) AS [t0] ON [e.OneToMany_Optional0].[OneToMany_Optional_InverseId] = [t0].[Id]
 ) AS [t1] ON [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t1].[Id]
-ORDER BY [t1].[c0], [t1].[Id]");
+ORDER BY [t1].[Id0], [t1].[Id]");
         }
 
         public override void Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times()
@@ -207,23 +207,23 @@ ORDER BY [t].[Id], [e.OneToMany_Optional].[Id]",
 FROM [Level3] AS [e.OneToMany_Optional.OneToMany_Optional]
 INNER JOIN [Level2] AS [l.OneToMany_Required_Inverse] ON [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId] = [l.OneToMany_Required_Inverse].[Id]
 INNER JOIN (
-    SELECT DISTINCT [e.OneToMany_Optional0].[Id], [t0].[Id] AS [c0]
+    SELECT DISTINCT [e.OneToMany_Optional0].[Id], [t0].[Id] AS [Id0]
     FROM [Level2] AS [e.OneToMany_Optional0]
     INNER JOIN (
         SELECT [e1].[Id]
         FROM [Level1] AS [e1]
     ) AS [t0] ON [e.OneToMany_Optional0].[OneToMany_Optional_InverseId] = [t0].[Id]
 ) AS [t1] ON [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t1].[Id]
-ORDER BY [t1].[c0], [t1].[Id], [l.OneToMany_Required_Inverse].[Id]",
+ORDER BY [t1].[Id0], [t1].[Id], [l.OneToMany_Required_Inverse].[Id]",
                 //
                 @"SELECT [l.OneToMany_Required_Inverse.OneToMany_Optional].[Id], [l.OneToMany_Required_Inverse.OneToMany_Optional].[Level2_Optional_Id], [l.OneToMany_Required_Inverse.OneToMany_Optional].[Level2_Required_Id], [l.OneToMany_Required_Inverse.OneToMany_Optional].[Name], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l.OneToMany_Required_Inverse.OneToMany_Optional]
 INNER JOIN (
-    SELECT DISTINCT [l.OneToMany_Required_Inverse0].[Id], [t3].[c0], [t3].[Id] AS [c1]
+    SELECT DISTINCT [l.OneToMany_Required_Inverse0].[Id], [t3].[Id0], [t3].[Id] AS [Id1]
     FROM [Level3] AS [e.OneToMany_Optional.OneToMany_Optional0]
     INNER JOIN [Level2] AS [l.OneToMany_Required_Inverse0] ON [e.OneToMany_Optional.OneToMany_Optional0].[OneToMany_Required_InverseId] = [l.OneToMany_Required_Inverse0].[Id]
     INNER JOIN (
-        SELECT DISTINCT [e.OneToMany_Optional1].[Id], [t2].[Id] AS [c0]
+        SELECT DISTINCT [e.OneToMany_Optional1].[Id], [t2].[Id] AS [Id0]
         FROM [Level2] AS [e.OneToMany_Optional1]
         INNER JOIN (
             SELECT [e2].[Id]
@@ -231,7 +231,7 @@ INNER JOIN (
         ) AS [t2] ON [e.OneToMany_Optional1].[OneToMany_Optional_InverseId] = [t2].[Id]
     ) AS [t3] ON [e.OneToMany_Optional.OneToMany_Optional0].[OneToMany_Optional_InverseId] = [t3].[Id]
 ) AS [t4] ON [l.OneToMany_Required_Inverse.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t4].[Id]
-ORDER BY [t4].[c0], [t4].[c1], [t4].[Id]");
+ORDER BY [t4].[Id0], [t4].[Id1], [t4].[Id]");
         }
 
         public override void Multi_level_include_with_short_circuiting()
@@ -260,12 +260,12 @@ ORDER BY [t].[DefaultText]",
 FROM [ComplexNavigationGlobalization] AS [x.Placeholder.Globalizations]
 LEFT JOIN [ComplexNavigationLanguage] AS [c.Language0] ON [x.Placeholder.Globalizations].[LanguageName] = [c.Language0].[Name]
 INNER JOIN (
-    SELECT DISTINCT [x.Placeholder1].[DefaultText], [x.Label1].[DefaultText] AS [c0]
+    SELECT DISTINCT [x.Placeholder1].[DefaultText], [x.Label1].[DefaultText] AS [DefaultText0]
     FROM [ComplexNavigationField] AS [x1]
     LEFT JOIN [ComplexNavigationString] AS [x.Placeholder1] ON [x1].[PlaceholderDefaultText] = [x.Placeholder1].[DefaultText]
     LEFT JOIN [ComplexNavigationString] AS [x.Label1] ON [x1].[LabelDefaultText] = [x.Label1].[DefaultText]
 ) AS [t0] ON [x.Placeholder.Globalizations].[ComplexNavigationStringDefaultText] = [t0].[DefaultText]
-ORDER BY [t0].[c0], [t0].[DefaultText]");
+ORDER BY [t0].[DefaultText0], [t0].[DefaultText]");
         }
 
         public override void Join_navigation_key_access_optional()
@@ -556,11 +556,11 @@ ORDER BY [e.OneToOne_Optional_FK].[Id], [e].[Id]",
 FROM [Level2] AS [e.OneToMany_Optional]
 LEFT JOIN [Level3] AS [l.OneToOne_Optional_FK] ON [e.OneToMany_Optional].[Id] = [l.OneToOne_Optional_FK].[Level2_Optional_Id]
 INNER JOIN (
-    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_FK1].[Id] AS [c0]
+    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_FK1].[Id] AS [Id0]
     FROM [Level1] AS [e1]
     LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK1] ON [e1].[Id] = [e.OneToOne_Optional_FK1].[Level1_Optional_Id]
 ) AS [t0] ON [e.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t0].[Id]
-ORDER BY [t0].[c0], [t0].[Id]",
+ORDER BY [t0].[Id0], [t0].[Id]",
                 //
                 @"SELECT [e.OneToOne_Optional_FK.OneToMany_Optional].[Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Name], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Optional_FK.OneToMany_Optional]
@@ -586,11 +586,11 @@ ORDER BY [e.OneToOne_Optional_Self].[Id], [e].[Id]",
 FROM [Level1] AS [e.OneToMany_Optional_Self]
 LEFT JOIN [Level1] AS [l.OneToOne_Optional_Self] ON [e.OneToMany_Optional_Self].[OneToOne_Optional_SelfId] = [l.OneToOne_Optional_Self].[Id]
 INNER JOIN (
-    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_Self1].[Id] AS [c0]
+    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_Self1].[Id] AS [Id0]
     FROM [Level1] AS [e1]
     LEFT JOIN [Level1] AS [e.OneToOne_Optional_Self1] ON [e1].[OneToOne_Optional_SelfId] = [e.OneToOne_Optional_Self1].[Id]
 ) AS [t0] ON [e.OneToMany_Optional_Self].[OneToMany_Optional_Self_InverseId] = [t0].[Id]
-ORDER BY [t0].[c0], [t0].[Id]",
+ORDER BY [t0].[Id0], [t0].[Id]",
                 //
                 @"SELECT [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[Id], [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[Date], [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[Name], [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_Self.OneToMany_Optional_Self].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e.OneToOne_Optional_Self.OneToMany_Optional_Self]
@@ -616,11 +616,11 @@ ORDER BY [e.OneToOne_Optional_FK].[Id], [e].[Id]",
 FROM [Level2] AS [e.OneToMany_Optional]
 LEFT JOIN [Level3] AS [l.OneToOne_Optional_FK] ON [e.OneToMany_Optional].[Id] = [l.OneToOne_Optional_FK].[Level2_Optional_Id]
 INNER JOIN (
-    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_FK1].[Id] AS [c0]
+    SELECT DISTINCT [e1].[Id], [e.OneToOne_Optional_FK1].[Id] AS [Id0]
     FROM [Level1] AS [e1]
     LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK1] ON [e1].[Id] = [e.OneToOne_Optional_FK1].[Level1_Optional_Id]
 ) AS [t0] ON [e.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t0].[Id]
-ORDER BY [t0].[c0], [t0].[Id]",
+ORDER BY [t0].[Id0], [t0].[Id]",
                 //
                 @"SELECT [e.OneToOne_Optional_FK.OneToMany_Optional].[Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Name], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Optional_FK.OneToMany_Optional]
@@ -1264,13 +1264,13 @@ ORDER BY [l.OneToOne_Optional_FK].[Id], [l].[Id]",
 FROM [Level2] AS [l.OneToMany_Optional]
 LEFT JOIN [Level3] AS [l.OneToOne_Optional_FK1] ON [l.OneToMany_Optional].[Id] = [l.OneToOne_Optional_FK1].[Level2_Optional_Id]
 INNER JOIN (
-    SELECT DISTINCT [l1].[Id], [l.OneToOne_Optional_FK2].[Id] AS [c0]
+    SELECT DISTINCT [l1].[Id], [l.OneToOne_Optional_FK2].[Id] AS [Id0]
     FROM (
         SELECT * FROM [Level1]
     ) AS [l1]
     LEFT JOIN [Level2] AS [l.OneToOne_Optional_FK2] ON [l1].[Id] = [l.OneToOne_Optional_FK2].[Level1_Optional_Id]
 ) AS [t0] ON [l.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t0].[Id]
-ORDER BY [t0].[c0], [t0].[Id]",
+ORDER BY [t0].[Id0], [t0].[Id]",
                     //
                     @"SELECT [l.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l.OneToOne_Optional_FK.OneToMany_Optional]
@@ -1407,7 +1407,7 @@ FROM [Level3] AS [e.OneToOne_Required_FK.OneToMany_Required]
 INNER JOIN (
     SELECT DISTINCT [t1].*
     FROM (
-        SELECT [e.OneToOne_Required_FK1].[Id], [e1].[Name], [e.OneToOne_Optional_FK1].[Id] AS [c0]
+        SELECT [e.OneToOne_Required_FK1].[Id], [e1].[Name], [e.OneToOne_Optional_FK1].[Id] AS [Id0]
         FROM [Level1] AS [e1]
         LEFT JOIN [Level2] AS [e.OneToOne_Required_FK1] ON [e1].[Id] = [e.OneToOne_Required_FK1].[Level1_Required_Id]
         LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK1] ON [e1].[Id] = [e.OneToOne_Optional_FK1].[Level1_Optional_Id]
@@ -1415,7 +1415,7 @@ INNER JOIN (
         OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
     ) AS [t1]
 ) AS [t2] ON [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_InverseId] = [t2].[Id]
-ORDER BY [t2].[Name], [t2].[c0], [t2].[Id]",
+ORDER BY [t2].[Name], [t2].[Id0], [t2].[Id]",
                     //
                     @"@__p_0: 0
 @__p_1: 10
@@ -1492,7 +1492,7 @@ ORDER BY [e].[Id], [e.OneToOne_Required_FK].[Id]",
                 @"SELECT [e.OneToOne_Required_FK.OneToMany_Optional].[Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Name], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Required_FK.OneToMany_Optional]
 INNER JOIN (
-    SELECT DISTINCT [e.OneToOne_Required_FK0].[Id], [e0].[Id] AS [c0]
+    SELECT DISTINCT [e.OneToOne_Required_FK0].[Id], [e0].[Id] AS [Id0]
     FROM [Level1] AS [e0]
     LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK0] ON [e0].[Id] = [e.OneToOne_Optional_FK0].[Level1_Optional_Id]
     LEFT JOIN [Level3] AS [e.OneToOne_Optional_FK.OneToOne_Optional_FK0] ON [e.OneToOne_Optional_FK0].[Id] = [e.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Level2_Optional_Id]
@@ -1501,7 +1501,7 @@ INNER JOIN (
     LEFT JOIN [Level3] AS [e.OneToOne_Required_FK.OneToOne_Optional_FK0] ON [e.OneToOne_Required_FK0].[Id] = [e.OneToOne_Required_FK.OneToOne_Optional_FK0].[Level2_Optional_Id]
     WHERE ([e.OneToOne_Required_FK.OneToOne_Optional_PK0].[Name] <> N'Foo') OR [e.OneToOne_Required_FK.OneToOne_Optional_PK0].[Name] IS NULL
 ) AS [t] ON [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
-ORDER BY [t].[c0], [t].[Id]");
+ORDER BY [t].[Id0], [t].[Id]");
         }
 
         public override void Correlated_subquery_doesnt_project_unnecessary_columns_in_top_level()

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -241,27 +241,27 @@ ORDER BY [t0].[Nickname], [t0].[Name]",
 FROM [Gear] AS [g.CityOfBirth.BornGears]
 LEFT JOIN [CogTag] AS [g.Tag1] ON ([g.CityOfBirth.BornGears].[Nickname] = [g.Tag1].[GearNickName]) AND ([g.CityOfBirth.BornGears].[SquadId] = [g.Tag1].[GearSquadId])
 INNER JOIN (
-    SELECT DISTINCT [g.CityOfBirth2].[Name], [g2].[Nickname], [g.AssignedCity2].[Name] AS [c0]
+    SELECT DISTINCT [g.CityOfBirth2].[Name], [g2].[Nickname], [g.AssignedCity2].[Name] AS [Name0]
     FROM [Gear] AS [g2]
     INNER JOIN [City] AS [g.CityOfBirth2] ON [g2].[CityOrBirthName] = [g.CityOfBirth2].[Name]
     LEFT JOIN [City] AS [g.AssignedCity2] ON [g2].[AssignedCityName] = [g.AssignedCity2].[Name]
     WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t1] ON [g.CityOfBirth.BornGears].[CityOrBirthName] = [t1].[Name]
 WHERE [g.CityOfBirth.BornGears].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [t1].[Nickname], [t1].[c0], [t1].[Name]",
+ORDER BY [t1].[Nickname], [t1].[Name0], [t1].[Name]",
                 //
                 @"SELECT [g.CityOfBirth.StationedGears].[Nickname], [g.CityOfBirth.StationedGears].[SquadId], [g.CityOfBirth.StationedGears].[AssignedCityName], [g.CityOfBirth.StationedGears].[CityOrBirthName], [g.CityOfBirth.StationedGears].[Discriminator], [g.CityOfBirth.StationedGears].[FullName], [g.CityOfBirth.StationedGears].[HasSoulPatch], [g.CityOfBirth.StationedGears].[LeaderNickname], [g.CityOfBirth.StationedGears].[LeaderSquadId], [g.CityOfBirth.StationedGears].[Rank], [g.Tag2].[Id], [g.Tag2].[GearNickName], [g.Tag2].[GearSquadId], [g.Tag2].[Note]
 FROM [Gear] AS [g.CityOfBirth.StationedGears]
 LEFT JOIN [CogTag] AS [g.Tag2] ON ([g.CityOfBirth.StationedGears].[Nickname] = [g.Tag2].[GearNickName]) AND ([g.CityOfBirth.StationedGears].[SquadId] = [g.Tag2].[GearSquadId])
 INNER JOIN (
-    SELECT DISTINCT [g.CityOfBirth3].[Name], [g3].[Nickname], [g.AssignedCity3].[Name] AS [c0]
+    SELECT DISTINCT [g.CityOfBirth3].[Name], [g3].[Nickname], [g.AssignedCity3].[Name] AS [Name0]
     FROM [Gear] AS [g3]
     INNER JOIN [City] AS [g.CityOfBirth3] ON [g3].[CityOrBirthName] = [g.CityOfBirth3].[Name]
     LEFT JOIN [City] AS [g.AssignedCity3] ON [g3].[AssignedCityName] = [g.AssignedCity3].[Name]
     WHERE [g3].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t2] ON [g.CityOfBirth.StationedGears].[AssignedCityName] = [t2].[Name]
 WHERE [g.CityOfBirth.StationedGears].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [t2].[Nickname], [t2].[c0], [t2].[Name]");
+ORDER BY [t2].[Nickname], [t2].[Name0], [t2].[Name]");
         }
 
         public override void Include_navigation_on_derived_type()
@@ -1437,7 +1437,7 @@ ORDER BY [t].[FullName], [g].[FullName]",
                 @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g.Weapons]
 INNER JOIN (
-    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [c0]
+    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [FullName0]
     FROM [Gear] AS [g1]
     LEFT JOIN (
         SELECT [g21].*
@@ -1446,7 +1446,7 @@ INNER JOIN (
     ) AS [t2] ON [g1].[LeaderNickname] = [t2].[Nickname]
     WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [t2].[Nickname] IS NULL
 ) AS [t3] ON [g.Weapons].[OwnerFullName] = [t3].[FullName]
-ORDER BY [t3].[c0], [t3].[FullName]",
+ORDER BY [t3].[FullName0], [t3].[FullName]",
                 //
                 @"SELECT [g2.Weapons].[Id], [g2.Weapons].[AmmunitionType], [g2.Weapons].[IsAutomatic], [g2.Weapons].[Name], [g2.Weapons].[OwnerFullName], [g2.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g2.Weapons]
@@ -1481,7 +1481,7 @@ ORDER BY [t].[FullName], [g].[FullName]",
                 @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g.Weapons]
 INNER JOIN (
-    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [c0]
+    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [FullName0]
     FROM [Gear] AS [g1]
     LEFT JOIN (
         SELECT [g21].*
@@ -1490,7 +1490,7 @@ INNER JOIN (
     ) AS [t2] ON [g1].[LeaderNickname] = [t2].[Nickname]
     WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [t2].[Nickname] IS NULL
 ) AS [t3] ON [g.Weapons].[OwnerFullName] = [t3].[FullName]
-ORDER BY [t3].[c0], [t3].[FullName]",
+ORDER BY [t3].[FullName0], [t3].[FullName]",
                 //
                 @"SELECT [g2.Weapons].[Id], [g2.Weapons].[AmmunitionType], [g2.Weapons].[IsAutomatic], [g2.Weapons].[Name], [g2.Weapons].[OwnerFullName], [g2.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g2.Weapons]
@@ -1525,7 +1525,7 @@ ORDER BY [t].[FullName], [g].[FullName]",
                 @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g.Weapons]
 INNER JOIN (
-    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [c0]
+    SELECT DISTINCT [g1].[FullName], [t2].[FullName] AS [FullName0]
     FROM [Gear] AS [g1]
     LEFT JOIN (
         SELECT [g21].*
@@ -1534,7 +1534,7 @@ INNER JOIN (
     ) AS [t2] ON [g1].[LeaderNickname] = [t2].[Nickname]
     WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [t2].[Nickname] IS NULL
 ) AS [t3] ON [g.Weapons].[OwnerFullName] = [t3].[FullName]
-ORDER BY [t3].[c0], [t3].[FullName]",
+ORDER BY [t3].[FullName0], [t3].[FullName]",
                 //
                 @"SELECT [g2.Weapons].[Id], [g2.Weapons].[AmmunitionType], [g2.Weapons].[IsAutomatic], [g2.Weapons].[Name], [g2.Weapons].[OwnerFullName], [g2.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g2.Weapons]
@@ -1583,7 +1583,7 @@ ORDER BY [t1].[FullName]",
                 @"SELECT [g2.Weapons].[Id], [g2.Weapons].[AmmunitionType], [g2.Weapons].[IsAutomatic], [g2.Weapons].[Name], [g2.Weapons].[OwnerFullName], [g2.Weapons].[SynergyWithId]
 FROM [Weapon] AS [g2.Weapons]
 INNER JOIN (
-    SELECT DISTINCT [t2].[FullName], [g1].[FullName] AS [c0]
+    SELECT DISTINCT [t2].[FullName], [g1].[FullName] AS [FullName0]
     FROM [Gear] AS [g1]
     LEFT JOIN (
         SELECT [g21].*
@@ -1592,7 +1592,7 @@ INNER JOIN (
     ) AS [t2] ON [g1].[LeaderNickname] = [t2].[Nickname]
     WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND [t2].[Nickname] IS NOT NULL
 ) AS [t3] ON [g2.Weapons].[OwnerFullName] = [t3].[FullName]
-ORDER BY [t3].[c0], [t3].[FullName]");
+ORDER BY [t3].[FullName0], [t3].[FullName]");
         }
 
         public override void Coalesce_operator_in_predicate()

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -783,7 +783,7 @@ ORDER BY [t3].[CustomerID]",
 SELECT [c2.Orders].[OrderID], [c2.Orders].[CustomerID], [c2.Orders].[EmployeeID], [c2.Orders].[OrderDate]
 FROM [Orders] AS [c2.Orders]
 INNER JOIN (
-    SELECT DISTINCT [t5].[CustomerID], [t4].[CustomerID] AS [c0]
+    SELECT DISTINCT [t5].[CustomerID], [t4].[CustomerID] AS [CustomerID0]
     FROM (
         SELECT TOP(@__p_0) [c3].*
         FROM [Customers] AS [c3]
@@ -796,7 +796,7 @@ INNER JOIN (
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t5]
 ) AS [t6] ON [c2.Orders].[CustomerID] = [t6].[CustomerID]
-ORDER BY [t6].[c0], [t6].[CustomerID]");
+ORDER BY [t6].[CustomerID0], [t6].[CustomerID]");
             }
         }
 
@@ -857,7 +857,7 @@ FROM [Orders] AS [c2.Orders]
 INNER JOIN (
     SELECT DISTINCT [t7].*
     FROM (
-        SELECT TOP(@__p_1) [t6].[CustomerID], [t5].[CustomerID] AS [c0]
+        SELECT TOP(@__p_1) [t6].[CustomerID], [t5].[CustomerID] AS [CustomerID0]
         FROM (
             SELECT TOP(@__p_0) [c3].*
             FROM [Customers] AS [c3]
@@ -872,7 +872,7 @@ INNER JOIN (
         ORDER BY [t5].[CustomerID], [t6].[CustomerID]
     ) AS [t7]
 ) AS [t8] ON [c2.Orders].[CustomerID] = [t8].[CustomerID]
-ORDER BY [t8].[c0], [t8].[CustomerID]");
+ORDER BY [t8].[CustomerID0], [t8].[CustomerID]");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -847,7 +847,7 @@ ORDER BY [t].[Id], [e.BaseCollectionOnBase].[Id]",
                 @"SELECT [e.BaseCollectionOnBase.NestedCollection].[Id], [e.BaseCollectionOnBase.NestedCollection].[Discriminator], [e.BaseCollectionOnBase.NestedCollection].[Name], [e.BaseCollectionOnBase.NestedCollection].[ParentCollectionId], [e.BaseCollectionOnBase.NestedCollection].[ParentReferenceId]
 FROM [NestedCollectionBase] AS [e.BaseCollectionOnBase.NestedCollection]
 INNER JOIN (
-    SELECT DISTINCT [e.BaseCollectionOnBase0].[Id], [t0].[Id] AS [c0]
+    SELECT DISTINCT [e.BaseCollectionOnBase0].[Id], [t0].[Id] AS [Id0]
     FROM [BaseCollectionOnBase] AS [e.BaseCollectionOnBase0]
     INNER JOIN (
         SELECT [e1].[Id]
@@ -857,7 +857,7 @@ INNER JOIN (
     WHERE [e.BaseCollectionOnBase0].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
 ) AS [t1] ON [e.BaseCollectionOnBase.NestedCollection].[ParentCollectionId] = [t1].[Id]
 WHERE [e.BaseCollectionOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
-ORDER BY [t1].[c0], [t1].[Id]");
+ORDER BY [t1].[Id0], [t1].[Id]");
         }
 
         public override void Nested_include_with_inheritance_collection_collection2()

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3840,7 +3840,7 @@ ORDER BY [t].[CustomerID]");
 
 SELECT TOP(2) [t].*
 FROM (
-    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [c0], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [CustomerID0], [o].[EmployeeID], [o].[OrderDate]
     FROM [Customers] AS [c]
     CROSS JOIN [Orders] AS [o]
     ORDER BY [c].[CustomerID], [o].[OrderID]

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -117,9 +117,9 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
                 @"@__p_0: 10
 @__p_1: 5
 
-SELECT [t].[OrderID], [t].[CustomerID], [t].[c0], [t].[ContactName], [t].[c1]
+SELECT [t].[OrderID], [t].[CustomerID], [t].[CustomerID0], [t].[ContactName], [t].[ContactName0]
 FROM (
-    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [c0], [ca].[ContactName], [cb].[ContactName] AS [c1], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    SELECT [o].[OrderID], [ca].[CustomerID], [cb].[CustomerID] AS [CustomerID0], [ca].[ContactName], [cb].[ContactName] AS [ContactName0], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
     FROM [Orders] AS [o]
     INNER JOIN [Customers] AS [ca] ON [o].[CustomerID] = [ca].[CustomerID]
     INNER JOIN [Customers] AS [cb] ON [o].[CustomerID] = [cb].[CustomerID]


### PR DESCRIPTION
Unique-fy the code to create uniquely aliased projection for subquery. (which was being used in AddToProjection & PushDownSubquery). This removes CreateUniqueProjectionAlias and introduces method CreateUniqueProjection which makes the projection alias unique (and replaces it in projection & order by)
Side effect of above is, for pushdownsubquery, we don't use ColumnAliasPrefix for new name. Instead we will unique-fy current column name.