### PR TITLE
Fix to #7975 - Query: we should propagate optional navigations thru nav rewrite, if the initial optional navigation was created using SelectMany-GroupJoin-DefaultIfEmpty

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -661,9 +661,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         private static string GetColumnName(Expression expression)
-            => (expression as AliasExpression)?.Alias
-               ?? (expression as ColumnExpression)?.Name
-               ?? (expression as ColumnReferenceExpression)?.Name;
+        {
+            expression = expression.RemoveConvert();
+            expression = (expression as NullableExpression)?.Operand.RemoveConvert()
+                         ?? expression;
+
+            return (expression as AliasExpression)?.Alias
+                   ?? (expression as ColumnExpression)?.Name
+                   ?? (expression as ColumnReferenceExpression)?.Name;
+        }
 
         /// <summary>
         ///     Clears the projection.

--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -273,6 +273,29 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
+        public override void Manually_created_left_join_propagates_nullability_to_navigations()
+        {
+        }
+
+        public override void Optional_navigation_propagates_nullability_to_manually_created_left_join1()
+        {
+        }
+        public override void Optional_navigation_propagates_nullability_to_manually_created_left_join2()
+        {
+        }
+
+        public override void GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened()
+        {
+        }
+
+        public override void GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened2()
+        {
+        }
+
+        public override void GroupJoin_with_complex_subquery_with_joins_does_not_get_flattened3()
+        {
+        }
+
         protected override IQueryable<Level1> GetExpectedLevelOne()
             => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 

--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1042,7 +1042,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 var query = context.Gears
-                    .Where(g => (g == null ? (bool?)null : (bool?)(g.LeaderNickname == "Marcus")) == (bool?)true)
+                    .Where(g => (g == null ? null : g.LeaderNickname) == "Marcus" == (bool?)true)
                     .ToList();
 
                 var result = query.ToList();
@@ -1102,7 +1102,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 var query = context.Gears
-                    .Where(g => (null == EF.Property<string>(g, "LeaderNickname") ? (bool?)null : (bool?)(g.LeaderNickname.Length == 5)) == (bool?)true)
+                    .Where(g => (null == EF.Property<string>(g, "LeaderNickname") ? (int?)null : g.LeaderNickname.Length) == 5 == (bool?)true)
                     .ToList();
 
                 var result = query.ToList();
@@ -1120,7 +1120,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             using (var context = CreateContext())
             {
                 var query = context.Gears
-                    .Where(g => (null != g.LeaderNickname ? (bool?)(EF.Property<string>(g, "LeaderNickname").Length == 5) : (bool?)null) == (bool?)true)
+                    .Where(g => (null != g.LeaderNickname ? (int?)(EF.Property<string>(g, "LeaderNickname").Length) : (int?)null) == 5 == (bool?)true)
                     .ToList();
 
                 var result = query.ToList();
@@ -3318,6 +3318,38 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 Assert.Equal(1, result.Count);
                 Assert.Equal("Marcus's Tag", result[0].Note);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_conditional_with_inheritance()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Factions
+                    .Where(f => f is LocustHorde)
+                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).CommanderName : null);
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Contains("Queen Myrrah"));
+                Assert.True(result.Contains("Unknown"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_null_conditional_with_inheritance_negative()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Factions
+                    .Where(f => f is LocustHorde)
+                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).Eradicated : null);
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Contains(true));
+                Assert.True(result.Contains(false));
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
+++ b/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
@@ -89,6 +89,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
             var newOuterKey = visitor.Visit(OuterKey);
             var newInnerKey = visitor.Visit(InnerKey);
 
+            if (newOuterKey.Type != newInnerKey.Type
+                && newOuterKey.Type.UnwrapNullableType() == newInnerKey.Type.UnwrapNullableType())
+            {
+                if (!newOuterKey.Type.IsNullableType())
+                {
+                    newOuterKey = Convert(newOuterKey, newInnerKey.Type);
+                }
+                else
+                {
+                    newInnerKey = Convert(newInnerKey, newOuterKey.Type);
+                }
+            }
+
             return newOuterCaller != OuterNullProtection || newOuterKey != OuterKey || newInnerKey != InnerKey
                 ? new NullConditionalEqualExpression(newOuterCaller, newOuterKey, newInnerKey)
                 : this;

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
         }
 
         /// <summary>
-        ///     Expression representing potentially nullable caller that needs to be tested for it's nullability. 
+        ///     Expression representing potentially nullable caller that needs to be tested for it's nullability.
         /// </summary>
         public virtual Expression Caller { get; }
 
@@ -115,8 +115,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
             var newCaller = visitor.Visit(Caller);
             var newAccessOperation = visitor.Visit(AccessOperation);
 
-            if (newCaller != Caller
-                || newAccessOperation != AccessOperation)
+            if (newCaller != Caller 
+                || newAccessOperation != AccessOperation
+                    && (newAccessOperation as NullConditionalExpression)?.AccessOperation != AccessOperation)
             {
                 return new NullConditionalExpression(newCaller, newAccessOperation);
             }

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -72,34 +72,10 @@ WHERE ([l1].[Id] IS NOT NULL AND [l1].[Id] IS NOT NULL) AND [l1].[Id] IS NOT NUL
             base.Nested_group_join_with_take();
         }
 
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Where_nav_prop_reference_optional2_via_DefaultIfEmpty()
-        {
-            base.Where_nav_prop_reference_optional2_via_DefaultIfEmpty();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
+        [ConditionalFact(Skip = "issue #8492")]
         public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection2()
         {
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection3()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection3();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection4()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection4();
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1883,7 +1883,7 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
             base.Optional_navigation_type_compensation_works_with_projection_into_anonymous_type();
 
             AssertSql(
-                @"SELECT [t0].[SquadId] AS [SquadId]
+                @"SELECT [t0].[SquadId]
 FROM [CogTag] AS [t]
 LEFT JOIN (
     SELECT [t.Gear].*
@@ -3102,6 +3102,29 @@ WHERE ([t0].[Discriminator] = N'Officer') AND ((
     FROM [Gear] AS [r]
     WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] = N'Dom')) AND (([t0].[Nickname] = [r].[LeaderNickname]) AND ([t0].[SquadId] = [r].[LeaderSquadId]))
 ) > 0)");
+        }
+
+        public override void Select_null_conditional_with_inheritance()
+        {
+            base.Select_null_conditional_with_inheritance();
+
+            AssertSql(
+                @"SELECT [f].[CommanderName]
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')");
+        }
+
+        public override void Select_null_conditional_with_inheritance_negative()
+        {
+            base.Select_null_conditional_with_inheritance_negative();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [f].[CommanderName] IS NOT NULL
+    THEN [f].[Eradicated] ELSE NULL
+END
+FROM [Faction] AS [f]
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/ComplexNavigationsOwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ComplexNavigationsOwnedQuerySqliteTest.cs
@@ -20,34 +20,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             base.Nested_group_join_with_take();
         }
 
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Where_nav_prop_reference_optional2_via_DefaultIfEmpty()
-        {
-            base.Where_nav_prop_reference_optional2_via_DefaultIfEmpty();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
+        [ConditionalFact(Skip = "issue #8492")]
         public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection2()
         {
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection3()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection3();
-        }
-
-        [ConditionalFact(Skip = "issue #8254")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection4()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection4();
         }
     }
 }


### PR DESCRIPTION
also fix to #7761 - Query : Missing null propagation logic for some complex queries with manually created GroupJoin-SelectMany-DefaultIfEmpty

Problem for queries with required navigations that were originating from qsre that was a GroupJoin-SelectMany-DefaultIfEmpty. In those cases, we should be producing LEFT JOINs for the navigations, even though they are required (because initial qsre is already "optional"). We would produce INNER JOINs instead, which would result in data corruption - returning fewer results than expected.

Fix is to use more sophisticated logic to determine whether the source qsre is "optional" and therefore we need to expand all its navigations to LOJs.

We also apply this logic to MemberAccess and EF.Property, effectively fully protecting against accidental NREs for InMemory and client eval scenarios (we were doing that before only for results of nav rewrite, now we also do it for manually created LOJs).