### PR TITLE
API review: Move provider-specific SQL generator classes back to public

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -16,7 +16,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+namespace Microsoft.EntityFrameworkCore.Migrations
 {
     public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
     {

--- a/src/EFCore.SqlServer/breakingchanges.netcore.json
+++ b/src/EFCore.SqlServer/breakingchanges.netcore.json
@@ -1,30 +1,41 @@
-[
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.SqlServerAnnotationProvider : Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension>",
-    "MemberId": "protected override Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension CloneExtension()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension>",
-    "MemberId": "public virtual System.Void UseRowNumberForPaging()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.SqlServerConventionSetBuilder : Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.RelationalConventionSetBuilder",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.Extensions.DependencyInjection.SqlServerServiceCollectionExtensions",
-    "MemberId": "public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddEntityFrameworkSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Removal"
-  }
-]
+  [
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.SqlServerAnnotationProvider : Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension>",
+      "MemberId": "protected override Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension CloneExtension()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqlServerOptionsExtension>",
+      "MemberId": "public virtual System.Void UseRowNumberForPaging()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
+      "MemberId": "protected virtual System.Void CreateIndexes(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Migrations.MigrationCommandListBuilder builder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
+      "MemberId": "protected virtual System.Void DropIndexes(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Migrations.MigrationCommandListBuilder builder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations, Microsoft.EntityFrameworkCore.Migrations.IMigrationsAnnotationProvider migrationsAnnotations)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.SqlServerConventionSetBuilder : Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.RelationalConventionSetBuilder",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.Extensions.DependencyInjection.SqlServerServiceCollectionExtensions",
+      "MemberId": "public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddEntityFrameworkSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Removal"
+    }
+  ]

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -10,10 +10,9 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+namespace Microsoft.EntityFrameworkCore.Migrations
 {
     public class SqliteMigrationsSqlGenerator : MigrationsSqlGenerator
     {

--- a/src/EFCore.Sqlite.Core/breakingchanges.netcore.json
+++ b/src/EFCore.Sqlite.Core/breakingchanges.netcore.json
@@ -1,30 +1,31 @@
-[
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsAnnotationProvider : Microsoft.EntityFrameworkCore.Migrations.MigrationsAnnotationProvider",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension>",
-    "MemberId": "protected override Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension CloneExtension()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension>",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder SuppressForeignKeyEnforcement()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.SqliteConventionSetBuilder : Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.RelationalConventionSetBuilder",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.Extensions.DependencyInjection.SqliteServiceCollectionExtensions",
-    "MemberId": "public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddEntityFrameworkSqlite(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Removal"
-  }
-]
+  [
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsAnnotationProvider : Microsoft.EntityFrameworkCore.Migrations.MigrationsAnnotationProvider",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension>",
+      "MemberId": "protected override Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension CloneExtension()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension>",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder SuppressForeignKeyEnforcement()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqliteMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.SqliteConventionSetBuilder : Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.RelationalConventionSetBuilder",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.Extensions.DependencyInjection.SqliteServiceCollectionExtensions",
+      "MemberId": "public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddEntityFrameworkSqlite(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Removal"
+    }
+  ]


### PR DESCRIPTION
Because they need to be inherited from in order to implement custom operations.
