### PR TITLE
Query: Add parenthesis when expanding InExpression with null values

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             newExpression = _predicateReductionExpressionOptimizer.Visit(newExpression);
             newExpression = _predicateNegationExpressionOptimizer.Visit(newExpression);
             newExpression = _reducingExpressionVisitor.Visit(newExpression);
-            newExpression = _booleanExpressionTranslatingVisitor.Translate(newExpression, searchCondition: searchCondition);
+            newExpression = _booleanExpressionTranslatingVisitor.Translate(newExpression, searchCondition);
 
             return newExpression;
         }
@@ -342,12 +342,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 var leftBooleanConstant = GetBooleanConstantValue(binaryExpression.Left);
                 var rightBooleanConstant = GetBooleanConstantValue(binaryExpression.Right);
 
-                if ((binaryExpression.NodeType == ExpressionType.Equal
-                     && leftBooleanConstant == true
-                     && rightBooleanConstant == true)
-                    || (binaryExpression.NodeType == ExpressionType.NotEqual
-                        && leftBooleanConstant == false
-                        && rightBooleanConstant == false))
+                if (binaryExpression.NodeType == ExpressionType.Equal
+                    && leftBooleanConstant == true
+                    && rightBooleanConstant == true
+                    || binaryExpression.NodeType == ExpressionType.NotEqual
+                    && leftBooleanConstant == false
+                    && rightBooleanConstant == false)
                 {
                     return;
                 }
@@ -686,7 +686,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                             new InExpression(inExpression.Operand, inValuesNotNull),
                             new IsNullExpression(inExpression.Operand));
 
-                    return Visit(relationalNullsInExpression);
+                    _relationalCommandBuilder.Append("(");
+
+                    Visit(relationalNullsInExpression);
+
+                    _relationalCommandBuilder.Append(")");
+
+                    return inExpression;
                 }
 
                 if (inValuesNotNull.Count > 0)

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
@@ -12,10 +11,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class GearsOfWarQuerySqlServerTest : GearsOfWarQueryTestBase<SqlServerTestStore, GearsOfWarQuerySqlServerFixture>
     {
+        // ReSharper disable once UnusedParameter.Local
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Entity_equality_empty()
@@ -1153,7 +1154,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
             base.Where_compare_anonymous_types();
 
             AssertSql(
-                @"");
+                "");
         }
 
         public override void Where_member_access_on_anonymous_type()
@@ -3071,7 +3072,18 @@ WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f].[Discriminator] = N'Locu
             base.Comparing_entities_using_Equals_inheritance();
 
             AssertSql(
-                @"");
+                "");
+        }
+
+        public override void Contains_on_nullable_array_produces_correct_sql()
+        {
+            base.Contains_on_nullable_array_produces_correct_sql();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[SquadId] < 2) AND ([g].[AssignedCityName] IN (N'Ephyra') OR [g].[AssignedCityName] IS NULL))");
+
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 {
     public class NullSemanticsQuerySqlServerTest : NullSemanticsQueryTestBase<SqlServerTestStore, NullSemanticsQuerySqlServerFixture>
     {
+        // ReSharper disable once UnusedParameter.Local
         public NullSemanticsQuerySqlServerTest(NullSemanticsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
@@ -666,7 +667,7 @@ INNER JOIN [NullSemanticsEntity2] AS [e2] ON [e1].[NullableIntA] = [e2].[Nullabl
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Contains_with_local_array_closure_false_with_null()
@@ -686,7 +687,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo') AND [e].[NullableStringA] IS NOT NUL
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Where_multiple_ors_with_null()
@@ -716,7 +717,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] I
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
-WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
+WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant()


### PR DESCRIPTION
Resolves #8304 

The issue is marked with 1.1.3
Should I create new branch?