### PR TITLE
Add a convention that configures table splitting for owned types

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -82,16 +82,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var relationalColumnAttributeConvention = new RelationalColumnAttributeConvention();
             conventionSet.PropertyAddedConventions.Add(relationalColumnAttributeConvention);
 
+            var sharedTableConvention = new SharedTableConvention(Dependencies.AnnotationProvider);
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention());
+            conventionSet.EntityTypeAddedConventions.Add(sharedTableConvention);
 
             conventionSet.BaseEntityTypeSetConventions.Add(new DiscriminatorConvention());
 
             conventionSet.BaseEntityTypeSetConventions.Add(
                 new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder));
 
+            conventionSet.EntityTypeAnnotationSetConventions.Add(sharedTableConvention);
+
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
 
             conventionSet.PropertyAnnotationSetConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
+
+            conventionSet.ForeignKeyUniquenessConventions.Add(sharedTableConvention);
+            conventionSet.ForeignKeyOwnershipConventions.Add(sharedTableConvention);
 
             return conventionSet;
         }

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SharedTableConvention :
+        IEntityTypeConvention,
+        IEntityTypeAnnotationSetConvention,
+        IForeignKeyOwnershipConvention,
+        IForeignKeyUniquenessConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SharedTableConvention([NotNull] IRelationalAnnotationProvider annotationProvider)
+        {
+            AnnotationProvider = annotationProvider;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IRelationalAnnotationProvider AnnotationProvider { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
+        {
+            var ownership = entityTypeBuilder.Metadata.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership && fk.IsUnique);
+            if (ownership != null)
+            {
+                SetOwnedTable(ownership);
+            }
+
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Annotation Apply(
+            InternalEntityTypeBuilder entityTypeBuilder, string name, Annotation annotation, Annotation oldAnnotation)
+        {
+            var entityType = entityTypeBuilder.Metadata;
+            var providerAnnotations = (AnnotationProvider.For(entityType) as RelationalEntityTypeAnnotations)?.ProviderFullAnnotationNames;
+            if (name == RelationalFullAnnotationNames.Instance.TableName
+                || name == RelationalFullAnnotationNames.Instance.Schema
+                || (providerAnnotations != null
+                    && (name == providerAnnotations.TableName
+                        || name == providerAnnotations.Schema)))
+            {
+                foreach (var foreignKey in entityType.GetReferencingForeignKeys())
+                {
+                    if (foreignKey.IsOwnership
+                        && foreignKey.IsUnique)
+                    {
+                        SetOwnedTable(foreignKey);
+                    }
+                }
+            }
+
+            return annotation;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
+        {
+            var foreignKey = relationshipBuilder.Metadata;
+            if (foreignKey.IsOwnership
+                && foreignKey.IsUnique)
+            {
+                SetOwnedTable(foreignKey);
+            }
+
+            return relationshipBuilder;
+        }
+
+        private void SetOwnedTable(ForeignKey foreignKey)
+        {
+            var ownerType = foreignKey.PrincipalEntityType;
+            foreignKey.DeclaringEntityType.Builder.Relational(ConfigurationSource.Convention)
+                .ToTable(AnnotationProvider.For(ownerType).TableName, AnnotationProvider.For(ownerType).Schema);
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
@@ -12,8 +12,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public class RelationalEntityTypeAnnotations : IRelationalEntityTypeAnnotations
     {
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalEntityTypeAnnotations(
             [NotNull] IEntityType entityType,
             [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
@@ -28,6 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Annotations = annotations;
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
+
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
 
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IEntityType EntityType => (IEntityType)Annotations.Metadata;
@@ -80,10 +80,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 return (string)Annotations.GetAnnotation(
                            RelationalFullAnnotationNames.Instance.Schema,
                            ProviderFullAnnotationNames?.Schema)
-                       ?? GetAnnotations((IMutableModel)EntityType.Model).DefaultSchema;
+                       ?? GetDefaultSchema();
             }
             [param: CanBeNull] set { SetSchema(value); }
         }
+
+        private string GetDefaultSchema()
+            => EntityType.HasDelegatedIdentity()
+            ? GetAnnotations(EntityType.DefiningEntityType).Schema
+            : GetAnnotations(EntityType.Model).DefaultSchema;
 
         protected virtual bool SetSchema([CanBeNull] string value)
             => Annotations.SetAnnotation(

--- a/src/EFCore.Relational/Metadata/RelationalForeignKeyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalForeignKeyAnnotations.cs
@@ -15,8 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     {
         protected const string DefaultForeignKeyNamePrefix = "FK";
 
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalForeignKeyAnnotations([NotNull] IForeignKey foreignKey,
             [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
             : this(new RelationalAnnotations(foreignKey), providerFullAnnotationNames)
@@ -29,6 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Annotations = annotations;
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
+
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
 
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IForeignKey ForeignKey => (IForeignKey)Annotations.Metadata;

--- a/src/EFCore.Relational/Metadata/RelationalIndexAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalIndexAnnotations.cs
@@ -15,8 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     {
         protected const string DefaultIndexNamePrefix = "IX";
 
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalIndexAnnotations([NotNull] IIndex index,
             [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
             : this(new RelationalAnnotations(index), providerFullAnnotationNames)
@@ -29,6 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Annotations = annotations;
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
+
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
 
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IIndex Index => (IIndex)Annotations.Metadata;

--- a/src/EFCore.Relational/Metadata/RelationalKeyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalKeyAnnotations.cs
@@ -15,8 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         protected const string DefaultPrimaryKeyNamePrefix = "PK";
         protected const string DefaultAlternateKeyNamePrefix = "AK";
 
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalKeyAnnotations([NotNull] IKey key,
             [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
             : this(new RelationalAnnotations(key), providerFullAnnotationNames)
@@ -29,6 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Annotations = annotations;
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
+
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
 
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IKey Key => (IKey)Annotations.Metadata;

--- a/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
@@ -4,15 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public class RelationalModelAnnotations : IRelationalModelAnnotations
     {
-        protected readonly RelationalFullAnnotationNames ProviderFullAnnotationNames;
-
         public RelationalModelAnnotations([NotNull] IModel model, [CanBeNull] RelationalFullAnnotationNames providerFullAnnotationNames)
             : this(new RelationalAnnotations(model), providerFullAnnotationNames)
         {
@@ -25,6 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Annotations = annotations;
             ProviderFullAnnotationNames = providerFullAnnotationNames;
         }
+
+        public virtual RelationalFullAnnotationNames ProviderFullAnnotationNames { get; }
 
         protected virtual RelationalAnnotations Annotations { get; }
         protected virtual IModel Model => (IModel)Annotations.Metadata;

--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
-        // One-to-many not supported yet
+        // #8172 - One-to-many not supported yet
         public override void Multiple_SelectMany_with_string_based_Include()
         {
         }
@@ -256,6 +256,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
+        public override void Comparing_collection_navigation_on_optional_reference_to_null()
+        {
+        }
+
         // Self-ref not supported
         public override void Join_navigation_translated_to_subquery_self_ref()
         {
@@ -281,10 +285,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
-        // #8172 - One-to-many not supported yet
-        public override void Comparing_collection_navigation_on_optional_reference_to_null()
-        {
-        }
+        protected override IQueryable<Level1> GetExpectedLevelOne()
+            => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 
         protected override IQueryable<Level2> GetExpectedLevelTwo()
             => GetExpectedLevelOne().Select(t => t.OneToOne_Required_PK).Where(t => t != null);

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
@@ -13,52 +13,39 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
         public static IReadOnlyList<Level3> LevelThrees { get; }
         public static IReadOnlyList<Level4> LevelFours { get; }
 
+        public static IReadOnlyList<Level1> SplitLevelOnes { get; }
+        public static IReadOnlyList<Level2> SplitLevelTwos { get; }
+        public static IReadOnlyList<Level3> SplitLevelThrees { get; }
+        public static IReadOnlyList<Level4> SplitLevelFours { get; }
+
         static ComplexNavigationsData()
         {
-            LevelOnes = CreateLevelOnes();
-            LevelTwos = CreateLevelTwos();
-            LevelThrees = CreateLevelThrees();
-            LevelFours = CreateLevelFours();
+            LevelOnes = CreateLevelOnes(tableSplitting: false);
+            LevelTwos = CreateLevelTwos(tableSplitting: false);
+            LevelThrees = CreateLevelThrees(tableSplitting: false);
+            LevelFours = CreateLevelFours(tableSplitting: false);
 
-            foreach (var l1 in LevelOnes)
-            {
-                l1.OneToMany_Optional = new List<Level2>();
-                l1.OneToMany_Optional_Self = new List<Level1>();
-                l1.OneToMany_Required = new List<Level2>();
-                l1.OneToMany_Required_Self = new List<Level1>();
-            }
+            WireUpPart1(LevelOnes, LevelTwos, LevelThrees, LevelFours, tableSplitting: false);
+            WireUpInversePart1(LevelOnes, LevelTwos, LevelThrees, LevelFours, tableSplitting: false);
 
-            foreach (var l2 in LevelTwos)
-            {
-                l2.OneToMany_Optional = new List<Level3>();
-                l2.OneToMany_Optional_Self = new List<Level2>();
-                l2.OneToMany_Required = new List<Level3>();
-                l2.OneToMany_Required_Self = new List<Level2>();
-            }
+            WireUpPart2(LevelOnes, LevelTwos, LevelThrees, LevelFours, tableSplitting: false);
+            WireUpInversePart2(LevelOnes, LevelTwos, LevelThrees, LevelFours, tableSplitting: false);
 
-            foreach (var l3 in LevelThrees)
-            {
-                l3.OneToMany_Optional = new List<Level4>();
-                l3.OneToMany_Optional_Self = new List<Level3>();
-                l3.OneToMany_Required = new List<Level4>();
-                l3.OneToMany_Required_Self = new List<Level3>();
-            }
+            SplitLevelOnes = CreateLevelOnes(tableSplitting: true);
+            SplitLevelTwos = CreateLevelTwos(tableSplitting: true);
+            SplitLevelThrees = CreateLevelThrees(tableSplitting: true);
+            SplitLevelFours = CreateLevelFours(tableSplitting: true);
 
-            foreach (var l4 in LevelFours)
-            {
-                l4.OneToMany_Optional_Self = new List<Level4>();
-                l4.OneToMany_Required_Self = new List<Level4>();
-            }
+            WireUpPart1(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
+            WireUpInversePart1(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
 
-            WireUpPart1(LevelOnes, LevelTwos, LevelThrees, LevelFours);
-            WireUpInversePart1(LevelOnes, LevelTwos, LevelThrees, LevelFours);
-
-            WireUpPart2(LevelOnes, LevelTwos, LevelThrees, LevelFours);
-            WireUpInversePart2(LevelOnes, LevelTwos, LevelThrees, LevelFours);
+            WireUpPart2(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
+            WireUpInversePart2(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
         }
 
-        public static Level1[] CreateLevelOnes() =>
-            new[]
+        public static IReadOnlyList<Level1> CreateLevelOnes(bool tableSplitting)
+        {
+            var result = new List<Level1>
             {
                 new Level1 { Id = 1, Name = "L1 01", Date = new DateTime(2001, 1, 1) },
                 new Level1 { Id = 2, Name = "L1 02", Date = new DateTime(2002, 2, 2) },
@@ -69,14 +56,33 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
                 new Level1 { Id = 7, Name = "L1 07", Date = new DateTime(2007, 7, 7) },
                 new Level1 { Id = 8, Name = "L1 08", Date = new DateTime(2008, 8, 8) },
                 new Level1 { Id = 9, Name = "L1 09", Date = new DateTime(2009, 9, 9) },
-                new Level1 { Id = 10, Name = "L1 10", Date = new DateTime(2010, 10, 10) },
-                new Level1 { Id = 11, Name = "L1 11", Date = new DateTime(2009, 11, 11) },
-                new Level1 { Id = 12, Name = "L1 12", Date = new DateTime(2008, 12, 12) },
-                new Level1 { Id = 13, Name = "L1 13", Date = new DateTime(2007, 1, 1) }
+                new Level1 { Id = 10, Name = "L1 10", Date = new DateTime(2010, 10, 10) }
             };
 
-        public static Level2[] CreateLevelTwos() =>
-            new[]
+            if (!tableSplitting)
+            {
+                result.AddRange(new List<Level1>
+                {
+                    new Level1 { Id = 11, Name = "L1 11", Date = new DateTime(2009, 11, 11) },
+                    new Level1 { Id = 12, Name = "L1 12", Date = new DateTime(2008, 12, 12) },
+                    new Level1 { Id = 13, Name = "L1 13", Date = new DateTime(2007, 1, 1) }
+                });
+            }
+
+            foreach (var l1 in result)
+            {
+                l1.OneToMany_Optional = new List<Level2>();
+                l1.OneToMany_Optional_Self = new List<Level1>();
+                l1.OneToMany_Required = new List<Level2>();
+                l1.OneToMany_Required_Self = new List<Level1>();
+            }
+
+            return result;
+        }
+
+        public static IReadOnlyList<Level2> CreateLevelTwos(bool tableSplitting)
+        {
+            var result = new List<Level2>
             {
                 new Level2 { Id = 1, Name = "L2 01", Date = new DateTime(2010, 10, 10) },
                 new Level2 { Id = 2, Name = "L2 02", Date = new DateTime(2002, 2, 2) },
@@ -87,12 +93,31 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
                 new Level2 { Id = 7, Name = "L2 07", Date = new DateTime(2007, 7, 7) },
                 new Level2 { Id = 8, Name = "L2 08", Date = new DateTime(2003, 3, 3) },
                 new Level2 { Id = 9, Name = "L2 09", Date = new DateTime(2009, 9, 9) },
-                new Level2 { Id = 10, Name = "L2 10", Date = new DateTime(2001, 1, 1) },
-                new Level2 { Id = 11, Name = "L2 11", Date = new DateTime(2000, 1, 1) }
+                new Level2 { Id = 10, Name = "L2 10", Date = new DateTime(2001, 1, 1) }
             };
 
-        public static Level3[] CreateLevelThrees() =>
-            new[]
+            if (!tableSplitting)
+            {
+                result.AddRange(new List<Level2>
+                {
+                    new Level2 { Id = 11, Name = "L2 11", Date = new DateTime(2000, 1, 1) }
+                });
+            }
+
+            foreach (var l2 in result)
+            {
+                l2.OneToMany_Optional = new List<Level3>();
+                l2.OneToMany_Optional_Self = new List<Level2>();
+                l2.OneToMany_Required = new List<Level3>();
+                l2.OneToMany_Required_Self = new List<Level2>();
+            }
+
+            return result;
+        }
+
+        public static IReadOnlyList<Level3> CreateLevelThrees(bool tableSplitting)
+        {
+            var result = new List<Level3>
             {
                 new Level3 { Id = 1, Name = "L3 01" },
                 new Level3 { Id = 2, Name = "L3 02" },
@@ -106,8 +131,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
                 new Level3 { Id = 10, Name = "L3 10" }
             };
 
-        public static Level4[] CreateLevelFours() =>
-            new[]
+            foreach (var l3 in result)
+            {
+                l3.OneToMany_Optional = new List<Level4>();
+                l3.OneToMany_Optional_Self = new List<Level3>();
+                l3.OneToMany_Required = new List<Level4>();
+                l3.OneToMany_Required_Self = new List<Level3>();
+            }
+
+            return result;
+        }
+
+        public static IReadOnlyList<Level4> CreateLevelFours(bool tableSplitting)
+        {
+            var result = new List<Level4>
             {
                 new Level4 { Id = 1, Name = "L4 01" },
                 new Level4 { Id = 2, Name = "L4 02" },
@@ -121,8 +158,18 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
                 new Level4 { Id = 10, Name = "L4 10" }
             };
 
+            foreach (var l4 in result)
+            {
+                l4.OneToMany_Optional_Self = new List<Level4>();
+                l4.OneToMany_Required_Self = new List<Level4>();
+            }
+
+            return result;
+        }
+
         public static void WireUpPart1(
-            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s)
+            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s,
+            bool tableSplitting)
         {
             l1s[0].OneToOne_Required_PK = l2s[0];
             l1s[1].OneToOne_Required_PK = l2s[1];
@@ -134,24 +181,56 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l1s[7].OneToOne_Required_PK = l2s[7];
             l1s[8].OneToOne_Required_PK = l2s[8];
             l1s[9].OneToOne_Required_PK = l2s[9];
-            l1s[10].OneToOne_Required_PK = l2s[10];
+            if (!tableSplitting)
+            {
+                l1s[10].OneToOne_Required_PK = l2s[10];
+            }
 
-            l1s[0].OneToOne_Required_FK = l2s[9];
-            l1s[1].OneToOne_Required_FK = l2s[8];
-            l1s[2].OneToOne_Required_FK = l2s[7];
-            l1s[3].OneToOne_Required_FK = l2s[6];
-            l1s[4].OneToOne_Required_FK = l2s[5];
-            l1s[5].OneToOne_Required_FK = l2s[4];
-            l1s[6].OneToOne_Required_FK = l2s[3];
-            l1s[7].OneToOne_Required_FK = l2s[2];
-            l1s[8].OneToOne_Required_FK = l2s[1];
-            l1s[9].OneToOne_Required_FK = l2s[0];
-            l1s[10].OneToOne_Required_FK = l2s[10];
+            if (tableSplitting)
+            {
+                l1s[0].OneToOne_Required_FK = l2s[0];
+                l1s[1].OneToOne_Required_FK = l2s[1];
+                l1s[2].OneToOne_Required_FK = l2s[2];
+                l1s[3].OneToOne_Required_FK = l2s[3];
+                l1s[4].OneToOne_Required_FK = l2s[4];
+                l1s[5].OneToOne_Required_FK = l2s[5];
+                l1s[6].OneToOne_Required_FK = l2s[6];
+                l1s[7].OneToOne_Required_FK = l2s[7];
+                l1s[8].OneToOne_Required_FK = l2s[8];
+                l1s[9].OneToOne_Required_FK = l2s[9];
+            }
+            else
+            {
+                l1s[0].OneToOne_Required_FK = l2s[9];
+                l1s[1].OneToOne_Required_FK = l2s[8];
+                l1s[2].OneToOne_Required_FK = l2s[7];
+                l1s[3].OneToOne_Required_FK = l2s[6];
+                l1s[4].OneToOne_Required_FK = l2s[5];
+                l1s[5].OneToOne_Required_FK = l2s[4];
+                l1s[6].OneToOne_Required_FK = l2s[3];
+                l1s[7].OneToOne_Required_FK = l2s[2];
+                l1s[8].OneToOne_Required_FK = l2s[1];
+                l1s[9].OneToOne_Required_FK = l2s[0];
+                l1s[10].OneToOne_Required_FK = l2s[10];
+            }
 
-            l1s[0].OneToMany_Required = new List<Level2> { l2s[0], l2s[1], l2s[2], l2s[3], l2s[4], l2s[5], l2s[6], l2s[7], l2s[8], l2s[9], l2s[10] };
+            l1s[0].OneToMany_Required = new List<Level2> { l2s[0], l2s[1], l2s[2], l2s[3], l2s[4], l2s[5], l2s[6], l2s[7], l2s[8], l2s[9] };
 
-            l1s[0].OneToMany_Required_Self = new List<Level1> { l1s[0], l1s[1], l1s[11] };
-            l1s[1].OneToMany_Required_Self = new List<Level1> { l1s[2], l1s[12] };
+            if (!tableSplitting)
+            {
+                l1s[0].OneToMany_Required.Add(l2s[10]);
+            }
+
+            l1s[0].OneToMany_Required_Self = new List<Level1> { l1s[0], l1s[1] };
+            if (!tableSplitting)
+            {
+                l1s[0].OneToMany_Required_Self.Add(l1s[11]);
+            }
+            l1s[1].OneToMany_Required_Self = new List<Level1> { l1s[2] };
+            if (!tableSplitting)
+            {
+                l1s[1].OneToMany_Required_Self.Add(l1s[12]);
+            }
             l1s[2].OneToMany_Required_Self = new List<Level1> { l1s[3] };
             l1s[3].OneToMany_Required_Self = new List<Level1> { l1s[4] };
             l1s[4].OneToMany_Required_Self = new List<Level1> { l1s[5] };
@@ -160,9 +239,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l1s[7].OneToMany_Required_Self = new List<Level1> { l1s[8] };
             l1s[8].OneToMany_Required_Self = new List<Level1> { l1s[9] };
             l1s[9].OneToMany_Required_Self = new List<Level1>();
-            l1s[10].OneToMany_Required_Self = new List<Level1> { l1s[10] };
-            l1s[11].OneToMany_Required_Self = new List<Level1>();
-            l1s[12].OneToMany_Required_Self = new List<Level1>();
+            if (!tableSplitting)
+            {
+                l1s[10].OneToMany_Required_Self = new List<Level1> { l1s[10] };
+                l1s[11].OneToMany_Required_Self = new List<Level1>();
+                l1s[12].OneToMany_Required_Self = new List<Level1>();
+            }
 
             l2s[0].OneToOne_Required_PK = l3s[0];
             l2s[1].OneToOne_Required_PK = l3s[1];
@@ -175,20 +257,40 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l2s[8].OneToOne_Required_PK = l3s[8];
             l2s[9].OneToOne_Required_PK = l3s[9];
 
-            l2s[0].OneToOne_Required_FK = l3s[9];
-            l2s[1].OneToOne_Required_FK = l3s[8];
-            l2s[2].OneToOne_Required_FK = l3s[7];
-            l2s[3].OneToOne_Required_FK = l3s[6];
-            l2s[4].OneToOne_Required_FK = l3s[5];
-            l2s[5].OneToOne_Required_FK = l3s[4];
-            l2s[6].OneToOne_Required_FK = l3s[3];
-            l2s[7].OneToOne_Required_FK = l3s[2];
-            l2s[8].OneToOne_Required_FK = l3s[1];
-            l2s[9].OneToOne_Required_FK = l3s[0];
+            if (tableSplitting)
+            {
+                l2s[0].OneToOne_Required_FK = l3s[0];
+                l2s[1].OneToOne_Required_FK = l3s[1];
+                l2s[2].OneToOne_Required_FK = l3s[2];
+                l2s[3].OneToOne_Required_FK = l3s[3];
+                l2s[4].OneToOne_Required_FK = l3s[4];
+                l2s[5].OneToOne_Required_FK = l3s[5];
+                l2s[6].OneToOne_Required_FK = l3s[6];
+                l2s[7].OneToOne_Required_FK = l3s[7];
+                l2s[8].OneToOne_Required_FK = l3s[8];
+                l2s[9].OneToOne_Required_FK = l3s[9];
+            }
+            else
+            {
+                l2s[0].OneToOne_Required_FK = l3s[9];
+                l2s[1].OneToOne_Required_FK = l3s[8];
+                l2s[2].OneToOne_Required_FK = l3s[7];
+                l2s[3].OneToOne_Required_FK = l3s[6];
+                l2s[4].OneToOne_Required_FK = l3s[5];
+                l2s[5].OneToOne_Required_FK = l3s[4];
+                l2s[6].OneToOne_Required_FK = l3s[3];
+                l2s[7].OneToOne_Required_FK = l3s[2];
+                l2s[8].OneToOne_Required_FK = l3s[1];
+                l2s[9].OneToOne_Required_FK = l3s[0];
+            }
 
             l2s[0].OneToMany_Required = new List<Level3> { l3s[0], l3s[1], l3s[2], l3s[3], l3s[4], l3s[5], l3s[6], l3s[7], l3s[8], l3s[9] };
 
-            l2s[0].OneToMany_Required_Self = new List<Level2> { l2s[0], l2s[1], l2s[10] };
+            l2s[0].OneToMany_Required_Self = new List<Level2> { l2s[0], l2s[1] };
+            if (!tableSplitting)
+            {
+                l2s[0].OneToMany_Required_Self.Add(l2s[10]);
+            }
             l2s[1].OneToMany_Required_Self = new List<Level2> { l2s[2] };
             l2s[2].OneToMany_Required_Self = new List<Level2> { l2s[3] };
             l2s[3].OneToMany_Required_Self = new List<Level2> { l2s[4] };
@@ -198,7 +300,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l2s[7].OneToMany_Required_Self = new List<Level2> { l2s[8] };
             l2s[8].OneToMany_Required_Self = new List<Level2> { l2s[9] };
             l2s[9].OneToMany_Required_Self = new List<Level2>();
-            l2s[10].OneToMany_Required_Self = new List<Level2>();
+            if (!tableSplitting)
+            {
+                l2s[10].OneToMany_Required_Self = new List<Level2>();
+            }
 
             l3s[0].OneToOne_Required_PK = l4s[0];
             l3s[1].OneToOne_Required_PK = l4s[1];
@@ -211,16 +316,32 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l3s[8].OneToOne_Required_PK = l4s[8];
             l3s[9].OneToOne_Required_PK = l4s[9];
 
-            l3s[0].OneToOne_Required_FK = l4s[9];
-            l3s[1].OneToOne_Required_FK = l4s[8];
-            l3s[2].OneToOne_Required_FK = l4s[7];
-            l3s[3].OneToOne_Required_FK = l4s[6];
-            l3s[4].OneToOne_Required_FK = l4s[5];
-            l3s[5].OneToOne_Required_FK = l4s[4];
-            l3s[6].OneToOne_Required_FK = l4s[3];
-            l3s[7].OneToOne_Required_FK = l4s[2];
-            l3s[8].OneToOne_Required_FK = l4s[1];
-            l3s[9].OneToOne_Required_FK = l4s[0];
+            if (tableSplitting)
+            {
+                l3s[0].OneToOne_Required_FK = l4s[0];
+                l3s[1].OneToOne_Required_FK = l4s[1];
+                l3s[2].OneToOne_Required_FK = l4s[2];
+                l3s[3].OneToOne_Required_FK = l4s[3];
+                l3s[4].OneToOne_Required_FK = l4s[4];
+                l3s[5].OneToOne_Required_FK = l4s[5];
+                l3s[6].OneToOne_Required_FK = l4s[6];
+                l3s[7].OneToOne_Required_FK = l4s[7];
+                l3s[8].OneToOne_Required_FK = l4s[8];
+                l3s[9].OneToOne_Required_FK = l4s[9];
+            }
+            else
+            {
+                l3s[0].OneToOne_Required_FK = l4s[9];
+                l3s[1].OneToOne_Required_FK = l4s[8];
+                l3s[2].OneToOne_Required_FK = l4s[7];
+                l3s[3].OneToOne_Required_FK = l4s[6];
+                l3s[4].OneToOne_Required_FK = l4s[5];
+                l3s[5].OneToOne_Required_FK = l4s[4];
+                l3s[6].OneToOne_Required_FK = l4s[3];
+                l3s[7].OneToOne_Required_FK = l4s[2];
+                l3s[8].OneToOne_Required_FK = l4s[1];
+                l3s[9].OneToOne_Required_FK = l4s[0];
+            }
 
             l3s[0].OneToMany_Required = new List<Level4> { l4s[0], l4s[1], l4s[2], l4s[3], l4s[4], l4s[5], l4s[6], l4s[7], l4s[8], l4s[9] };
 
@@ -248,7 +369,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
         }
 
         public static void WireUpInversePart1(
-            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s)
+            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s,
+            bool tableSplitting)
         {
             l2s[0].OneToOne_Required_PK_Inverse = l1s[0];
             l2s[1].OneToOne_Required_PK_Inverse = l1s[1];
@@ -260,31 +382,61 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l2s[7].OneToOne_Required_PK_Inverse = l1s[7];
             l2s[8].OneToOne_Required_PK_Inverse = l1s[8];
             l2s[9].OneToOne_Required_PK_Inverse = l1s[9];
-            l2s[10].OneToOne_Required_PK_Inverse = l1s[10];
+            if (!tableSplitting)
+            {
+                l2s[10].OneToOne_Required_PK_Inverse = l1s[10];
+            }
 
-            l2s[9].OneToOne_Required_FK_Inverse = l1s[0];
-            l2s[8].OneToOne_Required_FK_Inverse = l1s[1];
-            l2s[7].OneToOne_Required_FK_Inverse = l1s[2];
-            l2s[6].OneToOne_Required_FK_Inverse = l1s[3];
-            l2s[5].OneToOne_Required_FK_Inverse = l1s[4];
-            l2s[4].OneToOne_Required_FK_Inverse = l1s[5];
-            l2s[3].OneToOne_Required_FK_Inverse = l1s[6];
-            l2s[2].OneToOne_Required_FK_Inverse = l1s[7];
-            l2s[1].OneToOne_Required_FK_Inverse = l1s[8];
-            l2s[0].OneToOne_Required_FK_Inverse = l1s[9];
-            l2s[10].OneToOne_Required_FK_Inverse = l1s[10];
+            if (tableSplitting)
+            {
+                l2s[0].OneToOne_Required_FK_Inverse = l1s[0];
+                l2s[1].OneToOne_Required_FK_Inverse = l1s[1];
+                l2s[2].OneToOne_Required_FK_Inverse = l1s[2];
+                l2s[3].OneToOne_Required_FK_Inverse = l1s[3];
+                l2s[4].OneToOne_Required_FK_Inverse = l1s[4];
+                l2s[5].OneToOne_Required_FK_Inverse = l1s[5];
+                l2s[6].OneToOne_Required_FK_Inverse = l1s[6];
+                l2s[7].OneToOne_Required_FK_Inverse = l1s[7];
+                l2s[8].OneToOne_Required_FK_Inverse = l1s[8];
+                l2s[9].OneToOne_Required_FK_Inverse = l1s[9];
 
-            l2s[9].Level1_Required_Id = l1s[0].Id;
-            l2s[8].Level1_Required_Id = l1s[1].Id;
-            l2s[7].Level1_Required_Id = l1s[2].Id;
-            l2s[6].Level1_Required_Id = l1s[3].Id;
-            l2s[5].Level1_Required_Id = l1s[4].Id;
-            l2s[4].Level1_Required_Id = l1s[5].Id;
-            l2s[3].Level1_Required_Id = l1s[6].Id;
-            l2s[2].Level1_Required_Id = l1s[7].Id;
-            l2s[1].Level1_Required_Id = l1s[8].Id;
-            l2s[0].Level1_Required_Id = l1s[9].Id;
-            l2s[10].Level1_Required_Id = l1s[10].Id;
+                l2s[0].Level1_Required_Id = l1s[0].Id;
+                l2s[1].Level1_Required_Id = l1s[1].Id;
+                l2s[2].Level1_Required_Id = l1s[2].Id;
+                l2s[3].Level1_Required_Id = l1s[3].Id;
+                l2s[4].Level1_Required_Id = l1s[4].Id;
+                l2s[5].Level1_Required_Id = l1s[5].Id;
+                l2s[6].Level1_Required_Id = l1s[6].Id;
+                l2s[7].Level1_Required_Id = l1s[7].Id;
+                l2s[8].Level1_Required_Id = l1s[8].Id;
+                l2s[9].Level1_Required_Id = l1s[9].Id;
+            }
+            else
+            {
+                l2s[9].OneToOne_Required_FK_Inverse = l1s[0];
+                l2s[8].OneToOne_Required_FK_Inverse = l1s[1];
+                l2s[7].OneToOne_Required_FK_Inverse = l1s[2];
+                l2s[6].OneToOne_Required_FK_Inverse = l1s[3];
+                l2s[5].OneToOne_Required_FK_Inverse = l1s[4];
+                l2s[4].OneToOne_Required_FK_Inverse = l1s[5];
+                l2s[3].OneToOne_Required_FK_Inverse = l1s[6];
+                l2s[2].OneToOne_Required_FK_Inverse = l1s[7];
+                l2s[1].OneToOne_Required_FK_Inverse = l1s[8];
+                l2s[0].OneToOne_Required_FK_Inverse = l1s[9];
+                l2s[10].OneToOne_Required_FK_Inverse = l1s[10];
+
+                l2s[9].Level1_Required_Id = l1s[0].Id;
+                l2s[8].Level1_Required_Id = l1s[1].Id;
+                l2s[7].Level1_Required_Id = l1s[2].Id;
+                l2s[6].Level1_Required_Id = l1s[3].Id;
+                l2s[5].Level1_Required_Id = l1s[4].Id;
+                l2s[4].Level1_Required_Id = l1s[5].Id;
+                l2s[3].Level1_Required_Id = l1s[6].Id;
+                l2s[2].Level1_Required_Id = l1s[7].Id;
+                l2s[1].Level1_Required_Id = l1s[8].Id;
+                l2s[0].Level1_Required_Id = l1s[9].Id;
+                l2s[10].Level1_Required_Id = l1s[10].Id;
+            }
 
             l2s[0].OneToMany_Required_Inverse = l1s[0];
             l2s[1].OneToMany_Required_Inverse = l1s[0];
@@ -296,13 +448,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l2s[7].OneToMany_Required_Inverse = l1s[0];
             l2s[8].OneToMany_Required_Inverse = l1s[0];
             l2s[9].OneToMany_Required_Inverse = l1s[0];
-            l2s[10].OneToMany_Required_Inverse = l1s[0];
+            if (!tableSplitting)
+            {
+                l2s[10].OneToMany_Required_Inverse = l1s[0];
+            }
 
             l1s[0].OneToMany_Required_Self_Inverse = l1s[0];
             l1s[1].OneToMany_Required_Self_Inverse = l1s[0];
-            l1s[11].OneToMany_Required_Self_Inverse = l1s[0];
             l1s[2].OneToMany_Required_Self_Inverse = l1s[1];
-            l1s[12].OneToMany_Required_Self_Inverse = l1s[1];
             l1s[3].OneToMany_Required_Self_Inverse = l1s[2];
             l1s[4].OneToMany_Required_Self_Inverse = l1s[3];
             l1s[5].OneToMany_Required_Self_Inverse = l1s[4];
@@ -310,7 +463,12 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l1s[7].OneToMany_Required_Self_Inverse = l1s[6];
             l1s[8].OneToMany_Required_Self_Inverse = l1s[7];
             l1s[9].OneToMany_Required_Self_Inverse = l1s[8];
-            l1s[10].OneToMany_Required_Self_Inverse = l1s[10];
+            if (!tableSplitting)
+            {
+                l1s[11].OneToMany_Required_Self_Inverse = l1s[0];
+                l1s[12].OneToMany_Required_Self_Inverse = l1s[1];
+                l1s[10].OneToMany_Required_Self_Inverse = l1s[10];
+            }
 
             l3s[0].OneToOne_Required_PK_Inverse = l2s[0];
             l3s[1].OneToOne_Required_PK_Inverse = l2s[1];
@@ -323,27 +481,54 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l3s[8].OneToOne_Required_PK_Inverse = l2s[8];
             l3s[9].OneToOne_Required_PK_Inverse = l2s[9];
 
-            l3s[9].OneToOne_Required_FK_Inverse = l2s[0];
-            l3s[8].OneToOne_Required_FK_Inverse = l2s[1];
-            l3s[7].OneToOne_Required_FK_Inverse = l2s[2];
-            l3s[6].OneToOne_Required_FK_Inverse = l2s[3];
-            l3s[5].OneToOne_Required_FK_Inverse = l2s[4];
-            l3s[4].OneToOne_Required_FK_Inverse = l2s[5];
-            l3s[3].OneToOne_Required_FK_Inverse = l2s[6];
-            l3s[2].OneToOne_Required_FK_Inverse = l2s[7];
-            l3s[1].OneToOne_Required_FK_Inverse = l2s[8];
-            l3s[0].OneToOne_Required_FK_Inverse = l2s[9];
+            if (tableSplitting)
+            {
+                l3s[0].OneToOne_Required_FK_Inverse = l2s[0];
+                l3s[1].OneToOne_Required_FK_Inverse = l2s[1];
+                l3s[2].OneToOne_Required_FK_Inverse = l2s[2];
+                l3s[3].OneToOne_Required_FK_Inverse = l2s[3];
+                l3s[4].OneToOne_Required_FK_Inverse = l2s[4];
+                l3s[5].OneToOne_Required_FK_Inverse = l2s[5];
+                l3s[6].OneToOne_Required_FK_Inverse = l2s[6];
+                l3s[7].OneToOne_Required_FK_Inverse = l2s[7];
+                l3s[8].OneToOne_Required_FK_Inverse = l2s[8];
+                l3s[9].OneToOne_Required_FK_Inverse = l2s[9];
 
-            l3s[9].Level2_Required_Id = l2s[0].Id;
-            l3s[8].Level2_Required_Id = l2s[1].Id;
-            l3s[7].Level2_Required_Id = l2s[2].Id;
-            l3s[6].Level2_Required_Id = l2s[3].Id;
-            l3s[5].Level2_Required_Id = l2s[4].Id;
-            l3s[4].Level2_Required_Id = l2s[5].Id;
-            l3s[3].Level2_Required_Id = l2s[6].Id;
-            l3s[2].Level2_Required_Id = l2s[7].Id;
-            l3s[1].Level2_Required_Id = l2s[8].Id;
-            l3s[0].Level2_Required_Id = l2s[9].Id;
+                l3s[0].Level2_Required_Id = l2s[0].Id;
+                l3s[1].Level2_Required_Id = l2s[1].Id;
+                l3s[2].Level2_Required_Id = l2s[2].Id;
+                l3s[3].Level2_Required_Id = l2s[3].Id;
+                l3s[4].Level2_Required_Id = l2s[4].Id;
+                l3s[5].Level2_Required_Id = l2s[5].Id;
+                l3s[6].Level2_Required_Id = l2s[6].Id;
+                l3s[7].Level2_Required_Id = l2s[7].Id;
+                l3s[8].Level2_Required_Id = l2s[8].Id;
+                l3s[9].Level2_Required_Id = l2s[9].Id;
+            }
+            else
+            {
+                l3s[9].OneToOne_Required_FK_Inverse = l2s[0];
+                l3s[8].OneToOne_Required_FK_Inverse = l2s[1];
+                l3s[7].OneToOne_Required_FK_Inverse = l2s[2];
+                l3s[6].OneToOne_Required_FK_Inverse = l2s[3];
+                l3s[5].OneToOne_Required_FK_Inverse = l2s[4];
+                l3s[4].OneToOne_Required_FK_Inverse = l2s[5];
+                l3s[3].OneToOne_Required_FK_Inverse = l2s[6];
+                l3s[2].OneToOne_Required_FK_Inverse = l2s[7];
+                l3s[1].OneToOne_Required_FK_Inverse = l2s[8];
+                l3s[0].OneToOne_Required_FK_Inverse = l2s[9];
+
+                l3s[9].Level2_Required_Id = l2s[0].Id;
+                l3s[8].Level2_Required_Id = l2s[1].Id;
+                l3s[7].Level2_Required_Id = l2s[2].Id;
+                l3s[6].Level2_Required_Id = l2s[3].Id;
+                l3s[5].Level2_Required_Id = l2s[4].Id;
+                l3s[4].Level2_Required_Id = l2s[5].Id;
+                l3s[3].Level2_Required_Id = l2s[6].Id;
+                l3s[2].Level2_Required_Id = l2s[7].Id;
+                l3s[1].Level2_Required_Id = l2s[8].Id;
+                l3s[0].Level2_Required_Id = l2s[9].Id;
+            }
 
             l3s[0].OneToMany_Required_Inverse = l2s[0];
             l3s[1].OneToMany_Required_Inverse = l2s[0];
@@ -358,7 +543,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
 
             l2s[0].OneToMany_Required_Self_Inverse = l2s[0];
             l2s[1].OneToMany_Required_Self_Inverse = l2s[0];
-            l2s[10].OneToMany_Required_Self_Inverse = l2s[0];
+            if (!tableSplitting)
+            {
+                l2s[10].OneToMany_Required_Self_Inverse = l2s[0];
+            }
 
             l2s[2].OneToMany_Required_Self_Inverse = l2s[1];
             l2s[3].OneToMany_Required_Self_Inverse = l2s[2];
@@ -380,27 +568,54 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
             l4s[8].OneToOne_Required_PK_Inverse = l3s[8];
             l4s[9].OneToOne_Required_PK_Inverse = l3s[9];
 
-            l4s[9].OneToOne_Required_FK_Inverse = l3s[0];
-            l4s[8].OneToOne_Required_FK_Inverse = l3s[1];
-            l4s[7].OneToOne_Required_FK_Inverse = l3s[2];
-            l4s[6].OneToOne_Required_FK_Inverse = l3s[3];
-            l4s[5].OneToOne_Required_FK_Inverse = l3s[4];
-            l4s[4].OneToOne_Required_FK_Inverse = l3s[5];
-            l4s[3].OneToOne_Required_FK_Inverse = l3s[6];
-            l4s[2].OneToOne_Required_FK_Inverse = l3s[7];
-            l4s[1].OneToOne_Required_FK_Inverse = l3s[8];
-            l4s[0].OneToOne_Required_FK_Inverse = l3s[9];
+            if (tableSplitting)
+            {
+                l4s[0].OneToOne_Required_FK_Inverse = l3s[0];
+                l4s[1].OneToOne_Required_FK_Inverse = l3s[1];
+                l4s[2].OneToOne_Required_FK_Inverse = l3s[2];
+                l4s[3].OneToOne_Required_FK_Inverse = l3s[3];
+                l4s[4].OneToOne_Required_FK_Inverse = l3s[4];
+                l4s[5].OneToOne_Required_FK_Inverse = l3s[5];
+                l4s[6].OneToOne_Required_FK_Inverse = l3s[6];
+                l4s[7].OneToOne_Required_FK_Inverse = l3s[7];
+                l4s[8].OneToOne_Required_FK_Inverse = l3s[8];
+                l4s[9].OneToOne_Required_FK_Inverse = l3s[9];
 
-            l4s[9].Level3_Required_Id = l3s[0].Id;
-            l4s[8].Level3_Required_Id = l3s[1].Id;
-            l4s[7].Level3_Required_Id = l3s[2].Id;
-            l4s[6].Level3_Required_Id = l3s[3].Id;
-            l4s[5].Level3_Required_Id = l3s[4].Id;
-            l4s[4].Level3_Required_Id = l3s[5].Id;
-            l4s[3].Level3_Required_Id = l3s[6].Id;
-            l4s[2].Level3_Required_Id = l3s[7].Id;
-            l4s[1].Level3_Required_Id = l3s[8].Id;
-            l4s[0].Level3_Required_Id = l3s[9].Id;
+                l4s[0].Level3_Required_Id = l3s[0].Id;
+                l4s[1].Level3_Required_Id = l3s[1].Id;
+                l4s[2].Level3_Required_Id = l3s[2].Id;
+                l4s[3].Level3_Required_Id = l3s[3].Id;
+                l4s[4].Level3_Required_Id = l3s[4].Id;
+                l4s[5].Level3_Required_Id = l3s[5].Id;
+                l4s[6].Level3_Required_Id = l3s[6].Id;
+                l4s[7].Level3_Required_Id = l3s[7].Id;
+                l4s[8].Level3_Required_Id = l3s[8].Id;
+                l4s[9].Level3_Required_Id = l3s[9].Id;
+            }
+            else
+            {
+                l4s[9].OneToOne_Required_FK_Inverse = l3s[0];
+                l4s[8].OneToOne_Required_FK_Inverse = l3s[1];
+                l4s[7].OneToOne_Required_FK_Inverse = l3s[2];
+                l4s[6].OneToOne_Required_FK_Inverse = l3s[3];
+                l4s[5].OneToOne_Required_FK_Inverse = l3s[4];
+                l4s[4].OneToOne_Required_FK_Inverse = l3s[5];
+                l4s[3].OneToOne_Required_FK_Inverse = l3s[6];
+                l4s[2].OneToOne_Required_FK_Inverse = l3s[7];
+                l4s[1].OneToOne_Required_FK_Inverse = l3s[8];
+                l4s[0].OneToOne_Required_FK_Inverse = l3s[9];
+
+                l4s[9].Level3_Required_Id = l3s[0].Id;
+                l4s[8].Level3_Required_Id = l3s[1].Id;
+                l4s[7].Level3_Required_Id = l3s[2].Id;
+                l4s[6].Level3_Required_Id = l3s[3].Id;
+                l4s[5].Level3_Required_Id = l3s[4].Id;
+                l4s[4].Level3_Required_Id = l3s[5].Id;
+                l4s[3].Level3_Required_Id = l3s[6].Id;
+                l4s[2].Level3_Required_Id = l3s[7].Id;
+                l4s[1].Level3_Required_Id = l3s[8].Id;
+                l4s[0].Level3_Required_Id = l3s[9].Id;
+            }
 
             l4s[0].OneToMany_Required_Inverse = l3s[0];
             l4s[1].OneToMany_Required_Inverse = l3s[0];
@@ -437,7 +652,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
         }
 
         public static void WireUpPart2(
-            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s)
+            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s,
+            bool tableSplitting)
         {
             l1s[0].OneToOne_Optional_PK = l2s[0];
             l1s[2].OneToOne_Optional_PK = l2s[2];
@@ -526,7 +742,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
         }
 
         public static void WireUpInversePart2(
-            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s)
+            IReadOnlyList<Level1> l1s, IReadOnlyList<Level2> l2s, IReadOnlyList<Level3> l3s, IReadOnlyList<Level4> l4s,
+            bool tableSplitting)
         {
             l2s[0].OneToOne_Optional_PK_Inverse = l1s[0];
             l2s[2].OneToOne_Optional_PK_Inverse = l1s[2];

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
@@ -8,20 +8,20 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels.ComplexNa
 {
     public class ComplexNavigationsModelInitializer
     {
-        public static void Seed(ComplexNavigationsContext context)
+        public static void Seed(ComplexNavigationsContext context, bool tableSplitting = false)
         {
-            var l1s = ComplexNavigationsData.CreateLevelOnes();
-            var l2s = ComplexNavigationsData.CreateLevelTwos();
-            var l3s = ComplexNavigationsData.CreateLevelThrees();
-            var l4s = ComplexNavigationsData.CreateLevelFours();
+            var l1s = ComplexNavigationsData.CreateLevelOnes(tableSplitting);
+            var l2s = ComplexNavigationsData.CreateLevelTwos(tableSplitting);
+            var l3s = ComplexNavigationsData.CreateLevelThrees(tableSplitting);
+            var l4s = ComplexNavigationsData.CreateLevelFours(tableSplitting);
 
             context.LevelOne.AddRange(l1s);
 
-            ComplexNavigationsData.WireUpPart1(l1s, l2s, l3s, l4s);
+            ComplexNavigationsData.WireUpPart1(l1s, l2s, l3s, l4s, tableSplitting);
 
             context.SaveChanges();
 
-            ComplexNavigationsData.WireUpPart2(l1s, l2s, l3s, l4s);
+            ComplexNavigationsData.WireUpPart2(l1s, l2s, l3s, l4s, tableSplitting);
 
             var globalizations = new List<ComplexNavigationGlobalization>();
             for (var i = 0; i < 10; i++)

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -113,6 +113,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IForeignKeyUniquenessConvention> ForeignKeyUniquenessConventions { get; } = new List<IForeignKeyUniquenessConvention>();
 
         /// <summary>
+        ///     Conventions to run when the ownership of a foreign key is changed.
+        /// </summary>
+        public virtual IList<IForeignKeyOwnershipConvention> ForeignKeyOwnershipConventions { get; } = new List<IForeignKeyOwnershipConvention>();
+
+        /// <summary>
         ///     Conventions to run when a property is added.
         /// </summary>
         public virtual IList<IPropertyConvention> PropertyAddedConventions { get; } = new List<IPropertyConvention>();

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -199,6 +199,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual InternalRelationshipBuilder OnForeignKeyOwnershipChanged([NotNull] InternalRelationshipBuilder relationshipBuilder)
+            => _scope.OnForeignKeyOwnershipChanged(Check.NotNull(relationshipBuilder, nameof(relationshipBuilder)));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalRelationshipBuilder OnPrincipalEndSet([NotNull] InternalRelationshipBuilder relationshipBuilder)
             => _scope.OnPrincipalEndSet(Check.NotNull(relationshipBuilder, nameof(relationshipBuilder)));
 

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
@@ -47,6 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public virtual OnNavigationAddedNode VisitOnNavigationAdded(OnNavigationAddedNode node) => node;
             public virtual OnNavigationRemovedNode VisitOnNavigationRemoved(OnNavigationRemovedNode node) => node;
             public virtual OnForeignKeyUniquenessChangedNode VisitOnForeignKeyUniquenessChanged(OnForeignKeyUniquenessChangedNode node) => node;
+            public virtual OnForeignKeyOwnershipChangedNode VisitOnForeignKeyOwnershipChanged(OnForeignKeyOwnershipChangedNode node) => node;
             public virtual OnPrincipalEndSetNode VisitOnPrincipalEndSet(OnPrincipalEndSetNode node) => node;
             public virtual OnPropertyAddedNode VisitOnPropertyAdded(OnPropertyAddedNode node) => node;
             public virtual OnPropertyNullableChangedNode VisitOnPropertyNullableChanged(OnPropertyNullableChangedNode node) => node;
@@ -161,6 +162,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override OnForeignKeyUniquenessChangedNode VisitOnForeignKeyUniquenessChanged(OnForeignKeyUniquenessChangedNode node)
             {
                 Dispatcher._immediateConventionScope.OnForeignKeyUniquenessChanged(node.RelationshipBuilder);
+                return null;
+            }
+
+            public override OnForeignKeyOwnershipChangedNode VisitOnForeignKeyOwnershipChanged(OnForeignKeyOwnershipChangedNode node)
+            {
+                Dispatcher._immediateConventionScope.OnForeignKeyOwnershipChanged(node.RelationshipBuilder);
                 return null;
             }
 

--- a/src/EFCore/Metadata/Conventions/Internal/IForeignKeyOwnershipConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IForeignKeyOwnershipConvention.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IForeignKeyOwnershipConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     break;
                 }
                 root = root.DefiningEntityType;
-                path.Push("->");
+                path.Push("#");
                 path.Push(definingNavigationName);
                 path.Push(".");
                 path.Push(((ITypeBase)root).DisplayName());

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -499,8 +499,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual ForeignKey SetIsOwnership(bool ownership, ConfigurationSource configurationSource)
         {
+            var isChanging = IsOwnership != ownership;
             _isOwnership = ownership;
             UpdateIsOwnershipConfigurationSource(configurationSource);
+
+            if (isChanging)
+            {
+                return DeclaringEntityType.Model.ConventionDispatcher.OnForeignKeyOwnershipChanged(Builder)?.Metadata;
+            }
 
             return this;
         }

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -348,20 +348,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         {
                             Metadata.HasPrincipalToDependent(navigationToDependentName, configurationSource.Value);
                         }
-
-                        if (dependentEntityType.HasDelegatedIdentity()
-                            && dependentEntityType.FindDefiningNavigation() == null
-                            && Metadata.GetPrincipalEndConfigurationSource().HasValue)
-                        {
-                            IsOwnership(true, ConfigurationSource.Convention);
-                        }
-                    }
-
-                    if (dependentEntityType.HasDelegatedIdentity()
-                        && dependentEntityType.FindDefiningNavigation() == null
-                        && Metadata.GetPrincipalEndConfigurationSource().HasValue)
-                    {
-                        IsOwnership(true, ConfigurationSource.Convention);
                     }
 
                     builder = batch.Run(builder);

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -57,14 +57,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ChangeTrackingStrategy ChangeTrackingStrategy { get; set; }
+        public virtual ChangeTrackingStrategy ChangeTrackingStrategy { [DebuggerStepThrough] get; set; }
             = ChangeTrackingStrategy.Snapshot;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ConventionDispatcher ConventionDispatcher { get; }
+        public virtual ConventionDispatcher ConventionDispatcher { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1606,6 +1606,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 ownershipNavigation, definingNavigation, entityType);
 
         /// <summary>
+        ///     The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not.
+        /// </summary>
+        public static string InconsistentOwnership([CanBeNull] object ownedEntityType, [CanBeNull] object nonOwnedEntityType)
+            => string.Format(
+                GetString("InconsistentOwnership", nameof(ownedEntityType), nameof(nonOwnedEntityType)),
+                ownedEntityType, nonOwnedEntityType);
+
+        /// <summary>
         ///     The entity type '{entityType}' has delegated identity and the given entity is currently referenced from several owner entities. To access the entry for a particular reference to this entity call '{targetEntryCall}' on the owner entry.
         /// </summary>
         public static string AmbiguousDelegatedIdentityEntity([CanBeNull] object entityType, [CanBeNull] object targetEntryCall)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -728,6 +728,9 @@
   </data>
   <data name="NonDefiningOwnership" xml:space="preserve">
     <value>The ownership navigation '{ownershipNavigation}' should be the same as the defining navigation '{definingNavigation}' for entity type '{entityType}'</value>
+  </data>
+  <data name="InconsistentOwnership" xml:space="preserve">
+    <value>The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not.</value>
   </data>
   <data name="AmbiguousDelegatedIdentityEntity" xml:space="preserve">
     <value>The entity type '{entityType}' has delegated identity and the given entity is currently referenced from several owner entities. To access the entry for a particular reference to this entity call '{targetEntryCall}' on the owner entry.</value>

--- a/test/EFCore.InMemory.FunctionalTests/ComplexNavigationsOwnedQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ComplexNavigationsOwnedQueryInMemoryFixture.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                 {
                     using (var context = new ComplexNavigationsContext(_options))
                     {
-                        ComplexNavigationsModelInitializer.Seed(context);
+                        ComplexNavigationsModelInitializer.Seed(context, tableSplitting: true);
                     }
                 });
         }

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerFixture.cs
@@ -16,9 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public static readonly string DatabaseName = "ComplexNavigationsOwned";
 
         private readonly DbContextOptions _options;
-
-        private readonly string _connectionString
-            = SqlServerTestStore.CreateConnectionString(DatabaseName);
+        private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
 
         public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
 
@@ -43,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                     using (var context = new ComplexNavigationsContext(_options))
                     {
                         context.Database.EnsureCreated();
-                        ComplexNavigationsModelInitializer.Seed(context);
+                        ComplexNavigationsModelInitializer.Seed(context, tableSplitting: true);
                     }
                 });
         }
@@ -57,27 +55,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             context.Database.UseTransaction(testStore.Transaction);
 
             return context;
-        }
-
-        protected override void Configure(ReferenceOwnershipBuilder<Level1, Level2> l2)
-        {
-            base.Configure(l2);
-
-            l2.ForSqlServerToTable("Level2");
-        }
-
-        protected override void Configure(ReferenceOwnershipBuilder<Level2, Level3> l3)
-        {
-            base.Configure(l3);
-
-            l3.ForSqlServerToTable("Level3");
-        }
-
-        protected override void Configure(ReferenceOwnershipBuilder<Level3, Level4> l4)
-        {
-            base.Configure(l4);
-
-            l4.ForSqlServerToTable("Level4");
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/ModelBuilderTest/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilderTest/SqlServerModelBuilderGenericTest.cs
@@ -132,5 +132,83 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             protected override TestModelBuilder CreateModelBuilder()
                 => CreateTestModelBuilder(SqlServerTestHelpers.Instance.CreateConventionBuilder());
         }
+
+        public class SqlServerGenericOwnedTypes : GenericOwnedTypes
+        {
+            [Fact]
+            public virtual void Owned_types_use_table_splitting()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                var bookOwnershipBuilder2 = modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel);
+                var bookLabel2OwnershipBuilder1 = bookOwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
+                var bookOwnershipBuilder1 = modelBuilder.Entity<Book>().OwnsOne(b => b.Label);
+                var bookLabel1OwnershipBuilder2 = bookOwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+
+                var book = model.FindEntityType(typeof(Book));
+                var bookOwnership1 = book.FindNavigation(nameof(Book.Label)).ForeignKey;
+                var bookOwnership2 = book.FindNavigation(nameof(Book.AlternateLabel)).ForeignKey;
+                var bookLabel1Ownership1 = bookOwnership1.DeclaringEntityType.FindNavigation(nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                var bookLabel1Ownership2 = bookOwnership1.DeclaringEntityType.FindNavigation(nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                var bookLabel2Ownership1 = bookOwnership2.DeclaringEntityType.FindNavigation(nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                var bookLabel2Ownership2 = bookOwnership2.DeclaringEntityType.FindNavigation(nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+
+                // Only owned types have the table name set
+                Assert.Equal(book.SqlServer().TableName, bookOwnership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookOwnership2.DeclaringEntityType.SqlServer().TableName);
+                Assert.NotEqual(book.SqlServer().TableName, bookLabel1Ownership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel1Ownership2.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel2Ownership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.NotEqual(book.SqlServer().TableName, bookLabel2Ownership2.DeclaringEntityType.SqlServer().TableName);
+
+                var bookLabel1OwnershipBuilder1 = bookOwnershipBuilder1.OwnsOne(l => l.AnotherBookLabel);
+                var bookLabel2OwnershipBuilder2 = bookOwnershipBuilder2.OwnsOne(l => l.SpecialBookLabel);
+                bookLabel1OwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+                bookLabel1OwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
+                bookLabel2OwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+                bookLabel2OwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
+
+                modelBuilder.Validate();
+
+                Assert.Equal(book.SqlServer().TableName, bookOwnership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookOwnership2.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel1Ownership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel1Ownership2.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel2Ownership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.Equal(book.SqlServer().TableName, bookLabel2Ownership2.DeclaringEntityType.SqlServer().TableName);
+
+                Assert.NotSame(bookOwnership1.DeclaringEntityType, bookOwnership2.DeclaringEntityType);
+                Assert.Equal(1, bookOwnership1.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal(1, bookOwnership1.DeclaringEntityType.GetForeignKeys().Count());
+
+                Assert.NotSame(bookLabel1Ownership1.DeclaringEntityType, bookLabel2Ownership1.DeclaringEntityType);
+                Assert.NotSame(bookLabel1Ownership2.DeclaringEntityType, bookLabel2Ownership2.DeclaringEntityType);
+                Assert.Equal(1, bookLabel1Ownership1.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal(1, bookLabel1Ownership2.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal(1, bookLabel2Ownership1.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal(1, bookLabel2Ownership2.DeclaringEntityType.GetForeignKeys().Count());
+
+                Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(BookLabel)));
+                Assert.Equal(4, model.GetEntityTypes().Count(e => e.ClrType == typeof(AnotherBookLabel)));
+                Assert.Equal(4, model.GetEntityTypes().Count(e => e.ClrType == typeof(SpecialBookLabel)));
+
+                Assert.Equal(nameof(Book.Label) + "_" + nameof(BookLabel.Id),
+                    bookOwnership1.DeclaringEntityType.FindProperty(nameof(BookLabel.Id)).SqlServer().ColumnName);
+                Assert.Equal(nameof(Book.AlternateLabel) + "_" + nameof(BookLabel.AnotherBookLabel) + "_" + nameof(BookLabel.Id),
+                    bookLabel2Ownership1.DeclaringEntityType.FindProperty(nameof(BookLabel.Id)).SqlServer().ColumnName);
+
+                bookOwnershipBuilder1.ForSqlServerToTable("Label");
+                bookOwnershipBuilder2.ForSqlServerToTable("AlternateLabel");
+
+                Assert.Equal(nameof(BookLabel.Id),
+                    bookOwnership1.DeclaringEntityType.FindProperty(nameof(BookLabel.Id)).SqlServer().ColumnName);
+                Assert.Equal(nameof(BookLabel.AnotherBookLabel) + "_" + nameof(BookLabel.Id),
+                    bookLabel2Ownership1.DeclaringEntityType.FindProperty(nameof(BookLabel.Id)).SqlServer().ColumnName);
+            }
+
+            protected override TestModelBuilder CreateModelBuilder()
+                => CreateTestModelBuilder(SqlServerTestHelpers.Instance.CreateConventionBuilder());
+        }
     }
 }

--- a/test/EFCore.SqlServer.Tests/ModelBuilderTest/SqlServerTestModelBuilderExtensions.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilderTest/SqlServerTestModelBuilderExtensions.cs
@@ -22,10 +22,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string name)
         {
             var genericBuilder = (builder as IInfrastructure<PropertyBuilder<TProperty>>)?.Instance;
-            if (genericBuilder != null)
-            {
-                genericBuilder.ForSqlServerHasColumnName(name);
-            }
+            genericBuilder?.ForSqlServerHasColumnName(name);
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> ForSqlServerToTable<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> builder, string name)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            var genericBuilder = (builder as IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>>)?.Instance;
+            genericBuilder?.ForSqlServerToTable(name);
 
             return builder;
         }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -90,6 +90,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Tests
             public ReferencedEntity ReferencedEntity { get; set; }
         }
 
+        public class AnotherSampleEntity
+        {
+            public int Id { get; set; }
+            public ReferencedEntity ReferencedEntity { get; set; }
+        }
+
         public class ReferencedEntity
         {
             public int Id { get; set; }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3065,10 +3065,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var derivedType = model.AddDelegatedIdentityEntityType(typeof(SpecialOrder), nameof(Customer.Orders), customerType);
 
             Assert.Equal(CoreStrings.DelegatedIdentityDerivedType(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(Order)),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => orderType.BaseType = baseType).Message);
             Assert.Equal(CoreStrings.DelegatedIdentityDerivedType(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(SpecialOrder)),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(SpecialOrder)),
                 Assert.Throws<InvalidOperationException>(() => derivedType.BaseType = orderType).Message);
         }
 
@@ -3082,10 +3082,10 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var derivedType = model.AddEntityType(typeof(SpecialOrder));
 
             Assert.Equal(CoreStrings.DelegatedIdentityDerivedType(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(Order)),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => orderType.BaseType = baseType).Message);
             Assert.Equal(CoreStrings.DelegatedIdentityBaseType(
-                typeof(SpecialOrder).DisplayName(fullName: false), nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(Order)),
+                typeof(SpecialOrder).DisplayName(fullName: false), nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => derivedType.BaseType = orderType).Message);
         }
 

--- a/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
@@ -120,17 +120,17 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             Assert.Equal(CoreStrings.ClashingDelegatedIdentityEntityType(typeof(Order).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => model.AddEntityType(typeof(Order))).Message);
             Assert.Equal(CoreStrings.ClashingNonDelegatedIdentityEntityType(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->"
-                + nameof(Order) + "." + nameof(Order.Customer) + "->" + nameof(Customer)),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#"
+                + nameof(Order) + "." + nameof(Order.Customer) + "#" + nameof(Customer)),
                 Assert.Throws<InvalidOperationException>(() => model.AddDelegatedIdentityEntityType(typeof(Customer), nameof(Order.Customer), delegatedOrderType)).Message);
 
             Assert.Equal(CoreStrings.ForeignKeySelfReferencingDelegatedIdentity(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(Order)),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order)),
                 Assert.Throws<InvalidOperationException>(
                     () => delegatedOrderType.AddForeignKey(fkProperty, orderKey, delegatedOrderType)).Message);
 
             Assert.Equal(CoreStrings.EntityTypeInUseByForeignKey(
-                nameof(Customer) + "." + nameof(Customer.Orders) + "->" + nameof(Order),
+                nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order),
                 nameof(Customer), Property.Format(fk.Properties)),
                 Assert.Throws<InvalidOperationException>(() => model.RemoveDelegatedIdentityEntityType(delegatedOrderType)).Message);
 

--- a/test/EFCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         protected class GenericTestReferenceOwnershipBuilder<TEntity, TRelatedEntity>
-            : TestReferenceOwnershipBuilder<TEntity, TRelatedEntity>
+            : TestReferenceOwnershipBuilder<TEntity, TRelatedEntity>, IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>>
             where TEntity : class
             where TRelatedEntity : class
         {
@@ -462,6 +462,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public override TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> UsePropertyAccessMode(
                 PropertyAccessMode propertyAccessMode)
                 => Wrap(ReferenceOwnershipBuilder.UsePropertyAccessMode(propertyAccessMode));
+
+            ReferenceOwnershipBuilder<TEntity, TRelatedEntity> IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>>.Instance
+                => ReferenceOwnershipBuilder;
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilderTest/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/OwnedTypesTestBase.cs
@@ -187,12 +187,16 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
-                modelBuilder.Entity<Book>()
-                    .OwnsOne(b => b.Label)
-                    .OwnsOne(l => l.AnotherBookLabel);
-                modelBuilder.Entity<Book>()
-                    .OwnsOne(b => b.AlternateLabel)
-                    .OwnsOne(l => l.SpecialBookLabel);
+                var bookOwnershipBuilder1 = modelBuilder.Entity<Book>().OwnsOne(b => b.Label);
+                var bookLabel1OwnershipBuilder1 = bookOwnershipBuilder1.OwnsOne(l => l.AnotherBookLabel);
+                bookLabel1OwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+                var bookLabel1OwnershipBuilder2 = bookOwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+                bookLabel1OwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
+                var bookOwnershipBuilder2 = modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel);
+                var bookLabel2OwnershipBuilder1 = bookOwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
+                bookLabel2OwnershipBuilder1.OwnsOne(l => l.SpecialBookLabel);
+                var bookLabel2OwnershipBuilder2 = bookOwnershipBuilder2.OwnsOne(l => l.SpecialBookLabel);
+                bookLabel2OwnershipBuilder2.OwnsOne(l => l.AnotherBookLabel);
 
                 modelBuilder.Validate();
 

--- a/test/EFCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/TestModel.cs
@@ -223,7 +223,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public int SelfRefId { get; set; }
         }
 
-        private class Book
+        protected class Book
         {
             public static readonly PropertyInfo BookDetailsNavigation = typeof(Book).GetProperty("Details");
 
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public BookDetails Details { get; set; }
         }
 
-        private abstract class BookDetailsBase
+        protected abstract class BookDetailsBase
         {
             public int Id { get; set; }
 
@@ -245,13 +245,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public Book AnotherBook { get; set; }
         }
 
-        private class BookDetails : BookDetailsBase
+        protected class BookDetails : BookDetailsBase
         {
             [NotMapped]
             public Book Book { get; set; }
         }
 
-        private class BookLabel
+        protected class BookLabel
         {
             public int Id { get; set; }
 
@@ -265,16 +265,16 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public AnotherBookLabel AnotherBookLabel { get; set; }
         }
 
-        private class SpecialBookLabel : BookLabel
+        protected class SpecialBookLabel : BookLabel
         {
             public BookLabel BookLabel { get; set; }
         }
 
-        private class ExtraSpecialBookLabel : SpecialBookLabel
+        protected class ExtraSpecialBookLabel : SpecialBookLabel
         {
         }
 
-        private class AnotherBookLabel : BookLabel
+        protected class AnotherBookLabel : BookLabel
         {
         }
 


### PR DESCRIPTION
The column names are prefixed by the navigation name