### PR TITLE
Query: Pushdown subquery appropriately before applying aggregate oper…

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -599,11 +599,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         {
             Check.NotNull(expression, nameof(expression));
 
-            if (_limit != null || _isDistinct)
-            {
-                PushDownSubquery();
-            }
-
             ClearProjection();
             AddToProjection(expression);
         }

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -477,15 +477,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [ConditionalFact]
         public virtual void Distinct_Take_Count()
         {
-            AssertQuery<Order>(
-                os => os.Distinct().Take(5).Count());
+            AssertQuery<Order>(os => os.Distinct().Take(5).Count());
         }
 
         [ConditionalFact]
         public virtual void Take_Distinct_Count()
         {
-            AssertQuery<Order>(
-                os => os.Take(5).Distinct().Count());
+            AssertQuery<Order>(os => os.Take(5).Distinct().Count());
         }
 
         [ConditionalFact]
@@ -498,22 +496,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         [ConditionalFact]
         public virtual void Any_simple()
         {
-            AssertQuery<Customer>(
-                cs => cs.Any());
+            AssertQuery<Customer>(cs => cs.Any());
         }
 
         [ConditionalFact]
         public virtual void OrderBy_Take_Count()
         {
-            AssertQuery<Order>(
-                os => os.OrderBy(o => o.OrderID).Take(5).Count());
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Take(5).Count());
         }
 
         [ConditionalFact]
         public virtual void Take_OrderBy_Count()
         {
-            AssertQuery<Order>(
-                os => os.Take(5).OrderBy(o => o.OrderID).Count());
+            AssertQuery<Order>(os => os.Take(5).OrderBy(o => o.OrderID).Count());
         }
 
         [ConditionalFact]
@@ -4751,13 +4746,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Select_Distinct_Count()
-        {
-            AssertQuery<Customer>(
-                cs => cs.Select(c => c.City).Distinct().Count());
-        }
-
-        [ConditionalFact]
         public virtual void Select_Select_Distinct_Count()
         {
             AssertQuery<Customer>(
@@ -7484,34 +7472,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
-        public virtual void Skip_Count()
-        {
-            AssertQuery<Customer>(
-                cs => cs.Skip(7).Count());
-        }
-
-        [ConditionalFact]
-        public virtual void Skip_LongCount()
-        {
-            AssertQuery<Customer>(
-                cs => cs.Skip(7).LongCount());
-        }
-
-        [ConditionalFact]
-        public virtual void OrderBy_Skip_Count()
-        {
-            AssertQuery<Customer>(
-                cs => cs.OrderBy(c => c.Country).Skip(7).Count());
-        }
-
-        [ConditionalFact]
-        public virtual void OrderBy_Skip_LongCount()
-        {
-            AssertQuery<Customer>(
-                cs => cs.OrderBy(c => c.Country).Skip(7).LongCount());
-        }
-
-        [ConditionalFact]
         public virtual void Contains_with_DateTime_Date()
         {
             var dates = new[] { new DateTime(1996, 07, 04), new DateTime(1996, 07, 16) };
@@ -7824,6 +7784,139 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 89);
         }
 
+        [ConditionalFact]
+        public virtual void Select_take_average()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Take(10).Average());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_count()
+        {
+            AssertQuery<Customer>(cs => cs.Take(7).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_orderBy_take_count()
+        {
+            AssertQuery<Customer>(cs => cs.OrderBy(c => c.Country).Take(7).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_long_count()
+        {
+            AssertQuery<Customer>(cs => cs.Take(7).LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_orderBy_take_long_count()
+        {
+            AssertQuery<Customer>(cs => cs.OrderBy(c => c.Country).Take(7).LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_max()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Take(10).Max());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_min()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Take(10).Min());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_sum()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Take(10).Sum());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_average()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Skip(10).Average());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_count()
+        {
+            AssertQuery<Customer>(cs => cs.Skip(7).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_orderBy_skip_count()
+        {
+            AssertQuery<Customer>(cs => cs.OrderBy(c => c.Country).Skip(7).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_long_count()
+        {
+            AssertQuery<Customer>(cs => cs.Skip(7).LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_orderBy_skip_long_count()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.Country).Skip(7).LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_max()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Skip(10).Max());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_min()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Skip(10).Min());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_skip_sum()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Select(o => o.OrderID).Skip(10).Sum());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_average()
+        {
+            AssertQuery<Order>(os => os.Select(o => o.OrderID).Distinct().Average());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_count()
+        {
+            AssertQuery<Customer>(cs => cs.Distinct().Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_long_count()
+        {
+            AssertQuery<Customer>(cs => cs.Distinct().LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_max()
+        {
+            AssertQuery<Order>(os => os.Select(o => o.OrderID).Distinct().Max());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_min()
+        {
+            AssertQuery<Order>(os => os.Select(o => o.OrderID).Distinct().Min());
+        }
+
+        [ConditionalFact]
+        public virtual void Select_distinct_sum()
+        {
+            AssertQuery<Order>(os => os.Select(o => o.OrderID).Distinct().Sum());
+        }
+        
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected QueryTestBase(TFixture fixture)

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1591,9 +1591,9 @@ FROM (
 ) AS [t]");
         }
 
-        public override void Select_Distinct_Count()
+        public override void Select_Select_Distinct_Count()
         {
-            base.Select_Distinct_Count();
+            base.Select_Select_Distinct_Count();
 
             AssertSql(
                 @"SELECT COUNT(*)
@@ -4069,6 +4069,35 @@ FROM (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Distinct_Take()
+        {
+            base.Distinct_Take();
+
+            AssertSql(
+                @"@__p_0: 5
+
+SELECT TOP(@__p_0) [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM (
+    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+) AS [t]
+ORDER BY [t].[OrderID]");
+        }
+
+        public override void Distinct_Take_Count()
+        {
+            base.Distinct_Take_Count();
+
+            AssertSql(
+                @"@__p_0: 5
+
+SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT TOP(@__p_0) [o].*
+    FROM [Orders] AS [o]
 ) AS [t]");
         }
 
@@ -7374,70 +7403,6 @@ LEFT JOIN [Employees] AS [e2] ON [e1].[EmployeeID] = [e2].[ReportsTo]
 ORDER BY [e1].[EmployeeID]");
         }
 
-        public override void Skip_Count()
-        {
-            base.Skip_Count();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT(*)
-FROM (
-    SELECT [c].*
-    FROM [Customers] AS [c]
-    ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
-) AS [t]");
-        }
-
-        public override void Skip_LongCount()
-        {
-            base.Skip_LongCount();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT_BIG(*)
-FROM (
-    SELECT [c].*
-    FROM [Customers] AS [c]
-    ORDER BY (SELECT 1)
-    OFFSET @__p_0 ROWS
-) AS [t]");
-        }
-
-        public override void OrderBy_Skip_Count()
-        {
-            base.OrderBy_Skip_Count();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT(*)
-FROM (
-    SELECT [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[Country]
-    OFFSET @__p_0 ROWS
-) AS [t]");
-        }
-
-        public override void OrderBy_Skip_LongCount()
-        {
-            base.OrderBy_Skip_LongCount();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT_BIG(*)
-FROM (
-    SELECT [c].*
-    FROM [Customers] AS [c]
-    ORDER BY [c].[Country]
-    OFFSET @__p_0 ROWS
-) AS [t]");
-        }
-
         public override void Contains_with_DateTime_Date()
         {
             base.Contains_with_DateTime_Date();
@@ -7870,10 +7835,328 @@ WHERE (
 ) IS NOT NULL");
         }
 
+        public override void Select_take_average()
+        {
+            base.Select_take_average();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT AVG(CAST([t].[OrderID] AS float))
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_count()
+        {
+            base.Select_take_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_orderBy_take_count()
+        {
+            base.Select_orderBy_take_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+) AS [t]");
+        }
+
+        public override void Select_take_long_count()
+        {
+            base.Select_take_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_orderBy_take_long_count()
+        {
+            base.Select_orderBy_take_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+) AS [t]");
+        }
+
+        public override void Select_take_max()
+        {
+            base.Select_take_max();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MAX([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_min()
+        {
+            base.Select_take_min();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MIN([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_sum()
+        {
+            base.Select_take_sum();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT SUM([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_skip_average()
+        {
+            base.Select_skip_average();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT AVG(CAST([t].[OrderID] AS float))
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_skip_count()
+        {
+            base.Select_skip_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_orderBy_skip_count()
+        {
+            base.Select_orderBy_skip_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_skip_long_count()
+        {
+            base.Select_skip_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    ORDER BY (SELECT 1)
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_orderBy_skip_long_count()
+        {
+            base.Select_orderBy_skip_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_skip_max()
+        {
+            base.Select_skip_max();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MAX([t].[OrderID])
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_skip_min()
+        {
+            base.Select_skip_min();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MIN([t].[OrderID])
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_skip_sum()
+        {
+            base.Select_skip_sum();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT SUM([t].[OrderID])
+FROM (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+    OFFSET @__p_0 ROWS
+) AS [t]");
+        }
+
+        public override void Select_distinct_average()
+        {
+            base.Select_distinct_average();
+
+            AssertSql(
+                @"SELECT AVG(CAST([t].[OrderID] AS float))
+FROM (
+    SELECT DISTINCT [o].[OrderID]
+    FROM [Orders] AS [o]
+) AS [t]");
+        }
+
+        public override void Select_distinct_count()
+        {
+            base.Select_distinct_count();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT DISTINCT [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_distinct_long_count()
+        {
+            base.Select_distinct_long_count();
+
+            AssertSql(
+                @"SELECT COUNT_BIG(*)
+FROM (
+    SELECT DISTINCT [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_distinct_max()
+        {
+            base.Select_distinct_max();
+
+            AssertSql(
+                @"SELECT MAX([t].[OrderID])
+FROM (
+    SELECT DISTINCT [o].[OrderID]
+    FROM [Orders] AS [o]
+) AS [t]");
+        }
+
+        public override void Select_distinct_min()
+        {
+            base.Select_distinct_min();
+
+            AssertSql(
+                @"SELECT MIN([t].[OrderID])
+FROM (
+    SELECT DISTINCT [o].[OrderID]
+    FROM [Orders] AS [o]
+) AS [t]");
+        }
+
+        public override void Select_distinct_sum()
+        {
+            base.Select_distinct_sum();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID])
+FROM (
+    SELECT DISTINCT [o].[OrderID]
+    FROM [Orders] AS [o]
+) AS [t]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
-        
-        private void AssertContainsSql(params string[] expected) 
+
+        private void AssertContainsSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
 
         protected override void ClearLog() 

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -477,78 +477,6 @@ SELECT CASE
 END");
         }
 
-        public override void Skip_Count()
-        {
-            base.Skip_Count();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT(*)
-FROM (
-    SELECT [t0].*
-    FROM (
-        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
-        FROM [Customers] AS [c]
-    ) AS [t0]
-    WHERE [t0].[__RowNumber__] > @__p_0
-) AS [t]");
-        }
-
-        public override void Skip_LongCount()
-        {
-            base.Skip_LongCount();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT_BIG(*)
-FROM (
-    SELECT [t0].*
-    FROM (
-        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
-        FROM [Customers] AS [c]
-    ) AS [t0]
-    WHERE [t0].[__RowNumber__] > @__p_0
-) AS [t]");
-        }
-
-        public override void OrderBy_Skip_Count()
-        {
-            base.OrderBy_Skip_Count();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT(*)
-FROM (
-    SELECT [t0].*
-    FROM (
-        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
-        FROM [Customers] AS [c]
-    ) AS [t0]
-    WHERE [t0].[__RowNumber__] > @__p_0
-) AS [t]");
-        }
-
-        public override void OrderBy_Skip_LongCount()
-        {
-            base.OrderBy_Skip_LongCount();
-
-            AssertSql(
-                @"@__p_0: 7
-
-SELECT COUNT_BIG(*)
-FROM (
-    SELECT [t0].*
-    FROM (
-        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
-        FROM [Customers] AS [c]
-    ) AS [t0]
-    WHERE [t0].[__RowNumber__] > @__p_0
-) AS [t]");
-        }
-
         public override void Include_with_orderby_skip_preserves_ordering()
         {
             base.Include_with_orderby_skip_preserves_ordering();
@@ -598,6 +526,268 @@ FROM (
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 ORDER BY [t].[City], [t].[CustomerID]");
+        }
+
+        public override void Select_take_average()
+        {
+            base.Select_take_average();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT AVG(CAST([t].[OrderID] AS float))
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_count()
+        {
+            base.Select_take_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_orderBy_take_count()
+        {
+            base.Select_orderBy_take_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+) AS [t]");
+        }
+
+        public override void Select_take_long_count()
+        {
+            base.Select_take_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
+        public override void Select_orderBy_take_long_count()
+        {
+            base.Select_orderBy_take_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT TOP(@__p_0) [c].*
+    FROM [Customers] AS [c]
+    ORDER BY [c].[Country]
+) AS [t]");
+        }
+
+        public override void Select_take_max()
+        {
+            base.Select_take_max();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MAX([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_min()
+        {
+            base.Select_take_min();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MIN([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_take_sum()
+        {
+            base.Select_take_sum();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT SUM([t].[OrderID])
+FROM (
+    SELECT TOP(@__p_0) [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]");
+        }
+
+        public override void Select_skip_average()
+        {
+            base.Select_skip_average();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT AVG(CAST([t].[OrderID] AS float))
+FROM (
+    SELECT [t0].[OrderID]
+    FROM (
+        SELECT [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_skip_count()
+        {
+            base.Select_skip_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT [t0].*
+    FROM (
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_orderBy_skip_count()
+        {
+            base.Select_orderBy_skip_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT(*)
+FROM (
+    SELECT [t0].*
+    FROM (
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_skip_long_count()
+        {
+            base.Select_skip_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT [t0].*
+    FROM (
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_orderBy_skip_long_count()
+        {
+            base.Select_orderBy_skip_long_count();
+
+            AssertSql(
+                @"@__p_0: 7
+
+SELECT COUNT_BIG(*)
+FROM (
+    SELECT [t0].*
+    FROM (
+        SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[Country]) AS [__RowNumber__]
+        FROM [Customers] AS [c]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_skip_max()
+        {
+            base.Select_skip_max();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MAX([t].[OrderID])
+FROM (
+    SELECT [t0].[OrderID]
+    FROM (
+        SELECT [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_skip_min()
+        {
+            base.Select_skip_min();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT MIN([t].[OrderID])
+FROM (
+    SELECT [t0].[OrderID]
+    FROM (
+        SELECT [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
+        }
+
+        public override void Select_skip_sum()
+        {
+            base.Select_skip_sum();
+
+            AssertSql(
+                @"@__p_0: 10
+
+SELECT SUM([t].[OrderID])
+FROM (
+    SELECT [t0].[OrderID]
+    FROM (
+        SELECT [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+    WHERE [t0].[__RowNumber__] > @__p_0
+) AS [t]");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
…ation

resolves #7693 
We had different locations & conditions to push down subquery while applying aggregate result operator. This unique-fy it in single place ensuring that SelectExpression is appropriate to apply aggregate operator.