### PR TITLE
[SMALL] Fix to #7516 - Query: Compiler crash for invalid Include path

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1352,7 +1352,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.
+        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results or the Include operation was specified on non-entity type.
         /// </summary>
         public static string LogIgnoredInclude([CanBeNull] object include)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -631,7 +631,7 @@
     <value>A parameterless constructor was not found on entity type '{entityType}'. In order to create an instance of '{entityType}' EF requires that a parameterless constructor be declared.</value>
   </data>
   <data name="LogIgnoredInclude" xml:space="preserve">
-    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.</value>
+    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results or the Include operation was specified on non-entity type.</value>
   </data>
   <data name="ConflictingRelationshipNavigation" xml:space="preserve">
     <value>Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship.</value>

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -130,7 +130,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             targetExpression,
                             includeResultOperator.QuerySource);
 
-                if (querySourceReferenceExpression == null)
+                if (querySourceReferenceExpression == null
+                    || navigationPath == null)
                 {
                     continue;
                 }

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -114,6 +114,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
                 }
             }
 
+            if (entityType == null)
+            {
+                return null;
+            }
+
             var navigationPath = new INavigation[NavigationPropertyPaths.Count];
 
             for (var i = 0; i < NavigationPropertyPaths.Count; i++)

--- a/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -55,7 +55,7 @@ select [<generated>_0]'
         }
 
         [Fact]
-        public virtual void Query_with_ignored_include_should_log_warning()
+        public virtual void Query_with_ignored_include_should_log_warning1()
         {
             using (var context = CreateContext())
             {
@@ -67,6 +67,23 @@ select [<generated>_0]'
 
                 Assert.NotNull(customers);
                 Assert.Contains(CoreStrings.LogIgnoredInclude("[c].Orders"), _fixture.TestSqlLoggerFactory.Log);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_ignored_include_should_log_warning2()
+        {
+            using (var context = CreateContext())
+            {
+                var results
+                    = context.Customers
+                        .Select(c => new Tuple<Customer, int>( c, 5 ))
+                        .Include(t => t.Item1.Orders)
+                        .ToList();
+
+                Assert.NotNull(results);
+                Assert.True(results.All(t => t.Item1.Orders == null));
+                Assert.Contains(CoreStrings.LogIgnoredInclude("new Tuple`2(Item1 = [c], Item2 = 5).Item1.Orders"), _fixture.TestSqlLoggerFactory.Log);
             }
         }
 


### PR DESCRIPTION
Problem was that when we tried to extract navigation paths specified in the Include we would throw if the Include was on non-entity type.
Fix is to log a warning for this case, just like we do for cases where included entity is not reachable in the final result.
We will still throw exception if user specifies incorrect navigation on existing entity.