### PR TITLE
[TINY] Enabling and fixing test for #6618 - Query: compilation error for queries projecting optional navigation, paging and another projecting of optional navigation

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -1897,13 +1897,13 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                   verifyOrdered: true);
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See Issue#6618
+        [ConditionalFact]
         public virtual void Optional_navigation_take_optional_navigation()
         {
             AssertQuery<Level1>(
                 l1s => l1s
                         .Select(l1 => l1.OneToOne_Optional_FK)
-                        .OrderBy(l2 => l2.Id)
+                        .OrderBy(l2 => (int?)l2.Id)
                         .Take(10)
                         .Select(l2 => l2.OneToOne_Optional_FK.Name),
                 l1s => l1s

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1722,7 +1722,13 @@ ORDER BY [l3].[Level2_Required_Id]");
             base.Optional_navigation_take_optional_navigation();
 
             AssertSql(
-                @"");
+                @"@__p_0: 10
+
+SELECT TOP(@__p_0) [l1.OneToOne_Optional_FK.OneToOne_Optional_FK].[Name]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+LEFT JOIN [Level3] AS [l1.OneToOne_Optional_FK.OneToOne_Optional_FK] ON [l1.OneToOne_Optional_FK].[Id] = [l1.OneToOne_Optional_FK.OneToOne_Optional_FK].[Level2_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]");
         }
 
         public override void Projection_select_correct_table_from_subquery_when_materialization_is_not_required()


### PR DESCRIPTION
Issue has been already fixed in the earlier checkin, but the test was incorrect and would fail for InMemory regardless - fixing the test and enabling it.