### PR TITLE
Introduce Microsoft.EntityFrameworkCore.Design namespace into the runtime

### DIFF
--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -98,19 +98,19 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             // Look for IDbContextFactory implementations
             var contextFactories = _startupAssembly.GetConstructableTypes()
-                .Where(t => typeof(IDbContextFactory<DbContext>).GetTypeInfo().IsAssignableFrom(t));
+                .Where(t => typeof(IDesignTimeDbContextFactory<DbContext>).GetTypeInfo().IsAssignableFrom(t));
             foreach (var factory in contextFactories)
             {
                 var manufacturedContexts =
                     from i in factory.ImplementedInterfaces
                     where i.GetTypeInfo().IsGenericType
-                          && i.GetGenericTypeDefinition() == typeof(IDbContextFactory<>)
+                          && i.GetGenericTypeDefinition() == typeof(IDesignTimeDbContextFactory<>)
                     select i.GenericTypeArguments[0];
                 foreach (var context in manufacturedContexts)
                 {
                     contexts.Add(
                         context,
-                        () => ((IDbContextFactory<DbContext>)Activator.CreateInstance(factory.AsType())).Create(_args));
+                        () => ((IDesignTimeDbContextFactory<DbContext>)Activator.CreateInstance(factory.AsType())).CreateDbContext(_args));
                 }
             }
 
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         private Func<DbContext> FindContextFactory(Type contextType)
         {
-            var factoryInterface = typeof(IDbContextFactory<>).MakeGenericType(contextType).GetTypeInfo();
+            var factoryInterface = typeof(IDesignTimeDbContextFactory<>).MakeGenericType(contextType).GetTypeInfo();
             var factory = contextType.GetTypeInfo().Assembly.GetConstructableTypes()
                 .Where(t => factoryInterface.IsAssignableFrom(t))
                 .FirstOrDefault();
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 return null;
             }
 
-            return () => ((IDbContextFactory<DbContext>)Activator.CreateInstance(factory.AsType())).Create(_args);
+            return () => ((IDesignTimeDbContextFactory<DbContext>)Activator.CreateInstance(factory.AsType())).CreateDbContext(_args);
         }
 
         private KeyValuePair<Type, Func<DbContext>> FindContextType(string name)

--- a/src/EFCore.Relational.Design.Specification.Tests/DesignTimeProviderServicesTest.cs
+++ b/src/EFCore.Relational.Design.Specification.Tests/DesignTimeProviderServicesTest.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Design;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerDesignTimeServices.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerDesignTimeServices.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/EFCore.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/EFCore.SqlServer/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Design;
 
 [assembly: DesignTimeProviderServices(
                typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqlServerDesignTimeServices",

--- a/src/EFCore.Sqlite.Core/Properties/AssemblyInfo.cs
+++ b/src/EFCore.Sqlite.Core/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Design;
 
 [assembly: DesignTimeProviderServices(
                typeName: "Microsoft.EntityFrameworkCore.Scaffolding.Internal.SqliteDesignTimeServices",

--- a/src/EFCore.Sqlite.Design/Internal/SqliteDesignTimeServices.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteDesignTimeServices.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/EFCore/Design/DesignTimeProviderServicesAttribute.cs
+++ b/src/EFCore/Design/DesignTimeProviderServicesAttribute.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure
+namespace Microsoft.EntityFrameworkCore.Design
 {
     /// <summary>
     ///     <para>

--- a/src/EFCore/Design/IDesignTimeDbContextFactory.cs
+++ b/src/EFCore/Design/IDesignTimeDbContextFactory.cs
@@ -1,28 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure
+namespace Microsoft.EntityFrameworkCore.Design
 {
     /// <summary>
     ///     A factory for creating derived <see cref="DbContext" /> instances. Implement this interface to enable
     ///     design-time services for context types that do not have a public default constructor. At design-time,
     ///     derived <see cref="DbContext" /> instances can be created in order to enable specific design-time
     ///     experiences such as Migrations. Design-time services will automatically discover implementations of
-    ///     this interface that are in the same assembly as the derived context.
+    ///     this interface that are in the startup assembly or the same assembly as the derived context.
     /// </summary>
     /// <typeparam name="TContext">The type of the context.</typeparam>
-    [Obsolete("Use IDesignTimeDbContextFactory instead.", error: true)]
-    public interface IDbContextFactory<out TContext>
+    public interface IDesignTimeDbContextFactory<out TContext>
         where TContext : DbContext
     {
         /// <summary>
         ///     Creates a new instance of a derived context.
         /// </summary>
-        /// <param name="options"> Information about the environment an application is running in. </param>
+        /// <param name="args"> Arguments provided by the design-time service. </param>
         /// <returns> An instance of <typeparamref name="TContext" />. </returns>
-        TContext Create([NotNull] DbContextFactoryOptions options);
+        TContext CreateDbContext([NotNull] string[] args);
     }
 }

--- a/src/EFCore/Design/IDesignTimeServices.cs
+++ b/src/EFCore/Design/IDesignTimeServices.cs
@@ -4,7 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure
+namespace Microsoft.EntityFrameworkCore.Design
 {
     /// <summary>
     ///     Enables configuring design-time services. Tools will automatically discover implementations of this

--- a/src/EFCore/Infrastructure/DbContextFactoryOptions.cs
+++ b/src/EFCore/Infrastructure/DbContextFactoryOptions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     Provides information about the environment an application is running in.
+    /// </summary>
+    public class DbContextFactoryOptions
+    {
+        /// <summary>
+        ///     Gets or sets the directory containing the application.
+        /// </summary>
+        [Obsolete("Use AppContext.BaseDirectory instead.", error: true)]
+        public virtual string ApplicationBasePath { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Gets or sets the directory containing the application content files.
+        /// </summary>
+        [Obsolete("Use Directory.GetCurrentDirectory() instead.", error: true)]
+        public virtual string ContentRootPath { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Gets or sets the name of the environment.
+        /// </summary>
+        [Obsolete("Use the ASPNETCORE_ENVIRONMENT environment variable instead.", error: true)]
+        public virtual string EnvironmentName { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -4,10 +4,6 @@
       "Kind": "Removal"
     },
     {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.DbContextFactoryOptions",
-      "Kind": "Removal"
-    },
-    {
       "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkServicesBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.Extensions.DependencyInjection.IServiceCollection>",
       "Kind": "Removal"
     },
@@ -454,11 +450,6 @@
       "Kind": "Removal"
     },
     {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextFactory<T0> where T0 : Microsoft.EntityFrameworkCore.DbContext",
-      "MemberId": "T0 Create(Microsoft.EntityFrameworkCore.Infrastructure.DbContextFactoryOptions options)",
-      "Kind": "Removal"
-    },
-    {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IModel : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
       "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IEntityType definingEntityType)",
       "Kind": "Addition"
@@ -584,8 +575,11 @@
       "Kind": "Addition"
     },
     {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextFactory<T0> where T0 : Microsoft.EntityFrameworkCore.DbContext",
-      "MemberId": "T0 Create(System.String[] args)",
-      "Kind": "Addition"
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDesignTimeServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.DesignTimeProviderServicesAttribute : System.Attribute",
+      "Kind": "Removal"
     }
   ]

--- a/src/EFCore/breakingchanges.netframework.json
+++ b/src/EFCore/breakingchanges.netframework.json
@@ -4,10 +4,6 @@
       "Kind": "Removal"
     },
     {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.DbContextFactoryOptions",
-      "Kind": "Removal"
-    },
-    {
       "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkServicesBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.Extensions.DependencyInjection.IServiceCollection>",
       "Kind": "Removal"
     },
@@ -454,11 +450,6 @@
       "Kind": "Removal"
     },
     {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextFactory<T0> where T0 : Microsoft.EntityFrameworkCore.DbContext",
-      "MemberId": "T0 Create(Microsoft.EntityFrameworkCore.Infrastructure.DbContextFactoryOptions options)",
-      "Kind": "Removal"
-    },
-    {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IModel : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
       "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IEntityType definingEntityType)",
       "Kind": "Addition"
@@ -584,8 +575,11 @@
       "Kind": "Addition"
     },
     {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextFactory<T0> where T0 : Microsoft.EntityFrameworkCore.DbContext",
-      "MemberId": "T0 Create(System.String[] args)",
-      "Kind": "Addition"
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDesignTimeServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.DesignTimeProviderServicesAttribute : System.Attribute",
+      "Kind": "Removal"
     }
   ]


### PR DESCRIPTION
This namespace (in Microsoft.EntityFrameworkCore.dll) includes the following hooks that applications and providers can use to influence the design-time experience.

* `[DesignTimeProviderServices]`--assembly-level attribute providers use to point to their design-time services
* `IDesignTimeDbContextFactory`--implemented by applications to instantiate their DbContext at design time (resolves #8499)
* `IDesignTimeServices`--implemented by providers and applications to add or replace design-time services

Fixes #8553