### PR TITLE
Diagnostics - Reworks timing infrastructure

### DIFF
--- a/src/EFCore.Relational/Diagnostics/CommandData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandData.cs
@@ -33,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         public CommandData(
             [NotNull] DbCommand command,
@@ -42,14 +42,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid commandId,
             Guid connectionId,
             bool async,
-            long timestamp)
+            DateTimeOffset startTime)
         {
             Command = command;
             CommandId = commandId;
             ConnectionId = connectionId;
             ExecuteMethod = executeMethod;
             Async = async;
-            Timestamp = timestamp;
+            StartTime = startTime;
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual bool Async { get; }
 
         /// <summary>
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        ///     The start time of this event.
         /// </summary>
-        public virtual long Timestamp { get; }
+        public virtual DateTimeOffset StartTime { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/CommandEndData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEndData.cs
@@ -33,11 +33,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public CommandEndData(
             [NotNull] DbCommand command,
@@ -45,16 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid commandId,
             Guid connectionId,
             bool async,
-            long timestamp,
-            long duration)
-            : base(command, executeMethod, commandId, connectionId, async, timestamp)
-        {
-            Duration = duration;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(command, executeMethod, commandId, connectionId, async, startTime)
+            => Duration = duration;
 
         /// <summary>
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </summary>
-        public virtual long Duration { get; }
+        public virtual TimeSpan Duration { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/CommandErrorData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandErrorData.cs
@@ -35,12 +35,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used
-        ///     with <see cref="RelationalEventId.CommandExecuting" /> to time execution.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public CommandErrorData(
             [NotNull] DbCommand command,
@@ -49,12 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             [NotNull] Exception exception,
             bool async,
-            long timestamp,
-            long duration)
-            : base(command, executeMethod, commandId, connectionId, async, timestamp, duration)
-        {
-            Exception = exception;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(command, executeMethod, commandId, connectionId, async, startTime, duration) 
+            => Exception = exception;
 
         /// <summary>
         ///     The exception that was thrown when execution failed.

--- a/src/EFCore.Relational/Diagnostics/CommandExecutedData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandExecutedData.cs
@@ -35,12 +35,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used
-        ///     with <see cref="RelationalEventId.CommandExecuting" /> to time execution.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public CommandExecutedData(
             [NotNull] DbCommand command,
@@ -49,12 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             [CanBeNull] object result,
             bool async,
-            long timestamp,
-            long duration)
-            : base(command, executeMethod, commandId, connectionId, async, timestamp, duration)
-        {
-            Result = result;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(command, executeMethod, commandId, connectionId, async, startTime, duration)
+            => Result = result;
 
         /// <summary>
         ///     The result of executing the command.

--- a/src/EFCore.Relational/Diagnostics/ConnectionData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionData.cs
@@ -27,19 +27,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the operation is happening asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         public ConnectionData(
             [NotNull] DbConnection connection,
             Guid connectionId,
             bool async,
-            long timestamp)
+            DateTimeOffset startTime)
         {
             Connection = connection;
             ConnectionId = connectionId;
             Async = async;
-            Timestamp = timestamp;
+            StartTime = startTime;
         }
 
         /// <summary>
@@ -58,8 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual bool Async { get; }
 
         /// <summary>
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        ///     The start time of this event.
         /// </summary>
-        public virtual long Timestamp { get; }
+        public virtual DateTimeOffset StartTime { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/ConnectionEndData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionEndData.cs
@@ -27,26 +27,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the operation is happening asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public ConnectionEndData(
             [NotNull] DbConnection connection,
             Guid connectionId,
             bool async,
-            long timestamp,
-            long duration)
-            : base(connection, connectionId, async, timestamp)
-        {
-            Duration = duration;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(connection, connectionId, async, startTime)
+            => Duration = duration;
 
         /// <summary>
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </summary>
-        public virtual long Duration { get; }
+        public virtual TimeSpan Duration { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/ConnectionErrorData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionErrorData.cs
@@ -29,23 +29,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the operation is happening asyncronously.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public ConnectionErrorData(
             [NotNull] DbConnection connection,
             Guid connectionId,
             [NotNull] Exception exception,
             bool async,
-            long timestamp,
-            long duration)
-            : base(connection, connectionId, async, timestamp, duration)
-        {
-            Exception = exception;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(connection, connectionId, async, startTime, duration) 
+            => Exception = exception;
 
         /// <summary>
         ///     The exception that was thrown when the connection failed.

--- a/src/EFCore.Relational/Diagnostics/DataReaderDisposingData.cs
+++ b/src/EFCore.Relational/Diagnostics/DataReaderDisposingData.cs
@@ -32,12 +32,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="recordsAffected">
         ///     Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used
-        ///     with <see cref="RelationalEventId.CommandExecuting" /> to time execution.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public DataReaderDisposingData(
             [NotNull] DbCommand command,
@@ -45,15 +44,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid commandId,
             Guid connectionId,
             int recordsAffected,
-            long timestamp,
-            long duration)
+            DateTimeOffset startTime,
+            TimeSpan duration)
         {
             Command = command;
             DataReader = dataReader;
             CommandId = commandId;
             ConnectionId = connectionId;
             RecordsAffected = recordsAffected;
-            Timestamp = timestamp;
+            StartTime = startTime;
             Duration = duration;
         }
 
@@ -83,14 +82,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual int RecordsAffected { get; }
 
         /// <summary>
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used
-        ///     with <see cref="RelationalEventId.CommandExecuting" /> to time execution.
+        ///     The start time of this event.
         /// </summary>
-        public virtual long Timestamp { get; }
+        public virtual DateTimeOffset StartTime { get; }
 
         /// <summary>
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </summary>
-        public virtual long Duration { get; }
+        public virtual TimeSpan Duration { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/TransactionData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionData.cs
@@ -27,19 +27,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId">
         ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         public TransactionData(
             [NotNull] DbTransaction transaction,
             Guid transactionId,
             Guid connectionId,
-            long timestamp)
+            DateTimeOffset startTime)
         {
             Transaction = transaction;
             TransactionId = transactionId;
             ConnectionId = connectionId;
-            Timestamp = timestamp;
+            StartTime = startTime;
         }
 
         /// <summary>
@@ -58,8 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public virtual Guid ConnectionId { get; }
 
         /// <summary>
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        ///     The start time of this event.
         /// </summary>
-        public virtual long Timestamp { get; }
+        public virtual DateTimeOffset StartTime { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/TransactionEndData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionEndData.cs
@@ -27,26 +27,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId">
         ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public TransactionEndData(
             [NotNull] DbTransaction transaction,
             Guid transactionId,
             Guid connectionId,
-            long timestamp,
-            long duration)
-            : base(transaction, transactionId, connectionId, timestamp)
-        {
-            Duration = duration;
-        }
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(transaction, transactionId, connectionId, startTime) 
+            => Duration = duration;
 
         /// <summary>
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </summary>
-        public virtual long Duration { get; }
+        public virtual TimeSpan Duration { get; }
     }
 }

--- a/src/EFCore.Relational/Diagnostics/TransactionErrorData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionErrorData.cs
@@ -30,11 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="exception">
         ///     The exception that was thrown when the transaction failed.
         /// </param>
-        /// <param name="timestamp">
-        ///     A timestamp from <see cref="Stopwatch.GetTimestamp" /> that can be used for timing.
+        /// <param name="startTime">
+        ///     The start time of this event.
         /// </param>
         /// <param name="duration">
-        ///     The duration of execution as ticks from <see cref="Stopwatch.GetTimestamp" />.
+        ///     The duration this event.
         /// </param>
         public TransactionErrorData(
             [NotNull] DbTransaction transaction,
@@ -42,9 +42,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             [NotNull] string action,
             [NotNull] Exception exception,
-            long timestamp,
-            long duration)
-            : base(transaction, transactionId, connectionId, timestamp, duration)
+            DateTimeOffset startTime,
+            TimeSpan duration)
+            : base(transaction, transactionId, connectionId, startTime, duration)
         {
             Action = action;
             Exception = exception;

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -185,8 +185,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             connection.Open();
 
-            var startTimestamp = Stopwatch.GetTimestamp();
             var commandId = Guid.NewGuid();
+
+            var startTime = DateTimeOffset.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
 
             SqlLogger.CommandExecuting(
                 dbCommand,
@@ -194,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 commandId,
                 connection.ConnectionId,
                 async: false, 
-                startTimestamp: startTimestamp);
+                startTime: startTime);
 
             object result;
             try
@@ -246,8 +248,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     }
                 }
 
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 SqlLogger.CommandExecuted(
                     dbCommand,
                     executeMethod,
@@ -255,8 +255,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     connection.ConnectionId,
                     result,
                     false,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
 
                 if (closeConnection)
                 {
@@ -265,8 +265,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception exception)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 SqlLogger.CommandError(
                     dbCommand,
                     executeMethod,
@@ -274,8 +272,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     connection.ConnectionId,
                     exception,
                     false,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
 
                 connection.Close();
 
@@ -306,8 +304,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             await connection.OpenAsync(cancellationToken);
 
-            var startTimestamp = Stopwatch.GetTimestamp();
             var commandId = Guid.NewGuid();
+
+            var startTime = DateTimeOffset.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
 
             SqlLogger.CommandExecuting(
                 dbCommand,
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 commandId,
                 connection.ConnectionId,
                 async: true, 
-                startTimestamp: startTimestamp);
+                startTime: startTime);
 
             object result;
             try
@@ -366,8 +366,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     }
                 }
 
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 SqlLogger.CommandExecuted(
                     dbCommand,
                     executeMethod,
@@ -375,8 +373,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     connection.ConnectionId,
                     result,
                     true,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
 
                 if (closeConnection)
                 {
@@ -385,8 +383,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception exception)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 SqlLogger.CommandError(
                     dbCommand,
                     executeMethod,
@@ -394,8 +390,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     connection.ConnectionId,
                     exception,
                     true,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
 
                 connection.Close();
 

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -28,7 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private readonly DbDataReader _reader;
         private readonly Guid _commandId;
         private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _logger;
-        private readonly long _startTimestamp;
+        private readonly DateTimeOffset _startTime;
+        private readonly Stopwatch _stopwatch;
 
         private bool _disposed;
 
@@ -56,7 +57,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             _reader = reader;
             _commandId = commandId;
             _logger = logger;
-            _startTimestamp = Stopwatch.GetTimestamp();
+            _startTime = DateTimeOffset.UtcNow;
+            _stopwatch = Stopwatch.StartNew();
         }
 
         /// <summary>
@@ -80,16 +82,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             if (!_disposed)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 _logger.DataReaderDisposing(
                     _connection,
                     _command,
                     _reader,
                     _commandId,
                     _reader.RecordsAffected,
-                    _startTimestamp,
-                    currentTimestamp);
+                    _startTime,
+                    _stopwatch.Elapsed);
 
                 _reader.Dispose();
                 _command.Dispose();

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -68,33 +68,30 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         public virtual void Commit()
         {
-            var startTimestamp = Stopwatch.GetTimestamp();
+            var startTime = DateTimeOffset.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
 
             try
             {
                 _dbTransaction.Commit();
 
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 _logger.TransactionCommitted(
                     _relationalConnection,
                     _dbTransaction,
                     TransactionId,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
             }
             catch (Exception e)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 _logger.TransactionError(
                     _relationalConnection,
                     _dbTransaction,
                     TransactionId,
                     "Commit",
                     e,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
                 throw;
             }
 
@@ -106,33 +103,30 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         public virtual void Rollback()
         {
-            var startTimestamp = Stopwatch.GetTimestamp();
+            var startTime = DateTimeOffset.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
 
             try
             {
                 _dbTransaction.Rollback();
 
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 _logger.TransactionRolledBack(
                     _relationalConnection,
                     _dbTransaction,
                     TransactionId,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
             }
             catch (Exception e)
             {
-                var currentTimestamp = Stopwatch.GetTimestamp();
-
                 _logger.TransactionError(
                     _relationalConnection,
                     _dbTransaction,
                     TransactionId,
                     "Rollback",
                     e,
-                    startTimestamp,
-                    currentTimestamp);
+                    startTime,
+                    stopwatch.Elapsed);
                 throw;
             }
 
@@ -156,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         _relationalConnection,
                         _dbTransaction,
                         TransactionId,
-                        Stopwatch.GetTimestamp());
+                        DateTimeOffset.UtcNow);
                 }
 
                 ClearTransaction();


### PR DESCRIPTION
Start capturing event start time (DateTimeOffset.UtcNow) and switch duration to TimeSpan.

- Aligns with AppInsights APIs and is generally just easier to use and more useful.
