### PR TITLE
Fix to #8364 - Query: comparing collection navigations to null or to each other doesn't work

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/WarningsTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/WarningsTestBase.cs
@@ -143,6 +143,26 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
+        [Fact]
+        public virtual void Comparing_collection_navigation_to_null_issues_possible_unintended_consequences_warning()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.Where(c => c.Orders != null).ToList();
+                Assert.Equal(91, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Comparing_two_collections_together_issues_possible_unintended_reference_comparison_warning()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.Where(c => c.Orders == c.Orders).ToList();
+                Assert.Equal(91, query.Count);
+            }
+        }
+
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected WarningsTestBase(TFixture fixture)

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
@@ -37,14 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if ((methodCallExpression.Method.Name == nameof(object.Equals))
-                && (methodCallExpression.Arguments.Count == 1)
-                && (methodCallExpression.Object != null))
+            if (methodCallExpression.Method.Name == nameof(object.Equals)
+                && methodCallExpression.Arguments.Count == 1
+                && methodCallExpression.Object != null)
             {
                 var argument = methodCallExpression.Arguments[0];
 
-                if ((methodCallExpression.Method.GetParameters()[0].ParameterType == typeof(object))
-                    && (methodCallExpression.Object.Type != argument.Type))
+                if (methodCallExpression.Method.GetParameters()[0].ParameterType == typeof(object)
+                    && methodCallExpression.Object.Type != argument.Type)
                 {
                     argument = argument.RemoveConvert();
 

--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -281,6 +281,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
+        // #8172 - One-to-many not supported yet
+        public override void Comparing_collection_navigation_on_optional_reference_to_null()
+        {
+        }
+
         protected override IQueryable<Level2> GetExpectedLevelTwo()
             => GetExpectedLevelOne().Select(t => t.OneToOne_Required_PK).Where(t => t != null);
 

--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3006,6 +3006,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 elementSorter: e => e.Id);
         }
 
+        [ConditionalFact]
+        public virtual void Comparing_collection_navigation_on_optional_reference_to_null()
+        {
+            AssertQueryScalar<Level1, int>(
+                l1s => l1s.Where(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional == null).Select(l1 => l1.Id),
+                l1s => l1s.Where(l1 => Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional) == null).Select(l1 => l1.Id));
+        }
+
         private static TResult Maybe<TResult>(object caller, Func<TResult> expression) where TResult : class
         {
             if (caller == null)

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -318,6 +318,64 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static void PossibleUnintendedCollectionNavigationNullComparisonWarning(
+            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] string navigationPath)
+        {
+            var eventId = CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning;
+
+            if (diagnostics.Logger.IsEnabled(eventId, LogLevel.Warning))
+            {
+                diagnostics.Logger.LogWarning(
+                    eventId,
+                    CoreStrings.PossibleUnintendedCollectionNavigationNullComparison(navigationPath));
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(eventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    eventId.Name,
+                    new
+                    {
+                        NavigationPath = navigationPath
+                    });
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void PossibleUnintendedReferenceComparisonWarning(
+            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] Expression left,
+            [NotNull] Expression right)
+        {
+            var eventId = CoreEventId.PossibleUnintendedReferenceComparisonWarning;
+
+            if (diagnostics.Logger.IsEnabled(eventId, LogLevel.Warning))
+            {
+                diagnostics.Logger.LogWarning(
+                    eventId,
+                    CoreStrings.PossibleUnintendedReferenceComparison(left, right));
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(eventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    eventId.Name,
+                    new
+                    {
+                        Left = left,
+                        Right = right
+                    });
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static void ModelValidationShadowKeyWarning(
             [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
             [NotNull] IEntityType entityType,

--- a/src/EFCore/Infrastructure/CoreEventId.cs
+++ b/src/EFCore/Infrastructure/CoreEventId.cs
@@ -65,6 +65,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             NavigationIncluded,
             IncludeIgnoredWarning,
             QueryExecutionPlanned,
+            PossibleUnintendedCollectionNavigationNullComparisonWarning,
+            PossibleUnintendedReferenceComparisonWarning,
 
             // Model validation events
             ModelValidationShadowKeyWarning = CoreBaseId + 300,
@@ -130,10 +132,24 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public static readonly EventId IncludeIgnoredWarning = MakeQueryId(Id.IncludeIgnoredWarning);
 
         /// <summary>
-        ///     A navigation was ignored while compiling a query.
+        ///     A query is planned for execution.
         ///     This event is in the <see cref="LoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId QueryExecutionPlanned = MakeQueryId(Id.QueryExecutionPlanned);
+
+        /// <summary>
+        ///     Possible uninteded comparison of collection navigation to null.
+        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        /// </summary>
+        public static readonly EventId PossibleUnintendedCollectionNavigationNullComparisonWarning
+            = MakeQueryId(Id.PossibleUnintendedCollectionNavigationNullComparisonWarning);
+
+        /// <summary>
+        ///     Possible uninteded reference comparison.
+        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        /// </summary>
+        public static readonly EventId PossibleUnintendedReferenceComparisonWarning
+            = MakeQueryId(Id.PossibleUnintendedReferenceComparisonWarning);
 
         private static readonly string _validationPrefix = LoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1645,6 +1645,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("IncludeNotSpecifiedDirectlyOnEntityType", nameof(include), nameof(invalidNavigation)),
                 include, invalidNavigation);
 
+        /// <summary>
+        ///     Collection navigations are only considered null if their parent entity is null. Use '.Any()' to check whether collection navigation '{navigationPath}' is empty.
+        /// </summary>
+        public static string PossibleUnintendedCollectionNavigationNullComparison([CanBeNull] object navigationPath)
+            => string.Format(
+                GetString("PossibleUnintendedCollectionNavigationNullComparison", nameof(navigationPath)),
+                navigationPath);
+
+        /// <summary>
+        ///     Possible unintended reference comparison between '{left}' and '{right}'.
+        /// </summary>
+        public static string PossibleUnintendedReferenceComparison([CanBeNull] object left, [CanBeNull] object right)
+            => string.Format(
+                GetString("PossibleUnintendedReferenceComparison", nameof(left), nameof(right)),
+                left, right);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -744,4 +744,10 @@
   <data name="IncludeNotSpecifiedDirectlyOnEntityType" xml:space="preserve">
     <value>The Include operation '{include}' is not supported. '{invalidNavigation}' must be a navigation property defined on an entity type.</value>
   </data>
+  <data name="PossibleUnintendedCollectionNavigationNullComparison" xml:space="preserve">
+    <value>Collection navigations are only considered null if their parent entity is null. Use '.Any()' to check whether collection navigation '{navigationPath}' is empty.</value>
+  </data>
+  <data name="PossibleUnintendedReferenceComparison" xml:space="preserve">
+    <value>Possible unintended reference comparison between '{left}' and '{right}'.</value>
+  </data>
 </root>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -26,7 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public EntityEqualityRewritingExpressionVisitor([NotNull] QueryCompilationContext queryCompilationContext)
+        public EntityEqualityRewritingExpressionVisitor(
+            [NotNull] QueryCompilationContext queryCompilationContext)
         {
             _queryCompilationContext = queryCompilationContext;
         }
@@ -56,7 +58,46 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var nonNullExpression = isLeftNullConstant ? newBinaryExpression.Right : newBinaryExpression.Left;
 
                 var qsre = nonNullExpression as QuerySourceReferenceExpression;
-                // If a navigation being compared to null then don't rewrite
+
+                var leftProperties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    newBinaryExpression.Left, _queryCompilationContext, out var leftNavigationQsre);
+
+                var rightProperties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    newBinaryExpression.Right, _queryCompilationContext, out var rightNavigationQsre);
+                
+                if (isNullComparison)
+                {
+                    var nonNullNavigationQsre = isLeftNullConstant ? rightNavigationQsre : leftNavigationQsre;
+                    var nonNullproperties = isLeftNullConstant ? rightProperties : leftProperties;
+
+                    if (IsCollectionNavigation(nonNullNavigationQsre, nonNullproperties))
+                    {
+                        // collection navigation is only null if its parent entity is null (null propagation thru navigation)
+                        // it is probable that user wanted to see if the collection is (not) empty, log warning suggesting to use Any() instead.
+                        _queryCompilationContext.Logger.PossibleUnintendedCollectionNavigationNullComparisonWarning(
+                            string.Join(".", nonNullproperties.Select(p => p.Name)));
+
+                        var callerExpression = CreateCollectionCallerExpression(nonNullNavigationQsre, nonNullproperties);
+
+                        return Visit(Expression.MakeBinary(newBinaryExpression.NodeType, callerExpression, Expression.Constant(null)));
+                    }
+                }
+
+                var collectionNavigationComparison = TryRewriteCollectionNavigationComparison(
+                    newBinaryExpression.Left, 
+                    newBinaryExpression.Right, 
+                    newBinaryExpression.NodeType, 
+                    leftNavigationQsre, 
+                    rightNavigationQsre, 
+                    leftProperties, 
+                    rightProperties);
+
+                if (collectionNavigationComparison != null)
+                {
+                    return collectionNavigationComparison;
+                }
+
+                // If a reference navigation is being compared to null then don't rewrite
                 if (isNullComparison
                     && qsre == null)
                 {
@@ -84,22 +125,156 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (entityType != null)
                 {
-                    var primaryKeyProperties = entityType.FindPrimaryKey().Properties;
-
-                    var newLeftExpression = isLeftNullConstant
-                        ? Expression.Constant(null, typeof(object))
-                        : CreateKeyAccessExpression(newBinaryExpression.Left, primaryKeyProperties, isNullComparison);
-
-                    var newRightExpression = isRightNullConstant
-                        ? Expression.Constant(null, typeof(object))
-                        : CreateKeyAccessExpression(newBinaryExpression.Right, primaryKeyProperties, isNullComparison);
-
-                    return Expression.MakeBinary(newBinaryExpression.NodeType, newLeftExpression, newRightExpression);
+                    return CreateKeyComparison(
+                        entityType,
+                        newBinaryExpression.Left,
+                        newBinaryExpression.Right,
+                        newBinaryExpression.NodeType,
+                        isLeftNullConstant,
+                        isRightNullConstant,
+                        isNullComparison);
                 }
             }
 
             return newBinaryExpression;
         }
+
+        private static readonly MethodInfo _objectEqualsMethodInfo
+            = typeof(object).GetRuntimeMethod(nameof(object.Equals), new[] { typeof(object), typeof(object) });
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            var newMethodCallExpression = (MethodCallExpression)base.VisitMethodCall(methodCallExpression);
+
+            Expression newLeftExpression = null;
+            Expression newRightExpression = null;
+
+            if (newMethodCallExpression.Method.Name == nameof(object.Equals)
+                && newMethodCallExpression.Object != null
+                && newMethodCallExpression.Arguments.Count == 1)
+            {
+                newLeftExpression = newMethodCallExpression.Object;
+                newRightExpression = newMethodCallExpression.Arguments[0];
+            }
+
+            if (newMethodCallExpression.Method.Equals(_objectEqualsMethodInfo))
+            {
+                newLeftExpression = newMethodCallExpression.Arguments[0];
+                newRightExpression = newMethodCallExpression.Arguments[1];
+            }
+
+            if (newLeftExpression != null
+                && newRightExpression != null)
+            {
+                var leftRootEntityType = _queryCompilationContext.Model.FindEntityType(newLeftExpression.Type)?.RootType();
+                var rightRootEntityType = _queryCompilationContext.Model.FindEntityType(newRightExpression.Type)?.RootType();
+                if (leftRootEntityType != null
+                    && leftRootEntityType == rightRootEntityType)
+                {
+                    return Visit(Expression.Equal(newLeftExpression, newRightExpression));
+                }
+
+                var isLeftNullConstant = newLeftExpression.IsNullConstantExpression();
+                var isRightNullConstant = newRightExpression.IsNullConstantExpression();
+
+                var leftProperties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    newLeftExpression, _queryCompilationContext, out var leftNavigationQsre);
+
+                var rightProperties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    newRightExpression, _queryCompilationContext, out var rightNavigationQsre);
+
+                if ((isLeftNullConstant || IsCollectionNavigation(leftNavigationQsre, leftProperties))
+                    && (isRightNullConstant || IsCollectionNavigation(rightNavigationQsre, rightProperties)))
+                {
+                    return Visit(Expression.Equal(newLeftExpression, newRightExpression));
+                }
+            }
+
+            return newMethodCallExpression;
+        }
+
+        private Expression TryRewriteCollectionNavigationComparison(
+            Expression leftExpressionn,
+            Expression rightExpressionn,
+            ExpressionType expressionType,
+            QuerySourceReferenceExpression leftNavigationQsre,
+            QuerySourceReferenceExpression rightNavigationQsre,
+            IList<IPropertyBase> leftProperties,
+            IList<IPropertyBase> rightProperties)
+        {
+            // if both collections are the same navigations, compare their parent entities (by key)
+            // otherwise we assume they are different references and return false
+            if (IsCollectionNavigation(leftNavigationQsre, leftProperties)
+                && IsCollectionNavigation(rightNavigationQsre, rightProperties))
+            {
+                _queryCompilationContext.Logger.PossibleUnintendedReferenceComparisonWarning(leftExpressionn, rightExpressionn);
+
+                if (leftProperties[leftProperties.Count - 1].Equals(rightProperties[rightProperties.Count - 1]))
+                {
+                    var newLeft = CreateCollectionCallerExpression(leftNavigationQsre, leftProperties);
+                    var newRight = CreateCollectionCallerExpression(rightNavigationQsre, rightProperties);
+
+                    return CreateKeyComparison(
+                        ((INavigation)leftProperties[leftProperties.Count - 1]).DeclaringEntityType,
+                        newLeft,
+                        newRight,
+                        expressionType,
+                        isLeftNullConstant: false,
+                        isRightNullConstant: false,
+                        isNullComparison: false);
+                }
+
+                return Expression.Constant(false);
+            }
+
+            return null;
+        }
+
+        private Expression CreateCollectionCallerExpression(
+            QuerySourceReferenceExpression qsre, 
+            IList<IPropertyBase> properties)
+        {
+            Expression result = qsre;
+            for (var i = 0; i < properties.Count - 1; i++)
+            {
+                result = result.CreateEFPropertyExpression(properties[i], makeNullable: false);
+            }
+
+            return result;
+        }
+
+        private static bool IsCollectionNavigation(QuerySourceReferenceExpression qsre, IList<IPropertyBase> properties)
+            => qsre != null
+                && properties.Count > 0
+                && properties[properties.Count - 1] is INavigation navigation
+                && navigation.IsCollection();
+
+        private Expression CreateKeyComparison(
+            IEntityType entityType, 
+            Expression left, 
+            Expression right, 
+            ExpressionType nodeType, 
+            bool isLeftNullConstant, 
+            bool isRightNullConstant, 
+            bool isNullComparison)
+        {
+            var primaryKeyProperties = entityType.FindPrimaryKey().Properties;
+
+            var newLeftExpression = isLeftNullConstant
+                ? Expression.Constant(null, typeof(object))
+                : CreateKeyAccessExpression(left, primaryKeyProperties, isNullComparison);
+
+            var newRightExpression = isRightNullConstant
+                ? Expression.Constant(null, typeof(object))
+                : CreateKeyAccessExpression(right, primaryKeyProperties, isNullComparison);
+
+            return Expression.MakeBinary(nodeType, newLeftExpression, newRightExpression);
+        }
+
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -55,29 +55,5 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection4();
         }
-
-        [ConditionalFact(Skip = "issue #8255")]
-        public override void Multiple_required_navigation_using_multiple_selects_with_string_based_Include()
-        {
-            base.Multiple_required_navigation_using_multiple_selects_with_string_based_Include();
-        }
-
-        [ConditionalFact(Skip = "issue #8255")]
-        public override void Multiple_required_navigations_with_Include()
-        {
-            base.Multiple_required_navigations_with_Include();
-        }
-
-        [ConditionalFact(Skip = "issue #8255")]
-        public override void Multiple_required_navigation_with_string_based_Include()
-        {
-            base.Multiple_required_navigation_with_string_based_Include();
-        }
-
-        [ConditionalFact(Skip = "issue #8255")]
-        public override void Multiple_required_navigation_using_multiple_selects_with_Include()
-        {
-            base.Multiple_required_navigation_using_multiple_selects_with_Include();
-        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2770,6 +2770,17 @@ LEFT JOIN [Level3] AS [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Requir
 WHERE ([l1.OneToOne_Required_PK].[Id] IS NOT NULL AND [l1.OneToOne_Required_PK.OneToOne_Required_PK].[Id] IS NOT NULL) AND [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK].[Id] IS NOT NULL");
         }
 
+        public override void Comparing_collection_navigation_on_optional_reference_to_null()
+        {
+            base.Comparing_collection_navigation_on_optional_reference_to_null();
+
+            AssertSql(
+                @"SELECT [l1].[Id]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+WHERE [l1.OneToOne_Optional_FK].[Id] IS NULL");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2944,6 +2944,47 @@ FROM [Faction] AS [f]
 WHERE [f].[Discriminator] = N'LocustHorde'");
         }
 
+        public override void Comparing_two_collection_navigations_composite_key()
+        {
+            base.Comparing_two_collection_navigations_composite_key();
+
+            AssertSql(
+                @"SELECT [g1].[Nickname] AS [Nickname1], [g2].[Nickname] AS [Nickname2]
+FROM [Gear] AS [g1]
+CROSS JOIN [Gear] AS [g2]
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND (([g1].[Nickname] = [g2].[Nickname]) AND ([g1].[SquadId] = [g2].[SquadId]))
+ORDER BY [Nickname1]");
+        }
+
+        public override void Comparing_two_collection_navigations_inheritance()
+        {
+            base.Comparing_two_collection_navigations_inheritance();
+
+            AssertSql(
+                @"SELECT [f].[Name], [o].[Nickname]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+LEFT JOIN (
+    SELECT [f.Commander.DefeatedBy].*
+    FROM [Gear] AS [f.Commander.DefeatedBy]
+    WHERE [f.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
+CROSS JOIN [Gear] AS [o]
+WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f].[Discriminator] = N'LocustHorde') AND ([o].[HasSoulPatch] = 1))) AND (([t0].[Nickname] = [o].[Nickname]) AND ([t0].[SquadId] = [o].[SquadId]))");
+        }
+
+        public override void Comparing_entities_using_Equals_inheritance()
+        {
+            base.Comparing_entities_using_Equals_inheritance();
+
+            AssertSql(
+                @"");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Lifting_when_subquery_nested_order_by_anonymous()
@@ -8193,6 +8194,151 @@ FROM (
     SELECT DISTINCT [o].[OrderID]
     FROM [Orders] AS [o]
 ) AS [t]");
+        }
+        public override void Comparing_entities_using_Equals()
+        {
+            base.Comparing_entities_using_Equals();
+
+            AssertSql(
+                @"SELECT [c1].[CustomerID] AS [Id1], [c2].[CustomerID] AS [Id2]
+FROM [Customers] AS [c1]
+CROSS JOIN [Customers] AS [c2]
+WHERE ([c1].[CustomerID] LIKE N'ALFKI' + N'%' AND (LEFT([c1].[CustomerID], LEN(N'ALFKI')) = N'ALFKI')) AND ([c1].[CustomerID] = [c2].[CustomerID])
+ORDER BY [Id1]");
+        }
+
+        public override void Comparing_different_entity_types_using_Equals()
+        {
+            base.Comparing_different_entity_types_using_Equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE ([c].[CustomerID] = N' ALFKI') AND ([o].[CustomerID] = N'ALFKI')");
+        }
+
+        public override void Comparing_entity_to_null_using_Equals()
+        {
+            base.Comparing_entity_to_null_using_Equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Comparing_navigations_using_Equals()
+        {
+            base.Comparing_navigations_using_Equals();
+
+            AssertSql(
+                @"SELECT [o1].[OrderID] AS [Id1], [o2].[OrderID] AS [Id2]
+FROM [Orders] AS [o1]
+CROSS JOIN [Orders] AS [o2]
+WHERE ([o1].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o1].[CustomerID], LEN(N'A')) = N'A')) AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
+ORDER BY [Id1], [Id2]");
+        }
+
+        public override void Comparing_navigations_using_static_Equals()
+        {
+            base.Comparing_navigations_using_static_Equals();
+
+            AssertSql(
+                @"SELECT [o1].[OrderID] AS [Id1], [o2].[OrderID] AS [Id2]
+FROM [Orders] AS [o1]
+CROSS JOIN [Orders] AS [o2]
+WHERE ([o1].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o1].[CustomerID], LEN(N'A')) = N'A')) AND (([o1].[CustomerID] = [o2].[CustomerID]) OR ([o1].[CustomerID] IS NULL AND [o2].[CustomerID] IS NULL))
+ORDER BY [Id1], [Id2]");
+        }
+
+        public override void Comparing_non_matching_entities_using_Equals()
+        {
+            base.Comparing_non_matching_entities_using_Equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Id1], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID] AS [Id2], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = N'ALFKI'");
+        }
+
+        public override void Comparing_non_matching_collection_navigations_using_Equals()
+        {
+            base.Comparing_non_matching_collection_navigations_using_Equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Id1], [o].[OrderID] AS [Id2]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE 0 = 1");
+        }
+
+        public override void Comparing_collection_navigation_to_null()
+        {
+            base.Comparing_collection_navigation_to_null();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NULL");
+        }
+
+        public override void Comparing_collection_navigation_to_null_complex()
+        {
+            base.Comparing_collection_navigation_to_null_complex();
+
+            AssertSql(
+                @"SELECT [od].[ProductID], [od].[OrderID]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+WHERE ([od].[OrderID] < 10250) AND [od.Order].[CustomerID] IS NOT NULL
+ORDER BY [od].[OrderID], [od].[ProductID]");
+        }
+
+        public override void Compare_collection_navigation_with_itself()
+        {
+            base.Compare_collection_navigation_with_itself();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')) AND ([c].[CustomerID] = [c].[CustomerID])");
+        }
+
+        public override void Compare_two_collection_navigations_with_different_query_sources()
+        {
+            base.Compare_two_collection_navigations_with_different_query_sources();
+
+            AssertSql(
+                @"SELECT [c1].[CustomerID] AS [Id1], [c2].[CustomerID] AS [Id2]
+FROM [Customers] AS [c1]
+CROSS JOIN [Customers] AS [c2]
+WHERE (([c1].[CustomerID] = N'ALFKI') AND ([c2].[CustomerID] = N'ALFKI')) AND ([c1].[CustomerID] = [c2].[CustomerID])");
+        }
+
+        public override void Compare_two_collection_navigations_using_equals()
+        {
+            base.Compare_two_collection_navigations_using_equals();
+
+            AssertSql(
+                @"SELECT [c1].[CustomerID] AS [Id1], [c2].[CustomerID] AS [Id2]
+FROM [Customers] AS [c1]
+CROSS JOIN [Customers] AS [c2]
+WHERE (([c1].[CustomerID] = N'ALFKI') AND ([c2].[CustomerID] = N'ALFKI')) AND ([c1].[CustomerID] = [c2].[CustomerID])");
+        }
+
+        public override void Compare_two_collection_navigations_with_different_property_chains()
+        {
+            base.Compare_two_collection_navigations_with_different_property_chains();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Id1], [o].[OrderID] AS [Id2]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE ([c].[CustomerID] = N'ALFKI') AND ([c].[CustomerID] = [o].[CustomerID])
+ORDER BY [Id1], [Id2]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
@@ -59,6 +59,22 @@ WHERE [x].[OrderID] = 10248",
                 @"(from Customer c in DbSet<Customer> where c.CustomerID == ""ALFKI"" select c).Single()")));
         }
 
+        public override void Comparing_collection_navigation_to_null_issues_possible_unintended_consequences_warning()
+        {
+            base.Comparing_collection_navigation_to_null_issues_possible_unintended_consequences_warning();
+
+            Assert.True(Fixture.TestSqlLoggerFactory.Log.Contains(
+                CoreStrings.PossibleUnintendedCollectionNavigationNullComparison("Orders")));
+        }
+
+        public override void Comparing_two_collections_together_issues_possible_unintended_reference_comparison_warning()
+        {
+            base.Comparing_two_collections_together_issues_possible_unintended_reference_comparison_warning();
+
+            Assert.True(Fixture.TestSqlLoggerFactory.Log.Contains(
+                CoreStrings.PossibleUnintendedReferenceComparison("[c].Orders", "[c].Orders")));
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
Also fixes (smaller in scope) #5825 - Query: Comparing collection navigation to NULL throws Null Exception

Problem was that we were not taking into account queries where collection navigation was being compared to null and/or each other. This would cause various exceptions during query compilation.

Some of the common cases can be simplified, making them much easier for the query compiler (i.e. navigation rewrite) to process.

When it comes to null comparison, we assume that collection navigation is only null if its parent entity is null, so we can actually just compare the parent entity to null instead
e.g.: customer.Orders == null ---> customer == null ---> customer.Id == null

However, it's possible that user wanted to check whether collection has any elements - we will issue a warning that the comparison to null could have unintended consequences and suggest to use .Any() instead.

When collection navigations are compared to each other we can also approximate by comparing the parent entities instead (if the collections are the same INavigation). If navigations are different, we assume they are never equal.
e.g.:
csutomer1.Orders == customer2.Orders ---> customer1.Id == customer2.Id
customer.Orders == company.ShippedOrders ---> false

This is not a perfect translation, since there can be two collections with exactly the same elements coming from different navigations (e.g. two empty collections: c.CompletedOrders, c.PendingOrders)
Therefore we also issue the warning in this case, saying that the result may not be what user expected.
