### PR TITLE
Relational().DatabaseName was confusing, make it a Scaffolding() one instead

### DIFF
--- a/src/EFCore.Design/Scaffolding/Configuration/Internal/ModelConfiguration.cs
+++ b/src/EFCore.Design/Scaffolding/Configuration/Internal/ModelConfiguration.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Configuration.Internal
         /// </summary>
         public virtual string ClassName()
         {
-            var annotatedName = AnnotationProvider.For(Model).DatabaseName;
+            var annotatedName = Model.Scaffolding().DatabaseName;
             if (!string.IsNullOrEmpty(annotatedName))
             {
                 return CSharpUtilities.GenerateCSharpIdentifier(annotatedName + DbContextSuffix, null);

--- a/src/EFCore.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
+++ b/src/EFCore.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
@@ -50,5 +50,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public const string DbSetName = "DbSetName";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public const string DatabaseName = "DatabaseName";
     }
 }

--- a/src/EFCore.Relational.Design/Metadata/Internal/ScaffoldingFullAnnotationNames.cs
+++ b/src/EFCore.Relational.Design/Metadata/Internal/ScaffoldingFullAnnotationNames.cs
@@ -19,12 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         protected ScaffoldingFullAnnotationNames(string prefix)
             : base(prefix)
         {
-            UseProviderMethodName = ScaffoldingAnnotationNames.UseProviderMethodName;
-            ColumnOrdinal = ScaffoldingAnnotationNames.ColumnOrdinal;
-            DependentEndNavigation = ScaffoldingAnnotationNames.DependentEndNavigation;
-            PrincipalEndNavigation = ScaffoldingAnnotationNames.PrincipalEndNavigation;
-            EntityTypeErrors = ScaffoldingAnnotationNames.EntityTypeErrors;
-            DbSetName = ScaffoldingAnnotationNames.DbSetName;
+            UseProviderMethodName = prefix + ScaffoldingAnnotationNames.UseProviderMethodName;
+            ColumnOrdinal = prefix + ScaffoldingAnnotationNames.ColumnOrdinal;
+            DependentEndNavigation = prefix + ScaffoldingAnnotationNames.DependentEndNavigation;
+            PrincipalEndNavigation = prefix + ScaffoldingAnnotationNames.PrincipalEndNavigation;
+            EntityTypeErrors = prefix + ScaffoldingAnnotationNames.EntityTypeErrors;
+            DbSetName = prefix + ScaffoldingAnnotationNames.DbSetName;
+            DatabaseName = prefix + ScaffoldingAnnotationNames.DatabaseName;
         }
 
         /// <summary>
@@ -69,5 +70,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public readonly string DbSetName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public readonly string DatabaseName;
     }
 }

--- a/src/EFCore.Relational.Design/Metadata/ScaffoldingModelAnnotations.cs
+++ b/src/EFCore.Relational.Design/Metadata/ScaffoldingModelAnnotations.cs
@@ -53,5 +53,18 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
                     Check.NotNull(value, nameof(value)));
             }
         }
+
+        public virtual string DatabaseName
+        {
+            get { return (string)Annotations.GetAnnotation(ScaffoldingFullAnnotationNames.Instance.DatabaseName, null); }
+            [param: CanBeNull]
+            set
+            {
+                Annotations.SetAnnotation(
+                    ScaffoldingFullAnnotationNames.Instance.DatabaseName,
+                    null,
+                    Check.NullButNotEmpty(value, nameof(value)));
+            }
+        }
     }
 }

--- a/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
 
             if (!string.IsNullOrEmpty(databaseModel.DatabaseName))
             {
-                modelBuilder.Model.Relational().DatabaseName = databaseModel.DatabaseName;
+                modelBuilder.Model.Scaffolding().DatabaseName = databaseModel.DatabaseName;
             }
 
             VisitSequences(modelBuilder, databaseModel.Sequences);

--- a/src/EFCore.Relational/Metadata/IRelationalModelAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/IRelationalModelAnnotations.cs
@@ -13,6 +13,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IReadOnlyList<ISequence> Sequences { get; }
 
         string DefaultSchema { get; }
-        string DatabaseName { get; }
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
@@ -49,12 +49,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string DatabaseName = "DatabaseName";
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public const string TableName = "TableName";
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModelBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModelBuilderAnnotations.cs
@@ -27,12 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool HasDatabaseName([CanBeNull] string value) => SetDatabaseName(value);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public virtual bool HasDefaultSchema([CanBeNull] string value) => SetDefaultSchema(value);
     }
 }

--- a/src/EFCore.Relational/Metadata/RelationalFullAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalFullAnnotationNames.cs
@@ -22,7 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             DefaultValueSql = prefix + RelationalAnnotationNames.DefaultValueSql;
             ComputedColumnSql = prefix + RelationalAnnotationNames.ComputedColumnSql;
             DefaultValue = prefix + RelationalAnnotationNames.DefaultValue;
-            DatabaseName = prefix + RelationalAnnotationNames.DatabaseName;
             TableName = prefix + RelationalAnnotationNames.TableName;
             Schema = prefix + RelationalAnnotationNames.Schema;
             DefaultSchema = prefix + RelationalAnnotationNames.DefaultSchema;
@@ -68,12 +67,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public readonly string DefaultValue;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public readonly string DatabaseName;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
@@ -72,22 +72,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 RelationalFullAnnotationNames.Instance.DefaultSchema,
                 ProviderFullAnnotationNames?.DefaultSchema,
                 Check.NullButNotEmpty(value, nameof(value)));
-
-        public virtual string DatabaseName
-        {
-            get
-            {
-                return (string)Annotations.GetAnnotation(
-                    RelationalFullAnnotationNames.Instance.DatabaseName,
-                    ProviderFullAnnotationNames?.DatabaseName);
-            }
-            [param: CanBeNull] set { SetDatabaseName(value); }
-        }
-
-        protected virtual bool SetDatabaseName([CanBeNull] string value)
-            => Annotations.SetAnnotation(
-                RelationalFullAnnotationNames.Instance.DatabaseName,
-                ProviderFullAnnotationNames?.DatabaseName,
-                Check.NullButNotEmpty(value, nameof(value)));
     }
 }

--- a/test/EFCore.Relational.Design.Tests/ScaffoldingMetadataExtenstionsTest.cs
+++ b/test/EFCore.Relational.Design.Tests/ScaffoldingMetadataExtenstionsTest.cs
@@ -49,5 +49,22 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
 
             Assert.Equal("Blogs", entity.Scaffolding().DbSetName);
         }
+
+        [Fact]
+        public void It_sets_gets_database_name()
+        {
+            var model = new Model();
+            var extensions = model.Scaffolding();
+
+            Assert.Null(extensions.DatabaseName);
+
+            extensions.DatabaseName = "Northwind";
+
+            Assert.Equal("Northwind", extensions.DatabaseName);
+
+            extensions.DatabaseName = null;
+
+            Assert.Null(extensions.DatabaseName);
+        }
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -487,24 +487,6 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
         }
 
         [Fact]
-        public void Can_get_and_set_database_name_on_model()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
-            var extensions = model.Relational();
-
-            Assert.Null(extensions.DefaultSchema);
-
-            extensions.DatabaseName = "Northwind";
-
-            Assert.Equal("Northwind", extensions.DatabaseName);
-
-            extensions.DatabaseName = null;
-
-            Assert.Null(extensions.DatabaseName);
-        }
-
-        [Fact]
         public void Can_get_and_set_sequence()
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());


### PR DESCRIPTION
Fix for #7936.

Users were finding the Relational().DatabaseName annotation confusing since it had no effect on the database you were connecting to at runtime. So make it into a Scaffolding() annotation instead to make it clear what it's being used for and make it only available at design-time.
