### PR TITLE
Query: Include: Log ignored Include warnings properly in new compiler.

### DIFF
--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -308,6 +308,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             includeCompiler.RewriteCollectionQueries(queryModel);
 
+            includeCompiler.LogIgnoredIncludes();
+
             // Second pass of optimizations
 
             _queryOptimizer.Optimize(QueryCompilationContext, queryModel);

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -101,6 +101,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             ApplyParentOrderings(queryModel, collectionQueryModelRewritingExpressionVisitor.ParentOrderings);
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void LogIgnoredIncludes()
+        {
+            foreach (var includeResultOperator in _includeResultOperators)
+            {
+                _queryCompilationContext.Logger
+                    .LogWarning(
+                        CoreEventId.IncludeIgnoredWarning,
+                        () => CoreStrings.LogIgnoredInclude(includeResultOperator.DisplayString()));
+            }
+        }
+
         private IEnumerable<IncludeLoadTree> CreateIncludeLoadTrees(
             Expression targetExpression)
         {
@@ -121,12 +136,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (querySourceReferenceExpression == null)
                 {
-                    _queryCompilationContext.Logger
-                        .LogWarning(
-                            CoreEventId.IncludeIgnoredWarning,
-                            () => CoreStrings.LogIgnoredInclude(
-                                $"{includeResultOperator.QuerySource.ItemName}.{navigationPath.Select(n => n.Name).Join(".")}"));
-
                     continue;
                 }
 
@@ -146,8 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _queryCompilationContext.Logger
                     .LogDebug(
                         CoreEventId.IncludingNavigation,
-                        () => CoreStrings.LogIncludingNavigation(
-                            $"{includeResultOperator.PathFromQuerySource}.{includeResultOperator.NavigationPropertyPaths.Join(".")}"));
+                        () => CoreStrings.LogIncludingNavigation(includeResultOperator.DisplayString()));
 
                 _includeResultOperators.Remove(includeResultOperator);
             }

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -45,8 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         public virtual IQuerySource QuerySource
         {
-            get { return _querySource ?? (_querySource = GetQuerySource(PathFromQuerySource)); }
-            set { _querySource = value; }
+            get => _querySource ?? (_querySource = GetQuerySource(PathFromQuerySource));
+            set => _querySource = value;
         }
 
         private static IQuerySource GetQuerySource(Expression expression)
@@ -138,6 +138,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         public override string ToString()
             => $@"Include(""{NavigationPropertyPaths.Join(".")}"")";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string DisplayString()
+            => $"{PathFromQuerySource}.{_navigationPropertyPaths.Join(".")}";
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -66,7 +66,7 @@ select [<generated>_0]'
                         .ToList();
 
                 Assert.NotNull(customers);
-                Assert.Contains(CoreStrings.LogIgnoredInclude("c.Orders"), _fixture.TestSqlLoggerFactory.Log);
+                Assert.Contains(CoreStrings.LogIgnoredInclude("[c].Orders"), _fixture.TestSqlLoggerFactory.Log);
             }
         }
 


### PR DESCRIPTION
Log any Includes left over at end of compilation.