### PR TITLE
Fix to #8385 - Query: inefficient translation of null protection logic for InMemory and some cases of relational

### DIFF
--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1151,6 +1151,57 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual void Select_null_propagation_optimization7()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Select(g => null != g.LeaderNickname ? g.LeaderNickname + g.LeaderNickname : null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.True(result.Contains(null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_optimization8()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Select(g => g != null ? g.LeaderNickname + g.LeaderNickname : null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.True(result.Any(string.IsNullOrEmpty));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_optimization9()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Select(g => g != null ? (int?)g.FullName.Length : (int?)null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal(1, result.Count(r => r == 16));
+                Assert.Equal(1, result.Count(r => r == 13));
+                Assert.Equal(2, result.Count(r => r == 12));
+                Assert.Equal(1, result.Count(r => r == 11));
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Select_null_propagation_negative1()
         {
             using (var context = CreateContext())
@@ -1180,6 +1231,148 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var result = query.ToList();
 
                 Assert.Equal(25, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative3()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from g1 in context.Gears
+                            join g2 in context.Gears on g1.HasSoulPatch equals true into grouping
+                            from g2 in grouping.DefaultIfEmpty()
+                            orderby g2.Nickname
+                            select new { g2.Nickname, Condition = g2 != null ? (bool?)(g2.LeaderNickname != null) : (bool?)null };
+
+                var result = query.ToList();
+
+                Assert.Equal(13, result.Count);
+                Assert.Equal(null, result[0].Nickname);
+                Assert.Equal(null, result[0].Condition);
+
+                Assert.Equal("Baird", result[3].Nickname);
+                Assert.Equal(true, result[3].Condition);
+
+                Assert.Equal("Marcus", result[9].Nickname);
+                Assert.Equal(false, result[9].Condition);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative4()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from g1 in context.Gears
+                            join g2 in context.Gears on g1.HasSoulPatch equals true into grouping
+                            from g2 in grouping.DefaultIfEmpty()
+                            orderby g2.Nickname
+                            select g2 != null ? new Tuple<string, int>(g2.Nickname, 5) : null;
+
+                var result = query.ToList();
+
+                Assert.Equal(13, result.Count);
+                Assert.Equal(null, result[0]);
+                Assert.Equal("Baird", result[3].Item1);
+                Assert.Equal(5, result[3].Item2);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative5()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from g1 in context.Gears
+                            join g2 in context.Gears on g1.HasSoulPatch equals true into grouping
+                            from g2 in grouping.DefaultIfEmpty()
+                            orderby g2.Nickname
+                            select g2 != null ? new { g2.Nickname, Five = 5 } : null;
+
+                var result = query.ToList();
+                Assert.Equal(13, result.Count);
+                Assert.Equal(null, result[0]);
+                Assert.Equal("Baird", result[3].Nickname);
+                Assert.Equal(5, result[3].Five);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative6()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Select(g => null != g.LeaderNickname ? EF.Property<string>(g, "LeaderNickname").Length != EF.Property<string>(g, "LeaderNickname").Length : (bool?)null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.True(result.Contains(null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative7()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Select(g => null != g.LeaderNickname ? g.LeaderNickname == g.LeaderNickname : (bool?)null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.True(result.Contains(null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_negative8()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags
+                    .Select(t => t.Gear.Squad != null ? t.Gear.AssignedCity.Name : null)
+                    .ToList();
+
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+                Assert.True(result.Contains(null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_works_for_navigations_with_composite_keys()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from t in context.Tags
+                            select t.Gear != null ? t.Gear.Nickname : null;
+
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_propagation_works_for_multiple_navigations_with_composite_keys()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from t in context.Tags
+                            select EF.Property<City>(EF.Property<CogTag>(t.Gear, "Tag").Gear, "AssignedCity") != null 
+                                ? EF.Property<string>(EF.Property<Gear>(t.Gear.Tag, "Gear").AssignedCity, "Name") 
+                                : null;
+
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
             }
         }
 

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -305,5 +305,56 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             return Expression.MakeMemberAccess(expression, member);
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool IsNullPropagationCandidate(
+            [NotNull] this ConditionalExpression conditionalExpression,
+            out Expression testExpression,
+            out Expression resultExpression)
+        {
+            Check.NotNull(conditionalExpression, nameof(conditionalExpression));
+
+            testExpression = null;
+            resultExpression = null;
+            var binaryTest = conditionalExpression.Test as BinaryExpression;
+
+            if (binaryTest == null
+                || !(binaryTest.NodeType == ExpressionType.Equal
+                     || binaryTest.NodeType == ExpressionType.NotEqual))
+            {
+                return false;
+            }
+
+            var isLeftNullConstant = binaryTest.Left.IsNullConstantExpression();
+            var isRightNullConstant = binaryTest.Right.IsNullConstantExpression();
+
+            if (isLeftNullConstant == isRightNullConstant)
+            {
+                return false;
+            }
+
+            if (binaryTest.NodeType == ExpressionType.Equal)
+            {
+                if (!conditionalExpression.IfTrue.IsNullConstantExpression())
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!conditionalExpression.IfFalse.IsNullConstantExpression())
+                {
+                    return false;
+                }
+            }
+
+            testExpression = isLeftNullConstant ? binaryTest.Right : binaryTest.Left;
+            resultExpression = binaryTest.NodeType == ExpressionType.Equal ? conditionalExpression.IfFalse : conditionalExpression.IfTrue;
+
+            return true;
+        }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ConditionalOptimizingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ConditionalOptimizingExpressionVisitor.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ConditionalOptimizingExpressionVisitor : ExpressionVisitorBase
+    {
+        private readonly NullCheckRewriteTester _nullCheckRewriteTester = new NullCheckRewriteTester();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitConditional(ConditionalExpression conditionalExpression)
+        {
+            if (conditionalExpression.Test is BinaryExpression binaryExpression)
+            {
+                // Converts '[q] != null ? [q] : [s]' into '[q] ?? [s]'
+                if (binaryExpression.NodeType == ExpressionType.NotEqual
+                    && binaryExpression.Left is QuerySourceReferenceExpression querySourceReferenceExpression1
+                    && binaryExpression.Right.IsNullConstantExpression()
+                    && ReferenceEquals(conditionalExpression.IfTrue, querySourceReferenceExpression1))
+                {
+                    return Expression.Coalesce(conditionalExpression.IfTrue, conditionalExpression.IfFalse);
+                }
+
+                // Converts 'null != [q] ? [q] : [s]' into '[q] ?? [s]'
+                if (binaryExpression.NodeType == ExpressionType.NotEqual
+                    && binaryExpression.Right is QuerySourceReferenceExpression querySourceReferenceExpression2
+                    && binaryExpression.Left.IsNullConstantExpression()
+                    && ReferenceEquals(conditionalExpression.IfTrue, querySourceReferenceExpression2))
+                {
+                    return Expression.Coalesce(conditionalExpression.IfTrue, conditionalExpression.IfFalse);
+                }
+
+                // Converts '[q] == null ? [s] : [q]' into '[s] ?? [q]'
+                if (binaryExpression.NodeType == ExpressionType.Equal
+                    && binaryExpression.Left is QuerySourceReferenceExpression querySourceReferenceExpression3
+                    && binaryExpression.Right.IsNullConstantExpression()
+                    && ReferenceEquals(conditionalExpression.IfFalse, querySourceReferenceExpression3))
+                {
+                    return Expression.Coalesce(conditionalExpression.IfTrue, conditionalExpression.IfFalse);
+                }
+
+                // Converts 'null == [q] ? [s] : [q]' into '[s] ?? [q]'
+                if (binaryExpression.NodeType == ExpressionType.Equal
+                    && binaryExpression.Right is QuerySourceReferenceExpression querySourceReferenceExpression4
+                    && binaryExpression.Left.IsNullConstantExpression()
+                    && ReferenceEquals(conditionalExpression.IfFalse, querySourceReferenceExpression4))
+                {
+                    return Expression.Coalesce(conditionalExpression.IfTrue, conditionalExpression.IfFalse);
+                }
+            }
+
+            if (conditionalExpression.IsNullPropagationCandidate(out var testExpression, out var resultExpression)
+                && _nullCheckRewriteTester.CanRewriteNullCheck(testExpression, resultExpression))
+            {
+                return new NullConditionalExpression(testExpression, resultExpression);
+            }
+
+            return base.VisitConditional(conditionalExpression);
+        }
+
+        private class NullCheckRewriteTester
+        {
+            private IQuerySource _querySource;
+            private readonly IList<string> _propertyNames = new List<string>();
+            private bool _additionalPropertyInResultExpression;
+            private bool? _canRewriteNullCheck;
+
+            public bool CanRewriteNullCheck(Expression testExpression, Expression resultExpression)
+            {
+                // rewrite following patterns:
+                // same qsre/member ---> a != null ? a : null
+                // one additional member ---> a != null ? a.Property : null
+                // nested ---> a.b.c != null ? a.b.c : null
+                // nested with additional member ---> a.b.c != null ? a.b.c.Property : null
+
+                // don't rewrite patterns like:
+                // member-qsre ---> a.Property != null ? a : null
+                // different qsres ---> a != null ? b : null
+                // different members ---> a.Property1 != null ? a.Property2 : null
+                // two+ additional members ---> a != null ? a.Property.Length : null
+                // different nesting ---> b.c != null ? a.b.c : null
+                AnalyzeTestExpression(testExpression);
+                if (_querySource == null)
+                {
+                    return false;
+                }
+
+                AnalyzeResultExpression(resultExpression);
+
+                return _canRewriteNullCheck ?? false;
+            }
+
+            private void AnalyzeTestExpression(Expression expression)
+            {
+                var processedExpression = expression.RemoveConvert();
+                if (processedExpression is QuerySourceReferenceExpression qsre)
+                {
+                    _querySource = qsre.ReferencedQuerySource;
+
+                    return;
+                }
+
+                if (processedExpression is MemberExpression memberExpression)
+                {
+                    _propertyNames.Add(memberExpression.Member.Name);
+                    AnalyzeTestExpression(memberExpression.Expression);
+
+                    return;
+                }
+
+                if (processedExpression is MethodCallExpression methodCallExpression
+                    && methodCallExpression.Method.IsEFPropertyMethod())
+                {
+                    _propertyNames.Add((string)((ConstantExpression)methodCallExpression.Arguments[1]).Value);
+                    AnalyzeTestExpression(methodCallExpression.Arguments[0]);
+                }
+            }
+
+            private void AnalyzeResultExpression(Expression expression)
+            {
+                var processedExpression = expression.RemoveConvert();
+                if (processedExpression is QuerySourceReferenceExpression qsre)
+                {
+                    _canRewriteNullCheck = qsre.ReferencedQuerySource == _querySource
+                        && _propertyNames.Count == 0;
+
+                    return;
+                }
+
+                if (processedExpression is MemberExpression memberExpression)
+                {
+                    if (_propertyNames.Count > 0
+                        && _propertyNames[0] == memberExpression.Member.Name)
+                    {
+                        _propertyNames.RemoveAt(0);
+                        AnalyzeResultExpression(memberExpression.Expression);
+                    }
+                    else if (!_additionalPropertyInResultExpression)
+                    {
+                        _additionalPropertyInResultExpression = true;
+                        AnalyzeResultExpression(memberExpression.Expression);
+                    }
+
+                    return;
+                }
+
+                if (processedExpression is MethodCallExpression methodCallExpression
+                    && methodCallExpression.IsEFProperty())
+                {
+                    var propertyName = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                    if (_propertyNames.Count > 0
+                        && _propertyNames[0] == propertyName)
+                    {
+                        _propertyNames.RemoveAt(0);
+                        AnalyzeResultExpression(methodCallExpression.Arguments[0]);
+                    }
+                    else if (!_additionalPropertyInResultExpression)
+                    {
+                        _additionalPropertyInResultExpression = true;
+                        AnalyzeResultExpression(methodCallExpression.Arguments[0]);
+                    }
+
+                    return;
+                }
+
+                if (processedExpression is UnaryExpression unary
+                    && processedExpression.NodeType == ExpressionType.TypeAs)
+                {
+                    AnalyzeResultExpression(unary.Operand);
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -206,12 +206,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     if (newAccessOperation != nullConditionalExpression.AccessOperation)
                     {
                         var test = ValueBufferNullComparisonCheck(newCaller);
-                        if (!newAccessOperation.Type.IsNullableType())
+                        var newAccessOperationWithoutConvert = newAccessOperation.RemoveConvert();
+                        if (!newAccessOperationWithoutConvert.Type.IsNullableType())
                         {
                             // since we are in the NullConditionalExpression, member we are trying to bind to could be coming from Left Join
                             // and therefore its value could be null, even though the property type itself is not nullable
                             // we need to compensate for this with additional check
-                            var nullableAccessOperation = TryCreateNullableAccessOperation(newAccessOperation);
+                            var nullableAccessOperation = TryCreateNullableAccessOperation(newAccessOperationWithoutConvert);
                             if (nullableAccessOperation != null)
                             {
                                 test = Expression.AndAlso(

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             VisitQueryModel(queryModel);
 
             queryModel.TransformExpressions(_transformingExpressionVisitor.Visit);
+            queryModel.TransformExpressions(new ConditionalOptimizingExpressionVisitor().Visit);
             queryModel.TransformExpressions(new EntityEqualityRewritingExpressionVisitor(queryCompilationContext).Visit);
             queryModel.TransformExpressions(new SubQueryMemberPushDownExpressionVisitor(queryCompilationContext).Visit);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -640,7 +640,7 @@ LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK] ON [e].[Id] = [e.OneToOne_Optiona
             base.Select_nav_prop_reference_optional1_via_DefaultIfEmpty();
 
             AssertSql(
-                @"SELECT [l2].[Name], [l2].[Id]
+                @"SELECT [l2].[Name]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l2] ON [l1].[Id] = [l2].[Level1_Optional_Id]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1058,6 +1058,36 @@ FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (CAST(LEN([g].[LeaderNickname]) AS int) = 5)");
         }
 
+        public override void Select_null_propagation_optimization7()
+        {
+            base.Select_null_propagation_optimization7();
+
+            AssertSql(
+                @"SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_null_propagation_optimization8()
+        {
+            base.Select_null_propagation_optimization8();
+
+            AssertSql(
+                @"SELECT [g].[LeaderNickname] + [g].[LeaderNickname]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_null_propagation_optimization9()
+        {
+            base.Select_null_propagation_optimization9();
+
+            AssertSql(
+                @"SELECT CAST(LEN([g].[FullName]) AS int)
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
         public override void Select_null_propagation_negative1()
         {
             base.Select_null_propagation_negative1();
@@ -1086,6 +1116,151 @@ END
 FROM [Gear] AS [g1]
 CROSS JOIN [Gear] AS [g2]
 WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_null_propagation_negative3()
+        {
+            base.Select_null_propagation_negative3();
+
+            AssertSql(
+                @"SELECT [t].[Nickname], CASE
+    WHEN [t].[Nickname] IS NOT NULL
+    THEN CASE
+        WHEN [t].[LeaderNickname] IS NOT NULL
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END ELSE NULL
+END AS [Condition]
+FROM [Gear] AS [g1]
+LEFT JOIN (
+    SELECT [g2].*
+    FROM [Gear] AS [g2]
+    WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g1].[HasSoulPatch] = 1
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname]");
+        }
+
+        public override void Select_null_propagation_negative4()
+        {
+            base.Select_null_propagation_negative4();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [t].[Nickname] IS NOT NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [t].[Nickname] AS [Item1]
+FROM [Gear] AS [g1]
+LEFT JOIN (
+    SELECT [g2].*
+    FROM [Gear] AS [g2]
+    WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g1].[HasSoulPatch] = 1
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname]");
+        }
+
+        public override void Select_null_propagation_negative5()
+        {
+            base.Select_null_propagation_negative5();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [t].[Nickname] IS NOT NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [t].[Nickname]
+FROM [Gear] AS [g1]
+LEFT JOIN (
+    SELECT [g2].*
+    FROM [Gear] AS [g2]
+    WHERE [g2].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g1].[HasSoulPatch] = 1
+WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname]");
+        }
+
+        public override void Select_null_propagation_negative6()
+        {
+            base.Select_null_propagation_negative6();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL
+    THEN CASE
+        WHEN CAST(LEN([g].[LeaderNickname]) AS int) <> CAST(LEN([g].[LeaderNickname]) AS int)
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END ELSE NULL
+END
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_null_propagation_negative7()
+        {
+            base.Select_null_propagation_negative7();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL
+    THEN CASE
+        WHEN (([g].[LeaderNickname] = [g].[LeaderNickname]) AND ([g].[LeaderNickname] IS NOT NULL AND [g].[LeaderNickname] IS NOT NULL)) OR ([g].[LeaderNickname] IS NULL AND [g].[LeaderNickname] IS NULL)
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END ELSE NULL
+END
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_null_propagation_negative8()
+        {
+            base.Select_null_propagation_negative8();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [t0].[SquadId] IS NOT NULL
+    THEN [t.Gear.AssignedCity].[Name] ELSE NULL
+END
+FROM [CogTag] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gear] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
+LEFT JOIN [City] AS [t.Gear.AssignedCity] ON [t0].[AssignedCityName] = [t.Gear.AssignedCity].[Name]");
+        }
+
+        public override void Select_null_propagation_works_for_navigations_with_composite_keys()
+        {
+            base.Select_null_propagation_works_for_navigations_with_composite_keys();
+
+            AssertSql(
+                @"SELECT [t0].[Nickname]
+FROM [CogTag] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gear] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])");
+        }
+
+        public override void Select_null_propagation_works_for_multiple_navigations_with_composite_keys()
+        {
+            base.Select_null_propagation_works_for_multiple_navigations_with_composite_keys();
+
+            AssertSql(
+                @"SELECT [t.Gear.Tag.Gear.AssignedCity].[Name]
+FROM [CogTag] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gear] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
+LEFT JOIN [CogTag] AS [t.Gear.Tag] ON (([t0].[Nickname] = [t.Gear.Tag].[GearNickName]) OR ([t0].[Nickname] IS NULL AND [t.Gear.Tag].[GearNickName] IS NULL)) AND (([t0].[SquadId] = [t.Gear.Tag].[GearSquadId]) OR ([t0].[SquadId] IS NULL AND [t.Gear.Tag].[GearSquadId] IS NULL))
+LEFT JOIN (
+    SELECT [t.Gear.Tag.Gear].*
+    FROM [Gear] AS [t.Gear.Tag.Gear]
+    WHERE [t.Gear.Tag.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t1] ON ([t.Gear.Tag].[GearNickName] = [t1].[Nickname]) AND ([t.Gear.Tag].[GearSquadId] = [t1].[SquadId])
+LEFT JOIN [City] AS [t.Gear.Tag.Gear.AssignedCity] ON [t1].[AssignedCityName] = [t.Gear.Tag.Gear.AssignedCity].[Name]");
         }
 
         public override void Select_conditional_with_anonymous_type_and_null_constant()

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -7564,7 +7564,7 @@ ORDER BY [t0].[ContactTitle]");
             base.No_orderby_added_for_fully_translated_manually_constructed_LOJ();
 
             AssertSql(
-                @"SELECT [e1].[City] AS [City1], [e2].[City] AS [City2], [e2].[EmployeeID]
+                @"SELECT [e1].[City] AS [City1], [e2].[City] AS [City2]
 FROM [Employees] AS [e1]
 LEFT JOIN [Employees] AS [e2] ON [e1].[EmployeeID] = [e2].[ReportsTo]");
         }


### PR DESCRIPTION
Moving some of the null conditional check optimization to QueryOptimizer.
QM expressions containing patterns like:
entity != null ? entity.Property : null

get converted to:
entity?.Property

Optimization on Query Model level is limited to member access, EF.Property and TypeAs
Optimization during SQL translation additionally handles all method calls and binary expressions (except equality)

This allows us to optimize more cases (e.g. composite keys) and overall simplifies query models.
Also improved null protection translation:
- we were incorrectly simplifying equality binary operations - those are not safe to translate because of null semantics

Also fixed small bug in binding where we would not protect from unexpectedly accessing null value from ValueBuffer in NullConditionals with Convert expressions.