### PR TITLE
Allow context.GetInfrastructure() with generic inference to work again

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         rootTypesOrder[sortedRoots[i]] = i;
                     }
 
-                    var stateManager = _currentContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+                    var stateManager = _currentContext.GetDependencies().StateManager;
 
                     ModificationCommandIdentityMap CommandIdentityMapFactory(
                         string name,

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -218,10 +218,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         private IStateManager StateManager
-            => Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            => Context.GetDependencies().StateManager;
 
         private IChangeDetector ChangeDetector
-            => Context.GetInfrastructure<DbContextDependencies>().ChangeDetector;
+            => Context.GetDependencies().ChangeDetector;
 
         private IEntityEntryGraphIterator GraphIterator
             => _graphIterator ?? (_graphIterator = Context.GetService<IEntityEntryGraphIterator>());

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -355,7 +355,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         private IEntityFinder Finder
-            => InternalEntry.StateManager.Context.GetInfrastructure<DbContextDependencies>().EntityFinderSource
+            => InternalEntry.StateManager.Context.GetDependencies().EntityFinderSource
                 .Create(InternalEntry.StateManager.Context, InternalEntry.EntityType);
     }
 }

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         private IEntityFinder TargetFinder
-            => InternalEntry.StateManager.Context.GetInfrastructure<DbContextDependencies>().EntityFinderSource
+            => InternalEntry.StateManager.Context.GetDependencies().EntityFinderSource
                 .Create(InternalEntry.StateManager.Context, Metadata.GetTargetType());
 
         /// <summary>

--- a/src/EFCore/Extensions/Internal/DbContextDependenciesExtensions.cs
+++ b/src/EFCore/Extensions/Internal/DbContextDependenciesExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class DbContextDependenciesExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IDbContextDependencies GetDependencies([NotNull] this IDbContextDependencies context)
+            => context;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IDbContextDependencies GetDependencies([NotNull] this ICurrentDbContext context)
+            => context.Context;
+    }
+}

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -99,6 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IResultOperatorHandler), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IModel), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ICurrentDbContext), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IDbContextDependencies), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDbContextOptions), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDatabase), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IDatabaseCreator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -199,6 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IChangeTrackerFactory, ChangeTrackerFactory>();
             TryAdd<IChangeDetector, ChangeDetector>();
             TryAdd<IDbContextServices, DbContextServices>();
+            TryAdd<IDbContextDependencies, DbContextDependencies>();
             TryAdd<IValueGeneratorSelector, ValueGeneratorSelector>();
             TryAdd<IConventionSetBuilder, NullConventionSetBuilder>();
             TryAdd<IModelValidator, CoreModelValidator>();
@@ -245,7 +247,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<ModelSourceDependencies>()
                 .AddDependencySingleton<ValueGeneratorCacheDependencies>()
                 .AddDependencySingleton<ModelValidatorDependencies>()
-                .AddDependencyScoped<DbContextDependencies>()
                 .AddDependencyScoped<ExecutionStrategyContextDependencies>()
                 .AddDependencyScoped<CompiledQueryCacheKeyGeneratorDependencies>()
                 .AddDependencyScoped<QueryContextDependencies>()

--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///         directly from your code. This type may change or be removed in future releases.
     ///     </para>
     /// </summary>
-    public sealed class DbContextDependencies
+    public sealed class DbContextDependencies : IDbContextDependencies
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public EntityFinder([NotNull] DbContext context, [NotNull] IEntityType entityType)
         {
             _model = context.Model;
-            _stateManager = context.GetInfrastructure<DbContextDependencies>().StateManager;
+            _stateManager = context.GetDependencies().StateManager;
             _queryRoot = (IQueryable<TEntity>)BuildQueryRoot(context, entityType);
         }
 

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IDbContextDependencies
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IModel Model { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IDbSetInitializer DbSetInitializer { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IEntityFinderSource EntityFinderSource { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IAsyncQueryProvider QueryProvider { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IStateManager StateManager { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IChangeDetector ChangeDetector { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IEntityGraphAttacher EntityGraphAttacher { get; }
+    }
+}

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private EntityQueryable<TEntity> CreateEntityQueryable()
-            => new EntityQueryable<TEntity>(_context.GetInfrastructure<DbContextDependencies>().QueryProvider);
+            => new EntityQueryable<TEntity>(_context.GetDependencies().QueryProvider);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => _context.UpdateRange(entities);
 
         private IEntityFinder<TEntity> Finder
-            => (IEntityFinder<TEntity>)_context.GetInfrastructure<DbContextDependencies>().EntityFinderSource.Create(_context, EntityType);
+            => (IEntityFinder<TEntity>)_context.GetDependencies().EntityFinderSource.Create(_context, EntityType);
 
         IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => EntityQueryable.GetEnumerator();
 

--- a/src/EFCore/Query/QueryContextDependencies.cs
+++ b/src/EFCore/Query/QueryContextDependencies.cs
@@ -65,17 +65,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     Gets the change detector.
         /// </summary>
-        public IChangeDetector ChangeDetector => CurrentDbContext.Context.GetInfrastructure<DbContextDependencies>().ChangeDetector;
+        public IChangeDetector ChangeDetector => CurrentDbContext.GetDependencies().ChangeDetector;
 
         /// <summary>
         ///     Gets the state manager.
         /// </summary>
-        public IStateManager StateManager => CurrentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+        public IStateManager StateManager => CurrentDbContext.GetDependencies().StateManager;
 
         /// <summary>
         ///     Gets the query provider.
         /// </summary>
-        public IQueryProvider QueryProvider => CurrentDbContext.Context.GetInfrastructure<DbContextDependencies>().QueryProvider;
+        public IQueryProvider QueryProvider => CurrentDbContext.GetDependencies().QueryProvider;
 
         /// <summary>
         ///     Gets the concurrency detector.

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_creates_valid_batch_for_shared_table_added_entities()
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var first = new FakeEntity { Id = 42, Value = "Test" };
             var firstEntry = stateManager.GetOrCreateEntry(first);
@@ -467,7 +467,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_creates_valid_batch_for_shared_table_modified_entities()
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var entity = new FakeEntity { Id = 42, Value = "Null"};
             var entry = stateManager.GetOrCreateEntry(entity);
@@ -518,7 +518,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_creates_valid_batch_for_shared_table_deleted_entities()
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var first = new FakeEntity { Id = 42, Value = "Test" };
             var firstEntry = stateManager.GetOrCreateEntry(first);
@@ -564,7 +564,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_throws_on_conflicting_updates_for_shared_table_added_entities(bool sensitiveLogging)
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var first = new FakeEntity { Id = 42, Value = "Test" };
             var firstEntry = stateManager.GetOrCreateEntry(first);
@@ -603,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_throws_on_conflicting_values_for_shared_table_added_entities(bool useCurrentValues, bool sensitiveLogging)
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var first = new FakeEntity { Id = 42, Value = "Test" };
             var firstEntry = stateManager.GetOrCreateEntry(first);
@@ -681,7 +681,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
         public void BatchCommands_throws_on_incomplete_updates_for_shared_table(EntityState state, bool sensitiveLogging)
         {
             var currentDbContext = CreateContextServices(CreateSharedTableModel()).GetRequiredService<ICurrentDbContext>();
-            var stateManager = currentDbContext.Context.GetInfrastructure<DbContextDependencies>().StateManager;
+            var stateManager = currentDbContext.GetDependencies().StateManager;
 
             var first = new FakeEntity { Id = 42, Value = "Test" };
             var firstEntry = stateManager.GetOrCreateEntry(first);

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -31,6 +31,17 @@ namespace Microsoft.EntityFrameworkCore.Tests
     public class DbContextTest
     {
         [Fact]
+        public void Can_use_GetInfrastructure_with_inferred_generic_to_get_service_provider()
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                Assert.Same(
+                    context.GetService<IChangeDetector>(),
+                    context.GetInfrastructure().GetService<IChangeDetector>());
+            }
+        }
+
+        [Fact]
         public void Set_throws_for_type_not_in_model()
         {
             var optionsBuilder = new DbContextOptionsBuilder();


### PR DESCRIPTION
Issue #8440

Reverts an unintentional breaking change created by adding another implementation of Infrastructure. The fix is to make DbContext explicitly implement IDbContextDependencies. The exposed services are still "hidden" and all documented as internal.