### PR TITLE
Query: FromSql: Adds support for interpolated strings!

### DIFF
--- a/src/EFCore.Relational/Query/ResultOperators/Internal/FromSqlExpressionNode.cs
+++ b/src/EFCore.Relational/Query/ResultOperators/Internal/FromSqlExpressionNode.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
             [NotNull] Expression arguments)
             : base(parseInfo, null, null)
         {
-            _sql = (string)sql.Value;
+            _sql = ((RelationalQueryableExtensions.SqlFormat)sql.Value).Format;
             _arguments = arguments;
         }
 

--- a/src/EFCore.Relational/RelationalQueryableExtensions.cs
+++ b/src/EFCore.Relational/RelationalQueryableExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -18,7 +19,8 @@ namespace Microsoft.EntityFrameworkCore
     {
         internal static readonly MethodInfo FromSqlMethodInfo
             = typeof(RelationalQueryableExtensions)
-                .GetTypeInfo().GetDeclaredMethod(nameof(FromSql));
+                .GetTypeInfo().GetDeclaredMethods(nameof(FromSql))
+                .Single(mi => mi.GetParameters().Length == 3);
 
         /// <summary>
         ///     <para>
@@ -44,18 +46,21 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="source">
         ///     An <see cref="IQueryable{T}" /> to use as the base of the raw SQL query (typically a <see cref="DbSet{TEntity}" />).
         /// </param>
-        /// <param name="sql"> The raw SQL query. </param>
+        /// <param name="sql">
+        ///     The raw SQL query. NB. A string literal may be passed here because <see cref="SqlFormat" />
+        ///     is implicitly convertible to string.
+        /// </param>
         /// <param name="parameters"> The values to be assigned to parameters. </param>
         /// <returns> An <see cref="IQueryable{T}" /> representing the raw SQL query. </returns>
         [StringFormatMethod("sql")]
         public static IQueryable<TEntity> FromSql<TEntity>(
             [NotNull] this IQueryable<TEntity> source,
-            [NotNull] [NotParameterized] string sql,
+            [NotParameterized] SqlFormat sql,
             [NotNull] params object[] parameters)
             where TEntity : class
         {
             Check.NotNull(source, nameof(source));
-            Check.NotEmpty(sql, nameof(sql));
+            Check.NotEmpty(sql.Format, nameof(sql));
             Check.NotNull(parameters, nameof(parameters));
 
             return source.Provider.CreateQuery<TEntity>(
@@ -65,6 +70,57 @@ namespace Microsoft.EntityFrameworkCore
                     source.Expression,
                     Expression.Constant(sql),
                     Expression.Constant(parameters)));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Creates a LINQ query based on an interpolated string SQL query.
+        ///     </para>
+        ///     <para>
+        ///         If the database provider supports composing on the supplied SQL, you can compose on top of the raw SQL query using
+        ///         LINQ operators - <code>context.Blogs.FromSql("SELECT * FROM dbo.Blogs").OrderBy(b => b.Name)</code>.
+        ///     </para>
+        ///     <para>
+        ///         As with any API that accepts SQL it is important to parameterize any user input to protect against a SQL injection
+        ///         attack. You can include interpolated parameter place holders in the SQL query string. Any interpolated parameter values
+        ///         you supply will automatically be converted to a DbParameter -
+        ///         <code>context.Blogs.FromSql($"SELECT * FROM [dbo].[SearchBlogs]({userSuppliedSearchTerm})")</code>.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the elements of <paramref name="source" />. </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to use as the base of the interpolated string SQL query (typically a <see cref="DbSet{TEntity}" />).
+        /// </param>
+        /// <param name="sql"> The interpolated string SQL query. </param>
+        /// <returns> An <see cref="IQueryable{T}" /> representing the interpolated string SQL query. </returns>
+        public static IQueryable<TEntity> FromSql<TEntity>(
+            [NotNull] this IQueryable<TEntity> source,
+            [NotNull] [NotParameterized] FormattableString sql)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(sql, nameof(sql));
+            Check.NotEmpty(sql.Format, nameof(source));
+
+            return source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    null,
+                    FromSqlMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    source.Expression,
+                    Expression.Constant(new SqlFormat(sql.Format)),
+                    Expression.Constant(sql.GetArguments())));
+        }
+
+        /// <summary>
+        ///     A SQL format string. This type enables overload resolution between
+        ///     the regular and interpolated FromSql overloads.
+        /// </summary>
+        public struct SqlFormat
+        {
+            public static implicit operator SqlFormat([NotNull] string s) => new SqlFormat(s);
+            public static implicit operator SqlFormat([NotNull] FormattableString fs) => default(SqlFormat);
+            public SqlFormat([NotNull] string s) => Format = s;
+            public string Format { get; }
         }
     }
 }

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1021,5 +1021,10 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
     "MemberId": "System.String get_Filter()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalQueryableExtensions",
+    "MemberId": "public static System.Linq.IQueryable<T0> FromSql<T0>(this System.Linq.IQueryable<T0> source, System.String sql, params System.Object[] parameters) where T0 : class",
+    "Kind": "Removal"
   }
 ]

--- a/src/EFCore.Relational/breakingchanges.netframework.json
+++ b/src/EFCore.Relational/breakingchanges.netframework.json
@@ -1021,5 +1021,10 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
     "MemberId": "System.String get_Filter()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalQueryableExtensions",
+    "MemberId": "public static System.Linq.IQueryable<T0> FromSql<T0>(this System.Linq.IQueryable<T0> source, System.String sql, params System.Object[] parameters) where T0 : class",
+    "Kind": "Removal"
   }
 ]

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -4,7 +4,6 @@
 using System.Data.Common;
 using System.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Specification.Tests;
-using Microsoft.EntityFrameworkCore.Specification.Tests.TestUtilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
@@ -15,6 +14,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             : base(fixture)
         {
             fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void From_sql_queryable_simple()
@@ -161,6 +161,19 @@ FROM (
 CROSS JOIN (
     SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN @__8__locals1_startDate_1 AND @__8__locals1_endDate_2
 ) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]",
+                //
+                @"@p0: Berlin (Size = 4000)
+@__8__locals1_startDate_1: 04/01/1998 00:00:00
+@__8__locals1_endDate_2: 05/01/1998 00:00:00
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
+) AS [c]
+CROSS JOIN (
+    SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN @__8__locals1_startDate_1 AND @__8__locals1_endDate_2
+) AS [o]
 WHERE [c].[CustomerID] = [o].[CustomerID]");
         }
 
@@ -207,6 +220,60 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
 @p1: Sales Representative (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
+        }
+
+        public override void From_sql_queryable_with_parameters_interpolated()
+        {
+            base.From_sql_queryable_with_parameters_interpolated();
+
+            AssertSql(
+                @"@p0: London (Size = 4000)
+@p1: Sales Representative (Size = 4000)
+
+SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
+        }
+
+        public override void From_sql_queryable_with_parameters_inline_interpolated()
+        {
+            base.From_sql_queryable_with_parameters_inline_interpolated();
+
+            AssertSql(
+                @"@p0: London (Size = 4000)
+@p1: Sales Representative (Size = 4000)
+
+SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
+        }
+
+        public override void From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated()
+        {
+            base.From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated();
+
+            AssertSql(
+                @"@p0: London (Size = 4000)
+@p1: 01/01/1997 00:00:00
+@p2: 01/01/1998 00:00:00
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
+) AS [c]
+CROSS JOIN (
+    SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN @p1 AND @p2
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]",
+                //
+                @"@p0: Berlin (Size = 4000)
+@p1: 04/01/1998 00:00:00
+@p2: 05/01/1998 00:00:00
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM (
+    SELECT * FROM ""Customers"" WHERE ""City"" = @p0
+) AS [c]
+CROSS JOIN (
+    SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN @p1 AND @p2
+) AS [o]
+WHERE [c].[CustomerID] = [o].[CustomerID]");
         }
 
         public override void From_sql_queryable_with_null_parameter()


### PR DESCRIPTION
Interpolated variables are parameterized and queries are cached in the usual way.
