### PR TITLE
Better thread safety in InheritanceFixtureBase

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
@@ -25,6 +25,11 @@ namespace Microsoft.EntityFrameworkCore
                         base.Discriminator_with_cast_in_shadow_property()).Message);
         }
 
+        public override void Can_use_of_type_animal()
+        {
+            base.Can_use_of_type_animal();
+        }
+
         public InheritanceInMemoryTest(InheritanceInMemoryFixture fixture)
             : base(fixture)
         {


### PR DESCRIPTION
Make InheritanceFixtureBase.IsSeeded flag static so that we don't need to rely on EnsureCreated to ensure seeding only runs once.

