### PR TITLE
[2.0.0-preview1] Core: Initial work on model-level entity type filters

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />

--- a/src/EFCore.Relational.Specification.Tests/FromSqlSprocQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/FromSqlSprocQueryTestBase.cs
@@ -221,17 +221,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+        protected NorthwindContext CreateContext() => Fixture.CreateContext(QueryTrackingBehavior.NoTracking);
 
-        protected FromSqlSprocQueryTestBase(TFixture fixture)
-        {
-            Fixture = fixture;
-        }
+        protected FromSqlSprocQueryTestBase(TFixture fixture) => Fixture = fixture;
 
         protected TFixture Fixture { get; }
 
         protected abstract string TenMostExpensiveProductsSproc { get; }
-
         protected abstract string CustomerOrderHistorySproc { get; }
     }
 }

--- a/src/EFCore.Relational.Specification.Tests/TestSqlLoggerFactory.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestSqlLoggerFactory.cs
@@ -79,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     newBaseLine += "Output truncated.";
                 }
 
+                _logger.TestOutputHelper?.WriteLine("---- New Baseline -------------------------------------------------------------------");
                 _logger.TestOutputHelper?.WriteLine(newBaseLine);
 
                 var contents = testInfo + newBaseLine + FileLineEnding + FileLineEnding;

--- a/src/EFCore.Specification.Tests/FiltersInheritanceTestBase.cs
+++ b/src/EFCore.Specification.Tests/FiltersInheritanceTestBase.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
+using Xunit;
+
+// ReSharper disable StringStartsWithIsCultureSpecific
+// ReSharper disable InconsistentNaming
+// ReSharper disable ConvertToExpressionBodyWhenPossible
+// ReSharper disable ConvertMethodToExpressionBody
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class FiltersInheritanceTestBase<TFixture> : IClassFixture<TFixture>, IDisposable
+        where TFixture : InheritanceFixtureBase, new()
+    {
+        [Fact]
+        public virtual void Can_use_of_type_animal()
+        {
+            var animals = _context.Set<Animal>().OfType<Animal>().OrderBy(a => a.Species).ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.IsType<Kiwi>(animals[0]);
+            Assert.Equal(1, _context.ChangeTracker.Entries().Count());
+        }
+
+        [Fact]
+        public virtual void Can_use_is_kiwi()
+        {
+            var kiwis = _context.Set<Animal>().Where(a => a is Kiwi).ToList();
+
+            Assert.Equal(1, kiwis.Count);
+        }
+
+        [Fact]
+        public virtual void Can_use_is_kiwi_with_other_predicate()
+        {
+            var animals = _context.Set<Animal>().Where(a => a is Kiwi && a.CountryId == 1).ToList();
+
+            Assert.Equal(1, animals.Count);
+        }
+
+        [Fact]
+        public virtual void Can_use_is_kiwi_in_projection()
+        {
+            var animals = _context.Set<Animal>().Select(a => a is Kiwi).ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.Equal(1, animals.Count(a => a));
+            Assert.Equal(0, animals.Count(a => !a));
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird()
+        {
+            var animals = _context.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species).ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.IsType<Kiwi>(animals[0]);
+            Assert.Equal(1, _context.ChangeTracker.Entries().Count());
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird_predicate()
+        {
+            var animals
+                = _context.Set<Animal>()
+                    .Where(a => a.CountryId == 1)
+                    .OfType<Bird>()
+                    .OrderBy(a => a.Species)
+                    .ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.IsType<Kiwi>(animals[0]);
+            Assert.Equal(1, _context.ChangeTracker.Entries().Count());
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird_with_projection()
+        {
+            var animals
+                = _context.Set<Animal>()
+                    .OfType<Bird>()
+                    .Select(b => new { b.EagleId })
+                    .ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.Equal(0, _context.ChangeTracker.Entries().Count());
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird_first()
+        {
+            var bird = _context.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species).First();
+
+            Assert.NotNull(bird);
+            Assert.IsType<Kiwi>(bird);
+            Assert.Equal(1, _context.ChangeTracker.Entries().Count());
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_kiwi()
+        {
+            var animals = _context.Set<Animal>().OfType<Kiwi>().ToList();
+
+            Assert.Equal(1, animals.Count);
+            Assert.IsType<Kiwi>(animals[0]);
+            Assert.Equal(1, _context.ChangeTracker.Entries().Count());
+        }
+
+        protected TFixture Fixture { get; }
+
+        private readonly InheritanceContext _context;
+
+        protected FiltersInheritanceTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            _context = fixture.CreateContext(enableFilters: true);
+        }
+
+        public void Dispose() => _context.Dispose();
+    }
+}

--- a/src/EFCore.Specification.Tests/FiltersTestBase.cs
+++ b/src/EFCore.Specification.Tests/FiltersTestBase.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Xunit;
+
+// ReSharper disable StaticMemberInGenericType
+// ReSharper disable InconsistentNaming
+// ReSharper disable ConvertToExpressionBodyWhenPossible
+// ReSharper disable ConvertMethodToExpressionBody
+// ReSharper disable StringStartsWithIsCultureSpecific
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests
+{
+    public abstract class FiltersTestBase<TFixture> : IClassFixture<TFixture>, IDisposable
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        [ConditionalFact]
+        public virtual void Count_query()
+        {
+            Assert.Equal(7, _context.Customers.Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Materialized_query()
+        {
+            Assert.Equal(7, _context.Customers.ToList().Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Find()
+        {
+            Assert.Null(_context.Find<Customer>("ALFKI"));
+        }
+
+
+        [ConditionalFact]
+        public virtual void Client_eval()
+        {
+            Assert.Equal(69, _context.Products.ToList().Count);
+        }
+
+        [ConditionalFact]
+        public virtual async Task Materialized_query_async()
+        {
+            Assert.Equal(7, (await _context.Customers.ToListAsync()).Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Materialized_query_parameter()
+        {
+            _context.TenantPrefix = "F";
+
+            Assert.Equal(8, _context.Customers.ToList().Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Materialized_query_parameter_new_context()
+        {
+            Assert.Equal(7, _context.Customers.ToList().Count);
+
+            using (var context = CreateContext())
+            {
+                context.TenantPrefix = "T";
+
+                Assert.Equal(6, context.Customers.ToList().Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Projection_query()
+        {
+            Assert.Equal(7, _context.Customers.Select(c => c.CustomerID).ToList().Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Projection_query_parameter()
+        {
+            _context.TenantPrefix = "F";
+
+            Assert.Equal(8, _context.Customers.Select(c => c.CustomerID).ToList().Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_query()
+        {
+            var results = _context.Customers.Include(c => c.Orders).ToList();
+
+            Assert.Equal(7, results.Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_query_opt_out()
+        {
+            var results = _context.Customers.Include(c => c.Orders).IgnoreQueryFilters().ToList();
+
+            Assert.Equal(91, results.Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Included_many_to_one_query()
+        {
+            var results = _context.Orders.Include(o => o.Customer).ToList();
+
+            Assert.Equal(830, results.Count);
+            Assert.True(results.All(o => o.Customer == null || o.CustomerID.StartsWith("B")));
+        }
+
+        [ConditionalFact]
+        public virtual void Included_one_to_many_query_with_client_eval()
+        {
+            var results = _context.Products.Include(p => p.OrderDetails).ToList();
+
+            Assert.Equal(69, results.Count);
+            Assert.True(
+                results.All(
+                    p => !p.OrderDetails.Any()
+                         || p.OrderDetails.All(od => od.Quantity > 50)));
+        }
+
+        [ConditionalFact]
+        public virtual void Navs_query()
+        {
+            var results
+                = (from c in _context.Customers
+                   from o in c.Orders
+                   from od in o.OrderDetails
+                   where od.Discount < 10
+                   select c).ToList();
+
+            Assert.Equal(5, results.Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Compiled_query()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context, string customerID)
+                    => context.Customers.Where(c => c.CustomerID == customerID));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("BERGS", query(context, "BERGS").First().CustomerID);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("BLAUS", query(context, "BLAUS").First().CustomerID);
+            }
+        }
+
+        protected TFixture Fixture { get; }
+
+        private readonly NorthwindContext _context;
+
+        protected FiltersTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            _context = CreateContext();
+        }
+
+        private NorthwindContext CreateContext()
+        {
+            return Fixture.CreateContext(enableFilters: true);
+        }
+
+        public void Dispose() => _context.Dispose();
+    }
+}

--- a/src/EFCore.Specification.Tests/InheritanceTestBase.cs
+++ b/src/EFCore.Specification.Tests/InheritanceTestBase.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 // ReSharper disable ReturnValueOfPureMethodIsNotUsed
 // ReSharper disable StringEndsWithIsCultureSpecific

--- a/src/EFCore.Specification.Tests/NorthwindQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/NorthwindQueryFixtureBase.cs
@@ -8,7 +8,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 {
     public abstract class NorthwindQueryFixtureBase
     {
+        private DbContextOptions _options;
+
         public abstract DbContextOptions BuildOptions(IServiceCollection additionalServices = null);
+
+        public virtual NorthwindContext CreateContext(
+            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll,
+            bool enableFilters = false)
+        {
+            EnableFilters = enableFilters;
+
+            return new NorthwindContext(_options ?? (_options = BuildOptions()), queryTrackingBehavior);
+        }
+
+        private bool EnableFilters { get; set; }
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -58,9 +71,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     });
 
             modelBuilder.Entity<OrderDetail>(e => { e.HasKey(od => new { od.OrderID, od.ProductID }); });
-        }
 
-        public abstract NorthwindContext CreateContext(
-            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll);
+            if (EnableFilters)
+            {
+                new NorthwindContext().ConfigureFilters(modelBuilder);
+            }
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+// ReSharper disable StringStartsWithIsCultureSpecific
+
 namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind
 {
     public class NorthwindContext : DbContext
@@ -8,9 +10,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind
         public NorthwindContext(
             DbContextOptions options,
             QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-            : base(queryTrackingBehavior == QueryTrackingBehavior.TrackAll
-                ? options
-                : new DbContextOptionsBuilder(options).UseQueryTrackingBehavior(queryTrackingBehavior).Options)
+            : base(
+                queryTrackingBehavior == QueryTrackingBehavior.TrackAll
+                    ? options
+                    : new DbContextOptionsBuilder(options).UseQueryTrackingBehavior(queryTrackingBehavior).Options)
+        {
+        }
+
+        internal NorthwindContext()
         {
         }
 
@@ -19,5 +26,23 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind
         public virtual DbSet<Order> Orders { get; set; }
         public virtual DbSet<OrderDetail> OrderDetails { get; set; }
         public virtual DbSet<Product> Products { get; set; }
+
+        public string TenantPrefix { get; set; } = "B";
+
+        public void ConfigureFilters(ModelBuilder modelBuilder)
+        {
+            // Called explictly from filter test fixtures. Code is here
+            // so we can capture TenantPrefix in filter exprs (simulates OnModelCreating).
+
+            modelBuilder.Entity<Customer>().HasQueryFilter(c => c.CompanyName.StartsWith(TenantPrefix));
+            modelBuilder.Entity<OrderDetail>().HasQueryFilter(od => od.Quantity > 50);
+            modelBuilder.Entity<Employee>().HasQueryFilter(e => e.Address.StartsWith("A"));
+            modelBuilder.Entity<Product>().HasQueryFilter(p => ClientMethod(p));
+        }
+
+        private static bool ClientMethod(Product product)
+        {
+            return !product.Discontinued;
+        }
     }
 }

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -2444,6 +2444,39 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion
 
+        #region Query Filters
+
+        internal static readonly MethodInfo IgnoreQueryFiltersMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethod(nameof(IgnoreQueryFilters));
+
+        /// <summary>
+        ///     Specifies that the current Entity Framework LINQ query should not have any
+        ///     model-level entity query filters applied.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <returns>
+        ///     A new query that will not apply any model-level entity query filters.
+        /// </returns>
+        public static IQueryable<TEntity> IgnoreQueryFilters<TEntity>(
+            [NotNull] this IQueryable<TEntity> source)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+
+            return
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: IgnoreQueryFiltersMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                            arguments: source.Expression))
+                    : source;
+        }
+
+        #endregion
+
         #region Tracking
 
         internal static readonly MethodInfo AsNoTrackingMethodInfo

--- a/src/EFCore/Infrastructure/CoreModelValidator.cs
+++ b/src/EFCore/Infrastructure/CoreModelValidator.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -41,6 +44,80 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             EnsureChangeTrackingStrategy(model);
             ValidateDelegatedIdentityNavigations(model);
             EnsureFieldMapping(model);
+            ValidateQueryFilters(model);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void ValidateQueryFilters([NotNull] IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+            
+            var filterValidatingExppressionVisitor = new FilterValidatingExppressionVisitor();
+
+            foreach (var entityType in model.GetEntityTypes())
+            {
+                if (entityType.Filter != null)
+                {
+                    if (entityType.BaseType != null)
+                    {
+                        ShowError(CoreStrings.BadFilterDerivedType(entityType.Filter, entityType.DisplayName()));
+                    }
+
+                    if (!filterValidatingExppressionVisitor.IsValid(entityType))
+                    {
+                        ShowError(CoreStrings.BadFilterExpression(entityType.Filter, entityType.DisplayName(), entityType.ClrType));
+                    }
+                }
+            }
+        }
+
+        private sealed class FilterValidatingExppressionVisitor : ExpressionVisitor
+        {
+            private IEntityType _entityType;
+
+            private bool _valid = true;
+
+            public bool IsValid(IEntityType entityType)
+            {
+                _entityType = entityType;
+
+                Visit(entityType.Filter.Body);
+
+                return _valid;
+            }
+
+            protected override Expression VisitMember(MemberExpression memberExpression)
+            {
+                if (memberExpression.Expression == _entityType.Filter.Parameters[0]
+                    && memberExpression.Member is PropertyInfo propertyInfo
+                    && _entityType.FindNavigation(propertyInfo) != null)
+                {
+                    _valid = false;
+
+                    return memberExpression;
+                }
+
+                return base.VisitMember(memberExpression);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+            {
+                if (methodCallExpression.IsEFProperty()
+                    && methodCallExpression.Arguments[0] == _entityType.Filter.Parameters[0]
+                    && (!(methodCallExpression.Arguments[1] is ConstantExpression constantExpression)
+                        || !(constantExpression.Value is string propertyName)
+                        || _entityType.FindNavigation(propertyName) != null))
+                {
+                    _valid = false;
+
+                    return methodCallExpression;
+                }
+
+                return base.VisitMethodCall(methodCallExpression);
+            }
         }
 
         /// <summary>
@@ -49,6 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         protected virtual void EnsureNoShadowEntities([NotNull] IModel model)
         {
+            Check.NotNull(model, nameof(model));
+
             var firstShadowEntity = model.GetEntityTypes().FirstOrDefault(entityType => !entityType.HasClrType());
             if (firstShadowEntity != null)
             {
@@ -62,6 +141,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         protected virtual void EnsureNoShadowKeys([NotNull] IModel model)
         {
+            Check.NotNull(model, nameof(model));
+
             foreach (var entityType in model.GetEntityTypes().Where(t => t.ClrType != null))
             {
                 foreach (var key in entityType.GetDeclaredKeys())
@@ -116,6 +197,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         protected virtual void EnsureClrInheritance([NotNull] IModel model)
         {
+            Check.NotNull(model, nameof(model));
+
             var validEntityTypes = new HashSet<IEntityType>();
             foreach (var entityType in model.GetEntityTypes())
             {
@@ -127,8 +210,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual void EnsureClrInheritance([NotNull] IModel model, [NotNull] IEntityType entityType, [NotNull] HashSet<IEntityType> validEntityTypes)
+        protected virtual void EnsureClrInheritance(
+            [NotNull] IModel model, [NotNull] IEntityType entityType, [NotNull] HashSet<IEntityType> validEntityTypes)
         {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(validEntityTypes, nameof(validEntityTypes));
+
             if (validEntityTypes.Contains(entityType))
             {
                 return;
@@ -195,6 +283,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         protected virtual void ValidateDelegatedIdentityNavigations([NotNull] IModel model)
         {
+            Check.NotNull(model, nameof(model));
+
             foreach (var entityType in model.GetEntityTypes())
             {
                 if (entityType.DefiningEntityType != null)
@@ -233,6 +323,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         protected virtual void EnsureFieldMapping([NotNull] IModel model)
         {
+            Check.NotNull(model, nameof(model));
+
             foreach (var entityType in model.GetEntityTypes())
             {
                 foreach (var propertyBase in entityType

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -173,6 +174,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotEmpty(propertyName, nameof(propertyName));
 
             Builder.Ignore(propertyName, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="filter">The LINQ predicate expression.</param>
+        /// <returns></returns>
+        public virtual EntityTypeBuilder HasQueryFilter([CanBeNull] LambdaExpression filter)
+        {
+            Builder.HasQueryFilter(filter);
 
             return this;
         }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -139,6 +139,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (EntityTypeBuilder<TEntity>)base.Ignore(propertyName);
 
         /// <summary>
+        ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="filter">The LINQ predicate expression.</param>
+        /// <returns></returns>
+        public virtual EntityTypeBuilder<TEntity> HasQueryFilter([CanBeNull] Expression<Func<TEntity, bool>> filter)
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(filter);
+
+        /// <summary>
         ///     Configures an index on the specified properties. If there is an existing index on the given
         ///     set of properties, then the existing index will be returned for configuration.
         /// </summary>

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -25,6 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the defining entity type if this entity type with delegated identity.
         /// </summary>
         IEntityType DefiningEntityType { get; }
+
+        /// <summary>
+        ///     Gets the LINQ expression filter automatically applied to queries for this entity type.
+        /// </summary>
+        LambdaExpression Filter { get; }
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -27,6 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets or sets the base type of the entity. Returns null if this is not a derived type in an inheritance hierarchy.
         /// </summary>
         new IMutableEntityType BaseType { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Gets the LINQ expression filter automatically applied to queries for this entity type.
+        /// </summary>
+        new LambdaExpression Filter { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Sets the primary key for this entity.

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -37,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private Key _primaryKey;
         private EntityType _baseType;
+        private LambdaExpression _filter;
 
         private ChangeTrackingStrategy? _changeTrackingStrategy;
 
@@ -117,6 +119,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual EntityType BaseType => _baseType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual LambdaExpression Filter
+        {
+            get => _filter;
+            [param: CanBeNull]
+            set
+            {
+                if (value != null
+                    && (value.Parameters.Count != 1
+                        || value.Parameters[0].Type != ClrType
+                        || value.ReturnType != typeof(bool)))
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.BadFilterExpression(value, this.DisplayName(), ClrType));
+                }
+
+                _filter = value;
+            }
+        }
 
         /// <summary>
         ///     Gets the name of the defining navigation for this entity type with delegated identity.
@@ -309,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual ChangeTrackingStrategy ChangeTrackingStrategy
         {
-            get { return _changeTrackingStrategy ?? Model.ChangeTrackingStrategy; }
+            get => _changeTrackingStrategy ?? Model.ChangeTrackingStrategy;
             set
             {
                 var errorMessage = this.CheckChangeTrackingStrategy(value);
@@ -459,8 +484,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return _baseType.FindPrimaryKey(properties);
             }
 
-            if ((_primaryKey != null)
-                && (PropertyListComparer.Instance.Compare(_primaryKey.Properties, properties) == 0))
+            if (_primaryKey != null
+                && PropertyListComparer.Instance.Compare(_primaryKey.Properties, properties) == 0)
             {
                 return _primaryKey;
             }
@@ -1118,7 +1143,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     duplicateProperty.DeclaringEntityType.DisplayName()));
             }
 
-            Debug.Assert(!GetNavigations().Any(n => (n.ForeignKey == foreignKey) && (n.IsDependentToPrincipal() == pointsToPrincipal)),
+            Debug.Assert(!GetNavigations().Any(n => n.ForeignKey == foreignKey && n.IsDependentToPrincipal() == pointsToPrincipal),
                 "There is another navigation corresponding to the same foreign key and pointing in the same direction.");
 
             Debug.Assert((pointsToPrincipal ? foreignKey.DeclaringEntityType : foreignKey.PrincipalEntityType) == this,
@@ -1749,10 +1774,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         IMutableEntityType IMutableEntityType.BaseType
         {
-            get { return _baseType; }
-            set { HasBaseType((EntityType)value); }
+            get => _baseType;
+            set => HasBaseType((EntityType)value);
         }
 
+        LambdaExpression IMutableEntityType.Filter
+        {
+            get => Filter;
+            set => Filter = value;
+        }
+        
         IEntityType IEntityType.DefiningEntityType => DefiningEntityType;
 
         IMutableKey IMutableEntityType.SetPrimaryKey(IReadOnlyList<IMutableProperty> properties)
@@ -1836,16 +1867,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 // Neither property is part of the Primary Key
                 // Compare the property names
-                if ((xIndex == -1)
-                    && (yIndex == -1))
+                if (xIndex == -1
+                    && yIndex == -1)
                 {
                     return StringComparer.Ordinal.Compare(x, y);
                 }
 
                 // Both properties are part of the Primary Key
                 // Compare the indices
-                if ((xIndex > -1)
-                    && (yIndex > -1))
+                if (xIndex > -1
+                    && yIndex > -1)
                 {
                     return xIndex - yIndex;
                 }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -599,6 +600,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void HasQueryFilter([CanBeNull] LambdaExpression filter)
+        {
+            Metadata.Filter = filter;
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1621,6 +1621,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("UntrackedDelegatedIdentityEntity", nameof(entityType), nameof(targetEntryCall)),
                 entityType, targetEntryCall);
 
+        /// <summary>
+        ///     The filter expression '{filter}' specified for entity type '{entityType}' is invalid. The expression must accept a single parameter of type '{clrType}', return bool, and may not contain references to navigation properties.
+        /// </summary>
+        public static string BadFilterExpression([CanBeNull] object filter, [CanBeNull] object entityType, [CanBeNull] object clrType)
+            => string.Format(
+                GetString("BadFilterExpression", nameof(filter), nameof(entityType), nameof(clrType)),
+                filter, entityType, clrType);
+
+        /// <summary>
+        ///     The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.
+        /// </summary>
+        public static string BadFilterDerivedType([CanBeNull] object filter, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("BadFilterDerivedType", nameof(filter), nameof(entityType)),
+                filter, entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -734,5 +734,11 @@
   </data>
   <data name="UntrackedDelegatedIdentityEntity" xml:space="preserve">
     <value>The entity type '{entityType}' has delegated identity and the given entity is currently not being tracked. To start tracking this entity call '{targetEntryCall}' on the owner entry.</value>
+  </data>
+  <data name="BadFilterExpression" xml:space="preserve">
+    <value>The filter expression '{filter}' specified for entity type '{entityType}' is invalid. The expression must accept a single parameter of type '{clrType}', return bool, and may not contain references to navigation properties.</value>
+  </data>
+  <data name="BadFilterDerivedType" xml:space="preserve">
+    <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.</value>
   </data>
 </root>

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -59,7 +59,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly IResultOperatorHandler _resultOperatorHandler;
         private readonly IEntityMaterializerSource _entityMaterializerSource;
         private readonly IExpressionPrinter _expressionPrinter;
+
         private readonly QueryCompilationContext _queryCompilationContext;
+
+        private readonly FilterApplyingExpressionVisitor _filterApplyingExpressionVisitor;
 
         private Expression _expression;
         private ParameterExpression _currentParameter;
@@ -97,6 +100,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             _queryCompilationContext = queryCompilationContext;
 
             LinqOperatorProvider = queryCompilationContext.LinqOperatorProvider;
+
+            _filterApplyingExpressionVisitor = new FilterApplyingExpressionVisitor(_queryCompilationContext);
         }
 
         /// <summary>
@@ -167,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SingleResultToSequence(queryModel);
 
                 TrackEntitiesInResults<TResult>(queryModel);
-
+                
                 InterceptExceptions();
 
                 return CreateExecutorLambda<IEnumerable<TResult>>();
@@ -271,6 +276,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             includeCompiler.RewriteCollectionQueries(queryModel);
 
             includeCompiler.LogIgnoredIncludes();
+
+            if (!_queryCompilationContext.IgnoreQueryFilters)
+            {
+                queryModel.TransformExpressions(_filterApplyingExpressionVisitor.Visit);
+            }
 
             // Second pass of optimizations
 
@@ -488,10 +498,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// >
         protected virtual Func<QueryContext, TResults> CreateExecutorLambda<TResults>()
         {
+            var expression = _expression;
+
+            var setFilterParameterExpressions 
+                = CreateSetFilterParametersExpressions(out var contextVariableExpression);
+
+            if (setFilterParameterExpressions != null)
+            {
+                expression
+                    = Expression.Block(
+                        new [] { contextVariableExpression },
+                        setFilterParameterExpressions.Concat(new[] { expression }));
+            }
+
             var queryExecutorExpression
                 = Expression
                     .Lambda<Func<QueryContext, TResults>>(
-                        _expression, QueryContextParameter);
+                        expression, 
+                        QueryContextParameter);
 
             try
             {
@@ -501,6 +525,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 QueryCompilationContext.Logger.QueryExecutionPlanned(_expressionPrinter, queryExecutorExpression);
             }
+        }
+
+        private static readonly MethodInfo _queryContextAddParameterMethodInfo
+            = typeof(QueryContext)
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(QueryContext.AddParameter));
+
+        private static readonly PropertyInfo _queryContextContextPropertyInfo
+            = typeof(QueryContext)
+                .GetTypeInfo()
+                .GetDeclaredProperty(nameof(QueryContext.Context));
+
+        private IEnumerable<Expression> CreateSetFilterParametersExpressions(
+            out ParameterExpression contextVariableExpression)
+        {
+            contextVariableExpression = null;
+
+            if (_filterApplyingExpressionVisitor.ContextParameters.Count == 0)
+            {
+                return null;
+            }
+
+            contextVariableExpression
+                = Expression.Variable(_queryCompilationContext.ContextType, "context");
+
+            var blockExpressions
+                = new List<Expression>
+                {
+                    Expression.Assign(
+                        contextVariableExpression,
+                        Expression.Convert(
+                            Expression.Property(
+                                QueryContextParameter,
+                                _queryContextContextPropertyInfo),
+                            _queryCompilationContext.ContextType))
+                };
+
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var keyValuePair in _filterApplyingExpressionVisitor.ContextParameters)
+            {
+                blockExpressions.Add(
+                    Expression.Call(
+                        QueryContextParameter,
+                        _queryContextAddParameterMethodInfo,
+                        Expression.Constant(keyValuePair.Key),
+                        Expression.Invoke(
+                            (LambdaExpression)keyValuePair.Value,
+                            contextVariableExpression)));
+            }
+
+            return blockExpressions;
         }
 
         /// <summary>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/FilterApplyingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/FilterApplyingExpressionVisitor.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class FilterApplyingExpressionVisitor : RelinqExpressionVisitor
+    {
+        private readonly QueryCompilationContext _queryCompilationContext;
+        private readonly Parameters _parameters = new Parameters();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, object> ContextParameters => _parameters.ParameterValues;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public FilterApplyingExpressionVisitor([NotNull] QueryCompilationContext queryCompilationContext)
+            => _queryCompilationContext = queryCompilationContext;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitConstant(ConstantExpression constantExpression)
+        {
+            if (constantExpression.IsEntityQueryable())
+            {
+                var type = ((IQueryable)constantExpression.Value).ElementType;
+                var entityType = _queryCompilationContext.Model.FindEntityType(type)?.RootType();
+
+                if (entityType?.Filter != null)
+                {
+                    var visitor
+                        = new ParameterExtractingExpressionVisitor(
+                            new EvaluatableExpressionFilter(),
+                            _parameters,
+                            _queryCompilationContext.Logger,
+                            parameterize: false,
+                            generateContextAccessors: true);
+
+                    var parameterizedFilter
+                        = (LambdaExpression)visitor.ExtractParameters(entityType.Filter);
+
+                    var mainFromClause
+                        = new MainFromClause(
+                            type.Name.Substring(0, 1).ToLowerInvariant(),
+                            type,
+                            constantExpression);
+
+                    var querySourceReferenceExpression = new QuerySourceReferenceExpression(mainFromClause);
+                    var selectClause = new SelectClause(querySourceReferenceExpression);
+                    var subQueryModel = new QueryModel(mainFromClause, selectClause);
+
+                    var predicate
+                        = ReplacingExpressionVisitor
+                            .Replace(
+                                parameterizedFilter.Parameters.Single(),
+                                querySourceReferenceExpression,
+                                parameterizedFilter.Body);
+
+                    subQueryModel.BodyClauses.Add(new WhereClause(predicate));
+
+                    return new SubQueryExpression(subQueryModel);
+                }
+            }
+
+            return constantExpression;
+        }
+
+        private sealed class Parameters : IParameterValues
+        {
+            private readonly IDictionary<string, object> _parameterValues = new Dictionary<string, object>();
+
+            public IReadOnlyDictionary<string, object> ParameterValues
+                => (IReadOnlyDictionary<string, object>)_parameterValues;
+
+            public void AddParameter(string name, object value)
+            {
+                _parameterValues.Add(name, value);
+            }
+
+            public object RemoveParameter(string name)
+            {
+                var value = _parameterValues[name];
+
+                _parameterValues.Remove(name);
+
+                return value;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+        {
+            subQueryExpression.QueryModel.TransformExpressions(Visit);
+
+            return subQueryExpression;
+        }
+    }
+}

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -21,31 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     {
         private static readonly TypeInfo _queryableTypeInfo = typeof(IQueryable).GetTypeInfo();
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static Expression ExtractParameters(
-            [NotNull] Expression expression,
-            [NotNull] QueryContext queryContext,
-            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger,
-            bool parameterize)
-        {
-            var visitor 
-                = new ParameterExtractingExpressionVisitor(
-                    evaluatableExpressionFilter, 
-                    queryContext, 
-                    logger,
-                    parameterize);
-
-            return visitor.ExtractParameters(expression);
-        }
-
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
-        private readonly QueryContext _queryContext;
+        private readonly IParameterValues _parameterValues;
         private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+
         private readonly bool _parameterize;
+        private readonly bool _generateContextAccessors;
 
         private PartialEvaluationInfo _partialEvaluationInfo;
 
@@ -57,14 +38,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         public ParameterExtractingExpressionVisitor(
             [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
-            [NotNull] QueryContext queryContext,
+            [NotNull] IParameterValues parameterValues,
             [NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger,
-            bool parameterize)
+            bool parameterize,
+            bool generateContextAccessors = false)
         {
             _evaluatableExpressionFilter = evaluatableExpressionFilter;
-            _queryContext = queryContext;
+            _parameterValues = parameterValues;
             _logger = logger;
             _parameterize = parameterize;
+            _generateContextAccessors = generateContextAccessors;
         }
 
         /// <summary>
@@ -101,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (declaringType == typeof(Queryable)
                 || declaringType == typeof(EntityFrameworkQueryableExtensions)
                 && (!methodInfo.IsGenericMethod
-                    || !methodInfo.GetGenericMethodDefinition() 
+                    || !methodInfo.GetGenericMethodDefinition()
                         .Equals(EntityFrameworkQueryableExtensions.StringIncludeMethodInfo)))
             {
                 return base.VisitMethodCall(methodCallExpression);
@@ -112,8 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (returnTypeInfo.IsGenericType
                 && returnTypeInfo.GetGenericTypeDefinition() == typeof(DbSet<>))
             {
-                string _;
-                var queryable = (IQueryable)Evaluate(methodCallExpression, out _);
+                var queryable = (IQueryable)Evaluate(methodCallExpression, out var _);
 
                 return ExtractParameters(queryable.Expression);
             }
@@ -153,11 +135,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     if (parameterInfos[i].GetCustomAttribute<NotParameterizedAttribute>() != null)
                     {
-                        var parameter = newArgument.RemoveConvert() as ParameterExpression;
-
-                        if (parameter != null)
+                        if (newArgument.RemoveConvert() is ParameterExpression parameter)
                         {
-                            newArgument = Expression.Constant(_queryContext.RemoveParameter(parameter.Name));
+                            newArgument = Expression.Constant(_parameterValues.RemoveParameter(parameter.Name));
                         }
                     }
 
@@ -193,8 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 return TryExtractParameter(memberExpression);
             }
 
-            string _;
-            var queryable = (IQueryable)Evaluate(memberExpression, out _);
+            var queryable = (IQueryable)Evaluate(memberExpression, out var _);
 
             return ExtractParameters(queryable.Expression);
         }
@@ -205,9 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitConstant(ConstantExpression constantExpression)
         {
-            var detachableContext = constantExpression.Value as IDetachableContext;
-
-            if (detachableContext != null)
+            if (constantExpression.Value is IDetachableContext detachableContext)
             {
                 return Expression.Constant(detachableContext.DetachContext());
             }
@@ -290,8 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var newLeftExpression = TryOptimize(binaryExpression.Left) ?? Visit(binaryExpression.Left);
 
-            var leftConstantExpression = newLeftExpression as ConstantExpression;
-            if (leftConstantExpression != null)
+            if (newLeftExpression is ConstantExpression leftConstantExpression)
             {
                 var constantValue = (bool)leftConstantExpression.Value;
                 if (constantValue && binaryExpression.NodeType == ExpressionType.OrElse
@@ -303,8 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var newRightExpression = TryOptimize(binaryExpression.Right) ?? Visit(binaryExpression.Right);
 
-            var rightConstantExpression = newRightExpression as ConstantExpression;
-            if (rightConstantExpression != null)
+            if (newRightExpression is ConstantExpression rightConstantExpression)
             {
                 var constantValue = (bool)rightConstantExpression.Value;
                 if (constantValue && binaryExpression.NodeType == ExpressionType.OrElse
@@ -322,8 +297,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (_partialEvaluationInfo.IsEvaluatableExpression(expression)
                 && !_queryableTypeInfo.IsAssignableFrom(expression.Type.GetTypeInfo()))
             {
-                string _;
-                var value = Evaluate(expression, out _);
+                var value = Evaluate(expression, out var _);
+
                 if (value is bool)
                 {
                     return Expression.Constant(value, typeof(bool));
@@ -335,20 +310,33 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private Expression TryExtractParameter(Expression expression)
         {
-            string parameterName;
+            var parameterValue = Evaluate(expression, out var parameterName);
 
-            var parameterValue = Evaluate(expression, out parameterName);
-
-            var parameterExpression = parameterValue as Expression;
-
-            if (parameterExpression != null)
+            if (parameterValue is Expression parameterExpression)
             {
                 return parameterExpression;
             }
 
             if (!_parameterize)
             {
-                return Expression.Constant(parameterValue);
+                if (_generateContextAccessors
+                    && expression is MemberExpression memberExpression
+                    && memberExpression.Expression != null
+                    && typeof(DbContext).GetTypeInfo()
+                        .IsAssignableFrom(memberExpression.Expression.Type.GetTypeInfo()))
+                {
+                    var contextParameterExpression
+                        = Expression.Parameter(memberExpression.Expression.Type, "context");
+
+                    parameterValue
+                        = Expression.Lambda(
+                            memberExpression.Update(contextParameterExpression),
+                            contextParameterExpression);
+                }
+                else
+                {
+                    return Expression.Constant(parameterValue);
+                }
             }
 
             if (parameterName == null)
@@ -368,9 +356,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 = CompiledQueryCache.CompiledQueryParameterPrefix
                   + parameterName
                   + "_"
-                  + _queryContext.ParameterValues.Count;
+                  + _parameterValues.ParameterValues.Count;
 
-            _queryContext.AddParameter(parameterName, parameterValue);
+            _parameterValues.AddParameter(parameterName, parameterValue);
 
             return Expression.Parameter(expression.Type, parameterName);
         }
@@ -396,9 +384,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     var memberExpression = (MemberExpression)expression;
                     var @object = Evaluate(memberExpression.Expression, out parameterName);
 
-                    var fieldInfo = memberExpression.Member as FieldInfo;
-
-                    if (fieldInfo != null)
+                    if (memberExpression.Member is FieldInfo fieldInfo)
                     {
                         parameterName = parameterName != null
                             ? parameterName + "_" + fieldInfo.Name
@@ -414,9 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         }
                     }
 
-                    var propertyInfo = memberExpression.Member as PropertyInfo;
-
-                    if (propertyInfo != null)
+                    if (memberExpression.Member is PropertyInfo propertyInfo)
                     {
                         parameterName = parameterName != null
                             ? parameterName + "_" + propertyInfo.Name

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (!_parametersInScope.ContainsKey(variable))
                 {
-                    _parametersInScope.Add(variable, "var" + _parametersInScope.Count);
+                    _parametersInScope.Add(variable, variable.Name);
                 }
             }
 

--- a/src/EFCore/Query/Internal/IParameterValues.cs
+++ b/src/EFCore/Query/Internal/IParameterValues.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IParameterValues
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ParameterValues { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void AddParameter([NotNull] string name, [CanBeNull] object value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        object RemoveParameter([NotNull] string name);
+    }
+}

--- a/src/EFCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/LinqOperatorProvider.cs
@@ -58,10 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             private readonly IEnumerable<TResult> _results;
 
-            public OrderedEnumerableAdapter(IEnumerable<TResult> results)
-            {
-                _results = results;
-            }
+            public OrderedEnumerableAdapter(IEnumerable<TResult> results) => _results = results;
 
             public IOrderedEnumerable<TResult> CreateOrderedEnumerable<TKey>(
                 Func<TResult, TKey> keySelector, IComparer<TKey> comparer, bool descending) => !descending

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 using Remotion.Linq.Clauses.StreamedData;
 using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
@@ -30,8 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     public class QueryCompiler : IQueryCompiler
     {
         private static MethodInfo CompileQueryMethod { get; }
-        = typeof(IDatabase).GetTypeInfo()
-            .GetDeclaredMethod(nameof(IDatabase.CompileQuery));
+            = typeof(IDatabase).GetTypeInfo()
+                .GetDeclaredMethod(nameof(IDatabase.CompileQuery));
 
         private static readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter
             = new EvaluatableExpressionFilter();
@@ -42,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly IDatabase _database;
         private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
         private readonly INodeTypeProviderFactory _nodeTypeProviderFactory;
+
         private readonly Type _contextType;
 
         private INodeTypeProvider _nodeTypeProvider;
@@ -65,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(database, nameof(database));
             Check.NotNull(logger, nameof(logger));
             Check.NotNull(currentContext, nameof(currentContext));
-
+            
             _queryContextFactory = queryContextFactory;
             _compiledQueryCache = compiledQueryCache;
             _compiledQueryCacheKeyGenerator = compiledQueryCacheKeyGenerator;
@@ -95,7 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var compiledQuery
                 = _compiledQueryCache
-                    .GetOrAddQuery(_compiledQueryCacheKeyGenerator.GenerateCacheKey(query, async: false),
+                    .GetOrAddQuery(
+                        _compiledQueryCacheKeyGenerator.GenerateCacheKey(query, async: false),
                         () => CompileQueryCore<TResult>(query, NodeTypeProvider, _database, _logger, _contextType));
 
             return compiledQuery(queryContext);
@@ -259,12 +262,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(query, nameof(query));
 
             return _compiledQueryCache
-                .GetOrAddAsyncQuery(_compiledQueryCacheKeyGenerator.GenerateCacheKey(query, async: true),
+                .GetOrAddAsyncQuery(
+                    _compiledQueryCacheKeyGenerator.GenerateCacheKey(query, async: true),
                     () => CompileAsyncQueryCore<TResult>(query, NodeTypeProvider, _database));
         }
 
         private static Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQueryCore<TResult>(
-            Expression query, INodeTypeProvider nodeTypeProvider, IDatabase database)
+            Expression query,
+            INodeTypeProvider nodeTypeProvider,
+            IDatabase database)
         {
             var queryModel
                 = CreateQueryParser(nodeTypeProvider)
@@ -285,24 +291,26 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(query, nameof(query));
             Check.NotNull(queryContext, nameof(queryContext));
 
-            return ParameterExtractingExpressionVisitor
-                .ExtractParameters(
-                    query,
-                    queryContext,
+            var visitor
+                = new ParameterExtractingExpressionVisitor(
                     _evaluatableExpressionFilter,
+                    queryContext,
                     _logger,
                     parameterize);
+
+            return visitor.ExtractParameters(query);
         }
 
         private static QueryParser CreateQueryParser(INodeTypeProvider nodeTypeProvider)
             => new QueryParser(
                 new ExpressionTreeParser(
                     nodeTypeProvider,
-                    new CompoundExpressionTreeProcessor(new IExpressionTreeProcessor[]
-                    {
-                        new PartialEvaluatingExpressionTreeProcessor(_evaluatableExpressionFilter),
-                        new TransformingExpressionTreeProcessor(ExpressionTransformerRegistry.CreateDefault())
-                    })));
+                    new CompoundExpressionTreeProcessor(
+                        new IExpressionTreeProcessor[]
+                        {
+                            new PartialEvaluatingExpressionTreeProcessor(_evaluatableExpressionFilter),
+                            new TransformingExpressionTreeProcessor(ExpressionTransformerRegistry.CreateDefault())
+                        })));
 
         private INodeTypeProvider NodeTypeProvider
             => _nodeTypeProvider

--- a/src/EFCore/Query/MethodInfoBasedNodeTypeRegistryFactory.cs
+++ b/src/EFCore/Query/MethodInfoBasedNodeTypeRegistryFactory.cs
@@ -56,6 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Register(TrackingExpressionNode.SupportedMethods, typeof(TrackingExpressionNode));
 
             _methodInfoBasedNodeTypeRegistry
+                .Register(IgnoreQueryFiltersExpressionNode.SupportedMethods, typeof(IgnoreQueryFiltersExpressionNode));
+
+            _methodInfoBasedNodeTypeRegistry
                 .Register(IncludeExpressionNode.SupportedMethods, typeof(IncludeExpressionNode));
 
             _methodInfoBasedNodeTypeRegistry

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -241,6 +241,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        ///     Gets a value indicating whether this query should have model-level query filters applied.
+        /// </summary>
+        /// <value>
+        ///     true if query filters should be applied, false if not.
+        /// </value>
+        public virtual bool IgnoreQueryFilters
+            => QueryAnnotations
+                .OfType<IgnoreQueryFiltersResultOperator>()
+                .Any();
+
+        /// <summary>
         ///     The query has at least one Include operation.
         /// </summary>
         public virtual bool IsIncludeQuery => QueryAnnotations.OfType<IncludeResultOperator>().Any();

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -18,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     /// <summary>
     ///     The principal data structure used by a compiled query during execution.
     /// </summary>
-    public class QueryContext : IDisposable
+    public class QueryContext : IDisposable, IParameterValues
     {
         private readonly Func<IQueryBuffer> _queryBufferFactory;
 
@@ -40,6 +39,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             _queryBufferFactory = queryBufferFactory;
             Dependencies = dependencies;
         }
+
+        /// <summary>
+        ///     Gets the current DbContext.
+        /// </summary>
+        public virtual DbContext Context => Dependencies.CurrentDbContext.Context;
 
         /// <summary>
         ///     Parameter object containing dependencies for this service.
@@ -95,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="name"> The name. </param>
         /// <param name="value"> The value. </param>
-        public virtual void AddParameter([NotNull] string name, [CanBeNull] object value)
+        public virtual void AddParameter(string name, object value)
         {
             Check.NotEmpty(name, nameof(name));
 
@@ -109,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <returns>
         ///     The parameter value.
         /// </returns>
-        public virtual object RemoveParameter([NotNull] string name)
+        public virtual object RemoveParameter(string name)
         {
             Check.NotEmpty(name, nameof(name));
 

--- a/src/EFCore/Query/ResultOperators/Internal/IgnoreQueryFiltersExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IgnoreQueryFiltersExpressionNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class TrackingExpressionNode : ResultOperatorExpressionNodeBase
+    public class IgnoreQueryFiltersExpressionNode : ResultOperatorExpressionNodeBase
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -21,15 +21,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
-            EntityFrameworkQueryableExtensions.AsNoTrackingMethodInfo,
-            EntityFrameworkQueryableExtensions.AsTrackingMethodInfo
+            EntityFrameworkQueryableExtensions.IgnoreQueryFiltersMethodInfo
         };
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public TrackingExpressionNode(MethodCallExpressionParseInfo parseInfo)
+        public IgnoreQueryFiltersExpressionNode(MethodCallExpressionParseInfo parseInfo)
             : base(parseInfo, null, null)
         {
         }
@@ -39,9 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
-            => new TrackingResultOperator(
-                tracking: ParsedExpression.Method.GetGenericMethodDefinition()
-                    .Equals(EntityFrameworkQueryableExtensions.AsTrackingMethodInfo));
+            => new IgnoreQueryFiltersResultOperator();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/ResultOperators/Internal/IgnoreQueryFiltersResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IgnoreQueryFiltersResultOperator.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System;
 using System.Linq.Expressions;
-using System.Reflection;
+using JetBrains.Annotations;
+using Remotion.Linq;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Parsing.Structure.IntermediateModel;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
 
 namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
 {
@@ -13,24 +15,38 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class TrackingExpressionNode : ResultOperatorExpressionNodeBase
+    public class IgnoreQueryFiltersResultOperator : SequenceTypePreservingResultOperatorBase, IQueryAnnotation
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
-        {
-            EntityFrameworkQueryableExtensions.AsNoTrackingMethodInfo,
-            EntityFrameworkQueryableExtensions.AsTrackingMethodInfo
-        };
+        public virtual IQuerySource QuerySource { get; [NotNull] set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public TrackingExpressionNode(MethodCallExpressionParseInfo parseInfo)
-            : base(parseInfo, null, null)
+        public virtual QueryModel QueryModel { get; [NotNull] set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string ToString() => "IgnoreQueryFilters()";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ResultOperatorBase Clone([NotNull] CloneContext cloneContext)
+            => new IgnoreQueryFiltersResultOperator();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void TransformExpressions([NotNull] Func<Expression, Expression> transformation)
         {
         }
 
@@ -38,19 +54,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
-            => new TrackingResultOperator(
-                tracking: ParsedExpression.Method.GetGenericMethodDefinition()
-                    .Equals(EntityFrameworkQueryableExtensions.AsTrackingMethodInfo));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Expression Resolve(
-            ParameterExpression inputParameter,
-            Expression expressionToBeResolved,
-            ClauseGenerationContext clauseGenerationContext)
-            => Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        public override StreamedSequence ExecuteInMemory<T>([NotNull] StreamedSequence input) => input;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/FiltersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/FiltersInMemoryTest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class FiltersInMemoryTest : FiltersTestBase<NorthwindQueryInMemoryFixture>
+    {
+        public FiltersInMemoryTest(NorthwindQueryInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/FiltersInheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/FiltersInheritanceInMemoryTest.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class FiltersInheritanceInMemoryTest : FiltersInheritanceTestBase<InheritanceInMemoryFixture>
+    {
+        public FiltersInheritanceInMemoryTest(InheritanceInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/InheritanceInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InheritanceInMemoryFixture.cs
@@ -2,33 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
     public class InheritanceInMemoryFixture : InheritanceFixtureBase
     {
-        private readonly DbContextOptionsBuilder _optionsBuilder = new DbContextOptionsBuilder();
-
-        public InheritanceInMemoryFixture()
+        public override DbContextOptions BuildOptions()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
-
-            _optionsBuilder
-                .UseInMemoryDatabase(nameof(InheritanceInMemoryFixture))
-                .UseInternalServiceProvider(serviceProvider);
-
-            using (var context = CreateContext())
-            {
-                SeedData(context);
-            }
+            return
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(InheritanceInMemoryFixture))
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkInMemoryDatabase()
+                            .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                            .BuildServiceProvider())
+                    .Options;
         }
-
-        public override InheritanceContext CreateContext()
-            => new InheritanceContext(_optionsBuilder.Options);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
@@ -10,32 +10,36 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
 {
     public class NorthwindQueryInMemoryFixture : NorthwindQueryFixtureBase
     {
-        private readonly DbContextOptions _options;
-
         private readonly TestLoggerFactory _testLoggerFactory = new TestLoggerFactory();
 
-        public NorthwindQueryInMemoryFixture()
+        public override NorthwindContext CreateContext(
+            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll,
+            bool enableFilters = false)
         {
-            _options = BuildOptions();
-
-            using (var context = CreateContext())
+            if (!IsSeeded)
             {
-                NorthwindData.Seed(context);
+                using (var context = base.CreateContext(queryTrackingBehavior, enableFilters))
+                {
+                    NorthwindData.Seed(context);
+                }
+
+                IsSeeded = true;
             }
+
+            return base.CreateContext(queryTrackingBehavior, enableFilters);
         }
+
+        private bool IsSeeded { get; set; }
 
         public override DbContextOptions BuildOptions(IServiceCollection serviceCollection = null)
             => new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(nameof(NorthwindQueryInMemoryFixture))
                 .UseInternalServiceProvider(
                     (serviceCollection ?? new ServiceCollection())
-                        .AddEntityFrameworkInMemoryDatabase()
-                        .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                        .AddSingleton<ILoggerFactory>(_testLoggerFactory)
-                        .BuildServiceProvider()).Options;
-
-        public override NorthwindContext CreateContext(
-            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-            => new NorthwindContext(_options, queryTrackingBehavior);
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                    .AddSingleton<ILoggerFactory>(_testLoggerFactory)
+                    .BuildServiceProvider())
+                .Options;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/FiltersInheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FiltersInheritanceSqlServerTest.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class FiltersInheritanceSqlServerTest : FiltersInheritanceTestBase<InheritanceSqlServerFixture>
+    {
+        public FiltersInheritanceSqlServerTest(InheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void Can_use_of_type_animal()
+        {
+            base.Can_use_of_type_animal();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+ORDER BY [a].[Species]");
+        }
+
+        public override void Can_use_is_kiwi()
+        {
+            base.Can_use_is_kiwi();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[Discriminator] = N'Kiwi')");
+        }
+
+        public override void Can_use_is_kiwi_with_other_predicate()
+        {
+            base.Can_use_is_kiwi_with_other_predicate();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND (([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1))");
+        }
+
+        public override void Can_use_is_kiwi_in_projection()
+        {
+            base.Can_use_is_kiwi_in_projection();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [a].[Discriminator] = N'Kiwi'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
+        }
+
+        public override void Can_use_of_type_bird()
+        {
+            base.Can_use_of_type_bird();
+
+            AssertSql(
+                @"SELECT [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
+FROM [Animal] AS [b]
+WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)
+ORDER BY [b].[Species]");
+        }
+
+        public override void Can_use_of_type_bird_predicate()
+        {
+            base.Can_use_of_type_bird_predicate();
+
+            AssertSql(
+                @"SELECT [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
+FROM [Animal] AS [b]
+WHERE ([b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)) AND ([b].[CountryId] = 1)
+ORDER BY [b].[Species]");
+        }
+
+        public override void Can_use_of_type_bird_with_projection()
+        {
+            base.Can_use_of_type_bird_with_projection();
+
+            AssertSql(
+                @"SELECT [b].[EagleId]
+FROM [Animal] AS [b]
+WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)");
+        }
+
+        public override void Can_use_of_type_bird_first()
+        {
+            base.Can_use_of_type_bird_first();
+
+            AssertSql(
+                @"SELECT TOP(1) [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
+FROM [Animal] AS [b]
+WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)
+ORDER BY [b].[Species]");
+        }
+
+        public override void Can_use_of_type_kiwi()
+        {
+            base.Can_use_of_type_kiwi();
+
+            AssertSql(
+                @"SELECT [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
+FROM [Animal] AS [k]
+WHERE ([k].[Discriminator] = N'Kiwi') AND ([k].[CountryId] = 1)");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Specification.Tests;
+using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class FiltersSqlServerTest : FiltersTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public FiltersSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void Count_query()
+        {
+            base.Count_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT COUNT(*)
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Client_eval()
+        {
+            base.Client_eval();
+
+            AssertSql(
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]");
+        }
+
+        public override void Materialized_query()
+        {
+            base.Materialized_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Find()
+        {
+            base.Find();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+@__get_Item_0: ALFKI (Size = 450)
+
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__get_Item_0)");
+        }
+
+        public override void Materialized_query_parameter()
+        {
+            base.Materialized_query_parameter();
+
+            AssertSql(
+                @"@__TenantPrefix_0: F (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Materialized_query_parameter_new_context()
+        {
+            base.Materialized_query_parameter_new_context();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')",
+                //
+                @"@__TenantPrefix_0: T (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Projection_query_parameter()
+        {
+            base.Projection_query_parameter();
+
+            AssertSql(
+                @"@__TenantPrefix_0: F (Size = 4000)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Projection_query()
+        {
+            base.Projection_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Include_query()
+        {
+            base.Include_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')
+ORDER BY [c].[CustomerID]",
+                //
+                @"@__TenantPrefix_1: B (Size = 4000)
+
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE ([c0].[CompanyName] LIKE @__TenantPrefix_1 + N'%' AND (LEFT([c0].[CompanyName], LEN(@__TenantPrefix_1)) = @__TenantPrefix_1)) OR (@__TenantPrefix_1 = N'')
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
+        }
+
+        public override void Include_query_opt_out()
+        {
+            base.Include_query_opt_out();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
+        }
+
+        public override void Included_many_to_one_query()
+        {
+            base.Included_many_to_one_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')
+) AS [t] ON [o].[CustomerID] = [t].[CustomerID]");
+        }
+
+        public override void Included_one_to_many_query_with_client_eval()
+        {
+            base.Included_one_to_many_query_with_client_eval();
+
+            AssertContains(
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
+FROM [Products] AS [p]
+ORDER BY [p].[ProductID]",
+                //
+                @"SELECT [p1].[ProductID], [p1].[Discontinued], [p1].[ProductName], [p1].[UnitPrice], [p1].[UnitsInStock]
+FROM [Products] AS [p1]",
+                //
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[Quantity] > 50");
+        }
+
+        public override void Navs_query()
+        {
+            base.Navs_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [c.Orders] ON [c].[CustomerID] = [c.Orders].[CustomerID]
+INNER JOIN (
+    SELECT [o].*
+    FROM [Order Details] AS [o]
+    WHERE [o].[Quantity] > 50
+) AS [t] ON [c.Orders].[OrderID] = [t].[OrderID]
+WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([t].[Discount] < 10E0)");
+        }
+
+        [ConditionalFact]
+        public void FromSql_is_composed()
+        {
+            using (var context = Fixture.CreateContext())
+            {
+                var results = context.Customers.FromSql("select * from Customers").ToList();
+
+                Assert.Equal(7, results.Count);
+            }
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    select * from Customers
+) AS [c]
+WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')");
+        }
+
+        public override void Compiled_query()
+        {
+            base.Compiled_query();
+
+            AssertSql(
+                @"@__TenantPrefix_0: B (Size = 4000)
+@__customerID: BERGS (Size = 450)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__customerID)",
+                //
+                @"@__TenantPrefix_0: B (Size = 4000)
+@__customerID: BLAUS (Size = 450)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__customerID)");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        private void AssertContains(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_projection();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_reprojection();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_composed();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_take();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             base.From_sql_queryable_stored_procedure_min();
 
             Assert.Equal(
-                @"[dbo].[Ten Most Expensive Products]",
+                "[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -142,7 +142,6 @@ FROM (
         }
 
         protected override string TenMostExpensiveProductsSproc => "[dbo].[Ten Most Expensive Products]";
-
         protected override string CustomerOrderHistorySproc => "[dbo].[CustOrderHist] @CustomerID = {0}";
 
         private const string FileLineEnding = @"

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -1,46 +1,37 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
-    public class InheritanceSqlServerFixture : InheritanceRelationalFixture, IDisposable
+    public class InheritanceSqlServerFixture : InheritanceRelationalFixture
     {
-        private readonly DbContextOptions _options;
-        private readonly SqlServerTestStore _testStore;
-
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
 
-        public InheritanceSqlServerFixture()
+        protected override void ClearLog()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFrameworkSqlServer()
-                .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
-
-            _testStore = SqlServerTestStore.Create("InheritanceSqlServerTest");
-
-            _options = new DbContextOptionsBuilder()
-                .EnableSensitiveDataLogging()
-                .UseSqlServer(_testStore.Connection, b => b.ApplyConfiguration())
-                .UseInternalServiceProvider(serviceProvider)
-                .Options;
-
-            using (var context = CreateContext())
-            {
-                context.Database.EnsureCreated();
-                SeedData(context);
-            }
+            TestSqlLoggerFactory.Clear();
         }
 
-        public override InheritanceContext CreateContext() => new InheritanceContext(_options);
-        public void Dispose() => _testStore.Dispose();
+        public override DbContextOptions BuildOptions()
+        {
+            return
+                new DbContextOptionsBuilder()
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(
+                        SqlServerTestStore.CreateConnectionString("InheritanceSqlServerTest"),
+                        b => b.ApplyConfiguration())
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkSqlServer()
+                            .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                            .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                            .BuildServiceProvider())
+                    .Options;
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +13,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
@@ -15,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
     public class NorthwindQuerySqlServerFixture : NorthwindQueryRelationalFixture, IDisposable
     {
         private readonly SqlServerTestStore _testStore = SqlServerTestStore.GetNorthwindStore();
-        
+
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
 
         public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
@@ -57,10 +56,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 .Property(p => p.UnitPrice)
                 .ForSqlServerHasColumnType("money");
         }
-
-        public override NorthwindContext CreateContext(
-            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-            => new NorthwindContext(BuildOptions(), queryTrackingBehavior);
 
         public void Dispose() => _testStore.Dispose();
     }

--- a/test/EFCore.SqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
@@ -12,44 +12,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class NorthwindSprocQuerySqlServerFixture : NorthwindSprocQueryRelationalFixture, IDisposable
     {
-        private readonly DbContextOptions _options;
         private readonly SqlServerTestStore _testStore;
 
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
 
-        public NorthwindSprocQuerySqlServerFixture()
-        {
-            _testStore = SqlServerTestStore.GetNorthwindStore();
-
-            _options = BuildOptions();
-        }
+        public NorthwindSprocQuerySqlServerFixture() => _testStore = SqlServerTestStore.GetNorthwindStore();
 
         public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
             => new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()
-                .UseInternalServiceProvider((additionalServices ?? new ServiceCollection())
+                .UseInternalServiceProvider(
+                    (additionalServices ?? new ServiceCollection())
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
                     .BuildServiceProvider())
-                .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration()).Options;
+                .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration())
+                .Options;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<OrderDetail>()
-                .Property(od => od.UnitPrice).ForSqlServerHasColumnType("money");
-        }
-
-        public override NorthwindContext CreateContext(
-            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-        {
-            var context = new NorthwindContext(_options, queryTrackingBehavior);
-
-            context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-
-            return context;
+                .Property(od => od.UnitPrice)
+                .ForSqlServerHasColumnType("money");
         }
 
         public void Dispose() => _testStore.Dispose();

--- a/test/EFCore.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Inheritance;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -10,28 +9,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
     public class InheritanceSqliteFixture : InheritanceRelationalFixture
     {
-        private readonly DbContextOptions _options;
-
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
 
-        public InheritanceSqliteFixture()
+        public override DbContextOptions BuildOptions()
         {
-            _options = new DbContextOptionsBuilder()
-                .UseSqlite(SqliteTestStore.CreateConnectionString("InheritanceSqlite"))
-                .UseInternalServiceProvider(new ServiceCollection()
-                    .AddEntityFrameworkSqlite()
-                    .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                    .BuildServiceProvider())
-                .Options;
-
-            using (var context = CreateContext())
-            {
-                context.Database.EnsureClean();
-                SeedData(context);
-            }
+            return
+                new DbContextOptionsBuilder()
+                    .UseSqlite(SqliteTestStore.CreateConnectionString("InheritanceSqliteTest"))
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkSqlite()
+                            .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                            .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                            .BuildServiceProvider())
+                    .Options;
         }
-
-        public override InheritanceContext CreateContext() => new InheritanceContext(_options);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -12,16 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
     public class NorthwindQuerySqliteFixture : NorthwindQueryRelationalFixture, IDisposable
     {
-        private readonly DbContextOptions _options;
-
         private readonly SqliteTestStore _testStore = SqliteTestStore.GetNorthwindStore();
 
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
-
-        public NorthwindQuerySqliteFixture()
-        {
-            _options = BuildOptions();
-        }
 
         public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
             => ConfigureOptions(
@@ -42,10 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
         protected virtual SqliteDbContextOptionsBuilder ConfigureOptions(SqliteDbContextOptionsBuilder sqliteDbContextOptionsBuilder)
             => sqliteDbContextOptionsBuilder;
-
-        public override NorthwindContext CreateContext(
-            QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-            => new NorthwindContext(_options, queryTrackingBehavior);
 
         public void Dispose() => _testStore.Dispose();
     }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.InMemory.FunctionalTests;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -50,6 +51,26 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
         private class D : C
         {
+        }
+
+        [Fact]
+        public void Invalid_filter_expressions_throws()
+        {
+            var model = new Model();
+
+            var entityTypeA = model.AddEntityType(typeof(A).Name);
+
+            Expression<Func<B, bool>> badExpression1 = b => false;
+
+            Assert.Equal(
+                CoreStrings.BadFilterExpression(badExpression1, entityTypeA.DisplayName(), entityTypeA.ClrType),
+                Assert.Throws<InvalidOperationException>(() => entityTypeA.Filter = badExpression1).Message);
+
+            Expression<Func<A, string>> badExpression2 = a => "";
+
+            Assert.Equal(
+                CoreStrings.BadFilterExpression(badExpression2, entityTypeA.DisplayName(), entityTypeA.ClrType),
+                Assert.Throws<InvalidOperationException>(() => entityTypeA.Filter = badExpression2).Message);
         }
 
         [Fact]


### PR DESCRIPTION
Core: Initial work on model-level entity type filters. E.g.
```c#
modelBuilder.Entity<Customer>().HasFilter(c => !c.IsDeleted);
modelBuilder.Entity<Order>().HasFilter(o => o.CustomerId == this._tenantId);
```
Such filters are automatically applied by the query compiler to any query targeting the corresponding EntityType.

Some key aspects of impl. so far:

- Client eval'd expressions are allowed.
- Nav references are not allowed. This is mostly to constrain the impl. cost.
- Evaluatable sub-trees in filter expressions are eval'd early (not parameterized) except for member accesses on DbContext objects. This permits the pattern in the second example above.
- Filters are only allowed on the root of hierarchies, again to constrain the impl. cost.

Open questions:

- Should Find ignore filters when hitting the store?
- We likely need to add an opt-out query operator.
- **Update:** What is required for owned types?
