### PR TITLE
Throw error on ignored includes

### DIFF
--- a/src/EFCore.Specification.Tests/NorthwindQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/NorthwindQueryFixtureBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,7 +19,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             EnableFilters = enableFilters;
 
-            return new NorthwindContext(_options ?? (_options = BuildOptions()), queryTrackingBehavior);
+            return new NorthwindContext(
+                _options
+                ?? (_options = new DbContextOptionsBuilder(BuildOptions())
+                    .ConfigureWarnings(w => w.Log(CoreEventId.IncludeIgnoredWarning)).Options),
+                queryTrackingBehavior);
         }
 
         private bool EnableFilters { get; set; }

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -32,11 +32,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private ILoggerFactory _loggerFactory;
         private IMemoryCache _memoryCache;
         private bool _sensitiveDataLoggingEnabled;
-        private WarningsConfiguration _warningsConfiguration = new WarningsConfiguration();
         private QueryTrackingBehavior _queryTrackingBehavior = QueryTrackingBehavior.TrackAll;
         private IDictionary<Type, Type> _replacedServices;
         private int? _maxPoolSize;
         private long? _serviceProviderHash;
+
+        private WarningsConfiguration _warningsConfiguration 
+            = new WarningsConfiguration().TryWithExplicit(CoreEventId.IncludeIgnoredWarning, WarningBehavior.Throw);
 
         /// <summary>
         ///     Creates a new set of options with everything set to default values.

--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -51,11 +51,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public virtual DiagnosticSource DiagnosticSource { get; }
 
-        private bool ShouldThrow(LogLevel logLevel, WarningBehavior? warningBehavior)
-            => warningBehavior == WarningBehavior.Throw
-               || (logLevel == LogLevel.Warning
-                   && _warningsConfiguration?.DefaultBehavior == WarningBehavior.Throw);
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -87,11 +82,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             var warningBehavior = _warningsConfiguration?.GetBehavior(eventId);
 
-            return warningBehavior == WarningBehavior.Ignore
-                ? WarningBehavior.Ignore
-                : (ShouldThrow(logLevel, warningBehavior)
+            return warningBehavior != null
+                ? warningBehavior.Value
+                : (logLevel == LogLevel.Warning
+                   && _warningsConfiguration?.DefaultBehavior == WarningBehavior.Throw)
                     ? WarningBehavior.Throw
-                    : WarningBehavior.Log);
+                    : WarningBehavior.Log;
         }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1409,7 +1409,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.
+        ///     The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results. The call to 'Include' can be removed without changing the query results. See https://go.microsoft.com/fwlink/?linkid=850303 for more information.
         /// </summary>
         public static readonly EventDefinition<string> LogIgnoredInclude
             = new EventDefinition<string>(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -644,7 +644,7 @@
     <value>A parameterless constructor was not found on entity type '{entityType}'. In order to create an instance of '{entityType}' EF requires that a parameterless constructor be declared.</value>
   </data>
   <data name="LogIgnoredInclude" xml:space="preserve">
-    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results.</value>
+    <value>The Include operation '{include}' was ignored because the target navigation is not reachable in the final query results. The call to 'Include' can be removed without changing the query results. See https://go.microsoft.com/fwlink/?linkid=850303 for more information.</value>
     <comment>Warning CoreEventId.IncludeIgnoredWarning string</comment>
   </data>
   <data name="ConflictingRelationshipNavigation" xml:space="preserve">

--- a/test/EFCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -19,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         public override DbContextOptions BuildOptions(IServiceCollection additionalServices = null)
             => ConfigureOptions(
                     new DbContextOptionsBuilder()
+                        .ConfigureWarnings(w => w.Log(CoreEventId.IncludeIgnoredWarning))
                         .EnableSensitiveDataLogging()
                         .UseInternalServiceProvider(
                             (additionalServices ?? new ServiceCollection())


### PR DESCRIPTION
Issue #8398

The warning is now configured to throw by default. Some of our tests intentionally create queries that have includes that will be ignored, so we switch back to Log for those tests.
