### PR TITLE
[SMALL] Fix to #3736 - Query :: some queries with Queryable.Cast<T> don't work

### DIFF
--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -3074,6 +3074,34 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Distinct_on_subquery_doesnt_get_lifted()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = from g in (from ig in ctx.Gears
+                                       select ig).Distinct()
+                            select g.HasSoulPatch;
+
+                var result = query.ToList();
+                Assert.Equal(5, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Cast_result_operator_on_subquery_is_properly_lifted_to_a_convert()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = from lh in (from f in ctx.Factions
+                                        select f).Cast<LocustHorde>()
+                            select lh.Eradicated;
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/EFCore/Query/Internal/QueryModelPrinter.cs
+++ b/src/EFCore/Query/Internal/QueryModelPrinter.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -197,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (resultOperators.Count == 1)
                 {
-                    TransformingVisitor.StringBuilder.Append($".{resultOperators[0]}");
+                    TransformingVisitor.StringBuilder.Append($".{ResultOperatorString(resultOperators[0])}");
                 }
                 else
                 {
@@ -208,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
             {
                 AppendLine("");
-                TransformingVisitor.StringBuilder.Append($".{resultOperator}");
+                TransformingVisitor.StringBuilder.Append($".{ResultOperatorString(resultOperator)}");
             }
 
             public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
@@ -216,6 +217,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 AppendLine();
                 TransformingVisitor.StringBuilder.Append("select ");
                 base.VisitSelectClause(selectClause, queryModel);
+            }
+
+            private string ResultOperatorString(ResultOperatorBase resultOperator)
+            {
+                switch(resultOperator)
+                {
+                    case CastResultOperator cast:
+                        return "Cast<" + cast.CastItemType.ShortDisplayName() + ">()";
+
+                    case OfTypeResultOperator ofType:
+                        return "OfType<" + ofType.SearchedItemType.ShortDisplayName() + ">()";
+
+                    default:
+                        return resultOperator.ToString();
+                }
             }
 
             private void AppendLine()

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2182,6 +2182,7 @@ WHERE 1 IN (
     FROM [Level3] AS [l3]
     WHERE [l1.OneToOne_Optional_FK].[Id] = [l3].[OneToMany_Optional_InverseId]
 )");
+
         }
 
         public override void Complex_query_with_optional_navigations_and_client_side_evaluation()
@@ -2526,10 +2527,13 @@ WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL");
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
 
             AssertSql(
-                @"SELECT DISTINCT [l1].[Id]
-FROM [Level1] AS [l1]
-LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
-WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL");
+                @"SELECT [t].[Id]
+FROM (
+    SELECT DISTINCT [l1].*
+    FROM [Level1] AS [l1]
+    LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]
+    WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL
+) AS [t]");
         }
 
         public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection3()

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2921,6 +2921,29 @@ WHERE [f2.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
 ORDER BY [t1].[Name], [t1].[Name0], [t1].[Id]");
         }
 
+        public override void Distinct_on_subquery_doesnt_get_lifted()
+        {
+            base.Distinct_on_subquery_doesnt_get_lifted();
+
+            AssertSql(
+                @"SELECT [t].[HasSoulPatch]
+FROM (
+    SELECT DISTINCT [ig].*
+    FROM [Gear] AS [ig]
+    WHERE [ig].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t]");
+        }
+
+        public override void Cast_result_operator_on_subquery_is_properly_lifted_to_a_convert()
+        {
+            base.Cast_result_operator_on_subquery_is_properly_lifted_to_a_convert();
+
+            AssertSql(
+                @"SELECT [f].[Eradicated]
+FROM [Faction] AS [f]
+WHERE [f].[Discriminator] = N'LocustHorde'");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that during optimization, when we flatten subqueries we didn't account for Cast result operator properly. This would fail when trying to access a property on a derived type, when derived type was coming from a subquery with Cast result operator.
Fix is to wrap qsres to that (former) subquery with Convert(s) the subquery was casted into.

Also fixed another issue around this area:

We tried to lift Distinct in some cases, which could lead to incorrect results. E.g

from outer in (ctx.Customers.Distinct())
select outer.Name

would get translated to:

(from outer in ctx.Customers
select outer.Name).Distinct()