### PR TITLE
Metadata: Detach should use existing ConfigurationSource instead of E…

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -286,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Debug.Assert(primaryKeyConfigurationSource.HasValue);
                     primaryKey = Tuple.Create(keyBuilder, primaryKeyConfigurationSource.Value);
                 }
-                var removedConfigurationSource = entityTypeBuilder.RemoveKey(keyToDetach, ConfigurationSource.Explicit);
+                var removedConfigurationSource = entityTypeBuilder.RemoveKey(keyToDetach, keyToDetach.GetConfigurationSource());
                 Debug.Assert(removedConfigurationSource != null);
 
                 detachedKeys.Add(Tuple.Create(keyBuilder, removedConfigurationSource.Value));
@@ -878,7 +878,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     var entityTypeBuilder = propertyToDetach.DeclaringEntityType.Builder;
                     var propertyBuilder = propertyToDetach.Builder;
                     var removedConfigurationSource = entityTypeBuilder
-                        .RemoveProperty(propertyToDetach, ConfigurationSource.Explicit);
+                        .RemoveProperty(propertyToDetach, propertyToDetach.GetConfigurationSource());
                     Debug.Assert(removedConfigurationSource.HasValue);
                     detachedProperties.Add(Tuple.Create(propertyBuilder, removedConfigurationSource.Value));
                 }
@@ -1018,7 +1018,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var relationshipBuilder = foreignKey.Builder;
             var relationshipConfigurationSource = foreignKey.DeclaringEntityType.Builder
-                .RemoveForeignKey(foreignKey, ConfigurationSource.Explicit);
+                .RemoveForeignKey(foreignKey, foreignKey.GetConfigurationSource());
             Debug.Assert(relationshipConfigurationSource != null);
 
             return new RelationshipBuilderSnapshot(relationshipBuilder, relationshipConfigurationSource.Value);
@@ -1217,7 +1217,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityTypeBuilder = indexToDetach.DeclaringEntityType.Builder;
             var indexBuilder = indexToDetach.Builder;
-            var removedConfigurationSource = entityTypeBuilder.RemoveIndex(indexToDetach, ConfigurationSource.Explicit);
+            var removedConfigurationSource = entityTypeBuilder.RemoveIndex(indexToDetach, indexToDetach.GetConfigurationSource());
             Debug.Assert(removedConfigurationSource != null);
             return new IndexBuilderSnapshot(indexBuilder, removedConfigurationSource.Value);
         }

--- a/test/EFCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -694,6 +694,26 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal(ConfigurationSource.Explicit, derivedEntityType.FindNavigation(nameof(DerivedTypeWithKeyAnnotation.Navigation)).ForeignKey.GetConfigurationSource());
                 Assert.Equal(ConfigurationSource.Explicit, derivedEntityType.GetPrimaryKeyConfigurationSource());
             }
+
+            [Fact]
+            public virtual void Ordering_of_entityType_discovery_does_not_affect_key_convention()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                var baseEntity = modelBuilder.Entity<StringIdBase>().Metadata;
+                var derivedEntity = modelBuilder.Entity<StringIdDerived>().Metadata;
+
+                Assert.Equal(baseEntity, derivedEntity.BaseType);
+                Assert.NotNull(baseEntity.FindPrimaryKey());
+
+
+                var modelBuilder2 = CreateModelBuilder();
+                var derivedEntity2 = modelBuilder2.Entity<StringIdDerived>().Metadata;
+                var baseEntity2 = modelBuilder2.Entity<StringIdBase>().Metadata;
+
+                Assert.Equal(baseEntity2, derivedEntity2.BaseType);
+                Assert.NotNull(baseEntity2.FindPrimaryKey());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/TestModel.cs
@@ -525,5 +525,14 @@ namespace Microsoft.EntityFrameworkCore.Tests
         protected class PoliceViewModel : ServicePersonViewModel
         {
         }
+
+        public class StringIdBase
+        {
+            public string Id { get; set; }
+        }
+
+        public class StringIdDerived : StringIdBase
+        {
+        }
     }
 }


### PR DESCRIPTION
…xplicit.

Issue: When Key is added we mark underlying properties as Required using same CS.
When key is removed, in order to restore requiredness, we set is required false for nullable properties using the source which is removing key.
While detaching we use Explicit source which marked string property as nullable explicitly, disallowing us to discover it as PK.
Ideally we should be restoring the values but since we don't have values saved second best option would be to use the same configuration source as defining

Resolves #7885 
Somewhat similar to #6919 
