### PR TITLE
Downgrade to valid package versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,6 +11,7 @@
     <MoqVersion>4.6.38-alpha</MoqVersion>
     <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <OldCoreFxVersion>4.3.0</OldCoreFxVersion>
     <RelinqVersion>2.1.1</RelinqVersion>
     <RoslynVersion>1.3.0</RoslynVersion>
     <SQLitePCLRawVersion>1.1.5</SQLitePCLRawVersion>

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Collections.NonGeneric" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="$(OldCoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Data.Common" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Data.Common" Version="$(OldCoreFxVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
   </ItemGroup>
 

--- a/src/EFCore.SqlServer/EFCore.SqlServer.csproj
+++ b/src/EFCore.SqlServer/EFCore.SqlServer.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Threading.Thread" Version="$(OldCoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These packages won't be shipping in the 2.0 wave, but are still required when targeting 1.x.