### PR TITLE
Fix test issue on SqlServer2016 with SqlServer Authentication

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/MemoryOptimizedTablesTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MemoryOptimizedTablesTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         [ConditionalFact]
         public void Can_create_memoryOptimized_table()
         {
-            using (var testStore = SqlServerTestStore.Create("MemoryOptimizedTablesTest"))
+            using (var testStore = SqlServerTestStore.Create("MemoryOptimizedTablesTest", deleteDatabase: true))
             {
                 var options = new DbContextOptionsBuilder()
                     .UseSqlServer(testStore.Connection, b => b.ApplyConfiguration())
@@ -35,8 +35,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 using (var context = new MemoryOptimizedContext(options))
                 {
                     Assert.Equal(fastUns.Select(f => f.Name), context.FastUns.OrderBy(f => f.Name).Select(f => f.Name).ToList());
-
-                    context.Database.EnsureDeleted();
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -42,8 +42,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
         public static SqlServerTestStore GetOrCreateShared(string name, Action initializeDatabase, bool cleanDatabase = true)
             => new SqlServerTestStore(name, cleanDatabase: cleanDatabase).CreateShared(initializeDatabase);
 
-        public static SqlServerTestStore Create(string name)
-            => new SqlServerTestStore(name).CreateTransient(true, false);
+        public static SqlServerTestStore Create(string name, bool deleteDatabase = false)
+            => new SqlServerTestStore(name).CreateTransient(true, deleteDatabase);
 
         public static SqlServerTestStore CreateScratch(bool createDatabase = true, bool useFileName = false)
             => new SqlServerTestStore(GetScratchDbName(), useFileName).CreateTransient(createDatabase, true);


### PR DESCRIPTION
`context.Database.EnsureDeleted()` fails in the test because we pass opened connection from SqlServerTestStore. & connection uses SQL Auth so when we try to connect to master for delete, it does not contain password and log in failure is caused.