### PR TITLE
Fix #7097 - Move AsyncEnumerable to root namespace.

### DIFF
--- a/src/EFCore/AsyncEnumerable.cs
+++ b/src/EFCore/AsyncEnumerable.cs
@@ -10,7 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query
+namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
     ///     Represents an asynchronous sequence produced by executing a compiled query.

--- a/src/EFCore/EF.CompileAsyncQuery.cs
+++ b/src/EFCore/EF.CompileAsyncQuery.cs
@@ -7,7 +7,6 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore


### PR DESCRIPTION
Doesn't address no. 2 on #7097 - "No easy way to call a singleton async operator on an AsyncEnumerable." I think we can address it if/when we get specific feedback.

