### PR TITLE
Fix to #8505 - Query: SubQueryMemberPushDown optimization is too aggressive, which may lead to invalid sql or data corruption

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -22,6 +22,18 @@ namespace Microsoft.EntityFrameworkCore
             base.Required_navigation_on_a_subquery_with_First_in_projection();
         }
 
+        [ConditionalFact(Skip = "issue #8526")]
+        public override void Select_subquery_with_client_eval_and_navigation1()
+        {
+            base.Select_subquery_with_client_eval_and_navigation1();
+        }
+
+        [ConditionalFact(Skip = "issue #8526")]
+        public override void Select_subquery_with_client_eval_and_navigation2()
+        {
+            base.Select_subquery_with_client_eval_and_navigation2();
+        }
+
         // Naked instances not supported
         public override void Key_equality_two_conditions_on_same_navigation()
         {

--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -1599,6 +1599,173 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Where_subquery_distinct_firstordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch && g.Weapons.Distinct().FirstOrDefault().IsAutomatic);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Select(r => r.Nickname).Contains("Marcus"));
+                Assert.True(result.Select(r => r.Nickname).Contains("Baird"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_distinct_first_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.OrderBy(g => g.Nickname).Where(g => g.HasSoulPatch && g.Weapons.Distinct().First().IsAutomatic);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Baird", result[0].Nickname);
+                Assert.Equal("Marcus", result[1].Nickname);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_distinct_singleordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .OrderBy(g => g.Nickname)
+                    .Where(g => g.HasSoulPatch && g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().SingleOrDefault().IsAutomatic);
+
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Baird", result[0].Nickname);
+                Assert.Equal("Marcus", result[1].Nickname);
+            }
+        }
+
+        [ConditionalFact(Skip = "issue #8582")]
+        public virtual void Where_subquery_distinct_lastordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .OrderBy(g => g.Nickname)
+                    .Where(g => !g.Weapons.Distinct().OrderBy(w => w.Id).LastOrDefault().IsAutomatic);
+
+                var result = query.ToList();
+
+                Assert.Equal(4, result.Count);
+                Assert.Equal("Baird", result[0].Nickname);
+                Assert.Equal("Dom", result[1].Nickname);
+                Assert.Equal("Marcus", result[2].Nickname);
+                Assert.Equal("Paduk", result[3].Nickname);
+            }
+        }
+
+        [ConditionalFact(Skip = "issue #8582")]
+        public virtual void Where_subquery_distinct_last_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .OrderBy(g => g.Nickname)
+                    .Where(g => !g.HasSoulPatch && g.Weapons.Distinct().Last().IsAutomatic);
+
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Cole Train", result[0].Nickname);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_distinct_orderby_firstordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().IsAutomatic);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Select(r => r.Nickname).Contains("Marcus"));
+                Assert.True(result.Select(r => r.Nickname).Contains("Baird"));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_union_firstordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch && g.Weapons.Union(g.Weapons).FirstOrDefault().IsAutomatic).ToList();
+
+                Assert.Equal(2, query.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_concat_firstordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch && g.Weapons.Concat(g.Weapons).FirstOrDefault().IsAutomatic);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+            }
+        }
+
+        [ConditionalFact(Skip = "issue #8525")]
+        public virtual void Where_subquery_concat_order_by_firstordefault_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.Weapons.Concat(g.Weapons).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+            }
+        }
+
+        [ConditionalFact(Skip = "issues: #8524, #8525")]
+        public virtual void Concat_with_collection_navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch).Select(g => g.Weapons.Union(g.Weapons).Count());
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+            }
+        }
+
+        [ConditionalFact(Skip = "issues: #8524, #8525")]
+        public virtual void Union_with_collection_navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.OfType<Officer>().Select(o => o.Reports.Union(o.Reports).Count());
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_subquery_distinct_firstordefault()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Where(g => g.HasSoulPatch).Select(g => g.Weapons.Distinct().FirstOrDefault().Name);
+                var result = query.ToList();
+
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Contains("Baird's Lancer"));
+                Assert.True(result.Contains("Marcus' Lancer"));
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Select_Where_Navigation_Client()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/SubQueryMemberPushDownExpressionVisitor.cs
@@ -1,11 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
@@ -34,20 +38,51 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var newExpression = Visit(memberExpression.Expression);
 
-            var subQueryExpression = newExpression as SubQueryExpression;
-            var subSelector = subQueryExpression?.QueryModel.SelectClause.Selector;
-
-            if (subSelector is QuerySourceReferenceExpression
-                || subSelector is SubQueryExpression)
+            if (newExpression is SubQueryExpression subQueryExpression)
             {
-                var querySourceMapping = new QuerySourceMapping();
-                var subQueryModel = subQueryExpression.QueryModel.Clone(querySourceMapping);
-                _queryCompilationContext.UpdateMapping(querySourceMapping);
+                var subSelector = subQueryExpression.QueryModel.SelectClause.Selector;
+                if ((subSelector is QuerySourceReferenceExpression || subSelector is SubQueryExpression)
+                    && !subQueryExpression.QueryModel.ResultOperators.Any(ro =>
+                        ro is ConcatResultOperator
+                        || ro is UnionResultOperator
+                        || ro is IntersectResultOperator
+                        || ro is ExceptResultOperator))
+                {
+                    if (!subQueryExpression.QueryModel.ResultOperators.Any(ro => ro is DistinctResultOperator))
+                    {
+                        var querySourceMapping = new QuerySourceMapping();
+                        var subQueryModel = subQueryExpression.QueryModel.Clone(querySourceMapping);
+                        _queryCompilationContext.UpdateMapping(querySourceMapping);
 
-                subQueryModel.SelectClause.Selector = VisitMember(memberExpression.Update(subQueryModel.SelectClause.Selector));
-                subQueryModel.ResultTypeOverride = subQueryModel.SelectClause.Selector.Type;
+                        subQueryModel.SelectClause.Selector = VisitMember(memberExpression.Update(subQueryModel.SelectClause.Selector));
+                        subQueryModel.ResultTypeOverride = subQueryModel.SelectClause.Selector.Type;
 
-                return new SubQueryExpression(subQueryModel);
+                        return new SubQueryExpression(subQueryModel);
+                    }
+
+                    var finalResultOperator = subQueryExpression.QueryModel.ResultOperators.Last();
+                    if (finalResultOperator is FirstResultOperator
+                        || finalResultOperator is SingleResultOperator
+                        || finalResultOperator is LastResultOperator)
+                    {
+                        var queryModel = subQueryExpression.QueryModel;
+                        queryModel.ResultOperators.Remove(finalResultOperator);
+
+                        queryModel.ResultTypeOverride = null;
+                        var newSubQueryExpression = new SubQueryExpression(queryModel);
+
+                        var mainFromClause = new MainFromClause(queryModel.GetNewName("subquery"), queryModel.SelectClause.Selector.Type, newSubQueryExpression);
+                        var selector = Expression.MakeMemberAccess(
+                            new QuerySourceReferenceExpression(mainFromClause),
+                            memberExpression.Member);
+
+                        var subqueryModel = new QueryModel(mainFromClause, new SelectClause(selector));
+                        subqueryModel.ResultOperators.Add(finalResultOperator);
+                        var subqueryExpression = new SubQueryExpression(subqueryModel);
+
+                        return subqueryExpression;
+                    }
+                }
             }
 
             return memberExpression.Update(newExpression);

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2896,6 +2896,68 @@ LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Opti
 WHERE [l1.OneToOne_Optional_FK].[Id] IS NULL");
         }
 
+        public override void Select_subquery_with_client_eval_and_navigation1()
+        {
+            base.Select_subquery_with_client_eval_and_navigation1();
+
+            AssertContainsSql(
+                @"SELECT 1
+FROM [Level2] AS [l2]",
+                //
+                @"SELECT TOP(1) [l.OneToOne_Required_FK_Inverse0].[Name]
+FROM [Level2] AS [l0]
+INNER JOIN [Level1] AS [l.OneToOne_Required_FK_Inverse0] ON [l0].[Level1_Required_Id] = [l.OneToOne_Required_FK_Inverse0].[Id]
+ORDER BY [l0].[Id]");
+        }
+
+        public override void Select_subquery_with_client_eval_and_navigation2()
+        {
+            base.Select_subquery_with_client_eval_and_navigation2();
+
+            AssertContainsSql(
+                @"SELECT 1
+FROM [Level2] AS [l2]",
+                //
+                @"SELECT TOP(1) [l.OneToOne_Required_FK_Inverse1].[Name]
+FROM [Level2] AS [l1]
+INNER JOIN [Level1] AS [l.OneToOne_Required_FK_Inverse1] ON [l1].[Level1_Required_Id] = [l.OneToOne_Required_FK_Inverse1].[Id]
+ORDER BY [l1].[Id]");
+        }
+
+        public override void Select_subquery_with_client_eval_and_multi_level_navigation()
+        {
+            base.Select_subquery_with_client_eval_and_multi_level_navigation();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Member_doesnt_get_pushed_down_into_subquery_with_result_operator()
+        {
+            base.Member_doesnt_get_pushed_down_into_subquery_with_result_operator();
+
+            AssertSql(
+                @"SELECT (
+    SELECT [t].[Name]
+    FROM (
+        SELECT DISTINCT [l3].*
+        FROM [Level3] AS [l3]
+    ) AS [t]
+    ORDER BY [t].[Id]
+    OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY
+)
+FROM [Level1] AS [l1]
+WHERE [l1].[Id] < 3");
+        }
+
+        public override void Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy()
+        {
+            base.Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy();
+
+            AssertSql(
+                @"");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1503,6 +1503,204 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((
 ) = 1)");
         }
 
+        public override void Where_subquery_distinct_firstordefault_boolean()
+        {
+            base.Where_subquery_distinct_firstordefault_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = 1) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT DISTINCT [w].*
+        FROM [Weapon] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+    ) AS [t]
+) = 1))");
+        }
+
+        public override void Where_subquery_distinct_first_boolean()
+        {
+            base.Where_subquery_distinct_first_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)
+ORDER BY [g].[Nickname]",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+
+SELECT TOP(1) [t0].[IsAutomatic]
+FROM (
+    SELECT DISTINCT [w0].*
+    FROM [Weapon] AS [w0]
+    WHERE @_outer_FullName = [w0].[OwnerFullName]
+) AS [t0]",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+
+SELECT TOP(1) [t0].[IsAutomatic]
+FROM (
+    SELECT DISTINCT [w0].*
+    FROM [Weapon] AS [w0]
+    WHERE @_outer_FullName = [w0].[OwnerFullName]
+) AS [t0]");
+        }
+
+        public override void Where_subquery_distinct_singleordefault_boolean()
+        {
+            base.Where_subquery_distinct_singleordefault_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)
+ORDER BY [g].[Nickname]",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+
+SELECT TOP(2) [t0].[IsAutomatic]
+FROM (
+    SELECT DISTINCT [w0].*
+    FROM [Weapon] AS [w0]
+    WHERE (CHARINDEX(N'Lancer', [w0].[Name]) > 0) AND (@_outer_FullName = [w0].[OwnerFullName])
+) AS [t0]",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+
+SELECT TOP(2) [t0].[IsAutomatic]
+FROM (
+    SELECT DISTINCT [w0].*
+    FROM [Weapon] AS [w0]
+    WHERE (CHARINDEX(N'Lancer', [w0].[Name]) > 0) AND (@_outer_FullName = [w0].[OwnerFullName])
+) AS [t0]");
+        }
+
+        public override void Where_subquery_distinct_lastordefault_boolean()
+        {
+            base.Where_subquery_distinct_lastordefault_boolean();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Where_subquery_distinct_last_boolean()
+        {
+            base.Where_subquery_distinct_last_boolean();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Where_subquery_distinct_orderby_firstordefault_boolean()
+        {
+            base.Where_subquery_distinct_orderby_firstordefault_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = 1) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT DISTINCT [w].*
+        FROM [Weapon] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+    ) AS [t]
+    ORDER BY [t].[Id]
+) = 1))");
+        }
+
+        public override void Where_subquery_union_firstordefault_boolean()
+        {
+            base.Where_subquery_union_firstordefault_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+@_outer_FullName1: Damon Baird (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+@_outer_FullName1: Marcus Fenix (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])");
+        }
+
+        public override void Where_subquery_concat_firstordefault_boolean()
+        {
+            base.Where_subquery_concat_firstordefault_boolean();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
+                //
+                @"@_outer_FullName: Damon Baird (Size = 450)
+@_outer_FullName1: Damon Baird (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])",
+                //
+                @"@_outer_FullName: Marcus Fenix (Size = 450)
+@_outer_FullName1: Marcus Fenix (Size = 450)
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])");
+        }
+
+        public override void Where_subquery_concat_order_by_firstordefault_boolean()
+        {
+            base.Where_subquery_concat_order_by_firstordefault_boolean();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Concat_with_collection_navigations()
+        {
+            base.Concat_with_collection_navigations();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Union_with_collection_navigations()
+        {
+            base.Union_with_collection_navigations();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Select_subquery_distinct_firstordefault()
+        {
+            base.Select_subquery_distinct_firstordefault();
+
+            AssertSql(
+                @"SELECT (
+    SELECT TOP(1) [t].[Name]
+    FROM (
+        SELECT DISTINCT [w].*
+        FROM [Weapon] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+    ) AS [t]
+)
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)");
+        }
+
         public override void Singleton_Navigation_With_Member_Access()
         {
             base.Singleton_Navigation_With_Member_Access();


### PR DESCRIPTION
Problem was that we were performing subquery member pushdown incorrectly in some cases, e.g. when subquery had Distinct result operator:

from Level1 l1 in DbSet<Level1>
select
    (from Level3 l3 in DbSet<Level3>
    select [l3])
    .Distinct()
    .FirstOrDefault().Name

previously we were translating this into:

from Level1 l1 in DbSet<Level1>
select
    (from Level3 l3 in DbSet<Level3>
    select [l3].Name)
    .Distinct()
    .FirstOrDefault()

Fix is to introduce a subquery, if Distinct result operator is present in a subquery:

from Level1 l1 in DbSet<Level1>
select
    (from subquery in (from Level3 l3 in DbSet<Level3>
                      select [l3])
                     .Distinct()
     select [subquery].Name)
   .FirstOrDefault()

Also added tests for a number of issues discovered when fixing this one