### PR TITLE
[2.0.0-preview1] Fix to #7499 - Where() on derived property fails with undefined property on base class exception

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -106,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return methodCallExpression;
             }
 
-            if (EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+            if (methodCallExpression.Method.IsEFPropertyMethod())
             {
                 var newArg0 = Visit(methodCallExpression.Arguments[0]);
 

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1048,7 +1048,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     var discriminatorProperty
                         = _relationalAnnotationProvider.For(concreteEntityTypes[0]).DiscriminatorProperty;
 
-                    var discriminatorPropertyExpression = CreatePropertyExpression(typeBinaryExpression.Expression, discriminatorProperty);
+                    var discriminatorPropertyExpression
+                        = typeBinaryExpression.Expression.CreateEFPropertyExpression(discriminatorProperty);
 
                     var discriminatorPredicate
                         = concreteEntityTypes
@@ -1839,8 +1840,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     var querySourceReference = new QuerySourceReferenceExpression(querySource);
                     var propertyExpression = isMemberExpression
-                        ? Expression.Property(querySourceReference, property.PropertyInfo)
-                        : CreatePropertyExpression(querySourceReference, property);
+                        ? querySourceReference.CreateEFPropertyExpression(property.PropertyInfo)
+                        : querySourceReference.CreateEFPropertyExpression(property);
 
                     if (propertyExpression.Type.GetTypeInfo().IsValueType)
                     {

--- a/src/EFCore.Specification.Tests/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryFixtureBase.cs
@@ -46,6 +46,15 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                     b.HasOne(sm => sm.Mission).WithMany(m => m.ParticipatingSquads).HasForeignKey(sm => sm.MissionId);
                     b.HasOne(sm => sm.Squad).WithMany(s => s.Missions).HasForeignKey(sm => sm.SquadId);
                 });
+
+            modelBuilder.Entity<Faction>().HasKey(f => f.Id);
+            modelBuilder.Entity<LocustHorde>().HasBaseType<Faction>();
+            modelBuilder.Entity<LocustHorde>().HasMany(h => h.Leaders).WithOne();
+            modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction);
+
+            modelBuilder.Entity<LocustLeader>().HasKey(l => l.Name);
+            modelBuilder.Entity<LocustCommander>().HasBaseType<LocustLeader>();
+            modelBuilder.Entity<LocustCommander>().HasOne(c => c.DefeatedBy).WithOne().HasForeignKey<LocustCommander>(c => new { c.DefeatedByNickname, c.DefeatedBySquadId });
         }
     }
 }

--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -2832,6 +2832,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Where_query_composition2_FirstOrDefault()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es.Take(3)
+                    where e1.FirstName ==
+                          (from e2 in es.OrderBy(e => e.EmployeeID)
+                           select e2)
+                          .FirstOrDefault().FirstName
+                    select e1,
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_query_composition2_FirstOrDefault_with_anonymous()
+        {
+            AssertQuery<Employee>(
+                es =>
+                    from e1 in es.Take(3)
+                    where e1.FirstName ==
+                          (from e2 in es.OrderBy(e => e.EmployeeID)
+                           select new { Foo = e2 })
+                          .FirstOrDefault().Foo.FirstName
+                    select e1,
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
         public virtual void Where_query_composition3()
         {
             AssertQuery<Customer>(

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Faction.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Faction.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWarModel
+{
+    public abstract class Faction
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public string CapitalName { get; set; }
+        public City Capital { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -19,5 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWa
         public DbSet<City> Cities { get; set; }
         public DbSet<Mission> Missions { get; set; }
         public DbSet<SquadMission> SquadMissions { get; set; }
+        public DbSet<Faction> Factions { get; set; }
+        public DbSet<LocustLeader> LocustLeaders { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -290,6 +290,36 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWa
             context.Gears.Add(paduk);
 
             context.SaveChanges();
+
+            var karn = new LocustLeader { Name = "General Karn", ThreatLevel = 3 };
+            var raam = new LocustLeader { Name = "General RAAM", ThreatLevel = 4 };
+            var skorge = new LocustLeader { Name = "High Priest Skorge", ThreatLevel = 1 };
+            var myrrah = new LocustCommander { Name = "Queen Myrrah", ThreatLevel = 5, DefeatedBy = marcus };
+            var theSpeaker = new LocustLeader { Name = "The Speaker", ThreatLevel = 3 };
+            var swarmCommander = new LocustCommander { Name = "Unknown", ThreatLevel = 0 };
+
+            context.LocustLeaders.AddRange(karn, raam, skorge, myrrah, theSpeaker, swarmCommander);
+            context.SaveChanges();
+
+            var locust = new LocustHorde
+            {
+                Name = "Locust",
+                Eradicated = true,
+                Commander = myrrah,
+                Leaders = new List<LocustLeader> { karn, raam, skorge, myrrah }
+
+            };
+
+            var swarm = new LocustHorde
+            {
+                Name = "Swarm",
+                Eradicated = false,
+                Commander = swarmCommander,
+                Leaders = new List<LocustLeader> { theSpeaker },
+            };
+
+            context.Factions.AddRange(locust, swarm);
+            context.SaveChanges();
         }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWarModel
+{
+    public class LocustCommander : LocustLeader
+    {
+        public LocustHorde CommandingFaction { get; set; }
+
+        public string DefeatedByNickname { get; set; }
+        public int? DefeatedBySquadId { get; set; }
+        public Gear DefeatedBy { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHorde.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHorde.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWarModel
+{
+    public class LocustHorde : Faction
+    {
+        public LocustCommander Commander { get; set; }
+        public List<LocustLeader> Leaders { get; set; }
+
+        public string CommanderName { get; set; }
+        public bool? Eradicated { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustLeader.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustLeader.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.GearsOfWarModel
+{
+    public class LocustLeader
+    {
+        public string Name { get; set; }
+        public short ThreatLevel { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
@@ -171,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Northwind
             private class ShadowStateAccessRewriter : ExpressionVisitorBase
             {
                 protected override Expression VisitMethodCall(MethodCallExpression expression)
-                    => EntityQueryModelVisitor.IsPropertyMethod(expression.Method)
+                    => expression.Method.IsEFPropertyMethod()
                         ? Expression.Property(
                             expression.Arguments[0].RemoveConvert(),
                             Expression.Lambda<Func<string>>(expression.Arguments[1]).Compile().Invoke())

--- a/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
+++ b/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Extensions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    [DebuggerStepThrough]
+
+    public static class EFPropertyExtensions
+    {
+        private static readonly string _efTypeName = typeof(EF).FullName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool IsEFProperty([NotNull] this MethodCallExpression methodCallExpression)
+            => IsEFPropertyMethod(methodCallExpression.Method);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool IsEFPropertyMethod([CanBeNull] this MethodInfo methodInfo)
+            => Equals(methodInfo, EF.PropertyMethod)
+               // fallback to string comparison because MethodInfo.Equals is not
+               // always true in .NET Native even if methods are the same
+               || methodInfo != null
+               && methodInfo.IsGenericMethod
+               && methodInfo.Name == nameof(EF.Property)
+               && methodInfo.DeclaringType?.FullName == _efTypeName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static Expression CreateEFPropertyExpression(
+            [NotNull] this Expression target,
+            [NotNull] IPropertyBase property,
+            bool makeNullable = true)
+            => CreateEFPropertyExpression(target, property.DeclaringType.ClrType, property.ClrType, property.Name, makeNullable);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static Expression CreateEFPropertyExpression(
+            [NotNull] this Expression target,
+            [NotNull] PropertyInfo propertyInfo)
+            => CreateEFPropertyExpression(target, propertyInfo.DeclaringType, propertyInfo.PropertyType, propertyInfo.Name, makeNullable: false);
+
+        private static Expression CreateEFPropertyExpression(
+            Expression target,
+            Type propertyDeclaringType,
+            Type propertyType,
+            string propertyName,
+            bool makeNullable)
+        {
+            if (propertyDeclaringType != target.Type
+                && target.Type.GetTypeInfo().IsAssignableFrom(propertyDeclaringType.GetTypeInfo()))
+            {
+                target = Expression.Convert(target, propertyDeclaringType);
+            }
+
+            if (makeNullable)
+            {
+                propertyType = propertyType.MakeNullable();
+            }
+
+            return Expression.Call(
+                EF.PropertyMethod.MakeGenericMethod(propertyType),
+                target,
+                Expression.Constant(propertyName));
+        }
+    }
+}

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -268,5 +268,42 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             return (expression as QuerySourceReferenceExpression)?.ReferencedQuerySource;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static BinaryExpression CreateAssignExpression(
+            [NotNull] this Expression left,
+            [NotNull] Expression right)
+        {
+            var leftType = left.Type;
+            if (leftType != right.Type
+                && right.Type.GetTypeInfo().IsAssignableFrom(leftType.GetTypeInfo()))
+            {
+                right = Expression.Convert(right, leftType);
+            }
+
+            return Expression.Assign(left, right);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static MemberExpression MakeMemberAccess(
+            [CanBeNull] this Expression expression,
+            [NotNull] MemberInfo member)
+        {
+            var memberDeclaringClrType = member.DeclaringType;
+            if (expression != null
+                && memberDeclaringClrType != expression.Type
+                && expression.Type.GetTypeInfo().IsAssignableFrom(memberDeclaringClrType.GetTypeInfo()))
+            {
+                expression = Expression.Convert(expression, memberDeclaringClrType);
+            }
+
+            return Expression.MakeMemberAccess(expression, member);
+        }
     }
 }

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -47,38 +47,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public static readonly ParameterExpression QueryContextParameter
             = Expression.Parameter(typeof(QueryContext), "queryContext");
 
-        private static readonly string _efTypeName = typeof(EF).FullName;
-
-        /// <summary>
-        ///     Determines if a <see cref="MethodInfo" /> is referencing the <see cref="EF.Property{TProperty}(object, string)" /> method.
-        /// </summary>
-        /// <param name="methodInfo"> The method info to check. </param>
-        /// <returns>
-        ///     True if <paramref name="methodInfo" /> is referencing <see cref="EF.Property{TProperty}(object, string)" />; otherwise fale;
-        /// </returns>
-        public static bool IsPropertyMethod([CanBeNull] MethodInfo methodInfo) =>
-            Equals(methodInfo, EF.PropertyMethod)
-            // fallback to string comparison because MethodInfo.Equals is not
-            // always true in .NET Native even if methods are the same
-            || methodInfo != null
-            && methodInfo.IsGenericMethod
-            && methodInfo.Name == nameof(EF.Property)
-            && methodInfo.DeclaringType?.FullName == _efTypeName;
-
-        /// <summary>
-        ///     Creates an expression to access the given property on an given entity.
-        /// </summary>
-        /// <param name="target"> The entity. </param>
-        /// <param name="property"> The property to be accessed. </param>
-        /// <returns> The newly created expression. </returns>
-        public static Expression CreatePropertyExpression(
-            [NotNull] Expression target,
-            [NotNull] IPropertyBase property)
-            => Expression.Call(
-                EF.PropertyMethod.MakeGenericMethod(property.ClrType.MakeNullable()),
-                target,
-                Expression.Constant(property.Name));
-
         private readonly IQueryOptimizer _queryOptimizer;
         private readonly INavigationRewritingExpressionVisitorFactory _navigationRewritingExpressionVisitorFactory;
         private readonly IQuerySourceTracingExpressionVisitorFactory _querySourceTracingExpressionVisitorFactory;

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationSubqueryInjector.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -77,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (!EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+            if (!methodCallExpression.Method.IsEFPropertyMethod())
             {
                 _shouldInject = true;
             }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -159,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             // If comparing with null then we need only first PK property
             return properties.Count == 1 || nullComparison
-                ? EntityQueryModelVisitor.CreatePropertyExpression(target, properties[0])
+                ? target.CreateEFPropertyExpression(properties[0])
                 : Expression.New(
                     AnonymousObject.AnonymousObjectCtor,
                     Expression.NewArrayInit(
@@ -167,8 +168,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         properties
                             .Select(
                                 p => Expression.Convert(
-                                    EntityQueryModelVisitor
-                                        .CreatePropertyExpression(target, p), typeof(object)))
+                                    target.CreateEFPropertyExpression(p), 
+                                    typeof(object)))
                             .Cast<Expression>()
                             .ToArray()));
         }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -152,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression node)
-            => EntityQueryModelVisitor.IsPropertyMethod(node.Method)
+            => node.Method.IsEFPropertyMethod()
                 ? node
                 : base.VisitMethodCall(node);
     }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 
@@ -60,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var newMethodCallExpression = (MethodCallExpression)base.VisitMethodCall(methodCallExpression);
 
-            if (EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+            if (methodCallExpression.Method.IsEFPropertyMethod())
             {
                 var subQueryExpression = newMethodCallExpression.Arguments[0] as SubQueryExpression;
                 if (subQueryExpression?.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression subSelector)

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -319,7 +320,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
             {
-                if (EntityQueryModelVisitor.IsPropertyMethod(methodCallExpression.Method))
+                if (methodCallExpression.Method.IsEFPropertyMethod())
                 {
                     _requiresBuffering = true;
 
@@ -503,7 +504,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
 
                 if (expression.RemoveConvert() is MethodCallExpression method
-                    && EntityQueryModelVisitor.IsPropertyMethod(method.Method))
+                    && method.Method.IsEFPropertyMethod())
                 {
                     return method.Arguments[0] as QuerySourceReferenceExpression;
                 }

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -499,5 +499,10 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
     "MemberId": "System.String get_InvariantName()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+    "MemberId": "public static System.Boolean IsPropertyMethod(System.Reflection.MethodInfo methodInfo)",
+    "Kind": "Removal"
   }
 ]

--- a/src/EFCore/breakingchanges.netframework.json
+++ b/src/EFCore/breakingchanges.netframework.json
@@ -499,5 +499,10 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
     "MemberId": "System.String get_InvariantName()",
     "Kind": "Addition"
-  }
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+    "MemberId": "public static System.Boolean IsPropertyMethod(System.Reflection.MethodInfo methodInfo)",
+    "Kind": "Removal"
+  }  
 ]

--- a/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     WHERE [c].[CustomerID] = N'ALFKI', 
                 shaper: BufferedEntityShaper<Customer>), 
             selector: (Customer c | CancellationToken ct) => Task<<>f__AnonymousType3<Customer, List<Order>>> _ExecuteAsync(
-                taskFactories: new Func<Task<object>>[]{ () => Task<object> _ToObjectTask(Task<List<Order>> ToList((IAsyncEnumerable<Order>) EnumerableAdapter<Order> _ToEnumerable(IAsyncEnumerable<Order> _InjectParameters(
+                taskFactories: new Func<Task<object>>[]{ () => Task<object> _ToObjectTask(Task<List<Order>> ToList((IAsyncEnumerable<Order>)EnumerableAdapter<Order> _ToEnumerable(IAsyncEnumerable<Order> _InjectParameters(
                                     queryContext: queryContext, 
                                     source: IAsyncEnumerable<Order> _ShapedQuery(
                                         queryContext: queryContext, 
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                                             entity: c) })))) }, 
                 selector: (Object[] results) => new <>f__AnonymousType3<Customer, List<Order>>(
                     c, 
-                    (List<Order>) results[0]
+                    (List<Order>)results[0]
                 )))",
                 Fixture.TestSqlLoggerFactory.Log);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -771,6 +771,41 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((1 & (
 ))");
         }
 
+        public override void Where_enum_has_flag_subquery_client_eval()
+        {
+            base.Where_enum_has_flag_subquery_client_eval();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"SELECT TOP(1) [x0].[Rank]
+FROM [Gear] AS [x0]
+WHERE [x0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [x0].[Nickname], [x0].[SquadId]",
+                //
+                @"SELECT TOP(1) [x0].[Rank]
+FROM [Gear] AS [x0]
+WHERE [x0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [x0].[Nickname], [x0].[SquadId]",
+                //
+                @"SELECT TOP(1) [x0].[Rank]
+FROM [Gear] AS [x0]
+WHERE [x0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [x0].[Nickname], [x0].[SquadId]",
+                //
+                @"SELECT TOP(1) [x0].[Rank]
+FROM [Gear] AS [x0]
+WHERE [x0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [x0].[Nickname], [x0].[SquadId]",
+                //
+                @"SELECT TOP(1) [x0].[Rank]
+FROM [Gear] AS [x0]
+WHERE [x0].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [x0].[Nickname], [x0].[SquadId]");
+        }
+
         public override void Where_enum_has_flag_with_non_nullable_parameter()
         {
             base.Where_enum_has_flag_with_non_nullable_parameter();
@@ -2628,6 +2663,264 @@ FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]");
         }
 
+        public override void Member_access_on_derived_entity_using_cast()
+        {
+            base.Member_access_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], [f].[Eradicated]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Member_access_on_derived_materialized_entity_using_cast()
+        {
+            base.Member_access_on_derived_materialized_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Member_access_on_derived_entity_using_cast_and_let()
+        {
+            base.Member_access_on_derived_entity_using_cast_and_let();
+
+            AssertSql(
+                @"SELECT [f].[Name], [f].[Eradicated]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Property_access_on_derived_entity_using_cast()
+        {
+            base.Property_access_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], [f].[Eradicated]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Navigation_access_on_derived_entity_using_cast()
+        {
+            base.Navigation_access_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], [t].[ThreatLevel] AS [Threat]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Navigation_access_on_derived_materialized_entity_using_cast()
+        {
+            base.Navigation_access_on_derived_materialized_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[ThreatLevel]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Navigation_access_via_EFProperty_on_derived_entity_using_cast()
+        {
+            base.Navigation_access_via_EFProperty_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], [t].[ThreatLevel] AS [Threat]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Navigation_access_fk_on_derived_entity_using_cast()
+        {
+            base.Navigation_access_fk_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], [f].[CommanderName]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Collection_navigation_access_on_derived_entity_using_cast()
+        {
+            base.Collection_navigation_access_on_derived_entity_using_cast();
+
+            AssertSql(
+                @"SELECT [f].[Name], (
+    SELECT COUNT(*)
+    FROM [LocustLeader] AS [l]
+    WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND ([f].[Id] = [l].[LocustHordeId])
+) AS [LeadersCount]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name]");
+        }
+
+        public override void Collection_navigation_access_on_derived_entity_using_cast_in_SelectMany()
+        {
+            base.Collection_navigation_access_on_derived_entity_using_cast_in_SelectMany();
+
+            AssertSql(
+                @"SELECT [f].[Name] AS [Name0], [f.Leaders].[Name] AS [LeaderName]
+FROM [Faction] AS [f]
+INNER JOIN [LocustLeader] AS [f.Leaders] ON [f].[Id] = [f.Leaders].[LocustHordeId]
+WHERE (([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')) AND [f.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [LeaderName]");
+        }
+
+        public override void Include_on_derived_entity_using_OfType()
+        {
+            base.Include_on_derived_entity_using_OfType();
+
+            AssertSql(
+                @"SELECT [lh].[Id], [lh].[CapitalName], [lh].[Discriminator], [lh].[Name], [lh].[CommanderName], [lh].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+FROM [Faction] AS [lh]
+LEFT JOIN (
+    SELECT [lh.Commander].*
+    FROM [LocustLeader] AS [lh.Commander]
+    WHERE [lh.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [lh].[CommanderName] = [t].[Name]
+WHERE [lh].[Discriminator] = N'LocustHorde'
+ORDER BY [lh].[Name], [lh].[Id]",
+                //
+                @"SELECT [lh.Leaders].[Name], [lh.Leaders].[Discriminator], [lh.Leaders].[LocustHordeId], [lh.Leaders].[ThreatLevel], [lh.Leaders].[DefeatedByNickname], [lh.Leaders].[DefeatedBySquadId]
+FROM [LocustLeader] AS [lh.Leaders]
+INNER JOIN (
+    SELECT DISTINCT [lh0].[Id], [lh0].[Name]
+    FROM [Faction] AS [lh0]
+    LEFT JOIN (
+        SELECT [lh.Commander0].*
+        FROM [LocustLeader] AS [lh.Commander0]
+        WHERE [lh.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t0] ON [lh0].[CommanderName] = [t0].[Name]
+    WHERE [lh0].[Discriminator] = N'LocustHorde'
+) AS [t1] ON [lh.Leaders].[LocustHordeId] = [t1].[Id]
+WHERE [lh.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t1].[Name], [t1].[Id]");
+        }
+
+        public override void Include_on_derived_entity_using_subquery_with_cast()
+        {
+            base.Include_on_derived_entity_using_subquery_with_cast();
+
+            AssertSql(
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name], [f].[Id]",
+                //
+                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId]
+FROM [LocustLeader] AS [f.Leaders]
+INNER JOIN (
+    SELECT DISTINCT [f0].[Id], [f0].[Name]
+    FROM [Faction] AS [f0]
+    LEFT JOIN (
+        SELECT [f.Commander0].*
+        FROM [LocustLeader] AS [f.Commander0]
+        WHERE [f.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t0] ON [f0].[CommanderName] = [t0].[Name]
+    WHERE ([f0].[Discriminator] = N'LocustHorde') AND ([f0].[Discriminator] = N'LocustHorde')
+) AS [t1] ON [f.Leaders].[LocustHordeId] = [t1].[Id]
+WHERE [f.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t1].[Name], [t1].[Id]");
+        }
+
+        public override void Include_on_derived_entity_using_subquery_with_cast_AsNoTracking()
+        {
+            base.Include_on_derived_entity_using_subquery_with_cast_AsNoTracking();
+
+            AssertSql(
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [f].[Name], [f].[Id]",
+                //
+                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId]
+FROM [LocustLeader] AS [f.Leaders]
+INNER JOIN (
+    SELECT DISTINCT [f0].[Id], [f0].[Name]
+    FROM [Faction] AS [f0]
+    LEFT JOIN (
+        SELECT [f.Commander0].*
+        FROM [LocustLeader] AS [f.Commander0]
+        WHERE [f.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t0] ON [f0].[CommanderName] = [t0].[Name]
+    WHERE ([f0].[Discriminator] = N'LocustHorde') AND ([f0].[Discriminator] = N'LocustHorde')
+) AS [t1] ON [f.Leaders].[LocustHordeId] = [t1].[Id]
+WHERE [f.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t1].[Name], [t1].[Id]");
+        }
+
+        public override void Include_on_derived_entity_using_subquery_with_cast_cross_product_base_entity()
+        {
+            base.Include_on_derived_entity_using_subquery_with_cast_cross_product_base_entity();
+
+            AssertSql(
+                @"SELECT [f2].[Id], [f2].[CapitalName], [f2].[Discriminator], [f2].[Name], [f2].[CommanderName], [f2].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [ff].[Id], [ff].[CapitalName], [ff].[Discriminator], [ff].[Name], [ff].[CommanderName], [ff].[Eradicated], [ff.Capital].[Name], [ff.Capital].[Location]
+FROM [Faction] AS [f2]
+LEFT JOIN (
+    SELECT [f2.Commander].*
+    FROM [LocustLeader] AS [f2.Commander]
+    WHERE [f2.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f2].[CommanderName] = [t].[Name]
+CROSS JOIN [Faction] AS [ff]
+LEFT JOIN [City] AS [ff.Capital] ON [ff].[CapitalName] = [ff.Capital].[Name]
+WHERE ([f2].[Discriminator] = N'LocustHorde') AND ([f2].[Discriminator] = N'LocustHorde')
+ORDER BY [f2].[Name], [ff].[Name], [f2].[Id]",
+                //
+                @"SELECT [f2.Leaders].[Name], [f2.Leaders].[Discriminator], [f2.Leaders].[LocustHordeId], [f2.Leaders].[ThreatLevel], [f2.Leaders].[DefeatedByNickname], [f2.Leaders].[DefeatedBySquadId]
+FROM [LocustLeader] AS [f2.Leaders]
+INNER JOIN (
+    SELECT DISTINCT [f20].[Id], [f20].[Name], [ff0].[Name] AS [Name0]
+    FROM [Faction] AS [f20]
+    LEFT JOIN (
+        SELECT [f2.Commander0].*
+        FROM [LocustLeader] AS [f2.Commander0]
+        WHERE [f2.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t0] ON [f20].[CommanderName] = [t0].[Name]
+    CROSS JOIN [Faction] AS [ff0]
+    LEFT JOIN [City] AS [ff.Capital0] ON [ff0].[CapitalName] = [ff.Capital0].[Name]
+    WHERE ([f20].[Discriminator] = N'LocustHorde') AND ([f20].[Discriminator] = N'LocustHorde')
+) AS [t1] ON [f2.Leaders].[LocustHordeId] = [t1].[Id]
+WHERE [f2.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t1].[Name], [t1].[Name0], [t1].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
@@ -2636,5 +2929,5 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
 
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();
-    }
+        }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -452,6 +452,51 @@ FROM [Employees] AS [e0]
 ORDER BY [e0].[EmployeeID]");
         }
 
+        public override void Where_query_composition2_FirstOrDefault()
+        {
+            base.Where_query_composition2_FirstOrDefault();
+
+            AssertSql(
+                @"@__p_0: 3
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+) AS [t]
+WHERE [t].[FirstName] = (
+    SELECT TOP(1) [e0].[FirstName]
+    FROM [Employees] AS [e0]
+    ORDER BY [e0].[EmployeeID]
+)");
+        }
+
+        public override void Where_query_composition2_FirstOrDefault_with_anonymous()
+        {
+            base.Where_query_composition2_FirstOrDefault_with_anonymous();
+
+            AssertSql(
+                @"@__p_0: 3
+
+SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
+FROM (
+    SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+    FROM [Employees] AS [e]
+) AS [t]",
+                //
+                @"SELECT TOP(1) [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e0]
+ORDER BY [e0].[EmployeeID]",
+                //
+                @"SELECT TOP(1) [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e0]
+ORDER BY [e0].[EmployeeID]",
+                //
+                @"SELECT TOP(1) [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e0]
+ORDER BY [e0].[EmployeeID]");
+        }
+
         public override void Where_shadow_subquery_FirstOrDefault()
         {
             base.Where_shadow_subquery_FirstOrDefault();


### PR DESCRIPTION
Problem was that we were not taking type differences and expression converts in various places during compilation. We sometimes remove converts when processing expressions, but then not accounting for them when we re-assemble the visited expression.
This caused many scenarios involving casts (e.g. accessing properties/navigations on derived types) to fail.

Fix is to start compensating for those where necessary. Created helper methods for EF.Property method call, member access and assignment and using them instead of regular Expression APIs.

Also fixed unrelated issue in the SqlTranslatingExpressionVisitor - when trying to translate MethodCall expression, we would force client evaluation, if arguments to the function was a subquery - this is not ideal, since we can translate some of the subqueries (ones that return single result).