### PR TITLE
Fix to #7131 - Projections With Full Types Not Fixing Up Navigations on Sqlite and SQL Server

### DIFF
--- a/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -429,7 +429,29 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
                         }
-                    });
+                    },
+                entryCount: 30);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_entity_and_collection_navigation()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs
+                      where c.CustomerID.StartsWith("A")
+                      orderby c.CustomerID
+                      select new { c, c.Orders },
+                asserter: (l2oItems, efItems) =>
+                    {
+                        foreach (var pair in
+                            from dynamic l2oItem in l2oItems
+                            join dynamic efItem in efItems on l2oItem.c.CustomerID equals efItem.c.CustomerID
+                            select new { l2oItem, efItem })
+                        {
+                            Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
+                        }
+                    },
+                entryCount: 34);
         }
 
         [ConditionalFact]
@@ -444,6 +466,27 @@ namespace Microsoft.EntityFrameworkCore.Specification.Tests
                         foreach (var pair in
                             from dynamic l2oItem in l2oItems
                             join dynamic efItem in efItems on l2oItem.OrderID equals efItem.OrderID
+                            select new { l2oItem, efItem })
+                        {
+                            Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
+                        }
+                    },
+                entryCount: 6);
+        }
+
+        [ConditionalFact]
+        public virtual void Elements_of_materialized_collection_navigation_not_tracked_for_queries_with_AsNoTracking()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs.AsNoTracking()
+                      where c.CustomerID.StartsWith("A")
+                      orderby c.CustomerID
+                      select new { c.CustomerID, c.Orders },
+                asserter: (l2oItems, efItems) =>
+                    {
+                        foreach (var pair in
+                            from dynamic l2oItem in l2oItems
+                            join dynamic efItem in efItems on l2oItem.CustomerID equals efItem.CustomerID
                             select new { l2oItem, efItem })
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);

--- a/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual object Create(IEnumerable<object> values)
+        public virtual object Create()
         {
             if (_createCollection == null)
             {
@@ -92,13 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     _propertyName, typeof(TEntity).ShortDisplayName(), typeof(TCollection).ShortDisplayName()));
             }
 
-            var collection = (ICollection<TElement>)_createCollection();
-            foreach (TElement value in values)
-            {
-                collection.Add(value);
-            }
-
-            return collection;
+            return _createCollection();
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/IClrCollectionAccessor.cs
+++ b/src/EFCore/Metadata/Internal/IClrCollectionAccessor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object Create([NotNull] IEnumerable<object> values);
+        object Create();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -261,15 +261,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var includeCompiler = new IncludeCompiler(QueryCompilationContext, _querySourceTracingExpressionVisitorFactory);
 
-            includeCompiler.CompileIncludes(queryModel, TrackResults(queryModel), asyncQuery);
+            var trackingQuery = TrackResults(queryModel);
+            includeCompiler.CompileIncludes(queryModel, trackingQuery, asyncQuery);
 
-            queryModel.TransformExpressions(new CollectionNavigationSubqueryInjector(this).Visit);
+            queryModel.TransformExpressions(new CollectionNavigationSubqueryInjector(this, /*shouldInject*/ false, trackingQuery).Visit);
 
-            var navigationRewritingExpressionVisitor = _navigationRewritingExpressionVisitorFactory.Create(this);
+            var navigationRewritingExpressionVisitor = _navigationRewritingExpressionVisitorFactory.Create(this, trackingQuery);
 
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 
-            includeCompiler.CompileIncludes(queryModel, TrackResults(queryModel), asyncQuery);
+            includeCompiler.CompileIncludes(queryModel, trackingQuery, asyncQuery);
 
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/INavigationRewritingExpressionVisitorFactory.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/INavigationRewritingExpressionVisitorFactory.cs
@@ -15,6 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        NavigationRewritingExpressionVisitor Create([NotNull] EntityQueryModelVisitor queryModelVisitor);
+        NavigationRewritingExpressionVisitor Create([NotNull] EntityQueryModelVisitor queryModelVisitor, bool trackingQuery);
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -206,8 +206,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public NavigationRewritingExpressionVisitor([NotNull] EntityQueryModelVisitor queryModelVisitor)
-            : this(queryModelVisitor, navigationExpansionSubquery: false)
+        public NavigationRewritingExpressionVisitor([NotNull] EntityQueryModelVisitor queryModelVisitor, bool trackingQuery)
+            : this(queryModelVisitor, /*navigationExpansionSubquery:*/ false, trackingQuery)
         {
         }
 
@@ -215,12 +215,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public NavigationRewritingExpressionVisitor([NotNull] EntityQueryModelVisitor queryModelVisitor, bool navigationExpansionSubquery)
+        public NavigationRewritingExpressionVisitor(
+            [NotNull] EntityQueryModelVisitor queryModelVisitor, 
+            bool navigationExpansionSubquery, 
+            bool trackingQuery)
         {
             Check.NotNull(queryModelVisitor, nameof(queryModelVisitor));
 
             _queryModelVisitor = queryModelVisitor;
-            _navigationRewritingQueryModelVisitor = new NavigationRewritingQueryModelVisitor(this, _queryModelVisitor, navigationExpansionSubquery);
+            _navigationRewritingQueryModelVisitor = new NavigationRewritingQueryModelVisitor(this, _queryModelVisitor, navigationExpansionSubquery, trackingQuery);
         }
 
         /// <summary>
@@ -1364,10 +1367,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             public NavigationRewritingQueryModelVisitor(
                 NavigationRewritingExpressionVisitor transformingVisitor,
                 EntityQueryModelVisitor queryModelVisitor,
-                bool navigationExpansionSubquery)
+                bool navigationExpansionSubquery,
+                bool trackingQuery)
                 : base(transformingVisitor)
             {
-                _subqueryInjector = new CollectionNavigationSubqueryInjector(queryModelVisitor, shouldInject: true);
+                _subqueryInjector = new CollectionNavigationSubqueryInjector(queryModelVisitor, /*shouldInject*/ true, trackingQuery);
                 _navigationExpansionSubquery = navigationExpansionSubquery;
             }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitorFactory.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitorFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual NavigationRewritingExpressionVisitor Create(EntityQueryModelVisitor queryModelVisitor)
-            => new NavigationRewritingExpressionVisitor(queryModelVisitor);
+        public virtual NavigationRewritingExpressionVisitor Create(EntityQueryModelVisitor queryModelVisitor, bool trackingQuery)
+            => new NavigationRewritingExpressionVisitor(queryModelVisitor, trackingQuery);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -508,6 +508,41 @@ FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
+        public override void Select_entity_and_collection_navigation()
+        {
+            base.Select_entity_and_collection_navigation();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
+        }
+
         public override void Select_collection_navigation_multi_part()
         {
             base.Select_collection_navigation_multi_part();
@@ -553,6 +588,41 @@ WHERE @_outer_CustomerID = [o0].[CustomerID]",
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]");
+        }
+
+        public override void Elements_of_materialized_collection_navigation_not_tracked_for_queries_with_AsNoTracking()
+        {
+            base.Elements_of_materialized_collection_navigation_not_tracked_for_queries_with_AsNoTracking();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ANATR (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: ANTON (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]",
+                //
+                @"@_outer_CustomerID: AROUT (Size = 450)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_any()


### PR DESCRIPTION
Problem was that entities created by MaterializeCollectionNavigation were not being tracked - TrackEntities only works on "naked" entities.

Fix is to add delegate argument to MaterializeCollectionNavigation method that would track the elements of the collection if the query is supposed to be tracked. We already have a similar logic for the Include.