### PR TITLE
[SMALL] Remove unnecessary argument (nullable caller) to the NullConditionalExpression

### DIFF
--- a/src/EFCore.Specification.Tests/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryTestBase.cs
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var predicate
                 = Expression.Lambda<Func<Customer, bool>>(
                     Expression.Equal(
-                        new NullConditionalExpression(c, c, Expression.Property(c, "CustomerID")),
+                        new NullConditionalExpression(c, Expression.Property(c, "CustomerID")),
                         Expression.Constant("ALFKI")),
                     c);
 
@@ -203,11 +203,10 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
             var c = Expression.Parameter(typeof(Customer));
 
             var nullConditionalExpression
-                = new NullConditionalExpression(c, c, Expression.Property(c, "CustomerID"));
+                = new NullConditionalExpression(c, Expression.Property(c, "CustomerID"));
 
             nullConditionalExpression
                 = new NullConditionalExpression(
-                    nullConditionalExpression,
                     nullConditionalExpression,
                     Expression.Property(nullConditionalExpression, "Length"));
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -88,14 +87,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var nullConditionalExpression = node as NullConditionalExpression;
             if (nullConditionalExpression != null)
             {
-                var newNullableCaller = Visit(nullConditionalExpression.NullableCaller);
                 var newCaller = Visit(nullConditionalExpression.Caller);
                 var newAccessOperation = Visit(nullConditionalExpression.AccessOperation);
 
-                return newNullableCaller != nullConditionalExpression.NullableCaller
-                    || newCaller != nullConditionalExpression.Caller
+                return newCaller != nullConditionalExpression.Caller
                     || newAccessOperation != nullConditionalExpression.AccessOperation
-                    ? new NullConditionalExpression(newNullableCaller, newCaller, newAccessOperation)
+                    ? new NullConditionalExpression(newCaller, newAccessOperation)
                     : node;
             }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -431,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     node.Member.Name,
                                     node.Type,
                                     e => e.MakeMemberAccess(node.Member),
-                                    e => new NullConditionalExpression(e, e, e.MakeMemberAccess(node.Member)));
+                                    e => new NullConditionalExpression(e, e.MakeMemberAccess(node.Member)));
                             }
 
                             return null;
@@ -450,7 +450,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             return _insideInnerKeySelector && _innerKeySelectorRequiresNullRefProtection
                 ? (Expression)new NullConditionalExpression(
-                    newExpression,
                     newExpression,
                     newMemberExpression)
                 : newMemberExpression;
@@ -531,10 +530,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                         : Expression.Call(node.Method, e, node.Arguments[1]),
                                     e => node.Arguments[0].Type != e.Type
                                         ? new NullConditionalExpression(
-                                            Expression.Convert(e, node.Arguments[0].Type),
                                             Expression.Convert(e, node.Arguments[0].Type), 
                                             Expression.Call(node.Method, Expression.Convert(e, node.Arguments[0].Type), node.Arguments[1]))
-                                        : new NullConditionalExpression(e, e, Expression.Call(node.Method, e, node.Arguments[1])));
+                                        : new NullConditionalExpression(e, Expression.Call(node.Method, e, node.Arguments[1])));
                             }
 
                             return null;
@@ -552,7 +550,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     : node;
 
                 return _insideInnerKeySelector && _innerKeySelectorRequiresNullRefProtection
-                    ? (Expression)new NullConditionalExpression(propertyArguments[0], propertyArguments[0], newPropertyExpression)
+                    ? (Expression)new NullConditionalExpression(propertyArguments[0], newPropertyExpression)
                     : newPropertyExpression;
             }
 
@@ -571,7 +569,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     var newMethodCallExpression = node.Update(nullConditionalExpression.AccessOperation, newArguments);
 
-                    return new NullConditionalExpression(newObject, node.Object, newMethodCallExpression);
+                    return new NullConditionalExpression(newObject, newMethodCallExpression);
                 }
             }
 
@@ -1273,7 +1271,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var propertyExpression = target.CreateEFPropertyExpression(property, makeNullable: false);
 
             return addNullCheck
-                ? new NullConditionalExpression(target, target, propertyExpression)
+                ? new NullConditionalExpression(target, propertyExpression)
                 : propertyExpression;
         }
 

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -785,14 +785,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             if (nullConditionalExpression.AccessOperation is MemberExpression memberExpression)
             {
-                Visit(nullConditionalExpression.NullableCaller);
+                Visit(nullConditionalExpression.Caller);
                 _stringBuilder.Append("?." + memberExpression.Member.Name);
             }
             else if (nullConditionalExpression.AccessOperation is MethodCallExpression methodCallExpression)
             {
                 if (methodCallExpression.Object != null)
                 {
-                    Visit(nullConditionalExpression.NullableCaller);
+                    Visit(nullConditionalExpression.Caller);
                     _stringBuilder.Append("?." + methodCallExpression.Method.Name + "(");
                     VisitArguments(methodCallExpression.Arguments, s => _stringBuilder.Append(s));
                     _stringBuilder.Append(")");
@@ -801,7 +801,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var method = methodCallExpression.Method;
 
                 _stringBuilder.Append(method.DeclaringType?.Name + "." + method.Name + "(?");
-                Visit(nullConditionalExpression.NullableCaller);
+                Visit(nullConditionalExpression.Caller);
                 _stringBuilder.Append("?, ");
                 VisitArguments(methodCallExpression.Arguments.Skip(1).ToList(), s => _stringBuilder.Append(s));
                 _stringBuilder.Append(")");

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -405,7 +405,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         Expression.Convert(
                             new NullConditionalExpression(
                                 parentQuerySourceReferenceExpression,
-                                parentQuerySourceReferenceExpression,
                                 propertyExpression),
                             typeof(object)));
                 }
@@ -464,7 +463,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         newExpression
                             = new NullConditionalExpression(
-                                methodCallExpression.Arguments[0],
                                 methodCallExpression.Arguments[0],
                                 methodCallExpression);
                     }


### PR DESCRIPTION
We don't need Caller and NullableCaller, removing one of them.