### PR TITLE
Make ColumnType return the mapped store type even when not set explicitly

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -61,6 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyAnnotationSetConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
             conventionSet.ForeignKeyUniquenessConventions.Add(sharedTableConvention);
             conventionSet.ForeignKeyOwnershipConventions.Add(sharedTableConvention);
+
+            conventionSet.ModelBuiltConventions.Add(new RelationalTypeMappingConvention(Dependencies.TypeMapper));
 
             return conventionSet;
         }

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTypeMappingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTypeMappingConvention.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class RelationalTypeMappingConvention : IModelConvention
+    {
+        private readonly IRelationalTypeMapper _typeMapper;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalTypeMappingConvention([NotNull] IRelationalTypeMapper typeMapper)
+            => _typeMapper = typeMapper;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            foreach (var property in modelBuilder.Metadata.GetEntityTypes().SelectMany(e => e.GetDeclaredProperties()))
+            {
+                property.Builder.HasAnnotation(
+                    RelationalAnnotationNames.TypeMapping,
+                    _typeMapper.FindMapping(property),
+                    ConfigurationSource.Convention);
+            }
+
+            return modelBuilder;
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -79,5 +79,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The name for filter annotations.
         /// </summary>
         public const string Filter = Prefix + "Filter";
+
+        /// <summary>
+        ///     The name for filter annotations.
+        /// </summary>
+        public const string TypeMapping = Prefix + "TypeMapping";
     }
 }

--- a/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -9,6 +9,7 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -126,7 +127,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         public virtual string ColumnType
         {
-            get => (string)Annotations.GetAnnotation(RelationalAnnotationNames.ColumnType);
+            get => (string)Annotations.GetAnnotation(RelationalAnnotationNames.ColumnType)
+                ?? ((RelationalTypeMapping)Annotations.GetAnnotation(RelationalAnnotationNames.TypeMapping))?.StoreType;
             [param: CanBeNull] set => SetColumnType(value);
         }
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -43,7 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(typeMapper, nameof(typeMapper));
             Check.NotNull(property, nameof(property));
 
-            var mapping = typeMapper.FindMapping(property);
+            var mapping = (RelationalTypeMapping)property[RelationalAnnotationNames.TypeMapping]
+                ?? typeMapper.FindMapping(property);
+
             if (mapping != null)
             {
                 return mapping;


### PR DESCRIPTION
Issue #8034, possible because of #7166

The idea here is to generate type mappings at model building type and then store them in the model. This allows `property.RelationalAnnotationNames().ColumnType` to always return the store type.

The solution is not perfect:
- A convention runs when the model is built, which means that ColumnType will remain null during OnModelCreating. This could be changed by lots of conventions that run whenever something that could change the mapping is changed.
- Because this is done by convention, and because conventions are not always run (e.g. ModelSnapshot, HistoryTable, using the ModelBuilder directly with an empty convention set) it means sometimes type mappings are not available. However, in the normal application scenario, they will always be available.

I will file an issue to look at these things post 2.0.
