### PR TITLE
[TINY] Modification to fix for #7516 - Query: Compiler crash for invalid Include path

### DIFF
--- a/src/EFCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/IncludeTestBase.cs
@@ -3081,6 +3081,28 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_specified_on_non_entity_not_supported(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.IncludeNotSpecifiedDirectlyOnEntityType(@"Include(""Item1.Orders"")", "Item1"),
+                    Assert.Throws<NotSupportedException>(
+                        () => useString
+                                ? context.Customers
+                                    .Select(c => new Tuple<Customer, int>(c, 5))
+                                    .Include(t => t.Item1.Orders)
+                                    .ToList()
+                                : context.Customers
+                                    .Select(c => new Tuple<Customer, int>(c, 5))
+                                    .Include("Item1.Orders")
+                                    .ToList()).Message);
+            }
+        }
+
         private static void CheckIsLoaded(
             NorthwindContext context,
             Customer customer,

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1352,7 +1352,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results or the Include operation was specified on non-entity type.
+        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.
         /// </summary>
         public static string LogIgnoredInclude([CanBeNull] object include)
             => string.Format(
@@ -1636,6 +1636,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("BadFilterDerivedType", nameof(filter), nameof(entityType)),
                 filter, entityType);
+
+        /// <summary>
+        ///     The Include operation '{include}' was invalid. '{invalidNavigation}' is not a navigation property defined on an entity type.
+        /// </summary>
+        public static string IncludeNotSpecifiedDirectlyOnEntityType([CanBeNull] object include, [CanBeNull] object invalidNavigation)
+            => string.Format(
+                GetString("IncludeNotSpecifiedDirectlyOnEntityType", nameof(include), nameof(invalidNavigation)),
+                include, invalidNavigation);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -631,7 +631,7 @@
     <value>A parameterless constructor was not found on entity type '{entityType}'. In order to create an instance of '{entityType}' EF requires that a parameterless constructor be declared.</value>
   </data>
   <data name="LogIgnoredInclude" xml:space="preserve">
-    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results or the Include operation was specified on non-entity type.</value>
+    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.</value>
   </data>
   <data name="ConflictingRelationshipNavigation" xml:space="preserve">
     <value>Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship.</value>
@@ -740,5 +740,8 @@
   </data>
   <data name="BadFilterDerivedType" xml:space="preserve">
     <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.</value>
+  </data>
+  <data name="IncludeNotSpecifiedDirectlyOnEntityType" xml:space="preserve">
+    <value>The Include operation '{include}' was invalid. '{invalidNavigation}' is not a navigation property defined on an entity type.</value>
   </data>
 </root>

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -116,7 +116,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
 
             if (entityType == null)
             {
-                return null;
+                throw new NotSupportedException(
+                    CoreStrings.IncludeNotSpecifiedDirectlyOnEntityType(
+                        ToString(), 
+                        NavigationPropertyPaths.FirstOrDefault()));
             }
 
             var navigationPath = new INavigation[NavigationPropertyPaths.Count];

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -1369,6 +1369,11 @@ INNER JOIN (
 ORDER BY [t].[c], [t].[CustomerID]");
         }
 
+        public override void Include_specified_on_non_entity_not_supported(bool useString)
+        {
+            base.Include_specified_on_non_entity_not_supported(useString);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
         

--- a/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -55,7 +55,7 @@ select [<generated>_0]'
         }
 
         [Fact]
-        public virtual void Query_with_ignored_include_should_log_warning1()
+        public virtual void Query_with_ignored_include_should_log_warning()
         {
             using (var context = CreateContext())
             {
@@ -67,23 +67,6 @@ select [<generated>_0]'
 
                 Assert.NotNull(customers);
                 Assert.Contains(CoreStrings.LogIgnoredInclude("[c].Orders"), _fixture.TestSqlLoggerFactory.Log);
-            }
-        }
-
-        [Fact]
-        public virtual void Query_with_ignored_include_should_log_warning2()
-        {
-            using (var context = CreateContext())
-            {
-                var results
-                    = context.Customers
-                        .Select(c => new Tuple<Customer, int>( c, 5 ))
-                        .Include(t => t.Item1.Orders)
-                        .ToList();
-
-                Assert.NotNull(results);
-                Assert.True(results.All(t => t.Item1.Orders == null));
-                Assert.Contains(CoreStrings.LogIgnoredInclude("new Tuple`2(Item1 = [c], Item2 = 5).Item1.Orders"), _fixture.TestSqlLoggerFactory.Log);
             }
         }
 


### PR DESCRIPTION
Instead of ignoring includes that are not specified directly on entity type we throw NotSupportedException