### PR TITLE
[AppVeyor] Skip test causing hang

### DIFF
--- a/src/EFCore.Specification.Tests/IncludeAsyncTestBase.cs
+++ b/src/EFCore.Specification.Tests/IncludeAsyncTestBase.cs
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Test hangs on single core machine. See issue#8384")]
         public virtual async Task Include_collection_on_inner_group_join_clause_with_filter()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
I was able to get hang process like appVeyor in SqlServer.FunctionalTests inside a VM. Debugging into VM this is the test which seems to cause the hang. Disabling it to verify if there are more reasons.