### PR TITLE
Unblock MonsterFixupTest for SQLCE (which only supports dates after 1753

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
@@ -63,6 +63,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
             private int _supplierId;
             private DateTime _eta;
 
+            public BackOrderLine()
+            {
+                ETA = DateTime.Now;
+            }
+
             public DateTime ETA
             {
                 get { return _eta; }
@@ -1437,6 +1442,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
             public AuditInfo()
             {
                 Concurrency = new ConcurrencyInfo();
+                ModifiedDate = DateTime.Now;
             }
 
             public DateTime ModifiedDate

--- a/src/EFCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
@@ -58,6 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
             private int _supplierId;
             private DateTime _eta;
 
+            public BackOrderLine()
+            {
+                ETA = DateTime.Now;
+            }
+
             public DateTime ETA
             {
                 get { return _eta; }
@@ -1432,6 +1437,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
             public AuditInfo()
             {
                 Concurrency = new ConcurrencyInfo();
+                ModifiedDate = DateTime.Now;
             }
 
             public DateTime ModifiedDate

--- a/src/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
@@ -32,6 +32,11 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
 
         public class BackOrderLine : OrderLine, IBackOrderLine
         {
+            public BackOrderLine()
+            {
+                ETA = DateTime.Now;
+            }
+
             public DateTime ETA { get; set; }
 
             public int SupplierId { get; set; }
@@ -445,6 +450,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests.TestModels
             public AuditInfo()
             {
                 Concurrency = new ConcurrencyInfo();
+                ModifiedDate = DateTime.Now;
             }
 
             public DateTime ModifiedDate { get; set; }


### PR DESCRIPTION
fixes #8496
