### PR TITLE
API review changes to LoggerCategory

### DIFF
--- a/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
+++ b/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
 
         void IObserver<DiagnosticListener>.OnNext(DiagnosticListener diagnosticListener)
         {
-            if (diagnosticListener.Name == LoggerCategory.Root)
+            if (diagnosticListener.Name == DbLoggerCategory.Root)
             {
                 lock (_sync)
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
                 var eventName = value.Key;
                 var eventData = value.Value;
 
-                Debug.Assert(eventName.StartsWith(LoggerCategory.Root, StringComparison.Ordinal));
+                Debug.Assert(eventName.StartsWith(DbLoggerCategory.Root, StringComparison.Ordinal));
                 Debug.Assert(eventData != null);
 
                 switch (eventData)

--- a/src/EFCore.Design/Design/Internal/OperationLogger.cs
+++ b/src/EFCore.Design/Design/Internal/OperationLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Func<TState, Exception, string> formatter)
         {
             // Only show SQL when verbose
-            if (_categoryName == LoggerCategory.Database.Sql.Name
+            if (_categoryName == DbLoggerCategory.Database.Command.Name
                 && eventId.Id == RelationalEventId.CommandExecuted.Id)
             {
                 logLevel = LogLevel.Debug;

--- a/src/EFCore.Design/Infrastructure/DesignEventId.cs
+++ b/src/EFCore.Design/Infrastructure/DesignEventId.cs
@@ -41,96 +41,96 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ForeignMigrations
         }
 
-        private static readonly string _migrationsPrefix = LoggerCategory.Migrations.Name + ".";
+        private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
         private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
         ///     Removing a migration without checking the database.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationForceRemove = MakeMigrationsId(Id.MigrationForceRemove);
 
         /// <summary>
         ///     Removing migration.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationRemoving = MakeMigrationsId(Id.MigrationRemoving);
 
         /// <summary>
         ///     A migration file was not found.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationFileNotFound = MakeMigrationsId(Id.MigrationFileNotFound);
 
         /// <summary>
         ///     A metadata file was not found.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationMetadataFileNotFound = MakeMigrationsId(Id.MigrationMetadataFileNotFound);
 
         /// <summary>
         ///     A manual migration deletion was detected.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationManuallyDeleted = MakeMigrationsId(Id.MigrationManuallyDeleted);
 
         /// <summary>
         ///     Removing model snapshot.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotRemoving = MakeMigrationsId(Id.SnapshotRemoving);
 
         /// <summary>
         ///     No model snapshot file named was found.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotFileNotFound = MakeMigrationsId(Id.SnapshotFileNotFound);
 
         /// <summary>
         ///     Writing model snapshot to file.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotWriting = MakeMigrationsId(Id.SnapshotWriting);
 
         /// <summary>
         ///     Reusing namespace of a type.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId NamespaceReusing = MakeMigrationsId(Id.NamespaceReusing);
 
         /// <summary>
         ///     Reusing directory for a file.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId DirectoryReusing = MakeMigrationsId(Id.DirectoryReusing);
 
         /// <summary>
         ///     Reverting model snapshot.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotReverting = MakeMigrationsId(Id.SnapshotReverting);
 
         /// <summary>
         ///     Writing migration to file.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationWriting = MakeMigrationsId(Id.MigrationWriting);
 
         /// <summary>
         ///     Resuing model snapshot name.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotNameReusing = MakeMigrationsId(Id.SnapshotNameReusing);
 
         /// <summary>
         ///     An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId DestructiveOperation = MakeMigrationsId(Id.DestructiveOperation);
 
         /// <summary>
         ///     The namespace contains migrations for a different context.
-        ///     This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         /// </summary>
         public static readonly EventId ForeignMigrations = MakeMigrationsId(Id.ForeignMigrations);
     }

--- a/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
+++ b/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignMigrations(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] string migrationNamespace)
         {
             var definition = DesignStrings.LogForeignMigrations;
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotNameReusing(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] string lastModelSnapshotName)
         {
             var definition = DesignStrings.LogReusingSnapshotName;
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DestructiveOperation(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IEnumerable<MigrationOperation> operations)
         {
             var definition = DesignStrings.LogDestructiveOperation;
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationForceRemove(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogForceRemoveMigration;
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationRemoving(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogRemovingMigration;
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationFileNotFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Migration migration,
             [NotNull] string fileName)
         {
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationMetadataFileNotFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Migration migration,
             [NotNull] string fileName)
         {
@@ -212,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationManuallyDeleted(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogManuallyDeleted;
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotRemoving(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotFileNotFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotReverting(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -317,7 +317,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationWriting(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] ScaffoldedMigration scaffoldedMigration,
             [NotNull] string fileName)
         {
@@ -342,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotWriting(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] ScaffoldedMigration scaffoldedMigration,
             [NotNull] string fileName)
         {
@@ -367,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void NamespaceReusing(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] Type type)
         {
             var definition = DesignStrings.LogReusingNamespace;
@@ -394,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DirectoryReusing(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] string fileName)
         {
             var definition = DesignStrings.LogReusingDirectory;

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private readonly IMigrationsIdGenerator _idGenerator;
         private readonly MigrationsCodeGenerator _migrationCodeGenerator;
         private readonly IHistoryRepository _historyRepository;
-        private readonly IDiagnosticsLogger<LoggerCategory.Migrations> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Migrations> _logger;
         private readonly string _activeProvider;
 
         public MigrationsScaffolder(
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             [NotNull] IMigrationsIdGenerator idGenerator,
             [NotNull] MigrationsCodeGenerator migrationCodeGenerator,
             [NotNull] IHistoryRepository historyRepository,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Migrations> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger,
             [NotNull] IDatabaseProvider databaseProvider)
         {
             Check.NotNull(currentContext, nameof(currentContext));

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<EntityTypeWriter>()
                 .AddSingleton<CodeWriter, StringBuilderCodeWriter>()
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
-                .AddSingleton<DiagnosticSource>(new DiagnosticListener(LoggerCategory.Root))
+                .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root))
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>));
     }
 }

--- a/src/EFCore.InMemory/Extensions/Internal/InMemoryLoggerExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/Internal/InMemoryLoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionIgnoredWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics)
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics)
         {
             var definition = InMemoryStrings.LogTransactionsNotSupported;
 
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ChangesSaved(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Update> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
             [NotNull] IEnumerable<IUpdateEntry> entries,
             int rowsAffected)
         {

--- a/src/EFCore.InMemory/Infrastructure/InMemoryEventId.cs
+++ b/src/EFCore.InMemory/Infrastructure/InMemoryEventId.cs
@@ -30,21 +30,21 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ChangesSaved = CoreEventId.ProviderBaseId + 100
         }
 
-        private static readonly string _transactionPrefix = LoggerCategory.Database.Transaction.Name + ".";
+        private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
         private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
 
         /// <summary>
         ///     Changes were saved to the database.
-        ///     This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         /// </summary>
         public static readonly EventId TransactionIgnoredWarning = MakeTransactionId(Id.TransactionIgnoredWarning);
 
-        private static readonly string _updatePrefix = LoggerCategory.Update.Name + ".";
+        private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
         ///     A transaction operation was requested, but ignored because in-memory does not support transactions.
-        ///     This event is in the <see cref="LoggerCategory.Update" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
         /// </summary>
         public static readonly EventId ChangesSaved = MakeUpdateId(Id.ChangesSaved);
     }

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -37,6 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<LoggerCategory.Update> updateLogger);
+        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class InMemoryDatabase : Database, IInMemoryDatabase
     {
         private readonly IInMemoryStore _store;
-        private readonly IDiagnosticsLogger<LoggerCategory.Update> _updateLogger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] DatabaseDependencies dependencies,
             [NotNull] IInMemoryStoreSource storeSource,
             [NotNull] IDbContextOptions options,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Update> updateLogger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
             : base(dependencies)
         {
             Check.NotNull(storeSource, nameof(storeSource));

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public virtual int ExecuteTransaction(
             IEnumerable<IUpdateEntry> entries,
-            IDiagnosticsLogger<LoggerCategory.Update> updateLogger)
+            IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
         {
             var rowsAffected = 0;
 

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -14,10 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     {
         private static readonly InMemoryTransaction _stubTransaction = new InMemoryTransaction();
 
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.Transaction> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> _logger;
 
         public InMemoryTransactionManager(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Transaction> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger)
         {
             Check.NotNull(logger, nameof(logger));
 

--- a/src/EFCore.Relational.Design/Infrastructure/RelationalDesignEventId.cs
+++ b/src/EFCore.Relational.Design/Infrastructure/RelationalDesignEventId.cs
@@ -58,186 +58,186 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             SequenceFound
         }
 
-        private static readonly string _scaffoldingPrefix = LoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     The database is missing a schema.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingSchemaWarning = MakeScaffoldingId(Id.MissingSchemaWarning);
 
         /// <summary>
         ///     The database is missing a table.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingTableWarning = MakeScaffoldingId(Id.MissingTableWarning);
 
         /// <summary>
         ///     The database has an unnamed sequence.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceNotNamedWarning = MakeScaffoldingId(Id.SequenceNotNamedWarning);
 
         /// <summary>
         ///     The database has a sequence of a type that is not supported.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceTypeNotSupportedWarning = MakeScaffoldingId(Id.SequenceTypeNotSupportedWarning);
 
         /// <summary>
         ///     An entity type could not be generated.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId UnableToGenerateEntityTypeWarning = MakeScaffoldingId(Id.UnableToGenerateEntityTypeWarning);
 
         /// <summary>
         ///     A column type could not be mapped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnTypeNotMappedWarning = MakeScaffoldingId(Id.ColumnTypeNotMappedWarning);
 
         /// <summary>
         ///     A table is missing a primary key.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingPrimaryKeyWarning = MakeScaffoldingId(Id.MissingPrimaryKeyWarning);
 
         /// <summary>
         ///     Columns in a primary key were not mapped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId PrimaryKeyColumnsNotMappedWarning = MakeScaffoldingId(Id.PrimaryKeyColumnsNotMappedWarning);
 
         /// <summary>
         ///     Columns in an index were not mapped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnsNotMappedWarning = MakeScaffoldingId(Id.IndexColumnsNotMappedWarning);
 
         /// <summary>
         ///     A foreign key references a missing table.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingTableWarning);
 
         /// <summary>
         ///     A foreign key references a missing table at the principal end.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingPrincipalTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingPrincipalTableWarning);
 
         /// <summary>
         ///     A foreign key references a table that was not mapped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesNotMappedTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesNotMappedTableWarning);
 
         /// <summary>
         ///     Columns in a foreign key were not mapped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnsNotMappedWarning = MakeScaffoldingId(Id.ForeignKeyColumnsNotMappedWarning);
 
         /// <summary>
         ///     A foreign key references missing prinicpal key columns.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingPrincipalKeyWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingPrincipalKeyWarning);
 
         /// <summary>
         ///     A principal key contains nullable columns.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalEndContainsNullableColumnsWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalEndContainsNullableColumnsWarning);
 
         /// <summary>
         ///     A foreign key is not named.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyNotNamedWarning = MakeScaffoldingId(Id.ForeignKeyNotNamedWarning);
 
         /// <summary>
         ///     A foreign key column was not found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyColumnMissingWarning);
 
         /// <summary>
         ///     A column referenced by a foreign key constraint was not found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalColumnMissingWarning);
 
         /// <summary>
         ///     A foreign key column was not named.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnNotNamedWarning = MakeScaffoldingId(Id.ForeignKeyColumnNotNamedWarning);
 
         /// <summary>
         ///     A column is not named. 
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnNotNamedWarning = MakeScaffoldingId(Id.ColumnNotNamedWarning);
 
         /// <summary>
         ///     An index is not named. 
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexNotNamedWarning = MakeScaffoldingId(Id.IndexNotNamedWarning);
 
         /// <summary>
         ///     The table referened by an index was not found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexTableMissingWarning = MakeScaffoldingId(Id.IndexTableMissingWarning);
 
         /// <summary>
         ///     An index column was not named.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnNotNamedWarning = MakeScaffoldingId(Id.IndexColumnNotNamedWarning);
 
         /// <summary>
         ///     A table was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TableFound = MakeScaffoldingId(Id.TableFound);
 
         /// <summary>
         ///     A table was skipped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TableSkipped = MakeScaffoldingId(Id.TableSkipped);
 
         /// <summary>
         ///     A column was skipped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnSkipped = MakeScaffoldingId(Id.ColumnSkipped);
 
         /// <summary>
         ///     An index was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexFound = MakeScaffoldingId(Id.IndexFound);
 
         /// <summary>
         ///     An index was skipped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnFound = MakeScaffoldingId(Id.IndexColumnFound);
 
         /// <summary>
         ///     A column of an index was skipped.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnSkipped = MakeScaffoldingId(Id.IndexColumnSkipped);
 
         /// <summary>
         ///     A sequence was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceFound = MakeScaffoldingId(Id.SequenceFound);
     }

--- a/src/EFCore.Relational.Design/Internal/RelationalDesignLoggerExtensions.cs
+++ b/src/EFCore.Relational.Design/Internal/RelationalDesignLoggerExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingSchemaWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string schemaName)
         {
             var definition = RelationalDesignStrings.LogMissingSchema;
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingTableWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogMissingTable;
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics)
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
         {
             var definition = RelationalDesignStrings.LogSequencesRequireName;
 
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceTypeNotSupportedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string sequenceName,
             [CanBeNull] string dataTypeName)
         {
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void UnableToGenerateEntityTypeWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogUnableToGenerateEntityType;
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnTypeNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName)
         {
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingPrimaryKeyWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogMissingPrimaryKey;
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PrimaryKeyColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingTableWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName)
         {
             var definition = RelationalDesignStrings.LogForeignKeyScaffoldErrorPrincipalTableNotFound;
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesNotMappedTableWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [NotNull] string principalTableName)
         {
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -313,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingPrincipalKeyWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string principalEntityTypeName,
             [NotNull] IList<string> principalColumnNames)
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyPrincipalEndContainsNullableColumnsWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string indexName,
             [CanBeNull] IList<string> nullablePropertyNames)
@@ -375,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string sequenceName,
             [CanBeNull] string sequenceTypeName,
             bool? cyclic,
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TableFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogFoundTable;
@@ -450,7 +450,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TableSkipped(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogTableNotInSelectionSet;
@@ -473,7 +473,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnSkipped(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName)
         {
@@ -498,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string indexName,
             bool? unique,
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogColumnNameEmptyOnTable;
@@ -552,7 +552,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnSkipped(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string indexName,
             [CanBeNull] string columnName)
@@ -579,7 +579,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogIndexNameEmpty;
@@ -602,7 +602,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexTableMissingWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
         {
@@ -627,7 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
         {
@@ -652,7 +652,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogForeignKeyNameEmpty;
@@ -675,7 +675,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnMissingWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
@@ -702,7 +702,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingPrincipalTableWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName,
             [CanBeNull] string principalTableName)
@@ -729,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
         {
@@ -754,7 +754,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName,
             bool? unique)
@@ -781,7 +781,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyPrincipalColumnMissingWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName,
             [CanBeNull] string principalColumnName,

--- a/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         internal const string NavigationNameUniquifyingPattern = "{0}Navigation";
         internal const string SelfReferencingPrincipalEndNavigationNamePattern = "Inverse{0}";
 
-        protected virtual IDiagnosticsLogger<LoggerCategory.Scaffolding> Logger { get; }
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
         protected virtual IRelationalTypeMapper TypeMapper { get; }
         protected virtual CandidateNamingService CandidateNamingService { get; }
 
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         private readonly IPluralizer _pluralizer;
 
         public RelationalScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore.Relational/Infrastructure/RelationalEventId.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalEventId.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ModelValidationKeyDefaultValueWarning = CoreEventId.RelationalBaseId + 600
         }
 
-        private static readonly string _connectionPrefix = LoggerCategory.Database.Connection.Name + ".";
+        private static readonly string _connectionPrefix = DbLoggerCategory.Database.Connection.Name + ".";
         private static EventId MakeConnectionId(Id id) => new EventId((int)id, _connectionPrefix + id);
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database connection is opening.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database connection has been opened.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEndData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database connection is closing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database connection has been closed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEndData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A error occurred while opening or using a database connection.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionErrorData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public static readonly EventId ConnectionError = MakeConnectionId(Id.ConnectionError);
 
-        private static readonly string _sqlPrefix = LoggerCategory.Database.Sql.Name + ".";
+        private static readonly string _sqlPrefix = DbLoggerCategory.Database.Command.Name + ".";
         private static EventId MakeCommandId(Id id) => new EventId((int)id, _sqlPrefix + id);
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database command is executing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Sql" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database command has been executed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Sql" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandExecutedData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         An error occurred while a database command was executing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Sql" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandErrorData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public static readonly EventId CommandError = MakeCommandId(Id.CommandError);
 
-        private static readonly string _transactionPrefix = LoggerCategory.Database.Transaction.Name + ".";
+        private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
         private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database transaction has been started.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Entity Framework started using an already existing database transaction.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database transaction has been committed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEndData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database transaction has been rolled back.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEndData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A database transaction has been disposed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -246,7 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         An error has occurred while using. committing, or rolling back a database transaction.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionErrorData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -259,7 +259,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         An application may have expected an ambient transaction to be used when it was actually ignorred.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -267,23 +267,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public static readonly EventId AmbientTransactionWarning = MakeTransactionId(Id.AmbientTransactionWarning);
 
-        private static readonly string _dataReaderPrefix = LoggerCategory.Database.DataReader.Name + ".";
-        private static EventId MakeReaderId(Id id) => new EventId((int)id, _dataReaderPrefix + id);
-
         /// <summary>
         ///     <para>
         ///         A database data reader has been disposed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Database.DataReader" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="DataReaderDisposingData" /> payload when used with a <see cref="DiagnosticSource" />.
         ///     </para>
         /// </summary>
-        public static readonly EventId DataReaderDisposing = MakeReaderId(Id.DataReaderDisposing);
+        public static readonly EventId DataReaderDisposing = MakeCommandId(Id.DataReaderDisposing);
 
-        private static readonly string _migrationsPrefix = LoggerCategory.Migrations.Name + ".";
+        private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
         private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
@@ -291,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Migrations is using a database connection.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigratorConnectionData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -304,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A migration is being reverted.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -317,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A migration is being applied.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -330,7 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Migrations is generating a "down" script.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationScriptingData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -343,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Migrations is generating an "up" script.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationScriptingData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -351,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         public static readonly EventId MigrationGeneratingUpScript = MakeMigrationsId(Id.MigrationGeneratingUpScript);
 
-        private static readonly string _queryPrefix = LoggerCategory.Query.Name + ".";
+        private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
 
         /// <summary>
@@ -359,7 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Part of a query is being evaluated on the client instead of on the database server.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId QueryClientEvaluationWarning = MakeQueryId(Id.QueryClientEvaluationWarning);
@@ -369,12 +366,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A query is using equals comparisons in a possibly unintended way.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId QueryPossibleUnintendedUseOfEqualsWarning = MakeQueryId(Id.QueryPossibleUnintendedUseOfEqualsWarning);
 
-        private static readonly string _validationPrefix = LoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
@@ -382,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         A single database default column value has been set on a key column.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId ModelValidationKeyDefaultValueWarning = MakeValidationId(Id.ModelValidationKeyDefaultValueWarning);

--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandExecuting(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Sql> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId, 
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private static bool ShouldLogParameterValues(
-            IDiagnosticsLogger<LoggerCategory.Database.Sql> diagnostics,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             DbCommand command)
             => command.Parameters.Count > 0
                && diagnostics.ShouldLogSensitiveData();
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandExecuted(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Sql> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandError(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Sql> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
@@ -169,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionOpening(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             bool async)
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionOpened(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             TimeSpan duration,
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionClosing(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime)
         {
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionClosed(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             TimeSpan duration)
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionError(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] Exception exception,
             DateTimeOffset startTime,
@@ -341,7 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionStarted(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionUsed(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -399,7 +399,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionCommitted(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionRolledBack(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -457,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionDisposed(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -484,7 +484,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionError(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -517,7 +517,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void AmbientTransactionWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startDate)
         {
@@ -542,7 +542,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DataReaderDisposing(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Database.DataReader> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader dataReader,
@@ -575,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrateUsingConnection(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] IRelationalConnection connection)
         {
@@ -608,7 +608,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationReverting(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration)
         {
@@ -637,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationApplying(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration)
         {
@@ -666,7 +666,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationGeneratingDownScript(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration,
             [CanBeNull] string fromMigration,
@@ -701,7 +701,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationGeneratingUpScript(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration,
             [CanBeNull] string fromMigration,
@@ -736,7 +736,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryClientEvaluationWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] QueryModel queryModel,
             [NotNull] object expression)
         {
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryPossibleUnintendedUseOfEqualsWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] MethodCallExpression methodCallExpression,
             [NotNull] Expression argument)
         {
@@ -789,7 +789,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ModelValidationKeyDefaultValueWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = RelationalStrings.LogKeyHasDefaultValue;

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         private readonly IMigrationCommandExecutor _migrationCommandExecutor;
         private readonly IRelationalConnection _connection;
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
-        private readonly IDiagnosticsLogger<LoggerCategory.Migrations> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Migrations> _logger;
         private readonly string _activeProvider;
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] IMigrationCommandExecutor migrationCommandExecutor,
             [NotNull] IRelationalConnection connection,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Migrations> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger,
             [NotNull] IDatabaseProvider databaseProvider)
         {
             Check.NotNull(migrationsAssembly, nameof(migrationsAssembly));

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
@@ -16,13 +16,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class EqualsTranslator : IMethodCallTranslator
     {
-        private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public EqualsTranslator([NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger)
+        public EqualsTranslator([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Check.NotNull(logger, nameof(logger));
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     </para>
         /// </summary>
         /// <param name="logger"> A logger. </param>
-        public RelationalCompositeMethodCallTranslatorDependencies([NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger)
+        public RelationalCompositeMethodCallTranslatorDependencies([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             Logger = logger;
         }
@@ -47,14 +47,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Query> Logger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger)
+        public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => new RelationalCompositeMethodCallTranslatorDependencies(logger);
     }
 }

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -26,18 +26,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommand(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             [NotNull] string commandText,
             [NotNull] IReadOnlyList<IRelationalParameter> parameters)
         {
-            Check.NotNull(sqlLogger, nameof(sqlLogger));
-            Check.NotNull(readerLogger, nameof(readerLogger));
+            Check.NotNull(logger, nameof(logger));
             Check.NotNull(commandText, nameof(commandText));
             Check.NotNull(parameters, nameof(parameters));
 
-            SqlLogger = sqlLogger;
-            ReaderLogger = readerLogger;
+            Logger = logger;
             CommandText = commandText;
             Parameters = parameters;
         }
@@ -46,13 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual IDiagnosticsLogger<LoggerCategory.Database.Sql> SqlLogger { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected virtual IDiagnosticsLogger<LoggerCategory.Database.DataReader> ReaderLogger { get; }
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -190,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             var startTime = DateTimeOffset.UtcNow;
             var stopwatch = Stopwatch.StartNew();
 
-            SqlLogger.CommandExecuting(
+            Logger.CommandExecuting(
                 dbCommand,
                 executeMethod,
                 commandId,
@@ -231,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                                     dbCommand,
                                     dbCommand.ExecuteReader(),
                                     commandId,
-                                    ReaderLogger);
+                                    Logger);
                         }
                         catch
                         {
@@ -248,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     }
                 }
 
-                SqlLogger.CommandExecuted(
+                Logger.CommandExecuted(
                     dbCommand,
                     executeMethod,
                     commandId,
@@ -265,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception exception)
             {
-                SqlLogger.CommandError(
+                Logger.CommandError(
                     dbCommand,
                     executeMethod,
                     commandId,
@@ -309,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             var startTime = DateTimeOffset.UtcNow;
             var stopwatch = Stopwatch.StartNew();
 
-            SqlLogger.CommandExecuting(
+            Logger.CommandExecuting(
                 dbCommand,
                 executeMethod,
                 commandId,
@@ -349,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                                 dbCommand,
                                 await dbCommand.ExecuteReaderAsync(cancellationToken),
                                 commandId,
-                                ReaderLogger);
+                                Logger);
                         }
                         catch
                         {
@@ -366,7 +357,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     }
                 }
 
-                SqlLogger.CommandExecuted(
+                Logger.CommandExecuted(
                     dbCommand,
                     executeMethod,
                     commandId,
@@ -383,7 +374,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
             catch (Exception exception)
             {
-                SqlLogger.CommandError(
+                Logger.CommandError(
                     dbCommand,
                     executeMethod,
                     commandId,

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
@@ -15,8 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class RelationalCommandBuilder : IRelationalCommandBuilder
     {
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.Sql> _sqlLogger;
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _readerLogger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
 
         private readonly IndentedStringBuilder _commandTextBuilder = new IndentedStringBuilder();
 
@@ -25,16 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilder(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             [NotNull] IRelationalTypeMapper typeMapper)
         {
-            Check.NotNull(sqlLogger, nameof(sqlLogger));
-            Check.NotNull(readerLogger, nameof(readerLogger));
+            Check.NotNull(logger, nameof(logger));
             Check.NotNull(typeMapper, nameof(typeMapper));
 
-            _sqlLogger = sqlLogger;
-            _readerLogger = readerLogger;
+            _logger = logger;
             ParameterBuilder = new RelationalParameterBuilder(typeMapper);
         }
 
@@ -53,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public virtual IRelationalCommand Build()
             => BuildCore(
-                _sqlLogger,
-                _readerLogger,
+                _logger,
                 _commandTextBuilder.ToString(),
                 ParameterBuilder.Parameters);
 
@@ -63,12 +58,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual IRelationalCommand BuildCore(
-                [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 [NotNull] string commandText,
                 [NotNull] IReadOnlyList<IRelationalParameter> parameters)
             => new RelationalCommand(
-                sqlLogger, readerLogger, commandText, parameters);
+                logger, commandText, parameters);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
@@ -13,8 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class RelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.Sql> _sqlLogger;
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _readerLogger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
         private readonly IRelationalTypeMapper _typeMapper;
 
         /// <summary>
@@ -22,16 +21,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilderFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             [NotNull] IRelationalTypeMapper typeMapper)
         {
-            Check.NotNull(sqlLogger, nameof(sqlLogger));
-            Check.NotNull(readerLogger, nameof(readerLogger));
+            Check.NotNull(logger, nameof(logger));
             Check.NotNull(typeMapper, nameof(typeMapper));
 
-            _sqlLogger = sqlLogger;
-            _readerLogger = readerLogger;
+            _logger = logger;
             _typeMapper = typeMapper;
         }
 
@@ -39,19 +35,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IRelationalCommandBuilder Create() => CreateCore(_sqlLogger, _readerLogger, _typeMapper);
+        public virtual IRelationalCommandBuilder Create() => CreateCore(_logger, _typeMapper);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual IRelationalCommandBuilder CreateCore(
-                [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 [NotNull] IRelationalTypeMapper relationalTypeMapper)
             => new RelationalCommandBuilder(
-                sqlLogger,
-                readerLogger,
+                logger,
                 relationalTypeMapper);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -44,8 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="connectionLogger"> The logger to which connection messages will be written. </param>
         public RelationalConnectionDependencies(
             [NotNull] IDbContextOptions contextOptions,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Transaction> transactionLogger,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Connection> connectionLogger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
             Check.NotNull(transactionLogger, nameof(transactionLogger));
@@ -64,13 +64,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger to which transaction messages will be written.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Database.Transaction> TransactionLogger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> TransactionLogger { get; }
 
 
         /// <summary>
         ///     The logger to which connection messages will be written.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Database.Connection> ConnectionLogger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Connection> ConnectionLogger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A replacement for the current dependency of this type.
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Database.Connection> connectionLogger)
+        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger)
             => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, connectionLogger);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A replacement for the current dependency of this type.
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Database.Transaction> transactionLogger)
+        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger)
             => new RelationalConnectionDependencies(ContextOptions, transactionLogger, ConnectionLogger);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private readonly DbCommand _command;
         private readonly DbDataReader _reader;
         private readonly Guid _commandId;
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
         private readonly DateTimeOffset _startTime;
         private readonly Stopwatch _stopwatch;
 
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
             Guid commandId,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.DataReader> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
         {
             Check.NotNull(command, nameof(command));
             Check.NotNull(reader, nameof(reader));

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     {
         private readonly IRelationalConnection _relationalConnection;
         private readonly DbTransaction _dbTransaction;
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.Transaction> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> _logger;
         private readonly bool _transactionOwned;
 
         private bool _connectionClosed;
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public RelationalTransaction(
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Database.Transaction> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
             bool transactionOwned)
         {
             Check.NotNull(connection, nameof(connection));

--- a/src/EFCore.Specification.Tests/TestHelpers.cs
+++ b/src/EFCore.Specification.Tests/TestHelpers.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
 
                 if (category.GetTypeInfo().ContainsGenericParameters)
                 {
-                    category = typeof(LoggerCategory.Infrastructure);
+                    category = typeof(DbLoggerCategory.Infrastructure);
                     loggerMethod = loggerMethod.MakeGenericMethod(category);
                 }
 

--- a/src/EFCore.SqlServer.Design/Infrastructure/SqlServerDesignEventId.cs
+++ b/src/EFCore.SqlServer.Design/Infrastructure/SqlServerDesignEventId.cs
@@ -31,36 +31,36 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             DataTypeDoesNotAllowSqlServerIdentityStrategyWarning
         }
 
-        private static readonly string _scaffoldingPrefix = LoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnFound = MakeScaffoldingId(Id.ColumnFound);
 
         /// <summary>
         ///     A column of a foreign key was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnFound = MakeScaffoldingId(Id.ForeignKeyColumnFound);
 
         /// <summary>
         ///     A default schema was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId DefaultSchemaFound = MakeScaffoldingId(Id.DefaultSchemaFound);
 
         /// <summary>
         ///     A type alias was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TypeAliasFound = MakeScaffoldingId(Id.TypeAliasFound);
 
         /// <summary>
         ///     The data type does not support the SQL Server identity strategy.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId DataTypeDoesNotAllowSqlServerIdentityStrategyWarning = MakeScaffoldingId(Id.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning);
     }

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerDatabaseModelFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerDatabaseModelFactory([NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger)
+        public SqlServerDatabaseModelFactory([NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IDiagnosticsLogger<LoggerCategory.Scaffolding> Logger { get; }
+        public virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
 
         private void ResetState()
         {

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerDesignLoggerExtensions.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerDesignLoggerExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName,
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string principalTableName,
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DefaultSchemaFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string schemaName)
         {
             var definition = SqlServerDesignStrings.LogFoundDefaultSchema;
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TypeAliasFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string typeAliasName,
             [CanBeNull] string systemTypeName)
         {
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DataTypeDoesNotAllowSqlServerIdentityStrategyWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string typeName)
         {

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore.SqlServer/Infrastructure/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlServerEventId.cs
@@ -28,18 +28,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ByteIdentityColumnWarning
         }
 
-        private static readonly string _validationPrefix = LoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     No explicit type for a decimal column.
-        ///     This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId DecimalTypeDefaultWarning = MakeValidationId(Id.DecimalTypeDefaultWarning);
 
         /// <summary>
         ///     A byte property is set up to use a SQL Server identity column.
-        ///     This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId ByteIdentityColumnWarning = MakeValidationId(Id.ByteIdentityColumnWarning);
     }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DecimalTypeDefaultWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = SqlServerStrings.LogDefaultDecimalTypeColumn;
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ByteIdentityColumnWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = SqlServerStrings.LogByteIdentityColumn;

--- a/src/EFCore.Sqlite.Core/Infrastructure/SqliteEventId.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SqliteEventId.cs
@@ -28,18 +28,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             SequenceConfiguredWarning
         }
 
-        private static readonly string _validationPrefix = LoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     A schema was configured for an entity type, but SQLite does not support schemas.
-        ///     This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId SchemaConfiguredWarning = MakeValidationId(Id.SchemaConfiguredWarning);
 
         /// <summary>
         ///     A sequence was configured for an entity type, but SQLite does not support sequences.
-        ///     This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId SequenceConfiguredWarning = MakeValidationId(Id.SequenceConfiguredWarning);
     }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SchemaConfiguredWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IEntityType entityType,
             [NotNull] string schema)
         {
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceConfiguredWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] ISequence sequence)
         {
             var definition = SqliteStrings.LogSequenceConfigured;

--- a/src/EFCore.Sqlite.Design/Infrastructure/SqliteDesignEventId.cs
+++ b/src/EFCore.Sqlite.Design/Infrastructure/SqliteDesignEventId.cs
@@ -29,24 +29,24 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             SchemasNotSupportedWarning
         }
 
-        private static readonly string _scaffoldingPrefix = LoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnFound = MakeScaffoldingId(Id.ColumnFound);
 
         /// <summary>
         ///     A column of a foreign key was found.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnFound = MakeScaffoldingId(Id.ForeignKeyColumnFound);
 
         /// <summary>
         ///     SQLite does not support schemas.
-        ///     This event is in the <see cref="LoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SchemasNotSupportedWarning = MakeScaffoldingId(Id.SchemasNotSupportedWarning);
     }

--- a/src/EFCore.Sqlite.Design/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteDatabaseModelFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqliteDatabaseModelFactory([NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger)
+        public SqliteDatabaseModelFactory([NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IDiagnosticsLogger<LoggerCategory.Scaffolding> Logger { get; }
+        public virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
 
         private DbConnection _connection;
         private TableSelectionSet _tableSelectionSet;

--- a/src/EFCore.Sqlite.Design/Internal/SqliteDesignLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteDesignLoggerExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName,
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnFound(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             int id,
             [CanBeNull] string principalTableName,
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SchemasNotSupportedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Scaffolding> diagnostics)
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
         {
             var definition = SqliteDesignStrings.LogUsingSchemaSelectionsWarning;
 

--- a/src/EFCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqliteScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore
         private IDbContextDependencies _dbContextDependencies;
         private DatabaseFacade _database;
         private ChangeTracker _changeTracker;
-        private IDiagnosticsLogger<LoggerCategory.Update> _updateLogger;
+        private IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
 
         private IServiceScope _serviceScope;
         private IDbContextPool _dbContextPool;
@@ -244,7 +244,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 contextServices.Initialize(scopedServiceProvider, options, this);
 
-                _updateLogger = scopedServiceProvider.GetRequiredService<IDiagnosticsLogger<LoggerCategory.Update>>();
+                _updateLogger = scopedServiceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Update>>();
 
                 return contextServices;
             }

--- a/src/EFCore/DbLoggerCategory.cs
+++ b/src/EFCore/DbLoggerCategory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore
     ///         <see cref="IDiagnosticsLogger{TLoggerCategory}" /> to create a logger.
     ///     </para>
     /// </summary>
-    public static class LoggerCategory
+    public static class DbLoggerCategory
     {
         /// <summary>
         ///     The root/prefix for all Entity Framework categories.
@@ -38,16 +38,9 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             /// <summary>
-            ///     Logger category for messages related to data reader operations.
+            ///     Logger category for command execution, including SQL sent to the database.
             /// </summary>
-            public class DataReader : LoggerCategory<DataReader>
-            {
-            }
-
-            /// <summary>
-            ///     Logger category for SQL sent to the database.
-            /// </summary>
-            public class Sql : LoggerCategory<Sql>
+            public class Command : LoggerCategory<Command>
             {
             }
 
@@ -62,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Logger category for messages related to <see cref="DbContext.SaveChanges()" />, excluding
         ///     messages specifically relating to database interactions which are covered by
-        ///     the <see cref="LoggerCategory.Database" /> categories.
+        ///     the <see cref="DbLoggerCategory.Database" /> categories.
         /// </summary>
         public class Update : LoggerCategory<Update>
         {
@@ -83,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Logger category for messages related to queries, excluding
-        ///     the generated SQL, which is in the <see cref="LoggerCategory.Database.Sql" /> category.
+        ///     the generated SQL, which is in the <see cref="Database.Command" /> category.
         /// </summary>
         public class Query : LoggerCategory<Query>
         {

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SaveChangesFailed(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Update> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
             [NotNull] Type contextType,
             [NotNull] Exception exception)
         {
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryIterationFailed(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] Type contextType,
             [NotNull] Exception exception)
         {
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryModelCompiling(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogCompilingQueryModel;
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void RowLimitingOperationWithoutOrderByWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogRowLimitingOperationWithoutOrderBy;
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void FirstWithoutOrderByAndFilterWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogFirstWithoutOrderByAndFilter;
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryModelOptimized(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogOptimizedQueryModel;
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void NavigationIncluded(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] string includeSpecification)
         {
             var definition = CoreStrings.LogIncludingNavigation;
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryExecutionPlanned(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] IExpressionPrinter expressionPrinter,
             [NotNull] Expression queryExecutorExpression)
         {
@@ -274,7 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IncludeIgnoredWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] string includeSpecification)
         {
             var definition = CoreStrings.LogIgnoredInclude;
@@ -299,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PossibleUnintendedCollectionNavigationNullComparisonWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] string navigationPath)
         {
             var definition = CoreStrings.LogPossibleUnintendedCollectionNavigationNullComparison;
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PossibleUnintendedReferenceComparisonWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
             [NotNull] Expression left,
             [NotNull] Expression right)
         {
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ModelValidationShadowKeyWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IEntityType entityType,
             [NotNull] IKey key)
         {
@@ -385,7 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ServiceProviderCreated(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Infrastructure> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
             [NotNull] IServiceProvider serviceProvider)
         {
             var definition = CoreStrings.LogServiceProviderCreated;
@@ -408,7 +408,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ManyServiceProvidersCreatedWarning(
-            [NotNull] this IDiagnosticsLogger<LoggerCategory.Infrastructure> diagnostics,
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
             [NotNull] ICollection<IServiceProvider> serviceProviders)
         {
             var definition = CoreStrings.LogManyServiceProvidersCreated;

--- a/src/EFCore/Infrastructure/CoreEventId.cs
+++ b/src/EFCore/Infrastructure/CoreEventId.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     The lower-bound for event IDs used by any Entity Framework or provider code design-time and tooling.
         /// </summary>
-        public const int CoreDesignBaseId = 100000;
+        public const int CoreDesignBaseId = 150000;
 
         /// <summary>
         ///     The lower-bound for event IDs used by any relational database provider.
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     The lower-bound for event IDs used by any relational database provider design-time and tooling.
         /// </summary>
-        public const int RelationalDesignBaseId = 200000;
+        public const int RelationalDesignBaseId = 250000;
 
         /// <summary>
         ///     The lower-bound for event IDs used only by database providers.
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     The lower-bound for event IDs used only by database provider design-time and tooling.
         /// </summary>
-        public const int ProviderDesignBaseId = 300000;
+        public const int ProviderDesignBaseId = 350000;
         
         // Warning: These values must not change between releases.
         // Only add new values to the end of sections, never in the middle.
@@ -77,90 +77,90 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ManyServiceProvidersCreatedWarning
         }
 
-        private static readonly string _updatePrefix = LoggerCategory.Update.Name + ".";
+        private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
         ///     An error occurred while attempting to save changes to the database.
-        ///     This event is in the <see cref="LoggerCategory.Update" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
         /// </summary>
         public static readonly EventId SaveChangesFailed = MakeUpdateId(Id.SaveChangesFailed);
 
-        private static readonly string _queryPrefix = LoggerCategory.Query.Name + ".";
+        private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
 
         /// <summary>
         ///     An error occurred while processing the results of a query.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId QueryIterationFailed = MakeQueryId(Id.QueryIterationFailed);
 
         /// <summary>
         ///     A query model is being compiled.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId QueryModelCompiling = MakeQueryId(Id.QueryModelCompiling);
 
         /// <summary>
         ///     A query uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId RowLimitingOperationWithoutOrderByWarning = MakeQueryId(Id.RowLimitingOperationWithoutOrderByWarning);
 
         /// <summary>
         ///     A query uses First/FirstOrDefault operation without OrderBy and filter which may lead to unpredictable results.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId FirstWithoutOrderByAndFilterWarning = MakeQueryId(Id.FirstWithoutOrderByAndFilterWarning);
 
         /// <summary>
         ///     A query model was optimized.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId QueryModelOptimized = MakeQueryId(Id.QueryModelOptimized);
 
         /// <summary>
         ///     A navigation was included in the query.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId NavigationIncluded = MakeQueryId(Id.NavigationIncluded);
 
         /// <summary>
         ///     A navigation was ignored while compiling a query.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId IncludeIgnoredWarning = MakeQueryId(Id.IncludeIgnoredWarning);
 
         /// <summary>
         ///     A query is planned for execution.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId QueryExecutionPlanned = MakeQueryId(Id.QueryExecutionPlanned);
 
         /// <summary>
         ///     Possible uninteded comparison of collection navigation to null.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId PossibleUnintendedCollectionNavigationNullComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedCollectionNavigationNullComparisonWarning);
 
         /// <summary>
         ///     Possible uninteded reference comparison.
-        ///     This event is in the <see cref="LoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
         /// </summary>
         public static readonly EventId PossibleUnintendedReferenceComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedReferenceComparisonWarning);
 
-        private static readonly string _validationPrefix = LoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     A warning during model validation indicating a key is configured on shadow properties.
-        ///     This event is in the <see cref="LoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId ModelValidationShadowKeyWarning = MakeValidationId(Id.ModelValidationShadowKeyWarning);
 
-        private static readonly string _infraPrefix = LoggerCategory.Infrastructure.Name + ".";
+        private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
         private static EventId MakeInfraId(Id id) => new EventId((int)id, _infraPrefix + id);
 
         /// <summary>
@@ -171,13 +171,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <summary>
         ///     A service provider was created for internal use by Entity Framework.
-        ///     This event is in the <see cref="LoggerCategory.Infrastructure" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
         /// </summary>
         public static readonly EventId ServiceProviderCreated = MakeInfraId(Id.ServiceProviderCreated);
 
         /// <summary>
         ///     Many service proviers were created in a single app domain.
-        ///     This event is in the <see cref="LoggerCategory.Infrastructure" /> category.
+        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
         /// </summary>
         public static readonly EventId ManyServiceProvidersCreatedWarning = MakeInfraId(Id.ManyServiceProvidersCreatedWarning);
     }

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IResettableService, IDbContextTransactionManager>(p => p.GetService<IDbContextTransactionManager>());
 
             ServiceCollectionMap
-                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(LoggerCategory.Root));
+                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root));
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<DatabaseProviderDependencies>()

--- a/src/EFCore/Infrastructure/EventDefinition.cs
+++ b/src/EFCore/Infrastructure/EventDefinition.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>
         public virtual void Log<TLoggerCategory>(

--- a/src/EFCore/Infrastructure/EventDefinition`.cs
+++ b/src/EFCore/Infrastructure/EventDefinition`.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg"> Message argument. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>

--- a/src/EFCore/Infrastructure/EventDefinition``.cs
+++ b/src/EFCore/Infrastructure/EventDefinition``.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Infrastructure/EventDefinition```.cs
+++ b/src/EFCore/Infrastructure/EventDefinition```.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Infrastructure/EventDefinition````.cs
+++ b/src/EFCore/Infrastructure/EventDefinition````.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Infrastructure/EventDefinition`````.cs
+++ b/src/EFCore/Infrastructure/EventDefinition`````.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Infrastructure/EventDefinition``````.cs
+++ b/src/EFCore/Infrastructure/EventDefinition``````.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Infrastructure/LoggerCategory.cs
+++ b/src/EFCore/Infrastructure/LoggerCategory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         private static string ToName(Type loggerCategoryType)
         {
-            const string outerClassName = "." + nameof(LoggerCategory);
+            const string outerClassName = "." + nameof(DbLoggerCategory);
 
             var name = loggerCategoryType.FullName.Replace('+', '.');
             var index = name.IndexOf(outerClassName, StringComparison.Ordinal);

--- a/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
+++ b/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     </para>
         /// </summary>
         /// <param name="logger"> The logger. </param>
-        public ModelValidatorDependencies([NotNull] IDiagnosticsLogger<LoggerCategory.Model.Validation> logger)
+        public ModelValidatorDependencies([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -53,14 +53,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Model.Validation> Logger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Model.Validation> logger)
+        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
             => new ModelValidatorDependencies(logger);
     }
 }

--- a/src/EFCore/Infrastructure/RawEventDefinition.cs
+++ b/src/EFCore/Infrastructure/RawEventDefinition.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="LoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="logAction"> A delegate that will log the message to an <see cref="ILogger" />. </param>
         public virtual void Log<TLoggerCategory>(

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                                 .EnsureInitialized(serviceProvider, options);
                         }
 
-                        var logger = serviceProvider.GetRequiredService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>();
+                        var logger = serviceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>();
 
                         logger.ServiceProviderCreated(serviceProvider);
 

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -293,9 +293,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private class NondeterministicResultCheckingVisitor : QueryModelVisitorBase
         {
-            private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
-            public NondeterministicResultCheckingVisitor([NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger)
+            public NondeterministicResultCheckingVisitor([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
                 => _logger = logger;
 
             public override void VisitQueryModel(QueryModel queryModel)

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
         private readonly IParameterValues _parameterValues;
-        private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
         private readonly bool _parameterize;
         private readonly bool _generateContextAccessors;
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         public ParameterExtractingExpressionVisitor(
             [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
             [NotNull] IParameterValues parameterValues,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             bool parameterize,
             bool generateContextAccessors = false)
         {

--- a/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -103,18 +103,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<T> _InterceptExceptions<T>(
-            IAsyncEnumerable<T> source, Type contextType, IDiagnosticsLogger<LoggerCategory.Query> logger, QueryContext queryContext)
+            IAsyncEnumerable<T> source, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
 
         private sealed class ExceptionInterceptor<T> : IAsyncEnumerable<T>
         {
             private readonly IAsyncEnumerable<T> _innerAsyncEnumerable;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
             private readonly QueryContext _queryContext;
 
             public ExceptionInterceptor(
-                IAsyncEnumerable<T> innerAsyncEnumerable, Type contextType, IDiagnosticsLogger<LoggerCategory.Query> logger, QueryContext queryContext)
+                IAsyncEnumerable<T> innerAsyncEnumerable, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
             {
                 _innerAsyncEnumerable = innerAsyncEnumerable;
                 _contextType = contextType;

--- a/src/EFCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/LinqOperatorProvider.cs
@@ -83,18 +83,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
         private static IEnumerable<T> _InterceptExceptions<T>(
-            IEnumerable<T> source, Type contextType, IDiagnosticsLogger<LoggerCategory.Query> logger, QueryContext queryContext)
+            IEnumerable<T> source, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
 
         private sealed class ExceptionInterceptor<T> : IEnumerable<T>
         {
             private readonly IEnumerable<T> _innerEnumerable;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
             private readonly QueryContext _queryContext;
 
             public ExceptionInterceptor(
-                IEnumerable<T> innerEnumerable, Type contextType, IDiagnosticsLogger<LoggerCategory.Query> logger, QueryContext queryContext)
+                IEnumerable<T> innerEnumerable, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
             {
                 _innerEnumerable = innerEnumerable;
                 _contextType = contextType;

--- a/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public QueryCompilationContextDependencies(
             [NotNull] IModel model,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] ICurrentDbContext currentContext)
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Query> Logger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public QueryCompilationContextDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger)
+        public QueryCompilationContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => new QueryCompilationContextDependencies(
                 Model,
                 logger,

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly ICompiledQueryCache _compiledQueryCache;
         private readonly ICompiledQueryCacheKeyGenerator _compiledQueryCacheKeyGenerator;
         private readonly IDatabase _database;
-        private readonly IDiagnosticsLogger<LoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private readonly INodeTypeProviderFactory _nodeTypeProviderFactory;
 
         private readonly Type _contextType;
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] ICompiledQueryCache compiledQueryCache,
             [NotNull] ICompiledQueryCacheKeyGenerator compiledQueryCacheKeyGenerator,
             [NotNull] IDatabase database,
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
             [NotNull] ICurrentDbContext currentContext)
         {
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Expression query, 
             INodeTypeProvider nodeTypeProvider, 
             IDatabase database, 
-            IDiagnosticsLogger<LoggerCategory.Query> logger, 
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger, 
             Type contextType)
         {
             var queryModel
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         private static Func<QueryContext, Task<TResult>> CreateCompiledSingletonAsyncQuery<TResult>(
-                Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery, IDiagnosticsLogger<LoggerCategory.Query> logger, Type contextType)
+                Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery, IDiagnosticsLogger<DbLoggerCategory.Query> logger, Type contextType)
             => qc => ExecuteSingletonAsyncQuery(qc, compiledQuery, logger, contextType);
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static async Task<TResult> ExecuteSingletonAsyncQuery<TResult>(
             QueryContext queryContext,
             Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery,
-            IDiagnosticsLogger<LoggerCategory.Query> logger,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             Type contextType)
         {
             try

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <value>
         ///     The logger.
         /// </value>
-        public virtual IDiagnosticsLogger<LoggerCategory.Query> Logger { get; }
+        public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
         ///     Gets the linq operator provider.

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger for this <see cref="ExecutionStrategy" />.
         /// </summary>
-        protected virtual IDiagnosticsLogger<LoggerCategory.Infrastructure> Logger { get; }
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger { get; }
 
         private static readonly AsyncLocal<bool?> _suspended = new AsyncLocal<bool?>();
 

--- a/src/EFCore/Storage/ExecutionStrategyContext.cs
+++ b/src/EFCore/Storage/ExecutionStrategyContext.cs
@@ -36,6 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger for the <see cref="ExecutionStrategy" />.
         /// </summary>
-        public virtual IDiagnosticsLogger<LoggerCategory.Infrastructure> Logger => Dependencies.Logger;
+        public virtual IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger => Dependencies.Logger;
     }
 }

--- a/src/EFCore/Storage/ExecutionStrategyContextDependencies.cs
+++ b/src/EFCore/Storage/ExecutionStrategyContextDependencies.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ExecutionStrategyContextDependencies(
             [NotNull] ICurrentDbContext currentDbContext,
             [CanBeNull] IDbContextOptions options,
-            [CanBeNull] IDiagnosticsLogger<LoggerCategory.Infrastructure> logger)
+            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
         {
             Check.NotNull(currentDbContext, nameof(currentDbContext));
 
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<LoggerCategory.Infrastructure> Logger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public ExecutionStrategyContextDependencies With([NotNull] IDiagnosticsLogger<LoggerCategory.Infrastructure> logger)
+        public ExecutionStrategyContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
             => new ExecutionStrategyContextDependencies(CurrentDbContext, Options, logger);
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Design.Internal
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new LoggerProvider(categoryName => new OperationLogger(categoryName, reporter)));
 
-            var logger = loggerFactory.CreateLogger(LoggerCategory.Database.Sql.Name);
+            var logger = loggerFactory.CreateLogger(DbLoggerCategory.Database.Command.Name);
             logger.Log<object>(
                 LogLevel.Information,
                 RelationalEventId.CommandExecuted,

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Tests.Migrations.Design
                 idGenerator,
                 new CSharpMigrationsGenerator(code, new CSharpMigrationOperationGenerator(code), new CSharpSnapshotGenerator(code)),
                 new MockHistoryRepository(),
-                new DiagnosticsLogger<LoggerCategory.Migrations>(
+                new DiagnosticsLogger<DbLoggerCategory.Migrations>(
                     new LoggerFactory(), 
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),

--- a/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Tests
                     () => transactionManager.RollbackTransaction()).Message);
         }
 
-        private class FakeLogger : IDiagnosticsLogger<LoggerCategory.Database.Transaction>, ILogger
+        private class FakeLogger : IDiagnosticsLogger<DbLoggerCategory.Database.Transaction>, ILogger
         {
             public void Log<TState>(
                 LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/EFCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -30,10 +30,10 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
         public RelationalDatabaseModelFactoryTest()
         {
             ILoggerFactory loggerFactory = new TestDesignLoggerFactory();
-            _logger = (TestDesignLoggerFactory.DesignLogger)loggerFactory.CreateLogger(LoggerCategory.Scaffolding.Name);
+            _logger = (TestDesignLoggerFactory.DesignLogger)loggerFactory.CreateLogger(DbLoggerCategory.Scaffolding.Name);
 
             _factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(), 
                     new DiagnosticListener("Fake")));
@@ -902,7 +902,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
             };
 
             var factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                     new TestDesignLoggerFactory(),
                     new LoggingOptions(), 
                     new DiagnosticListener("Fake")),
@@ -964,7 +964,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
             };
 
             var factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                     new TestDesignLoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),
@@ -993,13 +993,13 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
         public IModel Create(DatabaseModel databaseModel) => CreateFromDatabaseModel(databaseModel);
 
         public FakeScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
             : this(logger, new NullPluralizer())
         {
         }
 
         public FakeScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<LoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
             [NotNull] IPluralizer pluralizer)
             : base(
                 logger,

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -300,8 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations
             string commandText = "Command Text",
             IReadOnlyList<IRelationalParameter> parameters = null)
             => new RelationalCommand(
-                new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                 commandText,
                 parameters ?? new IRelationalParameter[0]);
     }

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -118,8 +118,7 @@ Statement3
         private MigrationCommandListBuilder CreateBuilder()
             => new MigrationCommandListBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -669,8 +669,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
         protected override ModelValidator CreateModelValidator()
             => new RelationalModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<LoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == LoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -16,8 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
@@ -33,8 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
@@ -51,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -14,8 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Builds_simple_command()
         {
             var commandBuilder = new RelationalCommandBuilder(
-                new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                 new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
 
             var command = commandBuilder.Build();
@@ -28,8 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Build_command_with_parameter()
         {
             var commandBuilder = new RelationalCommandBuilder(
-                new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                 new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
 
             commandBuilder.ParameterBuilder.AddParameter(

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -903,7 +903,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<LoggerCategory.Database.Sql>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
                     new ListLoggerFactory(log),
                     new FakeLoggingOptions(false),
                     new DiagnosticListener("Fake")),
@@ -957,7 +957,7 @@ Logged Command",
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<LoggerCategory.Database.Sql>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
                     new ListLoggerFactory(log),
                     new FakeLoggingOptions(true),
                     new DiagnosticListener("Fake")),
@@ -1011,7 +1011,7 @@ Logged Command",
             var diagnostic = new List<Tuple<string, object>>();
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<LoggerCategory.Database.Sql>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
                     new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
@@ -1079,7 +1079,7 @@ Logged Command",
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<LoggerCategory.Database.Sql>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
                     new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
@@ -1164,12 +1164,11 @@ Logged Command",
         }
 
         private IRelationalCommand CreateRelationalCommand(
-            IDiagnosticsLogger<LoggerCategory.Database.Sql> logger = null,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger = null,
             string commandText = "Command Text",
             IReadOnlyList<IRelationalParameter> parameters = null)
             => new RelationalCommand(
-                logger ?? new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                logger ?? new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                 commandText,
                 parameters ?? new IRelationalParameter[0]);
     }

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Storage
             var transaction = new RelationalTransaction(
                 connection,
                 dbTransaction,
-                new DiagnosticsLogger<LoggerCategory.Database.Transaction>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -19,11 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvi
             : base(
                 new RelationalConnectionDependencies(
                     options,
-                    new DiagnosticsLogger<LoggerCategory.Database.Transaction>(
+                    new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener")),
-                    new DiagnosticsLogger<LoggerCategory.Database.Connection>(
+                    new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"))))

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -530,8 +530,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Update
                 IUpdateSqlGenerator sqlGenerator = null)
                 : base(
                     new RelationalCommandBuilderFactory(
-                        new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                        new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                        new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                         new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                     new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                     sqlGenerator ?? new FakeSqlGenerator(

--- a/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests
             TestStore.ExecuteNonQuery(createSql);
 
             return new SqlServerDatabaseModelFactory(
-                    new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                    new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                         TestDesignLoggerFactory,
                         new LoggingOptions(),
                         new DiagnosticListener("Fake")))

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerDatabaseCleaner.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerDatabaseCleaner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
     {
         protected override IInternalDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
             => new SqlServerDatabaseModelFactory(
-                new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")));

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
@@ -13,35 +13,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
 {
     public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.Sql> _logger;
-        private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _readerLogger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
         private readonly IRelationalTypeMapper _typeMapper;
 
         public TestRelationalCommandBuilderFactory(
-            IDiagnosticsLogger<LoggerCategory.Database.Sql> logger,
-            IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
             IRelationalTypeMapper typeMapper)
         {
             _logger = logger;
-            _readerLogger = readerLogger;
             _typeMapper = typeMapper;
         }
 
         public virtual IRelationalCommandBuilder Create()
-            => new TestRelationalCommandBuilder(_logger, _readerLogger, _typeMapper);
+            => new TestRelationalCommandBuilder(_logger, _typeMapper);
 
         private class TestRelationalCommandBuilder : IRelationalCommandBuilder
         {
-            private readonly IDiagnosticsLogger<LoggerCategory.Database.Sql> _logger;
-            private readonly IDiagnosticsLogger<LoggerCategory.Database.DataReader> _readerLogger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
 
             public TestRelationalCommandBuilder(
-                IDiagnosticsLogger<LoggerCategory.Database.Sql> logger,
-                IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 IRelationalTypeMapper typeMapper)
             {
                 _logger = logger;
-                _readerLogger = readerLogger;
                 ParameterBuilder = new RelationalParameterBuilder(typeMapper);
             }
 
@@ -52,7 +46,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
             public IRelationalCommand Build()
                 => new TestRelationalCommand(
                     _logger,
-                    _readerLogger,
                     ((IInfrastructure<IndentedStringBuilder>)this).Instance.ToString(),
                     ParameterBuilder.Parameters);
         }
@@ -62,12 +55,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
             private readonly RelationalCommand _realRelationalCommand;
 
             public TestRelationalCommand(
-                IDiagnosticsLogger<LoggerCategory.Database.Sql> logger,
-                IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 string commandText,
                 IReadOnlyList<IRelationalParameter> parameters)
             {
-                _realRelationalCommand = new RelationalCommand(logger, readerLogger, commandText, parameters);
+                _realRelationalCommand = new RelationalCommand(logger, commandText, parameters);
             }
 
             public string CommandText => _realRelationalCommand.CommandText;

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities
                 new RelationalTransaction(
                     connection,
                     transaction,
-                    new DiagnosticsLogger<LoggerCategory.Database.Transaction>(
+                    new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
                         loggerFactory, new LoggingOptions(), diagnosticSource),
                     transactionOwned))
         {

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -143,8 +143,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Migrations
             var typeMapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
 
             var commandBuilderFactory = new RelationalCommandBuilderFactory(
-                new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                 typeMapper);
 
             return new SqlServerHistoryRepository(

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -80,11 +80,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             return new RelationalConnectionDependencies(
                 options,
-                new DiagnosticsLogger<LoggerCategory.Database.Transaction>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener")),
-                new DiagnosticsLogger<LoggerCategory.Database.Connection>(
+                new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener")));

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -217,8 +217,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
         protected override ModelValidator CreateModelValidator()
             => new SqlServerModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<LoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == LoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -20,8 +20,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Update
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new SqlServerTypeMapper(
                         new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(
@@ -50,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Update
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new SqlServerTypeMapper(
                         new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -17,8 +17,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Update
         {
             var batch = new SqlServerModificationCommandBatch(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                    new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                     new SqlServerTypeMapper(new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),

--- a/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
@@ -133,54 +133,49 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         private class BadDataCommandBuilderFactory : RelationalCommandBuilderFactory
         {
             public BadDataCommandBuilderFactory(
-                IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                 IRelationalTypeMapper typeMapper)
-                : base(sqlLogger, readerLogger, typeMapper)
+                : base(logger, typeMapper)
             {
             }
 
             public object[] Values { private get; set; }
 
             protected override IRelationalCommandBuilder CreateCore(
-                    IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                    IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                     IRelationalTypeMapper relationalTypeMapper)
                 => new BadDataRelationalCommandBuilder(
-                    sqlLogger, readerLogger, relationalTypeMapper, Values);
+                    logger, relationalTypeMapper, Values);
 
             private class BadDataRelationalCommandBuilder : RelationalCommandBuilder
             {
                 private readonly object[] _values;
 
                 public BadDataRelationalCommandBuilder(
-                    IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                    IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                     IRelationalTypeMapper typeMapper,
                     object[] values)
-                    : base(sqlLogger, readerLogger, typeMapper)
+                    : base(logger, typeMapper)
                 {
                     _values = values;
                 }
 
                 protected override IRelationalCommand BuildCore(
-                        IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                        IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                        IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                         string commandText,
                         IReadOnlyList<IRelationalParameter> parameters)
-                    => new BadDataRelationalCommand(sqlLogger, readerLogger, commandText, parameters, _values);
+                    => new BadDataRelationalCommand(logger, commandText, parameters, _values);
 
                 private class BadDataRelationalCommand : RelationalCommand
                 {
                     private readonly object[] _values;
 
                     public BadDataRelationalCommand(
-                        IDiagnosticsLogger<LoggerCategory.Database.Sql> sqlLogger,
-                        IDiagnosticsLogger<LoggerCategory.Database.DataReader> readerLogger,
+                        IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
                         string commandText,
                         IReadOnlyList<IRelationalParameter> parameters,
                         object[] values)
-                        : base(sqlLogger, readerLogger, commandText, parameters)
+                        : base(logger, commandText, parameters)
                     {
                         _values = values;
                     }

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
     {
         protected override IInternalDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
             => new SqliteDatabaseModelFactory(
-                new DiagnosticsLogger<LoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")));

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -117,8 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Migrations
                     new SqliteMigrationsSqlGenerator(
                         new MigrationsSqlGeneratorDependencies(
                             new RelationalCommandBuilderFactory(
-                                new FakeDiagnosticsLogger<LoggerCategory.Database.Sql>(),
-                                new FakeDiagnosticsLogger<LoggerCategory.Database.DataReader>(),
+                                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
                                 typeMapper),
                             new SqliteSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                             typeMapper)),

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -76,8 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests
         protected override ModelValidator CreateModelValidator()
             => new SqliteModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<LoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == LoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -2274,7 +2274,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContextWithOC1A())
@@ -2304,8 +2304,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
-                Assert.Contains(LoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContextWithOC1B(loggerFactory, memoryCache))
@@ -2332,7 +2332,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
@@ -2370,8 +2370,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
-                Assert.Contains(LoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
@@ -2398,7 +2398,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2434,7 +2434,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2466,7 +2466,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContext1A(options))
@@ -2504,8 +2504,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
-                Assert.Contains(LoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContext1A(options))
@@ -2538,7 +2538,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2570,7 +2570,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var context = new DbContext(options))
@@ -2608,8 +2608,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
-                Assert.Contains(LoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new DbContext(options))
@@ -2642,7 +2642,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2679,7 +2679,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -2721,7 +2721,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2756,7 +2756,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2796,7 +2796,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2832,7 +2832,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2873,7 +2873,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2911,7 +2911,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2953,7 +2953,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2989,7 +2989,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3029,7 +3029,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3071,7 +3071,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3109,7 +3109,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3151,7 +3151,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3187,7 +3187,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3230,7 +3230,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3267,7 +3267,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3318,7 +3318,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3393,7 +3393,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3448,7 +3448,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3513,7 +3513,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3567,7 +3567,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3635,7 +3635,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3685,7 +3685,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3759,7 +3759,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3792,7 +3792,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 .AddDbContext<DbContext>((p, b) => b.UseTransientInMemoryDatabase().UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
             using (var serviceScope = appServiceProivder
                 .GetRequiredService<IServiceScopeFactory>()
@@ -3801,10 +3801,10 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
                 _ = context.Model;
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             }
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
         }
 
         [Fact]
@@ -3819,7 +3819,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                         .UseLoggerFactory(loggerFactory = new WrappingLoggerFactory(p.GetService<ILoggerFactory>())))
                 .BuildServiceProvider();
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
             Assert.Null(loggerFactory);
 
             using (var serviceScope = appServiceProivder
@@ -3829,13 +3829,13 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
                 _ = context.Model;
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == LoggerCategory.Infrastructure.Name));
+                Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
             }
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<LoggerCategory.Infrastructure>>());
-            Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == LoggerCategory.Infrastructure.Name));
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+            Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -15,19 +15,19 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
         [Fact]
         public void Can_filter_for_messages_of_one_category()
         {
-            FilterTest(c => c == LoggerCategory.Database.Sql.Name, "SQL1", "SQL2");
+            FilterTest(c => c == DbLoggerCategory.Database.Command.Name, "SQL1", "SQL2");
         }
 
         [Fact]
         public void Can_filter_for_messages_of_one_subcategory()
         {
-            FilterTest(c => c.StartsWith(LoggerCategory.Database.Name), "DB1", "SQL1", "DB2", "SQL2");
+            FilterTest(c => c.StartsWith(DbLoggerCategory.Database.Name), "DB1", "SQL1", "DB2", "SQL2");
         }
 
         [Fact]
         public void Can_filter_for_all_EF_messages()
         {
-            FilterTest(c => c.StartsWith(LoggerCategory.Root), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
+            FilterTest(c => c.StartsWith(DbLoggerCategory.Root), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
         }
 
         [Fact]
@@ -43,9 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
 
             loggerFactory.AddProvider(loggerProvider);
 
-            var dbLogger = new DiagnosticsLogger<LoggerCategory.Database>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
-            var sqlLogger = new DiagnosticsLogger<LoggerCategory.Database.Sql>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
-            var queryLogger = new DiagnosticsLogger<LoggerCategory.Query>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var dbLogger = new DiagnosticsLogger<DbLoggerCategory.Database>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var sqlLogger = new DiagnosticsLogger<DbLoggerCategory.Database.Command>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var queryLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
             var randomLogger = loggerFactory.CreateLogger("Random");
 
             dbLogger.Logger.LogInformation(1, "DB1");

--- a/test/EFCore.Tests/Infrastructure/LoggerCategoryTest.cs
+++ b/test/EFCore.Tests/Infrastructure/LoggerCategoryTest.cs
@@ -5,40 +5,38 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tests.Infrastructure
 {
-    public class LoggerCategoryTest
+    public class DbLoggerCategoryTest
     {
         [Fact]
         public void Logger_categories_have_the_correct_names()
         {
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database", LoggerCategory.Database.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Sql", LoggerCategory.Database.Sql.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Connection", LoggerCategory.Database.Connection.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.DataReader", LoggerCategory.Database.DataReader.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Transaction", LoggerCategory.Database.Transaction.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Infrastructure", LoggerCategory.Infrastructure.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Migrations", LoggerCategory.Migrations.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Scaffolding", LoggerCategory.Scaffolding.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Model", LoggerCategory.Model.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Model.Validation", LoggerCategory.Model.Validation.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Query", LoggerCategory.Query.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Update", LoggerCategory.Update.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database", DbLoggerCategory.Database.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Command", DbLoggerCategory.Database.Command.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Connection", DbLoggerCategory.Database.Connection.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Transaction", DbLoggerCategory.Database.Transaction.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Infrastructure", DbLoggerCategory.Infrastructure.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Migrations", DbLoggerCategory.Migrations.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Scaffolding", DbLoggerCategory.Scaffolding.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Model", DbLoggerCategory.Model.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Model.Validation", DbLoggerCategory.Model.Validation.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Query", DbLoggerCategory.Query.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Update", DbLoggerCategory.Update.Name);
         }
 
         [Fact]
-        public void LoggerCategory_instances_generate_the_correct_names()
+        public void DbLoggerCategory_instances_generate_the_correct_names()
         {
-            Assert.Equal(LoggerCategory.Database.Name, new LoggerCategory.Database());
-            Assert.Equal(LoggerCategory.Database.Sql.Name, new LoggerCategory.Database.Sql());
-            Assert.Equal(LoggerCategory.Database.Connection.Name, new LoggerCategory.Database.Connection());
-            Assert.Equal(LoggerCategory.Database.DataReader.Name, new LoggerCategory.Database.DataReader());
-            Assert.Equal(LoggerCategory.Database.Transaction.Name, new LoggerCategory.Database.Transaction());
-            Assert.Equal(LoggerCategory.Infrastructure.Name, new LoggerCategory.Infrastructure());
-            Assert.Equal(LoggerCategory.Migrations.Name, new LoggerCategory.Migrations());
-            Assert.Equal(LoggerCategory.Scaffolding.Name, new LoggerCategory.Scaffolding());
-            Assert.Equal(LoggerCategory.Model.Name, new LoggerCategory.Model());
-            Assert.Equal(LoggerCategory.Model.Validation.Name, new LoggerCategory.Model.Validation());
-            Assert.Equal(LoggerCategory.Query.Name, new LoggerCategory.Query());
-            Assert.Equal(LoggerCategory.Update.Name, new LoggerCategory.Update());
+            Assert.Equal(DbLoggerCategory.Database.Name, new DbLoggerCategory.Database());
+            Assert.Equal(DbLoggerCategory.Database.Command.Name, new DbLoggerCategory.Database.Command());
+            Assert.Equal(DbLoggerCategory.Database.Connection.Name, new DbLoggerCategory.Database.Connection());
+            Assert.Equal(DbLoggerCategory.Database.Transaction.Name, new DbLoggerCategory.Database.Transaction());
+            Assert.Equal(DbLoggerCategory.Infrastructure.Name, new DbLoggerCategory.Infrastructure());
+            Assert.Equal(DbLoggerCategory.Migrations.Name, new DbLoggerCategory.Migrations());
+            Assert.Equal(DbLoggerCategory.Scaffolding.Name, new DbLoggerCategory.Scaffolding());
+            Assert.Equal(DbLoggerCategory.Model.Name, new DbLoggerCategory.Model());
+            Assert.Equal(DbLoggerCategory.Model.Validation.Name, new DbLoggerCategory.Model.Validation());
+            Assert.Equal(DbLoggerCategory.Query.Name, new DbLoggerCategory.Query());
+            Assert.Equal(DbLoggerCategory.Update.Name, new DbLoggerCategory.Update());
         }
     }
 }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -105,15 +105,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Tests
         protected ModelValidatorTest()
         {
             Log = new List<Tuple<LogLevel, string>>();
-            Logger = new DiagnosticsLogger<LoggerCategory.Model.Validation>(
-                new ListLoggerFactory(Log, l => l == LoggerCategory.Model.Validation.Name),
+            Logger = new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
                 new LoggingOptions(),
                 new DiagnosticListener("Fake"));
         }
 
         protected List<Tuple<LogLevel, string>> Log { get; }
 
-        protected IDiagnosticsLogger<LoggerCategory.Model.Validation> Logger { get; }
+        protected IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
 
         protected virtual void VerifyWarning(string expectedMessage, IModel model)
         {

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1586,7 +1586,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             var modelValidator = new CoreModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<LoggerCategory.Model.Validation>(
+                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))));

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -625,7 +625,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             }
         }
 
-        private class FakeLogger : IDiagnosticsLogger<LoggerCategory.Model.Validation>, ILogger
+        private class FakeLogger : IDiagnosticsLogger<DbLoggerCategory.Model.Validation>, ILogger
         {
             public void Log<TState>(
                 LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/EFCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var modelBuilder = ((IInfrastructure<InternalModelBuilder>)ModelBuilder).Instance.Validate();
                 new CoreModelValidator(
                         new ModelValidatorDependencies(
-                            new DiagnosticsLogger<LoggerCategory.Model.Validation>(
+                            new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
                                 new LoggerFactory(),
                                 new LoggingOptions(),
                                 new DiagnosticListener("Fake"))))

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
         private readonly CoreModelValidator _coreModelValidator
             = new CoreModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<LoggerCategory.Model.Validation>(
+                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))));

--- a/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
+++ b/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.TestUtilities
         private IDbContextTransaction _currentTransaction;
 
         public TestInMemoryTransactionManager(
-            IDiagnosticsLogger<LoggerCategory.Database.Transaction> logger)
+            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger)
             : base(logger)
         {
         }


### PR DESCRIPTION
- Rename to DbLoggerCategory
- Rename DbLoggerCategory.Database.Sql to DbLoggerCategory.Database.Command
- Remove DbLoggerCategory.Database.DataReader and use DbLoggerCategory.Database.Command instead
