### PR TITLE
Bump version of DiagnosticSource, which is being brought in by higher…

### DIFF
--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -17,7 +17,7 @@ Microsoft.EntityFrameworkCore.DbSet</Description>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Remotion.Linq" Version="$(RelinqVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(ImmutableCollectionsVersion)" />


### PR DESCRIPTION
… version of SqlClient

The SqlClient brings in higher version of DiagnosticSource transitively. But we reference CoreFxVersion in EF Core still which is breaking testing in VS.

Once CoreFxVersion aligns with SqlClientVersion, this will go away.
