### PR TITLE
Re-Enable testing Convert.ToString on netcoreapp2.0

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -5574,8 +5574,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [ConditionalFact] // TODO: See issue#6803
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Convert.ToString(string) does not exist on .Net Core 1.0.1.")]
+        [ConditionalFact]
         public virtual void Convert_ToString()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>


### PR DESCRIPTION
It works now because we use SDK 2.0 & Specification.Tests target netcoreapp2.0
Resolves #6803 

