### PR TITLE
Query: Adds simple redundant SelectExpression join elimination.

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -13,6 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     /// <summary>
     ///     A column expression.
     /// </summary>
+    [DebuggerDisplay("Column: {ToString()}")]
     public class ColumnExpression : Expression
     {
         private readonly IProperty _property;

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 #endif
 
         private static readonly ExpressionEqualityComparer _expressionEqualityComparer = new ExpressionEqualityComparer();
+
         private readonly RelationalQueryCompilationContext _queryCompilationContext;
         private readonly IRelationalAnnotationProvider _relationalAnnotationProvider;
         private readonly List<Expression> _projection = new List<Expression>();
@@ -503,7 +504,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return AddToProjection(
                 BindProperty(property, querySource));
         }
-
+        
         /// <summary>
         ///     Adds an expression to the projection.
         /// </summary>
@@ -567,6 +568,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             }
 
             return _projection.Count - 1;
+        }
+
+        /// <summary>
+        ///     TODO
+        /// </summary>
+        /// <param name="expressions"></param>
+        public virtual void ReplaceProjection(
+            [NotNull] IEnumerable<Expression> expressions)
+        {
+            Check.NotNull(expressions, nameof(expressions));
+            
+            ClearProjection();
+
+            _projection.AddRange(expressions);
         }
 
         /// <summary>
@@ -646,11 +661,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         private static string GetColumnName(Expression expression)
-        {
-            return (expression as AliasExpression)?.Alias
-                   ?? (expression as ColumnExpression)?.Name
-                   ?? (expression as ColumnReferenceExpression)?.Name;
-        }
+            => (expression as AliasExpression)?.Alias
+               ?? (expression as ColumnExpression)?.Name
+               ?? (expression as ColumnReferenceExpression)?.Name;
 
         /// <summary>
         ///     Clears the projection.
@@ -846,6 +859,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             {
                 AddToOrderBy(ordering);
             }
+        }
+        
+        /// <summary>
+        ///     TODO
+        /// </summary>
+        /// <param name="orderings"> The orderings expressions. </param>
+        public virtual void ReplaceOrderBy([NotNull] IEnumerable<Ordering> orderings)
+        {
+            Check.NotNull(orderings, nameof(orderings));
+
+            _orderBy.Clear();
+            _orderBy.AddRange(orderings);
         }
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -338,6 +338,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Simple_owned_level1()
+        {
+            AssertQuery<Level1>(l1s => l1s.Include(l1 => l1.OneToOne_Required_PK), elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
+        public virtual void Simple_owned_level1_level2()
+        {
+            AssertQuery<Level1>(l1s => l1s.Include(l1 => l1.OneToOne_Required_PK.OneToOne_Required_PK), elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
+        public virtual void Simple_owned_level1_level2_level3()
+        {
+            AssertQuery<Level1>(
+                l1s
+                    => l1s.Include(l1 => l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK),
+                elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
         public virtual void Navigation_key_access_required_comparison()
         {
             AssertQueryScalar<Level2, int>(

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Specification.Tests;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
@@ -16,9 +17,54 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             : base(fixture)
         {
             fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         // TODO: Assert SQL
+
+        [Fact]
+        public override void Simple_owned_level1()
+        {
+            base.Simple_owned_level1();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+FROM [Level1] AS [l1]");
+        }
+
+        [Fact]
+        public override void Simple_owned_level1_level2()
+        {
+            base.Simple_owned_level1_level2();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+FROM [Level1] AS [l1]");
+        }
+
+        [Fact]
+        public override void Simple_owned_level1_level2_level3()
+        {
+            base.Simple_owned_level1_level2_level3();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+FROM [Level1] AS [l1]");
+        }
+
+        [Fact]
+        public override void Level4_Include()
+        {
+            base.Level4_Include();
+
+            AssertSql(
+                @"SELECT [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[Id], [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_Date], [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_Level1_Optional_Id], [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_Level1_Required_Id], [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_Name], [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[Id], [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level1] AS [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse] ON [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Required_Id] = [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse].[Id]
+LEFT JOIN [Level1] AS [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse] ON [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id] = [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[Id]
+LEFT JOIN [Level1] AS [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK] ON [l1.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[Id] = [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse.OneToOne_Optional_FK].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id]
+WHERE ([l1].[Id] IS NOT NULL AND [l1].[Id] IS NOT NULL) AND [l1].[Id] IS NOT NULL");
+        }
 
         [ConditionalFact(Skip = "issue #4311")]
         public override void Nested_group_join_with_take()
@@ -55,5 +101,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection4();
         }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
Fix: #8372

