### PR TITLE
[WIP] Target .NET Standard 2.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,8 @@
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- TODO: Remove -->
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>
 

--- a/build/common.props
+++ b/build/common.props
@@ -12,6 +12,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <DebugType Condition="'$(Configuration)' == 'Debug' AND '$(OS)' == 'Windows_NT'">full</DebugType>
+    <!-- TODO: Remove -->
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.rd.xml" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <DependencyModelVersion>2.0.0-*</DependencyModelVersion>
     <EF6Version>6.1.3</EF6Version>
     <ImmutableCollectionsVersion>1.3.1</ImmutableCollectionsVersion>
@@ -15,11 +15,5 @@
     <SystemInteractiveAsyncVersion>3.1.1</SystemInteractiveAsyncVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
-    <!--
-      * Use 4.4.0-* instead of $(CoreFxVersion) to workaround "SqlClient fails with netcoreapp2.0 on Win7/Server2008"
-      * https://github.com/dotnet/corefx/issues/18406
-      * Remove when $(CoreFxVersion) is upgraded to 4.4.0-*
-    -->
-    <SqlClientVersion>4.4.0-*</SqlClientVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.Design/Design/Internal/ForwardingProxy.cs
+++ b/src/EFCore.Design/Design/Internal/ForwardingProxy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         {
 #if NET46
             return target as T ?? new ForwardingProxy<T>(target).GetTransparentProxy();
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_3 || NETSTANDARD2_0
             return (T)target;
 #else
 #error target frameworks need to be updated.

--- a/src/EFCore.Design/Design/Internal/ForwardingProxy`.cs
+++ b/src/EFCore.Design/Design/Internal/ForwardingProxy`.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         public new virtual T GetTransparentProxy() => (T)base.GetTransparentProxy();
     }
 }
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_3 || NETSTANDARD2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -425,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
     }
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
     public partial class OperationExecutor : MarshalByRefObject
     {
         public partial class OperationBase : MarshalByRefObject

--- a/src/EFCore.Design/Design/OperationReportHandler.cs
+++ b/src/EFCore.Design/Design/OperationReportHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             => _verboseHandler?.Invoke(message);
     }
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
     public partial class OperationReportHandler : MarshalByRefObject
     {
     }

--- a/src/EFCore.Design/Design/OperationResultHandler.cs
+++ b/src/EFCore.Design/Design/OperationResultHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
     }
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
     public partial class OperationResultHandler : MarshalByRefObject
     {
     }

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Shared design-time components for Entity Framework Core tools.</Description>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Design</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/EFCore.Relational.Design.Specification.Tests/EFCore.Relational.Design.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Design.Specification.Tests/EFCore.Relational.Design.Specification.Tests.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(DependencyModelVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Shared Entity Framework Core components for relational database providers.</Description>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Relational</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -16,6 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="$(CoreFxVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="System.Data.Common" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -15,7 +15,7 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using IsolationLevel = System.Data.IsolationLevel;
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 using System.Transactions;
 #elif NETSTANDARD1_3
 #else
@@ -400,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void CheckForAmbientTransactions()
         {
-#if NET46
+#if NET46 || NETSTANDARD2_0
             if (Transaction.Current != null)
             {
                 Dependencies.TransactionLogger.AmbientTransactionWarning(this);

--- a/src/EFCore.Specification.Tests/DatabindingTestBase.cs
+++ b/src/EFCore.Specification.Tests/DatabindingTestBase.cs
@@ -430,8 +430,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-#if NET46
-
         [Fact]
         public virtual void DbSet_Local_ToBindingList_contains_Unchanged_Modified_and_Added_entities_but_not_Deleted_entities()
         {
@@ -741,10 +739,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 Assert.False(ferrari.Drivers.Contains(alonso)); // But has been removed from nav prop
             }
         }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
 
         protected F1Context CreateF1Context()
         {

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -14,8 +14,10 @@
     <ProjectReference Include="..\EFCore\EFCore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="$(CoreFxVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -10,13 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.Concurren
 {
     public class Team
     {
-#if NET46
         private readonly ObservableCollection<Driver> _drivers = new ObservableCollectionListSource<Driver>();
-#elif NETCOREAPP2_0
-        private readonly ObservableCollection<Driver> _drivers = new ObservableCollection<Driver>();
-#else
-#error target frameworks need to be updated.
-#endif
         private readonly ObservableCollection<Sponsor> _sponsors = new ObservableCollection<Sponsor>();
 
         public int Id { get; set; }

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Microsoft SQL Server database provider for Entity Framework Core.</Description>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.SqlServer</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\EFCore.Relational\EFCore.Relational.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsSqlGenerator.cs
@@ -535,7 +535,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         {
             Check.NotNull(fileName, nameof(fileName));
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
             if (fileName.StartsWith("|DataDirectory|", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/EFCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
+++ b/src/EFCore/ChangeTracking/Internal/ObservableBackedBindingList.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/EFCore/ChangeTracking/Internal/SortableBindingList.cs
+++ b/src/EFCore/ChangeTracking/Internal/SortableBindingList.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
 using System;
 using System.Collections;

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     public class LocalView<TEntity> : ICollection<TEntity>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
         where TEntity : class
     {
-#if NET46
+#if NET46 || NETSTANDARD2_0
         private ObservableBackedBindingList<TEntity> _bindingList;
 #elif NETSTANDARD1_3
 #else
@@ -296,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         private void OnCollectionChanged(NotifyCollectionChangedAction action, object item)
             => OnCollectionChanged(new NotifyCollectionChangedEventArgs(action, item));
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
         /// <summary>
         ///     Returns an <see cref="BindingList{T}" /> implementation that stays in sync with this collection.
         /// </summary>

--- a/src/EFCore/ChangeTracking/ObservableCollectionListSource.cs
+++ b/src/EFCore/ChangeTracking/ObservableCollectionListSource.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/EFCore/ChangeTracking/ObservableHashSet.cs
+++ b/src/EFCore/ChangeTracking/ObservableHashSet.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         : ISet<T>, IReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
     {
         private HashSet<T> _set;
-#if NET46
+#if NET46 || NETSTANDARD2_0
         private ObservableBackedBindingList<T> _bindingList;
 #elif NETSTANDARD1_3
 #else
@@ -466,7 +466,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         protected virtual void OnCollectionChanged([NotNull] NotifyCollectionChangedEventArgs e)
             => CollectionChanged?.Invoke(this, e);
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
         /// <summary>
         ///     Returns an <see cref="BindingList{T}" /> implementation that stays in sync with this collection.
         /// </summary>

--- a/src/EFCore/ChangeTracking/ObservableHashSetListSource.cs
+++ b/src/EFCore/ChangeTracking/ObservableHashSetListSource.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/EFCore/DbSet`.cs
+++ b/src/EFCore/DbSet`.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 using System.ComponentModel;
 using Microsoft.EntityFrameworkCore.Internal;
 #elif NETSTANDARD1_3
@@ -509,7 +509,7 @@ namespace Microsoft.EntityFrameworkCore
         }
     }
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
     public abstract partial class DbSet<TEntity> : IListSource
         where TEntity : class

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -6,7 +6,7 @@
 Commonly Used Types:
 Microsoft.EntityFrameworkCore.DbContext
 Microsoft.EntityFrameworkCore.DbSet</Description>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -23,7 +23,6 @@ Microsoft.EntityFrameworkCore.DbSet</Description>
     <PackageReference Include="System.Collections.Immutable" Version="$(ImmutableCollectionsVersion)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Interactive.Async" Version="$(SystemInteractiveAsyncVersion)" />
-    <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Properties\CoreStrings.Designer.tt">

--- a/src/EFCore/Extensions/ObservableCollectionExtensions.cs
+++ b/src/EFCore/Extensions/ObservableCollectionExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
+#if NET46 || NETSTANDARD2_0
 
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/test/EFCore.Benchmarks.EFCore/InitializationTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/InitializationTests.cs
@@ -91,13 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore
             }
         }
 
-#if NET46
-        private partial class ColdStartEnabledTests : MarshalByRefObject
-        {
-        }
-#endif
-
-        private partial class ColdStartEnabledTests
+        private class ColdStartEnabledTests : MarshalByRefObject
         {
             public void CreateAndDisposeUnusedContext(IMetricCollector collector, int count)
             {

--- a/test/EFCore.Benchmarks/BenchmarkTestCaseRunner.cs
+++ b/test/EFCore.Benchmarks/BenchmarkTestCaseRunner.cs
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         {
 #if NET46
             return ".NET Framework";
-#elif NETSTANDARD1_6
+#elif NETCOREAPP2_0
             return ".NET Core";
 #else
 #error target frameworks need to be updated.

--- a/test/EFCore.Benchmarks/ColdStartSandbox.cs
+++ b/test/EFCore.Benchmarks/ColdStartSandbox.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         }
     }
 }
-#elif NETSTANDARD1_6
+#elif NETCOREAPP2_0
 #else
 #error target frameworks need to be updated.
 #endif

--- a/test/EFCore.Benchmarks/EFCore.Benchmarks.csproj
+++ b/test/EFCore.Benchmarks/EFCore.Benchmarks.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Benchmarks</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="$(SqlClientVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(CoreFxVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>

--- a/test/EFCore.Benchmarks/MetricCollector.cs
+++ b/test/EFCore.Benchmarks/MetricCollector.cs
@@ -7,19 +7,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks
 {
-#if NET46
-    public partial class MetricCollector : MarshalByRefObject
-    {
-        private partial class Scope : MarshalByRefObject
-        {
-        }
-    }
-#elif NETSTANDARD1_6
-#else
-#error target frameworks need to be updated.
-#endif
-
-    public partial class MetricCollector : IMetricCollector
+    public class MetricCollector : MarshalByRefObject, IMetricCollector
     {
         private bool _collecting;
         private readonly Stopwatch _timer = new Stopwatch();
@@ -94,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
             info.AddValue(nameof(MemoryDelta), MemoryDelta);
         }
 
-        private partial class Scope : IDisposable
+        private class Scope : MarshalByRefObject, IDisposable
         {
             private readonly IMetricCollector _collector;
 

--- a/test/EFCore.Benchmarks/NullMetricCollector.cs
+++ b/test/EFCore.Benchmarks/NullMetricCollector.cs
@@ -6,19 +6,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks
 {
-#if NET46
-    public partial class NullMetricCollector : MarshalByRefObject
-    {
-        private partial class Scope : MarshalByRefObject
-        {
-        }
-    }
-#elif NETSTANDARD1_6
-#else
-#error target frameworks need to be updated.
-#endif
-
-    public partial class NullMetricCollector : IMetricCollector
+    public class NullMetricCollector : MarshalByRefObject, IMetricCollector
     {
         private readonly Scope _scope;
 
@@ -47,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
 
         public long MemoryDelta => 0;
 
-        private partial class Scope : IDisposable
+        private class Scope : MarshalByRefObject, IDisposable
         {
             public void Dispose()
             {

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -655,6 +655,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 Sql);
         }
 
+#if NET46
+
         [Fact]
         public virtual void CreateDatabaseOperation_with_filename_and_datadirectory()
         {
@@ -698,6 +700,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
                 Sql);
         }
+#elif NETCOREAPP2_0
+#else
+#error target frameworks need to be updated.
+#endif
 
         [Fact]
         public virtual void AlterDatabaseOperationOperation()

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -655,8 +655,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 Sql);
         }
 
-#if NET46
-
         [Fact]
         public virtual void CreateDatabaseOperation_with_filename_and_datadirectory()
         {
@@ -700,10 +698,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
                 Sql);
         }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
 
         [Fact]
         public virtual void AlterDatabaseOperationOperation()

--- a/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
-
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -444,7 +442,3 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
     }
 }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif

--- a/test/EFCore.Tests/ChangeTracking/Internal/ObservableCollectionListSourceTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ObservableCollectionListSourceTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
-
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -85,7 +83,3 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
     }
 }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif

--- a/test/EFCore.Tests/ChangeTracking/Internal/ObservableHashSetListSourceTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ObservableHashSetListSourceTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
-
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -87,7 +85,3 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
     }
 }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif

--- a/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET46
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -180,7 +178,3 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
     }
 }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif

--- a/test/EFCore.Tests/ChangeTracking/ObservableHashSetTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ObservableHashSetTest.cs
@@ -485,8 +485,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             Assert.Equal(new[] { "Brendan", "Nate" }, hashSet.OrderBy(i => i));
         }
 
-#if NET46
-
         [Fact]
         public void The_BindingList_returned_from_ObservableHasSet_is_cached()
         {
@@ -508,10 +506,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking
             Assert.NotNull(bindingListAgain);
             Assert.NotSame(bindingList, bindingListAgain);
         }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
 
         private static void AssertCountChanging<T>(
             ObservableHashSet<T> hashSet,

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -521,7 +521,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
         }
 
-#if NET46
         [Fact]
         public void Throws_when_using_with_IListSource()
         {
@@ -531,10 +530,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
                     Assert.Throws<NotSupportedException>(() => ((IListSource)context.Gus).GetList()).Message);
             }
         }
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
 
         private class Category
         {


### PR DESCRIPTION
Blocked on mirroring the 4.4.0 corefx packages
Blocked on API Check (throws *Could not load assembly 'netstandard'.*) cc @javiercn

Open question:
* Should we test on `netcoreapp1.1` to cover the `netstandard1.3` cross-targeted assemblies?
