### PR TITLE
Enable full build on AppVeyor with SQL Server 2016 settings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 2.0.0-preview1-{build}
 init:
   - git config --global core.autocrlf true
 build_script:
-  - ps: .\build.ps1 /p:TestGroup=SqlServer
+  - ps: .\build.ps1
 clone_depth: 1
 test: off
 deploy: off
@@ -20,6 +20,8 @@ environment:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     Test__SqlServer__DefaultConnection: Server=(local)\SQL2016;Database=master;User ID=sa;Password=Password12!
+    Test__SqlServer__SupportsMemoryOptimized: true
+    Test__SqlServer__SupportsHiddenColumns: true
 matrix:
   fast_finish: true
 artifacts:

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,9 +1,9 @@
 <Project>
-    <PropertyGroup>
-        <CoreOnly Condition="'$(CoreOnly)' == ''">False</CoreOnly>
-    </PropertyGroup>
-    <ItemGroup>
-        <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks.EF6\*.csproj" Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'" />
-        <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks\*.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <CoreOnly Condition="'$(CoreOnly)' == ''">False</CoreOnly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks.EF6\*.csproj" Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'" />
+    <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks\*.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
~~It hangs most times
Our appveyor build has been unreliable recently because net46 hangs while running sqlserver.functionaltests. Since it is not appveyor we are not able to find the root cause of hang (perhaps in MSBuild or test runner, I may have repro in a VM which got stuck at similar point).~~

~~While the underlying issue is resolved out we should disable testing offending assembly.
Testing if netcoreapp2.0 is working fine (by skipping net46 with new CoreOnly switch). If possible I may add specific project disabling.~~

The issue for hang #8384  which was disabled in #8383 So we no longer have hangs.
PR #8382 Fixed issue with test which used SQL Auth on SqlServer 2016. This enable SqlServer 2016 specific tests.
PR #8377  Removed appdomains for net46 testing which cut down build time by more than half. Testing out the full build settings.