### PR TITLE
Suppress symbols nupkgs for metapackages

### DIFF
--- a/src/EFCore.Sqlite/EFCore.Sqlite.csproj
+++ b/src/EFCore.Sqlite/EFCore.Sqlite.csproj
@@ -10,6 +10,7 @@
     <PackageId>Microsoft.EntityFrameworkCore.Sqlite</PackageId>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>

--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
@@ -11,6 +11,7 @@
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -10,6 +10,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 


### PR DESCRIPTION
Suppress producing \*.symbols.nupkg files for packages that don't include build output.