### PR TITLE
Fix to #7787 - Query: NullConditional is not added to some complex queries with optional navigation and collection with subquery

### DIFF
--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1259,7 +1259,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             where (new { Name = g.LeaderNickname } ?? new { Name = g.FullName }) != null
                             select g.Nickname;
 
-               var result = query.ToList();
+                var result = query.ToList();
                 Assert.Equal(5, result.Count);
             }
         }
@@ -1683,7 +1683,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass. See issue#4978")] 
+        [ConditionalFact(Skip = "Test does not pass. See issue#4978")]
         public virtual void Non_unicode_string_literals_is_used_for_non_unicode_column_with_concat()
         {
             using (var context = CreateContext())
@@ -1733,7 +1733,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             select g2 ?? g1;
 
                 var result = query.ToList();
-                
+
                 Assert.Equal("Marcus", result[0].Nickname);
                 Assert.Equal(2, result[0].Weapons.Count);
                 Assert.Equal("Baird", result[1].Nickname);
@@ -2327,8 +2327,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 ClearLog();
 
                 var actual = (from g in context.Gears
-                             where g.Tag.Note != "Foo"
-                             select g.SquadId).Sum();
+                              where g.Tag.Note != "Foo"
+                              select g.SquadId).Sum();
 
                 Assert.Equal(expected, actual);
             }
@@ -2388,7 +2388,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                              join g in context.Gears on s.Id equals g.SquadId into grouping
                              from g in grouping.DefaultIfEmpty()
                              where s.Name == "Kilo"
-                             select  s).FirstOrDefault();
+                             select s).FirstOrDefault();
 
                 Assert.Equal("Kilo", query?.Name);
             }
@@ -2722,10 +2722,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var ctx = CreateContext())
             {
                 var query = from gear in (from gear in ctx.Gears
-                                       join tag in ctx.Tags on gear.Nickname equals tag.GearNickName
-                                       orderby tag.Note
-                                       where tag.GearNickName != "Cole Train"
-                                       select gear).AsTracking()
+                                          join tag in ctx.Tags on gear.Nickname equals tag.GearNickName
+                                          orderby tag.Note
+                                          where tag.GearNickName != "Cole Train"
+                                          select gear).AsTracking()
                             join tag in ctx.Tags on gear.Nickname equals tag.GearNickName
                             orderby gear.Nickname, tag.Id
                             select gear.Nickname;
@@ -2874,7 +2874,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                             from v in Veterans(g.Reports)
                             orderby g.Nickname, v.Nickname
                             select new { g = g.Nickname, v = v.Nickname };
-                            
+
                 var result = query.ToList();
 
                 Assert.Equal(3, result.Count);
@@ -3151,8 +3151,8 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             {
 
                 var query = from lh in (from f in ctx.Factions
-                                       where f is LocustHorde
-                                       select (LocustHorde)f).Include(h => h.Commander).Include(h => h.Leaders)
+                                        where f is LocustHorde
+                                        select (LocustHorde)f).Include(h => h.Commander).Include(h => h.Leaders)
                             orderby lh.Name
                             select lh;
 
@@ -3305,6 +3305,19 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 var query = context.Gears.Where(g => g.SquadId < 2 && cities.Contains(g.AssignedCity.Name)).ToList();
 
                 Assert.Equal(2, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_navigation_with_collection_composite_key()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Where(t => t.Gear is Officer && ((Officer)t.Gear).Reports.Count(r => r.Nickname == "Dom") > 0);
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Marcus's Tag", result[0].Note);
             }
         }
 

--- a/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -1025,6 +1025,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                                   select c.CustomerID));
         }
 
+        [ConditionalFact]
+        public virtual void Navigation_with_collection_with_nullable_type_key()
+        {
+            AssertQuery<Order>(
+                os => os.Where(o => o.Customer.Orders.Count(oo => oo.OrderID > 10260) > 30),
+                entryCount: 31);
+        }
+
         protected QueryNavigationsTestBase(TFixture fixture)
         {
             Fixture = fixture;

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -100,6 +100,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 return node;
             }
 
+            if (node is NullConditionalEqualExpression nullConditionalEqualExpression)
+            {
+                Visit(nullConditionalEqualExpression.OuterNullProtection);
+                Visit(
+                    Expression.Equal(
+                        nullConditionalEqualExpression.OuterKey,
+                        nullConditionalEqualExpression.InnerKey));
+
+                return node;
+            }
+
             return base.VisitExtension(node);
         }
 

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class NullConditionalEqualExpression : Expression
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public NullConditionalEqualExpression(
+            [NotNull] Expression outerNullProtection,
+            [NotNull] Expression outerKey,
+            [NotNull] Expression innerKey)
+        {
+            Check.NotNull(outerNullProtection, nameof(outerNullProtection));
+            Check.NotNull(outerKey, nameof(outerKey));
+            Check.NotNull(innerKey, nameof(innerKey));
+
+            OuterNullProtection = outerNullProtection;
+            OuterKey = outerKey;
+            InnerKey = innerKey;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression OuterNullProtection { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression OuterKey { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression InnerKey { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Type Type => typeof(bool);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override bool CanReduce => true;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression Reduce()
+            => AndAlso(
+                OuterNullProtection,
+                Equal(
+                    OuterKey,
+                    InnerKey));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newOuterCaller = visitor.Visit(OuterNullProtection);
+            var newOuterKey = visitor.Visit(OuterKey);
+            var newInnerKey = visitor.Visit(InnerKey);
+
+            return newOuterCaller != OuterNullProtection || newOuterKey != OuterKey || newInnerKey != InnerKey
+                ? new NullConditionalEqualExpression(newOuterCaller, newOuterKey, newInnerKey)
+                : this;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string ToString()
+            => OuterKey + " ?= " + InnerKey;
+    }
+}

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -257,6 +257,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         {
                             hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalExpression.AccessOperation);
                         }
+                        else if (obj is NullConditionalEqualExpression nullConditionalEqualExpression)
+                        {
+                            hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalEqualExpression.OuterNullProtection);
+                            hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalEqualExpression.OuterKey);
+                            hashCode += (hashCode * 397) ^ GetHashCode(nullConditionalEqualExpression.InnerKey);
+                        }
                         else
                         {
                             hashCode += (hashCode * 397) ^ obj.GetHashCode();
@@ -573,6 +579,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     return Compare(
                         nullConditionalExpressionA.AccessOperation,
                         nullConditionalExpressionB.AccessOperation);
+                }
+
+                if (a is NullConditionalEqualExpression nullConditionalEqualExpressionA
+                    && b is NullConditionalEqualExpression nullConditionalEqualExpressionB)
+                {
+                    return Compare(
+                               nullConditionalEqualExpressionA.OuterNullProtection,
+                               nullConditionalEqualExpressionB.OuterNullProtection)
+                        && Compare(
+                               nullConditionalEqualExpressionA.OuterKey,
+                               nullConditionalEqualExpressionB.OuterKey)
+                        && Compare(
+                               nullConditionalEqualExpressionA.InnerKey,
+                               nullConditionalEqualExpressionB.InnerKey);
                 }
 
                 return a.Equals(b);

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -764,6 +764,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     VisitNullConditionalExpression(nullConditional);
                     break;
 
+                case NullConditionalEqualExpression nullConditionalEqualExpression:
+                    VisitNullConditionalEqualExpression(nullConditionalEqualExpression);
+                    break;
+
                 default:
                     UnhandledExpressionType(extensionExpression);
                     break;
@@ -808,6 +812,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 Visit(nullConditionalExpression.AccessOperation);
                 _stringBuilder.Append("?");
             }
+        }
+
+        private void VisitNullConditionalEqualExpression(NullConditionalEqualExpression nullConditionalEqualExpression)
+        {
+            Visit(nullConditionalEqualExpression.OuterKey);
+            _stringBuilder.Append(" ?= ");
+            Visit(nullConditionalEqualExpression.InnerKey);
         }
 
         private void VisitArguments(IList<Expression> arguments, Action<string> appendAction, string lastSeparator = "")

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -427,13 +427,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             groupJoinCompensatingVisitor.VisitQueryModel(queryModel);
 
-            var optionalCollectionNavigationCompensatingVisitor = new OptionalCollectionNavigationCompensatingVisitor();
-            optionalCollectionNavigationCompensatingVisitor.VisitQueryModel(queryModel);
-
             QuerySourcesRequiringMaterialization.UnionWith(
                 querySourcesRequiringMaterialization
-                    .Concat(groupJoinCompensatingVisitor.QuerySources)
-                    .Concat(optionalCollectionNavigationCompensatingVisitor.QuerySources));
+                    .Concat(groupJoinCompensatingVisitor.QuerySources));
         }
 
         private class GroupJoinMaterializationCompensatingVisitor : QueryModelVisitorBase
@@ -469,70 +465,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 RequiresMaterializationExpressionVisitor.HandleUnderlyingQuerySources(querySource, MarkForMaterialization);
                 QuerySources.Add(querySource);
-            }
-        }
-
-        /// <summary>
-        ///     Temporary measure for issue #7787
-        ///     Problem is that for cases where collection navigation is chained after optional navigation we don't currently have robust null
-        ///     protection logic in place
-        ///     Since those cases don't need to be materialized, we will now try to bind to a value buffer, which may result in null reference for
-        ///     InMemory scenarios
-        ///     Workaround is to detect those cases and force materialization so that null protection is handled by GetValue() method based on entity
-        /// </summary>
-        private class OptionalCollectionNavigationCompensatingVisitor : QueryModelVisitorBase
-        {
-            public ISet<IQuerySource> QuerySources { get; } = new HashSet<IQuerySource>();
-
-            public override void VisitQueryModel(QueryModel queryModel)
-            {
-                queryModel.TransformExpressions(new TransformingQueryModelExpressionVisitor<OptionalCollectionNavigationCompensatingVisitor>(this).Visit);
-
-                base.VisitQueryModel(queryModel);
-            }
-
-            public override void VisitWhereClause(WhereClause whereClause, QueryModel queryModel, int index)
-            {
-                if (whereClause.Predicate is BinaryExpression binaryExpression
-                    && binaryExpression.NodeType == ExpressionType.Equal)
-                {
-                    var rightQsre = GetPropertyAccessQsre(binaryExpression.Right);
-                    if (rightQsre?.ReferencedQuerySource is MainFromClause)
-                    {
-                        var leftQsre = GetPropertyAccessQsre(binaryExpression.Left);
-                        MaterializeOptionalNavigationSource(leftQsre);
-                    }
-                }
-
-                base.VisitWhereClause(whereClause, queryModel, index);
-            }
-
-            private static QuerySourceReferenceExpression GetPropertyAccessQsre(Expression expression)
-            {
-                if (expression.RemoveConvert() is MemberExpression member)
-                {
-                    return member.Expression as QuerySourceReferenceExpression;
-                }
-
-                if (expression.RemoveConvert() is MethodCallExpression method
-                    && method.Method.IsEFPropertyMethod())
-                {
-                    return method.Arguments[0] as QuerySourceReferenceExpression;
-                }
-
-                return null;
-            }
-
-            private void MaterializeOptionalNavigationSource(QuerySourceReferenceExpression sourceQsre)
-            {
-                if (sourceQsre?.ReferencedQuerySource is AdditionalFromClause additionalFromClause)
-                {
-                    var flattenedGroupJoin = additionalFromClause.TryGetFlattenedGroupJoinClause();
-                    if (flattenedGroupJoin != null)
-                    {
-                        QuerySources.Add(flattenedGroupJoin.JoinClause);
-                    }
-                }
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1283,7 +1283,7 @@ ORDER BY [t].[Id]");
             base.Where_navigation_property_to_collection();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Required_FK].[Id], [l1.OneToOne_Required_FK].[Date], [l1.OneToOne_Required_FK].[Level1_Optional_Id], [l1.OneToOne_Required_FK].[Level1_Required_Id], [l1.OneToOne_Required_FK].[Name], [l1.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l1].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
 WHERE (
@@ -2174,7 +2174,7 @@ INNER JOIN [Level2] AS [l2] ON [l1].[Id] = (
             base.Contains_with_subquery_optional_navigation_and_constant_item();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [l1]
 LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 WHERE 1 IN (
@@ -2182,7 +2182,6 @@ WHERE 1 IN (
     FROM [Level3] AS [l3]
     WHERE [l1.OneToOne_Optional_FK].[Id] = [l3].[OneToMany_Optional_InverseId]
 )");
-
         }
 
         public override void Complex_query_with_optional_navigations_and_client_side_evaluation()
@@ -2730,7 +2729,7 @@ WHERE EXISTS (
             base.Navigations_compared_to_each_other4();
 
             AssertSql(
-                @"SELECT [l2.OneToOne_Required_FK].[Id], [l2.OneToOne_Required_FK].[Level2_Optional_Id], [l2.OneToOne_Required_FK].[Level2_Required_Id], [l2.OneToOne_Required_FK].[Name], [l2.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l2.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l2.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [l2].[Name]
+                @"SELECT [l2].[Name]
 FROM [Level2] AS [l2]
 LEFT JOIN [Level3] AS [l2.OneToOne_Required_FK] ON [l2].[Id] = [l2.OneToOne_Required_FK].[Level2_Required_Id]
 WHERE EXISTS (
@@ -2744,7 +2743,7 @@ WHERE EXISTS (
             base.Navigations_compared_to_each_other5();
 
             AssertSql(
-                @"SELECT [l2.OneToOne_Required_FK].[Id], [l2.OneToOne_Required_FK].[Level2_Optional_Id], [l2.OneToOne_Required_FK].[Level2_Required_Id], [l2.OneToOne_Required_FK].[Name], [l2.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Required_InverseId], [l2.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [l2.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [l2.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [l2].[Name]
+                @"SELECT [l2].[Name]
 FROM [Level2] AS [l2]
 LEFT JOIN [Level3] AS [l2.OneToOne_Optional_PK] ON [l2].[Id] = [l2.OneToOne_Optional_PK].[OneToOne_Optional_PK_InverseId]
 LEFT JOIN [Level3] AS [l2.OneToOne_Required_FK] ON [l2].[Id] = [l2.OneToOne_Required_FK].[Level2_Required_Id]

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -3083,7 +3083,25 @@ WHERE (([f].[Discriminator] = N'LocustHorde') AND (([f].[Discriminator] = N'Locu
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[SquadId] < 2) AND ([g].[AssignedCityName] IN (N'Ephyra') OR [g].[AssignedCityName] IS NULL))");
+        }
 
+        public override void Optional_navigation_with_collection_composite_key()
+        {
+            base.Optional_navigation_with_collection_composite_key();
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
+FROM [CogTag] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gear] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
+WHERE ([t0].[Discriminator] = N'Officer') AND ((
+    SELECT COUNT(*)
+    FROM [Gear] AS [r]
+    WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] = N'Dom')) AND (([t0].[Nickname] = [r].[LeaderNickname]) AND ([t0].[SquadId] = [r].[LeaderSquadId]))
+) > 0)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -513,7 +513,7 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             base.Select_collection_navigation_multi_part();
 
             AssertSql(
-                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region], [o].[OrderID]
+                @"SELECT [o].[OrderID], [o.Customer].[CustomerID]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 WHERE [o].[CustomerID] = N'ALFKI'",
@@ -1234,6 +1234,21 @@ LEFT JOIN (
     INNER JOIN [Orders] AS [o] ON [od].[OrderID] = 10260
     INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
+        }
+
+        public override void Navigation_with_collection_with_nullable_type_key()
+        {
+            base.Navigation_with_collection_with_nullable_type_key();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (
+    SELECT COUNT(*)
+    FROM [Orders] AS [oo]
+    WHERE ([oo].[OrderID] > 10260) AND ([o.Customer].[CustomerID] = [oo].[CustomerID])
+) > 30");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was happening for InMemory queries with optional navigation and collection navigation, e.g.:

from e in entities
where e.Optional.Collection.Where(predicate)
select e

those would get rewritten into:

from e in entities
join o in optionals on e.Id equals o.EntityId into grouping
from o in grouping.DefaultIfEmpty()
where o.Collection.Where(predicate)
select e

and then:

from e in entities
join o in optionals on e.Id equals o.EntityId into grouping
from o in grouping.DefaultIfEmpty()
join c in collections
where o.Id == c.OptionalId && predicate
select e

Problem was that o could be null (because of the optional navigation), which would result in NRE for InMemory.

We could add null compensation on the o.Id, but then null semantics would kick in for relational producing the following predicate:

WHERE o.Id = c.OptionalId OR o.Id IS NULL AND c.OptionalId IS NULL

and we would get bad results for some cases (when o is null and collection element FK is null)

Instead, fix is to introduce new reducible expression when creating predicate for the collection navigation rewrite, that for InMemory unwraps to:

o != null && o.Id == c.OptionalId

and for relational to simple comparison predicate: o.ID = c.OptionalId

Additionally, we can now remove workaround for this issue during RequiresMaterialization calculation, which results in more efficient queries on relational (we no longer need to unnecessarily materialize some entities)