### PR TITLE
Tools: Add a netcoreapp2.0 version of ef.dll

### DIFF
--- a/src/EFCore.Design/Design/OperationReportHandler.cs
+++ b/src/EFCore.Design/Design/OperationReportHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Design
     public partial class OperationReportHandler : MarshalByRefObject
     {
     }
-#elif NETSTANDARD1_3 || NETCOREAPP1_0
+#elif NETSTANDARD1_3 || NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/EFCore.Design/Design/OperationResultHandler.cs
+++ b/src/EFCore.Design/Design/OperationResultHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Design
     public partial class OperationResultHandler : MarshalByRefObject
     {
     }
-#elif NETSTANDARD1_3 || NETCOREAPP1_0
+#elif NETSTANDARD1_3 || NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
@@ -26,6 +26,8 @@
     <file src="../ef/bin/x86/$configuration$/net46/ef.x86.exe" target="tools/net46/" />
     <file src="../ef/bin/$configuration$/netcoreapp1.0/ef.dll" target="tools/netcoreapp1.0/" />
     <file src="../ef/bin/$configuration$/netcoreapp1.0/ef.runtimeconfig.json" target="tools/netcoreapp1.0/" />
+    <file src="../ef/bin/$configuration$/netcoreapp2.0/ef.dll" target="tools/netcoreapp2.0/" />
+    <file src="../ef/bin/$configuration$/netcoreapp2.0/ef.runtimeconfig.json" target="tools/netcoreapp2.0/" />
     <file src="prefercliruntime" target="prefercliruntime" />
   </files>
 </package>

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -26,5 +26,7 @@
     <file src="../ef/bin/x86/$configuration$/net46/ef.x86.exe" target="tools/net46/" />
     <file src="../ef/bin/$configuration$/netcoreapp1.0/ef.dll" target="tools/netcoreapp1.0/" />
     <file src="../ef/bin/$configuration$/netcoreapp1.0/ef.runtimeconfig.json" target="tools/netcoreapp1.0/" />
+    <file src="../ef/bin/$configuration$/netcoreapp2.0/ef.dll" target="tools/netcoreapp2.0/" />
+    <file src="../ef/bin/$configuration$/netcoreapp2.0/ef.runtimeconfig.json" target="tools/netcoreapp2.0/" />
   </files>
 </package>

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -784,7 +784,17 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
         $projectAssetsFile = GetCsproj2Property $startupProject 'ProjectAssetsFile'
         $runtimeConfig = Join-Path $targetDir ($startupTargetName + '.runtimeconfig.json')
         $runtimeFrameworkVersion = GetCsproj2Property $startupProject 'RuntimeFrameworkVersion'
-        $efPath = Join-Path $PSScriptRoot 'netcoreapp1.0\ef.dll'
+
+        if ($frameworkName.Version -lt [version]'2.0')
+        {
+            $efFramework = "netcoreapp1.0"
+        }
+        else
+        {
+            $efFramework = "netcoreapp2.0"
+        }
+
+        $efPath = Join-Path $PSScriptRoot ($efFramework + '\ef.dll')
 
         $dotnetParams = 'exec', '--depsfile', $depsFile
 

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -150,7 +150,13 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     args.Add(startupProject.RuntimeFrameworkVersion);
                 }
 
-                args.Add(Path.Combine(toolsPath, "netcoreapp1.0", "ef.dll"));
+                args.Add(
+                    Path.Combine(
+                        toolsPath,
+                        targetFramework.Version < new Version(2, 0)
+                            ? "netcoreapp1.0"
+                            : "netcoreapp2.0",
+                       "ef.dll"));
             }
             else
             {

--- a/src/ef/AppDomainOperationExecutor.cs
+++ b/src/ef/AppDomainOperationExecutor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         }
     }
 }
-#elif NETCOREAPP1_0
+#elif NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                     _dataDir.Value(),
                     _rootNamespace.Value());
             }
-#elif NETCOREAPP1_0
+#elif NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/ef/ReflectionOperationExecutor.cs
+++ b/src/ef/ReflectionOperationExecutor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
         {
 #if NET46
             AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
-#elif NETCOREAPP1_0
+#elif NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
 
         public override void Dispose()
             => AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
-#elif NETCOREAPP1_0
+#elif NETCOREAPP1_0 || NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -3,13 +3,12 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net46;netcoreapp2.0</TargetFrameworks>
     <Description>Entity Framework Core Command Line Tools</Description>
     <OutputType>Exe</OutputType>
     <AssemblyName Condition="'$(Platform)' == 'x86'">ef.x86</AssemblyName>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
-    <RuntimeFrameworkVersion>1.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Without this, we execute the `netcoreapp1.0` version on `netcoreapp2.0`.

This is theoretically better/mathematically correct since they *could* introduce breaking changes in 2.0.