### PR TITLE
Make context.GetService<> fallback to the app service provider

### DIFF
--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -863,7 +863,6 @@
       "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression aliasExpression)",
       "Kind": "Removal"
     },
-  Successfully created package 'C:\aspnet\EntityFramework/artifacts\build\Microsoft.EntityFrameworkCore.SqlServer.Design.2.0.0-preview2-t004850761.nupkg'.
     {
       "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
       "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression columnExpression)",

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -2736,14 +2736,20 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        private class SomeAppService
+        {
+        }
+
         [Fact]
         public void Can_add_derived_context_with_options()
         {
             var appServiceProivder = new ServiceCollection()
                 .AddDbContext<ConstructorTestContextWithOC3A>(b => b.UseInMemoryDatabase(Guid.NewGuid().ToString()))
+                .AddSingleton<SomeAppService>()
                 .BuildServiceProvider();
 
             var singleton = new object[4];
+            SomeAppService appSingleton;
 
             using (var serviceScope = appServiceProivder
                 .GetRequiredService<IServiceScopeFactory>()
@@ -2757,6 +2763,11 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+
+                appSingleton = context.GetService<SomeAppService>();
+                Assert.NotNull(appSingleton);
+
+                Assert.Same(appSingleton, serviceScope.ServiceProvider.GetService<SomeAppService>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2769,6 +2780,9 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
                 Assert.Same(singleton[3], context.GetService<IDbContextOptions>());
+
+                Assert.Same(appSingleton, context.GetService<SomeAppService>());
+                Assert.Same(appSingleton, serviceScope.ServiceProvider.GetService<SomeAppService>());
             }
         }
 


### PR DESCRIPTION
Issue #7185

This makes it easier for applications that are using AddDbContext to get access to services registered on the container that was used for AddDbContext.
