### PR TITLE
[TINY] Fix to #8216 - Query: navigation rewrite fails for queries with navigation inside a subquery inside join inner key selector

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -16,18 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
         {
         }
 
-        [ConditionalFact(Skip = "issue #8216")]
-        public override void Query_source_materialization_bug_4547()
-        {
-            base.Query_source_materialization_bug_4547();
-        }
-
-        [ConditionalFact(Skip = "issue #8216")]
-        public override void Select_join_with_key_selector_being_a_subquery()
-        {
-            base.Select_join_with_key_selector_being_a_subquery();
-        }
-
         [ConditionalFact(Skip = "issue #8248")]
         public override void Required_navigation_on_a_subquery_with_First_in_projection()
         {

--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -1457,6 +1457,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                           into
                           grouping
                           from subQuery3 in grouping.DefaultIfEmpty()
+                          orderby subQuery3 != null ? (int?)subQuery3.Id : null
                           select subQuery3 != null ? (int?)subQuery3.Id : null
                       ).FirstOrDefault()
                       select e1.Id);

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -268,7 +268,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitSubQuery(SubQueryExpression expression)
         {
+            var oldInsideInnerKeySelector = _insideInnerKeySelector;
+            _insideInnerKeySelector = false;
+
             Rewrite(expression.QueryModel, _queryModel);
+
+            _insideInnerKeySelector = oldInsideInnerKeySelector;
 
             return expression;
         }

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1141,6 +1141,7 @@ INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
     SELECT TOP(1) [subQuery30].[Id]
     FROM [Level2] AS [subQuery20]
     LEFT JOIN [Level3] AS [subQuery30] ON [subQuery20].[Id] = [subQuery30].[Level2_Optional_Id]
+    ORDER BY [subQuery30].[Id]
 )");
         }
 


### PR DESCRIPTION
Problem was that navigation inside inner key selector of a JoinClause was always being rewritten to subquery (needed for #3103). However, we should only be doing this for "naked" navs - if the nav itself is inside a subquery it can be safely rewritten into a join.

Fix is to "reset" the state indicating whether we are inside join inner key selector every time we visit SubQuery.