### PR TITLE
Query: Testing out a fix for #8393

### DIFF
--- a/src/EFCore.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EFCore.Relational/Query/AsyncQueryMethodProvider.cs
@@ -35,12 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryContext queryContext,
             ShaperCommandContext shaperCommandContext,
             IShaper<T> shaper)
-            => AsyncLinqOperatorProvider
-                ._Select(
-                    new AsyncQueryingEnumerable(
-                        (RelationalQueryContext)queryContext,
-                        shaperCommandContext),
-                    vb => shaper.Shape(queryContext, vb)); // TODO: Pass shaper to underlying enumerable
+            => new AsyncQueryingEnumerable<T>(
+                (RelationalQueryContext)queryContext,
+                shaperCommandContext,
+                shaper);
 
         /// <summary>
         ///     The default if empty shaped query method.
@@ -56,19 +54,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryContext queryContext,
             ShaperCommandContext shaperCommandContext,
             IShaper<T> shaper)
-            => AsyncLinqOperatorProvider
-                ._Select(
-                    new DefaultIfEmptyAsyncEnumerable(
-                        new AsyncQueryingEnumerable(
-                            (RelationalQueryContext)queryContext,
-                            shaperCommandContext)),
-                    vb => shaper.Shape(queryContext, vb));
+            => new DefaultIfEmptyAsyncEnumerable(
+                    _Query((RelationalQueryContext)queryContext, shaperCommandContext))
+                .Select(vb => shaper.Shape(queryContext, vb));
 
         private sealed class DefaultIfEmptyAsyncEnumerable : IAsyncEnumerable<ValueBuffer>
         {
             private readonly IAsyncEnumerable<ValueBuffer> _source;
 
-            public DefaultIfEmptyAsyncEnumerable(IAsyncEnumerable<ValueBuffer> source) 
+            public DefaultIfEmptyAsyncEnumerable(IAsyncEnumerable<ValueBuffer> source)
                 => _source = source;
 
             public IAsyncEnumerator<ValueBuffer> GetEnumerator()
@@ -80,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 private bool _checkedEmpty;
 
-                public DefaultIfEmptyAsyncEnumerator(IAsyncEnumerator<ValueBuffer> enumerator) 
+                public DefaultIfEmptyAsyncEnumerator(IAsyncEnumerator<ValueBuffer> enumerator)
                     => _enumerator = enumerator;
 
                 public async Task<bool> MoveNext(CancellationToken cancellationToken)
@@ -129,7 +123,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         private static IAsyncEnumerable<ValueBuffer> _Query(
             QueryContext queryContext,
             ShaperCommandContext shaperCommandContext)
-            => new AsyncQueryingEnumerable((RelationalQueryContext)queryContext, shaperCommandContext);
+            => new AsyncQueryingEnumerable<ValueBuffer>(
+                (RelationalQueryContext)queryContext,
+                shaperCommandContext,
+                IdentityShaper.Instance);
 
         /// <summary>
         ///     The get result method.
@@ -475,22 +472,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private sealed class InjectParametersEnumerator : IAsyncEnumerator<TElement>
             {
-                private readonly ParameterInjector<TElement> _parameterInjector;
                 private readonly IAsyncEnumerator<TElement> _innerEnumerator;
-                private bool _disposed;
 
                 public InjectParametersEnumerator(ParameterInjector<TElement> parameterInjector)
                 {
-                    _parameterInjector = parameterInjector;
-
-                    for (var i = 0; i < _parameterInjector._parameterNames.Length; i++)
+                    for (var i = 0; i < parameterInjector._parameterNames.Length; i++)
                     {
-                        _parameterInjector._queryContext.AddParameter(
-                            _parameterInjector._parameterNames[i],
-                            _parameterInjector._parameterValues[i]);
+                        parameterInjector._queryContext.SetParameter(
+                            parameterInjector._parameterNames[i],
+                            parameterInjector._parameterValues[i]);
                     }
 
-                    _innerEnumerator = _parameterInjector._innerEnumerable.GetEnumerator();
+                    _innerEnumerator = parameterInjector._innerEnumerable.GetEnumerator();
                 }
 
                 public TElement Current => _innerEnumerator.Current;
@@ -498,20 +491,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 public async Task<bool> MoveNext(CancellationToken cancellationToken)
                     => await _innerEnumerator.MoveNext(cancellationToken);
 
-                public void Dispose()
-                {
-                    if (!_disposed)
-                    {
-                        _innerEnumerator.Dispose();
-
-                        foreach (var parameterName in _parameterInjector._parameterNames)
-                        {
-                            _parameterInjector._queryContext.RemoveParameter(parameterName);
-                        }
-
-                        _disposed = true;
-                    }
-                }
+                public void Dispose() => _innerEnumerator.Dispose();
             }
         }
     }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IdentityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IdentityShaper.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    public sealed class IdentityShaper : IShaper<ValueBuffer>
+    {
+        public static readonly IdentityShaper Instance = new IdentityShaper();
+
+        private IdentityShaper()
+        {
+        }
+
+        public ValueBuffer Shape(QueryContext queryContext, ValueBuffer valueBuffer) => valueBuffer;
+
+        public bool IsShaperForQuerySource(IQuerySource querySource) => false;
+
+        public void SaveAccessorExpression(QuerySourceMapping querySourceMapping)
+        {
+        }
+
+        public Expression GetAccessorExpression(IQuerySource querySource) => null;
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/IValueBufferCursor.cs
+++ b/src/EFCore.Relational/Query/Internal/IValueBufferCursor.cs
@@ -17,12 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        ValueBuffer Current { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         void BufferAll();
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/AsyncQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/AsyncQueryTestBase.cs
@@ -43,6 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         }
 
         [ConditionalFact]
+        public virtual async Task Where_subquery_correlated_client_eval()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Take(5).OrderBy(c1 => c1.CustomerID).Where(c1 => cs.Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
         public virtual async Task ToListAsync_can_be_canceled()
         {
             for (var i = 0; i < 10; i++)
@@ -3441,7 +3449,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 14);
         }
 
-        [ConditionalFact(Skip = "The test fails with MARS=false. See issue#8393")]
+        [ConditionalFact]
         public virtual async Task Except_nested()
         {
             await AssertQuery<Customer>(
@@ -3486,7 +3494,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                 entryCount: 3);
         }
 
-        [ConditionalFact(Skip = "The test fails with MARS=false. See issue#8393")]
+        [ConditionalFact]
         public virtual async Task Intersect_nested()
         {
             await AssertQuery<Customer>(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/FilterApplyingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/FilterApplyingExpressionVisitor.cs
@@ -107,6 +107,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 return value;
             }
+
+            public void SetParameter(string name, object value)
+            {
+                _parameterValues[name] = value;
+            }
         }
 
         /// <summary>

--- a/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -504,7 +504,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         // ReSharper disable once InconsistentNaming
-        public static IAsyncEnumerable<TResult> _Select<TSource, TResult>(
+        private static IAsyncEnumerable<TResult> _Select<TSource, TResult>(
             [NotNull] IAsyncEnumerable<TSource> source, [NotNull] Func<TSource, TResult> selector)
             => source.Select(selector);
 

--- a/src/EFCore/Query/Internal/IParameterValues.cs
+++ b/src/EFCore/Query/Internal/IParameterValues.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -26,5 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         object RemoveParameter([NotNull] string name);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void SetParameter([NotNull] string name, [CanBeNull] object value);
     }
 }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -107,6 +107,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        ///     Sets a parameter value.
+        /// </summary>
+        /// <param name="name"> The name. </param>
+        /// <param name="value"> The value. </param>
+        public virtual void SetParameter(string name, object value)
+        {
+            Check.NotEmpty(name, nameof(name));
+
+            _parameterValues[name] = value;
+        }
+
+        /// <summary>
         ///     Removes a parameter by name.
         /// </summary>
         /// <param name="name"> The name. </param>

--- a/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             : base(fixture)
         {
             fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override async Task ToList_on_nav_in_projection_is_async()
@@ -153,6 +154,22 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
                 Assert.Equal(5, tasks[0].Count);
                 Assert.Equal(6, tasks[1].Count);
                 Assert.Equal(4, tasks[2].Count);
+            }
+        }
+
+        [Fact]
+        public async Task Concurrent_async_queries_are_serialized2()
+        {
+            using (var context = CreateContext())
+            {
+                await context.OrderDetails
+                    .Where(od => od.OrderID > 0)
+                    .Intersect(
+                        context.OrderDetails
+                            .Where(od => od.OrderID > 0))
+                    .Intersect(
+                        context.OrderDetails
+                            .Where(od => od.OrderID > 0)).ToListAsync();
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -68,8 +68,7 @@ FROM [Orders] AS [c1_Orders]");
         [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Failing after netcoreapp2.0 upgrade")]
         public virtual void Cache_key_contexts_are_detached()
         {
-            WeakReference wr;
-            MakeGarbage(CreateContext(), out wr);
+            MakeGarbage(CreateContext(), out var wr);
 
             GC.Collect();
 


### PR DESCRIPTION
- Fixes a race in async ShapedQuery execution.
- Optimizes ShapedQuery by pushing down shaper to inner enumerable.
- Removes IValueBufferCursor.Current - no longer used.
