### PR TITLE
Removing obsolete members

### DIFF
--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,19 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
 
         /// <summary>
-        ///     Executes the command with no results.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <returns> The number of rows affected. </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        int ExecuteNonQuery(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection);
-
-        /// <summary>
         ///     Asynchronously executes the command with no results.
         /// </summary>
         /// <param name="connection"> The connection to execute against. </param>
@@ -65,23 +51,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         Task<int> ExecuteNonQueryAsync(
             [NotNull] IRelationalConnection connection,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        ///     Asynchronously executes the command with no results.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous operation. The task result contains the number of rows affected.
-        /// </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        Task<int> ExecuteNonQueryAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -93,19 +62,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         object ExecuteScalar(
             [NotNull] IRelationalConnection connection,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
-
-        /// <summary>
-        ///     Executes the command with a single scalar result.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <returns> The result of the command. </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        object ExecuteScalar(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection);
 
         /// <summary>
         ///     Asynchronously executes the command with a single scalar result.
@@ -121,22 +77,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
             CancellationToken cancellationToken = default(CancellationToken));
 
-        /// <summary>
-        ///     Asynchronously executes the command with a single scalar result.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous operation. The task result contains the result of the command.
-        /// </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        Task<object> ExecuteScalarAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection,
-            CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         ///     Executes the command with a <see cref="RelationalDataReader" /> result.
@@ -149,19 +89,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues);
 
         /// <summary>
-        ///     Executes the command with a <see cref="RelationalDataReader" /> result.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <returns> The result of the command. </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        RelationalDataReader ExecuteReader(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection);
-
-        /// <summary>
         ///     Asynchronously executes the command with a <see cref="RelationalDataReader" /> result.
         /// </summary>
         /// <param name="connection"> The connection to execute against. </param>
@@ -173,23 +100,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         Task<RelationalDataReader> ExecuteReaderAsync(
             [NotNull] IRelationalConnection connection,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        ///     Asynchronously executes the command with a <see cref="RelationalDataReader" /> result.
-        /// </summary>
-        /// <param name="connection"> The connection to execute against. </param>
-        /// <param name="parameterValues"> The values for the parameters. </param>
-        /// <param name="manageConnection"> A value indicating whether to open and close the connection as needed. </param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous operation. The task result contains the result of the command.
-        /// </returns>
-        [Obsolete("Use overload without 'manageConnection' parameter")]
-        Task<RelationalDataReader> ExecuteReaderAsync(
-            [NotNull] IRelationalConnection connection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
-            bool manageConnection,
             CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -69,10 +68,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 DbCommandMethod.ExecuteNonQuery,
                 parameterValues);
 
-        int IRelationalCommand.ExecuteNonQuery(
-            IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            => ExecuteNonQuery(connection, parameterValues);
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -87,10 +82,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 parameterValues,
                 cancellationToken: cancellationToken).Cast<object, int>();
 
-        Task<int> IRelationalCommand.ExecuteNonQueryAsync(
-            IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            => ExecuteNonQueryAsync(connection, parameterValues, cancellationToken);
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -102,9 +93,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 Check.NotNull(connection, nameof(connection)),
                 DbCommandMethod.ExecuteScalar,
                 parameterValues);
-
-        object IRelationalCommand.ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            => ExecuteScalar(connection, parameterValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -120,10 +108,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 parameterValues,
                 cancellationToken: cancellationToken);
 
-        Task<object> IRelationalCommand.ExecuteScalarAsync(
-            IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            => ExecuteScalarAsync(connection, parameterValues, cancellationToken);
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -136,10 +120,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 DbCommandMethod.ExecuteReader,
                 parameterValues,
                 closeConnection: false);
-
-        RelationalDataReader IRelationalCommand.ExecuteReader(
-            IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            => ExecuteReader(connection, parameterValues);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -155,10 +135,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 parameterValues,
                 closeConnection: false,
                 cancellationToken: cancellationToken).Cast<object, RelationalDataReader>();
-
-        Task<RelationalDataReader> IRelationalCommand.ExecuteReaderAsync(
-            IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            => ExecuteReaderAsync(connection, parameterValues, cancellationToken);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1,1361 +1,1393 @@
-[
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T0 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T1 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression : System.Linq.Expressions.Expression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseCreator : Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator, Microsoft.EntityFrameworkCore.Internal.IServiceInjectionSite",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.DatabaseProviderServices, Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseProviderServices",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression : System.Linq.Expressions.Expression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.CrossJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InnerJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.LeftOuterJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.NotNullableExpression : System.Linq.Expressions.Expression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DbCommandLogData : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String, System.Object>>",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DbParameterLogData",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public enum Microsoft.EntityFrameworkCore.Infrastructure.RelationalEventId",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.Infrastructure.RelationalServiceCollectionExtensions",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.WarningConfigurationBuilderExtensions",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
-    "MemberId": "Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder",
-    "MemberId": "Microsoft.EntityFrameworkCore.Storage.RawSqlCommand Build(System.String sql, System.Collections.Generic.IReadOnlyList<System.Object> parameters)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMemberTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator",
-    "MemberId": "protected .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapper : Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper",
-    "MemberId": "protected .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.Extensions.Logging.ILogger logger)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "protected virtual Microsoft.Extensions.Logging.ILogger get_Logger()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "public System.Threading.Tasks.Task OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "public System.Void Close()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "public System.Void Open()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IForeignKey foreignKey, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IIndex index, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IKey key, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "protected virtual System.Boolean SetDatabaseName(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "public System.String get_DatabaseName()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "public virtual System.Void set_DatabaseName(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
-    "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Migrations.HistoryRepository : Microsoft.EntityFrameworkCore.Migrations.IHistoryRepository",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.IDatabaseCreator databaseCreator, Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder rawSqlCommandBuilder, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory get_ParameterNameGeneratorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory get_CommandBuilderFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper get_RelationalTypeMapper()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper get_SqlGenerationHelper()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.UpdateSqlGenerator : Microsoft.EntityFrameworkCore.Update.IUpdateSqlGenerator",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMethodCallTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator",
-    "MemberId": "protected .ctor(Microsoft.Extensions.Logging.ILogger logger)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
-    "MemberId": "protected override System.Linq.Expressions.Expression VisitMethodCall(System.Linq.Expressions.MethodCallExpression node)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Remotion.Linq.Clauses.IQuerySource querySource)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
-    "MemberId": "public override System.Linq.Expressions.Expression Visit(System.Linq.Expressions.Expression node)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
-    "MemberId": "protected override System.Void IncludeNavigations(Microsoft.EntityFrameworkCore.Query.IncludeSpecification includeSpecification, System.Type resultType, System.Linq.Expressions.Expression accessorExpression, System.Boolean querySourceRequiresTracking)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
-    "MemberId": "protected override System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel, System.Collections.Generic.IReadOnlyCollection<Microsoft.EntityFrameworkCore.Query.IncludeSpecification> includeSpecifications)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
-    "MemberId": "protected virtual System.Void OptimizeJoinClause(Remotion.Linq.Clauses.JoinClause joinClause, Remotion.Linq.QueryModel queryModel, System.Int32 index, System.Action baseVisitAction, System.Reflection.MethodInfo operatorToFlatten, System.Boolean groupJoin = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
-    "MemberId": "protected virtual System.Void WarnClientEval(System.Object expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory includeExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory conditionalRemovingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory queryFlattenerFactory, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor parentQueryModelVisitor)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions get_ContextOptions()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_RelationalAnnotationProvider()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory get_CompositePredicateExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory get_ConditionalRemovingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory get_IncludeExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory get_QueryFlattenerFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory get_SqlTranslatingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory includeExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory conditionalRemovingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory queryFlattenerFactory, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_Annotations()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper get_TypeMapper()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper get_SqlGenerationHelper()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.RelationalValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_RelationalExtensions()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.RelationalValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache cache, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalExtensions)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "protected virtual System.Linq.Expressions.Expression VisitNotIn(Microsoft.EntityFrameworkCore.Query.Expressions.InExpression inExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "protected virtual System.String get_ConcatOperator()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "protected virtual System.Void VisitProjection(System.Collections.Generic.IReadOnlyList<System.Linq.Expressions.Expression> projections)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory relationalCommandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression selectExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public System.Linq.Expressions.Expression VisitCount(Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression countExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public System.Linq.Expressions.Expression VisitLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression lateralJoinExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public System.Linq.Expressions.Expression VisitMax(Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression maxExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public System.Linq.Expressions.Expression VisitMin(Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression minExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public System.Linq.Expressions.Expression VisitSum(Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression sumExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
-    "MemberId": "public virtual System.Linq.Expressions.Expression VisitIsNotNull(Microsoft.EntityFrameworkCore.Query.Expressions.IsNullExpression isNotNullExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeExpressionFragmentTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsAnnotationProvider : Microsoft.EntityFrameworkCore.Migrations.IMigrationsAnnotationProvider",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ParameterNameGeneratorFactory : Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.TypedRelationalValueBufferFactoryFactory : Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UntypedRelationalValueBufferFactoryFactory : Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext : Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.ILinqOperatorProvider linqOperatorProvider, Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider queryMethodProvider, System.Type contextType, System.Boolean trackQueryResults)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContextFactory : Microsoft.EntityFrameworkCore.Query.Internal.QueryCompilationContextFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContextFactory> logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Remotion.Linq.Parsing.Structure.NodeTypeProviders.MethodInfoBasedNodeTypeRegistry methodInfoBasedNodeTypeRegistry, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalEntityQueryableExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory selectExpressionFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMaterializerFactory materializerFactory, Microsoft.EntityFrameworkCore.Query.Internal.IShaperCommandContextFactory shaperCommandContextFactory, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalEntityQueryableExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.EntityQueryableExpressionVisitor",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory selectExpressionFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMaterializerFactory materializerFactory, Microsoft.EntityFrameworkCore.Query.Internal.IShaperCommandContextFactory shaperCommandContextFactory, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Remotion.Linq.Clauses.IQuerySource querySource)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
-    "MemberId": "public Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor : Remotion.Linq.Parsing.ThrowingExpressionVisitor",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression operand, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression subQuery)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression operand, System.Collections.Generic.IReadOnlyList<System.Linq.Expressions.Expression> values)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression get_Operand()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalDatabase : Microsoft.EntityFrameworkCore.Storage.Database",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.IQueryCompilationContextFactory queryCompilationContextFactory, Microsoft.EntityFrameworkCore.Update.ICommandBatchPreparer batchPreparer, Microsoft.EntityFrameworkCore.Update.IBatchExecutor batchExecutor, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpressionFactory : Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext, System.String alias)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression AddToOrderBy(System.String column, Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase table, Remotion.Linq.Clauses.OrderingDirection orderingDirection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddLeftOuterJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddLeftOuterJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddAliasToProjection(System.String alias, System.Linq.Expressions.Expression expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression aliasExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression columnExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddToProjection(System.Linq.Expressions.Expression expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddToProjection(System.Linq.Expressions.Expression expression, System.Boolean resetProjectStar)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Int32 AddToProjection(System.String column, Microsoft.EntityFrameworkCore.Metadata.IProperty property, Remotion.Linq.Clauses.IQuerySource querySource)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Linq.Expressions.Expression UpdateColumnExpression(System.Linq.Expressions.Expression expression, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.String get_ProjectStarAlias()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddCrossJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddTable(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Boolean createUniqueAlias = True)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddTables(System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase> tableExpressions)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddToOrderBy(Remotion.Linq.Clauses.Ordering ordering)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void AddToOrderBy(System.Collections.Generic.IEnumerable<Remotion.Linq.Clauses.Ordering> orderings)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void ClearColumnProjections()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void RemoveFromProjection(System.Collections.Generic.IEnumerable<Remotion.Linq.Clauses.Ordering> orderBy)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void set_ProjectStarAlias(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void SetProjectionConditionalExpression(System.Linq.Expressions.ConditionalExpression conditionalExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalDataReader : System.IDisposable",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbCommand command, System.Data.Common.DbDataReader reader)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalTransaction : Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<System.Data.Common.DbTransaction>",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Boolean transactionOwned)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public .ctor(System.Func<Microsoft.EntityFrameworkCore.Query.Internal.IQueryBuffer> queryBufferFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> stateManager, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategyFactory executionStrategyFactory)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Storage.ValueBuffer GetIncludeValueBuffer(System.Int32 queryIndex)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Threading.Tasks.Task RegisterValueBufferCursorAsync(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor, System.Nullable<System.Int32> queryIndex, System.Threading.CancellationToken cancellationToken)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Void BeginIncludeScope()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Void EndIncludeScope()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Void RegisterValueBufferCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor, System.Nullable<System.Int32> queryIndex)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public .ctor(System.Linq.Expressions.Expression expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Boolean get_IsProjected()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Linq.Expressions.Expression get_SourceExpression()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Reflection.MemberInfo get_SourceMember()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_Alias(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_IsProjected(System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_SourceExpression(System.Linq.Expressions.Expression value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_SourceMember(System.Reflection.MemberInfo value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ExistsExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public .ctor(System.Linq.Expressions.Expression expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ExistsExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Linq.Expressions.Expression get_Expression()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Update.ModificationCommand",
-    "MemberId": "public .ctor(System.String name, System.String schema, System.Func<System.String> generateParameterName, System.Func<Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations> getPropertyExtensions)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public .ctor(System.String name, System.Type type, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Boolean get_IsNullable()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.String get_TableAlias()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_IsNullable(System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public abstract System.Void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_CommandTimeout(System.Nullable<System.Int32> value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_Connection(System.Data.Common.DbConnection value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_ConnectionString(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_ExecutionStrategyFactory(System.Func<Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_MaxBatchSize(System.Nullable<System.Int32> value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_MigrationsAssembly(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_MigrationsHistoryTableName(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_MigrationsHistoryTableSchema(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public virtual System.Void set_UseRelationalNulls(System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalQueryableExtensions",
-    "MemberId": "public static System.Linq.IQueryable<T0> FromSql<T0>(this System.Linq.IQueryable<T0> source, System.String sql, params System.Object[] parameters) where T0 : class",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions",
-    "MemberId": "public static System.Threading.Tasks.Task<System.Int32> ExecuteSqlCommandAsync(this Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade databaseFacade, System.String sql, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), params System.Object[] parameters)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_IncludeMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Type get_GroupJoinIncludeType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Type get_RelatedEntitiesLoaderType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Reflection.MethodInfo get_IncludeMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Type get_GroupJoinIncludeType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "public System.Type get_RelatedEntitiesLoaderType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.CreateIndexOperation> CreateIndex(System.String name, System.String table, System.String column, System.String schema = null, System.Boolean unique = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.CreateIndexOperation> CreateIndex(System.String name, System.String table, System.String[] columns, System.String schema = null, System.Boolean unique = False)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
-    "MemberId": "public virtual System.Boolean CanSetAnnotation(System.String relationalAnnotationName, System.String providerAnnotationName, System.Object value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
-    "MemberId": "public virtual System.Boolean SetAnnotation(System.String relationalAnnotationName, System.String providerAnnotationName, System.Object value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
-    "MemberId": "public virtual System.Object GetAnnotation(System.String fallbackAnnotationName, System.String primaryAnnotationName)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SqlFunctionExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Collections.Generic.IReadOnlyCollection<System.Linq.Expressions.Expression> get_Arguments()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SqlFunctionExpression : System.Linq.Expressions.Expression",
-    "MemberId": "public virtual System.Void set_FunctionName(System.String value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Linq.Expressions.Expression get_Predicate()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
-    "MemberId": "public virtual System.Void set_Predicate(System.Linq.Expressions.Expression value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitCount(Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression countExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression lateralJoinExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitMax(Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression maxExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitMin(Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression minExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitSum(Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression sumExpression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Reflection.MethodInfo get_IncludeMethod()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Type get_GroupJoinIncludeType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-    "MemberId": "System.Type get_RelatedEntitiesLoaderType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
-    "MemberId": "System.String get_DatabaseName()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Threading.Tasks.Task OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void Close()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void Open()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
-    "MemberId": "Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean inProjection = False)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder",
-    "MemberId": "Microsoft.EntityFrameworkCore.Storage.RawSqlCommand Build(System.String sql, System.Collections.Generic.IEnumerable<System.Object> parameters)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Boolean Close()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Boolean Open()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Guid get_ConnectionId()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Threading.Tasks.Task<System.Boolean> OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitColumnReference(Microsoft.EntityFrameworkCore.Query.Expressions.ColumnReferenceExpression columnReferenceExpression)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitCrossJoinLateral(Microsoft.EntityFrameworkCore.Query.Expressions.CrossJoinLateralExpression crossJoinLateralExpression)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
-    "MemberId": "System.Linq.Expressions.Expression VisitSqlFragment(Microsoft.EntityFrameworkCore.Query.Expressions.SqlFragmentExpression sqlFragmentExpression)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
-    "MemberId": "System.String get_Filter()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor get_ActiveCursor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void set_ActiveCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "public Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor get_ActiveCursor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
-    "MemberId": "public System.Void set_ActiveCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Threading.SemaphoreSlim get_Semaphore()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual System.Void DeregisterValueBufferCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Threading.SemaphoreSlim get_Semaphore()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Threading.Tasks.Task RegisterBufferableAsync(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable, System.Threading.CancellationToken cancellationToken)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void RegisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapperExtensions",
-    "MemberId": "public static System.Boolean IsTypeMapped(this Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, System.Type clrType)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions",
-    "MemberId": "public static System.Int32 ExecuteSqlCommand(this Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade databaseFacade, System.String sql, params System.Object[] parameters)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Byte value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Byte[] value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Char value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Data.DbType value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.DateTime value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.DateTimeOffset value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Decimal value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Double value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Enum value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Guid value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int16 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int32 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int64 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Object value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.Single value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.String value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String GenerateLiteralValue(System.TimeSpan value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DateTimeFormat()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DateTimeFormatString()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DateTimeOffsetFormat()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DateTimeOffsetFormatString()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DecimalFormat()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_DecimalFormatString()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.String get_FloatingPointFormatString()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Byte value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Byte[] value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Char value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Data.DbType value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.DateTime value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.DateTimeOffset value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Decimal value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Double value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Enum value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Guid value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int16 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int32 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int64 value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Object value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Single value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.String value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.TimeSpan value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "public System.String GenerateLiteral(System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "public System.Void GenerateLiteral(System.Text.StringBuilder builder, System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "System.String GenerateLiteral(System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "System.Void GenerateLiteral(System.Text.StringBuilder builder, System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "protected abstract Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension Clone()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "public abstract System.Boolean ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Addition"
-  }
-]
+  [
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T0 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T1 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression : System.Linq.Expressions.Expression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseCreator : Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator, Microsoft.EntityFrameworkCore.Internal.IServiceInjectionSite",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.DatabaseProviderServices, Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseProviderServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression : System.Linq.Expressions.Expression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.CrossJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InnerJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.LeftOuterJoinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.NotNullableExpression : System.Linq.Expressions.Expression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression : Microsoft.EntityFrameworkCore.Query.Expressions.AggregateExpression",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DbCommandLogData : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String, System.Object>>",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DbParameterLogData",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public enum Microsoft.EntityFrameworkCore.Infrastructure.RelationalEventId",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Infrastructure.RelationalServiceCollectionExtensions",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.WarningConfigurationBuilderExtensions",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
+      "MemberId": "Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor get_ActiveCursor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Threading.Tasks.Task OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Void Close()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Void Open()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Void set_ActiveCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.RawSqlCommand Build(System.String sql, System.Collections.Generic.IReadOnlyList<System.Object> parameters)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.RelationalDataReader ExecuteReader(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "System.Int32 ExecuteNonQuery(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "System.Object ExecuteScalar(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "System.Threading.Tasks.Task<Microsoft.EntityFrameworkCore.Storage.RelationalDataReader> ExecuteReaderAsync(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "System.Threading.Tasks.Task<System.Int32> ExecuteNonQueryAsync(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalCommand",
+      "MemberId": "System.Threading.Tasks.Task<System.Object> ExecuteScalarAsync(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> parameterValues, System.Boolean manageConnection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMemberTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator",
+      "MemberId": "protected .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapper : Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper",
+      "MemberId": "protected .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.Extensions.Logging.ILogger logger)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "protected virtual Microsoft.Extensions.Logging.ILogger get_Logger()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "public Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor get_ActiveCursor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "public System.Threading.Tasks.Task OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "public System.Void Close()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "public System.Void Open()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.RelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalConnection",
+      "MemberId": "public System.Void set_ActiveCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalEntityTypeAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalEntityTypeAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalForeignKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalForeignKeyAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IForeignKey foreignKey, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IIndex index, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalKeyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalKeyAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IKey key, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "protected virtual System.Boolean SetDatabaseName(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "public System.String get_DatabaseName()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalModelAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "public virtual System.Void set_DatabaseName(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations annotations, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
+      "MemberId": "protected readonly Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames ProviderFullAnnotationNames",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalPropertyAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Metadata.Internal.RelationalFullAnnotationNames providerFullAnnotationNames)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Migrations.HistoryRepository : Microsoft.EntityFrameworkCore.Migrations.IHistoryRepository",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.IDatabaseCreator databaseCreator, Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder rawSqlCommandBuilder, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory get_ParameterNameGeneratorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory get_CommandBuilderFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper get_RelationalTypeMapper()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorFactoryBase : Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper get_SqlGenerationHelper()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.UpdateSqlGenerator : Microsoft.EntityFrameworkCore.Update.IUpdateSqlGenerator",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMethodCallTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator",
+      "MemberId": "protected .ctor(Microsoft.Extensions.Logging.ILogger logger)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
+      "MemberId": "protected override System.Linq.Expressions.Expression VisitMethodCall(System.Linq.Expressions.MethodCallExpression node)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Remotion.Linq.Clauses.IQuerySource querySource)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ProjectionExpressionVisitor",
+      "MemberId": "public override System.Linq.Expressions.Expression Visit(System.Linq.Expressions.Expression node)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+      "MemberId": "protected override System.Void IncludeNavigations(Microsoft.EntityFrameworkCore.Query.IncludeSpecification includeSpecification, System.Type resultType, System.Linq.Expressions.Expression accessorExpression, System.Boolean querySourceRequiresTracking)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+      "MemberId": "protected override System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel, System.Collections.Generic.IReadOnlyCollection<Microsoft.EntityFrameworkCore.Query.IncludeSpecification> includeSpecifications)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+      "MemberId": "protected virtual System.Void OptimizeJoinClause(Remotion.Linq.Clauses.JoinClause joinClause, Remotion.Linq.QueryModel queryModel, System.Int32 index, System.Action baseVisitAction, System.Reflection.MethodInfo operatorToFlatten, System.Boolean groupJoin = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+      "MemberId": "protected virtual System.Void WarnClientEval(System.Object expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory includeExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory conditionalRemovingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory queryFlattenerFactory, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor parentQueryModelVisitor)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions get_ContextOptions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_RelationalAnnotationProvider()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory get_CompositePredicateExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory get_ConditionalRemovingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory get_IncludeExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory get_QueryFlattenerFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory get_SqlTranslatingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IIncludeExpressionVisitorFactory includeExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IConditionalRemovingExpressionVisitorFactory conditionalRemovingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQueryFlattenerFactory queryFlattenerFactory, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_Annotations()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper get_TypeMapper()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper get_SqlGenerationHelper()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider annotations)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.RelationalValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider get_RelationalExtensions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.RelationalValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache cache, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalExtensions)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "protected virtual System.Linq.Expressions.Expression VisitNotIn(Microsoft.EntityFrameworkCore.Query.Expressions.InExpression inExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "protected virtual System.String get_ConcatOperator()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "protected virtual System.Void VisitProjection(System.Collections.Generic.IReadOnlyList<System.Linq.Expressions.Expression> projections)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory relationalCommandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression selectExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public System.Linq.Expressions.Expression VisitCount(Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression countExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public System.Linq.Expressions.Expression VisitLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression lateralJoinExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public System.Linq.Expressions.Expression VisitMax(Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression maxExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public System.Linq.Expressions.Expression VisitMin(Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression minExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public System.Linq.Expressions.Expression VisitSum(Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression sumExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public virtual System.Linq.Expressions.Expression VisitIsNotNull(Microsoft.EntityFrameworkCore.Query.Expressions.IsNullExpression isNotNullExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Byte value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Byte[] value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Char value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Data.DbType value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.DateTime value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.DateTimeOffset value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Decimal value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Double value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Enum value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Guid value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int16 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int32 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Int64 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Object value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.Single value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.String value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String GenerateLiteralValue(System.TimeSpan value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DateTimeFormat()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DateTimeFormatString()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DateTimeOffsetFormat()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DateTimeOffsetFormatString()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DecimalFormat()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_DecimalFormatString()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.String get_FloatingPointFormatString()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Byte value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Byte[] value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Char value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Data.DbType value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.DateTime value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.DateTimeOffset value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Decimal value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Double value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Enum value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Guid value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int16 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int32 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Int64 value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Object value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.Single value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.String value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "protected virtual System.Void GenerateLiteralValue(System.Text.StringBuilder builder, System.TimeSpan value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "public System.String GenerateLiteral(System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalSqlGenerationHelper : Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "public System.Void GenerateLiteral(System.Text.StringBuilder builder, System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeExpressionFragmentTranslator : Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationsAnnotationProvider : Microsoft.EntityFrameworkCore.Migrations.IMigrationsAnnotationProvider",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ParameterNameGeneratorFactory : Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.TypedRelationalValueBufferFactoryFactory : Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UntypedRelationalValueBufferFactoryFactory : Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext : Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.ILinqOperatorProvider linqOperatorProvider, Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider queryMethodProvider, System.Type contextType, System.Boolean trackQueryResults)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContextFactory : Microsoft.EntityFrameworkCore.Query.Internal.QueryCompilationContextFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContextFactory> logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Remotion.Linq.Parsing.Structure.NodeTypeProviders.MethodInfoBasedNodeTypeRegistry methodInfoBasedNodeTypeRegistry, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalEntityQueryableExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory selectExpressionFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMaterializerFactory materializerFactory, Microsoft.EntityFrameworkCore.Query.Internal.IShaperCommandContextFactory shaperCommandContextFactory, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalEntityQueryableExpressionVisitor : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.EntityQueryableExpressionVisitor",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory selectExpressionFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMaterializerFactory materializerFactory, Microsoft.EntityFrameworkCore.Query.Internal.IShaperCommandContextFactory shaperCommandContextFactory, Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Remotion.Linq.Clauses.IQuerySource querySource)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
+      "MemberId": "public Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor : Remotion.Linq.Parsing.ThrowingExpressionVisitor",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IRelationalAnnotationProvider relationalAnnotationProvider, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper, Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean bindParentQueries = False, System.Boolean inProjection = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression operand, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression subQuery)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression operand, System.Collections.Generic.IReadOnlyList<System.Linq.Expressions.Expression> values)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.InExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression get_Operand()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalProjectionExpressionVisitorFactory : Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalDatabase : Microsoft.EntityFrameworkCore.Storage.Database",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.IQueryCompilationContextFactory queryCompilationContextFactory, Microsoft.EntityFrameworkCore.Update.ICommandBatchPreparer batchPreparer, Microsoft.EntityFrameworkCore.Update.IBatchExecutor batchExecutor, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpressionFactory : Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory, Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContext queryCompilationContext, System.String alias)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression AddToOrderBy(System.String column, Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase table, Remotion.Linq.Clauses.OrderingDirection orderingDirection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddInnerJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddLeftOuterJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase AddLeftOuterJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddAliasToProjection(System.String alias, System.Linq.Expressions.Expression expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression aliasExpression)",
+      "Kind": "Removal"
+    },
+  Successfully created package 'C:\aspnet\EntityFramework/artifacts\build\Microsoft.EntityFrameworkCore.SqlServer.Design.2.0.0-preview2-t004850761.nupkg'.
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddToProjection(Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression columnExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddToProjection(System.Linq.Expressions.Expression expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddToProjection(System.Linq.Expressions.Expression expression, System.Boolean resetProjectStar)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Int32 AddToProjection(System.String column, Microsoft.EntityFrameworkCore.Metadata.IProperty property, Remotion.Linq.Clauses.IQuerySource querySource)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Linq.Expressions.Expression UpdateColumnExpression(System.Linq.Expressions.Expression expression, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.String get_ProjectStarAlias()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddCrossJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> projection)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddTable(Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression, System.Boolean createUniqueAlias = True)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddTables(System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase> tableExpressions)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddToOrderBy(Remotion.Linq.Clauses.Ordering ordering)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void AddToOrderBy(System.Collections.Generic.IEnumerable<Remotion.Linq.Clauses.Ordering> orderings)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void ClearColumnProjections()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void RemoveFromProjection(System.Collections.Generic.IEnumerable<Remotion.Linq.Clauses.Ordering> orderBy)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void set_ProjectStarAlias(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void SetProjectionConditionalExpression(System.Linq.Expressions.ConditionalExpression conditionalExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalDataReader : System.IDisposable",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbCommand command, System.Data.Common.DbDataReader reader)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalTransaction : Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<System.Data.Common.DbTransaction>",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, System.Data.Common.DbTransaction transaction, Microsoft.Extensions.Logging.ILogger logger, System.Boolean transactionOwned)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public .ctor(System.Func<Microsoft.EntityFrameworkCore.Query.Internal.IQueryBuffer> queryBufferFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> stateManager, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategyFactory executionStrategyFactory)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Storage.ValueBuffer GetIncludeValueBuffer(System.Int32 queryIndex)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Threading.SemaphoreSlim get_Semaphore()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Threading.Tasks.Task RegisterValueBufferCursorAsync(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor, System.Nullable<System.Int32> queryIndex, System.Threading.CancellationToken cancellationToken)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Void BeginIncludeScope()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Void DeregisterValueBufferCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Void EndIncludeScope()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryContext : Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual System.Void RegisterValueBufferCursor(Microsoft.EntityFrameworkCore.Query.Internal.IValueBufferCursor valueBufferCursor, System.Nullable<System.Int32> queryIndex)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public .ctor(System.Linq.Expressions.Expression expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Boolean get_IsProjected()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Linq.Expressions.Expression get_SourceExpression()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Reflection.MemberInfo get_SourceMember()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_Alias(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_IsProjected(System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_SourceExpression(System.Linq.Expressions.Expression value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.AliasExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_SourceMember(System.Reflection.MemberInfo value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ExistsExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public .ctor(System.Linq.Expressions.Expression expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ExistsExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Linq.Expressions.Expression get_Expression()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Update.ModificationCommand",
+      "MemberId": "public .ctor(System.String name, System.String schema, System.Func<System.String> generateParameterName, System.Func<Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations> getPropertyExtensions)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public .ctor(System.String name, System.Type type, Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase tableExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Boolean get_IsNullable()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.String get_TableAlias()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.ColumnExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_IsNullable(System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public abstract System.Void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_CommandTimeout(System.Nullable<System.Int32> value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_Connection(System.Data.Common.DbConnection value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_ConnectionString(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_ExecutionStrategyFactory(System.Func<Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_MaxBatchSize(System.Nullable<System.Int32> value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_MigrationsAssembly(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_MigrationsHistoryTableName(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_MigrationsHistoryTableSchema(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public virtual System.Void set_UseRelationalNulls(System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapperExtensions",
+      "MemberId": "public static System.Boolean IsTypeMapped(this Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper, System.Type clrType)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions",
+      "MemberId": "public static System.Int32 ExecuteSqlCommand(this Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade databaseFacade, System.String sql, params System.Object[] parameters)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions",
+      "MemberId": "public static System.Threading.Tasks.Task<System.Int32> ExecuteSqlCommandAsync(this Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade databaseFacade, System.String sql, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), params System.Object[] parameters)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalQueryableExtensions",
+      "MemberId": "public static System.Linq.IQueryable<T0> FromSql<T0>(this System.Linq.IQueryable<T0> source, System.String sql, params System.Object[] parameters) where T0 : class",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_IncludeMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Type get_GroupJoinIncludeType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.AsyncQueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Type get_RelatedEntitiesLoaderType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Reflection.MethodInfo get_IncludeMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Type get_GroupJoinIncludeType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryMethodProvider : Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "public System.Type get_RelatedEntitiesLoaderType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.CreateIndexOperation> CreateIndex(System.String name, System.String table, System.String column, System.String schema = null, System.Boolean unique = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.CreateIndexOperation> CreateIndex(System.String name, System.String table, System.String[] columns, System.String schema = null, System.Boolean unique = False)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
+      "MemberId": "public virtual System.Boolean CanSetAnnotation(System.String relationalAnnotationName, System.String providerAnnotationName, System.Object value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
+      "MemberId": "public virtual System.Boolean SetAnnotation(System.String relationalAnnotationName, System.String providerAnnotationName, System.Object value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalAnnotations",
+      "MemberId": "public virtual System.Object GetAnnotation(System.String fallbackAnnotationName, System.String primaryAnnotationName)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SqlFunctionExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Collections.Generic.IReadOnlyCollection<System.Linq.Expressions.Expression> get_Arguments()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SqlFunctionExpression : System.Linq.Expressions.Expression",
+      "MemberId": "public virtual System.Void set_FunctionName(System.String value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Linq.Expressions.Expression get_Predicate()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.Expressions.JoinExpressionBase : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+      "MemberId": "public virtual System.Void set_Predicate(System.Linq.Expressions.Expression value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitCount(Microsoft.EntityFrameworkCore.Query.Expressions.CountExpression countExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitLateralJoin(Microsoft.EntityFrameworkCore.Query.Expressions.LateralJoinExpression lateralJoinExpression)",
+  Successfully created package 'C:\aspnet\EntityFramework/artifacts\build\Microsoft.EntityFrameworkCore.Tools.DotNet.2.0.0-preview2-t004850761.nupkg'.
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitMax(Microsoft.EntityFrameworkCore.Query.Expressions.MaxExpression maxExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitMin(Microsoft.EntityFrameworkCore.Query.Expressions.MinExpression minExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitSum(Microsoft.EntityFrameworkCore.Query.Expressions.SumExpression sumExpression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Object CreateGroupJoinInclude(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Metadata.INavigation> navigationPath, System.Boolean querySourceRequiresTracking, System.Object existingGroupJoinInclude, System.Object relatedEntitiesLoaders)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Reflection.MethodInfo get_CreateCollectionRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Reflection.MethodInfo get_CreateReferenceRelatedEntitiesLoaderMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Reflection.MethodInfo get_IncludeMethod()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Type get_GroupJoinIncludeType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+      "MemberId": "System.Type get_RelatedEntitiesLoaderType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "System.String GenerateLiteral(System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "System.Void GenerateLiteral(System.Text.StringBuilder builder, System.Object value, Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping typeMapping = null)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalModelAnnotations",
+      "MemberId": "System.String get_DatabaseName()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ISqlTranslatingExpressionVisitorFactory",
+      "MemberId": "Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitor Create(Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor queryModelVisitor, Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression targetSelectExpression = null, System.Linq.Expressions.Expression topLevelPredicate = null, System.Boolean inProjection = False)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.RawSqlCommand Build(System.String sql, System.Collections.Generic.IEnumerable<System.Object> parameters)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "protected abstract Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension Clone()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "public abstract System.Boolean ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Boolean Close()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Boolean Open()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Guid get_ConnectionId()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Threading.SemaphoreSlim get_Semaphore()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Threading.Tasks.Task RegisterBufferableAsync(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable, System.Threading.CancellationToken cancellationToken)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Threading.Tasks.Task<System.Boolean> OpenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+      "MemberId": "System.Void RegisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitColumnReference(Microsoft.EntityFrameworkCore.Query.Expressions.ColumnReferenceExpression columnReferenceExpression)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitCrossJoinLateral(Microsoft.EntityFrameworkCore.Query.Expressions.CrossJoinLateralExpression crossJoinLateralExpression)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+      "MemberId": "System.Linq.Expressions.Expression VisitSqlFragment(Microsoft.EntityFrameworkCore.Query.Expressions.SqlFragmentExpression sqlFragmentExpression)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+      "MemberId": "System.String get_Filter()",
+      "Kind": "Addition"
+    }
+  ]

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -2294,29 +2294,6 @@ namespace Microsoft.EntityFrameworkCore
                     : source);
 
         /// <summary>
-        ///     This method exists only for binary compatibility and is obsolete. Use
-        ///     <see
-        ///         cref="ThenInclude{TEntity,TPreviousProperty,TProperty}(IIncludableQueryable{TEntity,IEnumerable{TPreviousProperty}},Expression{System.Func{TPreviousProperty,TProperty}})" />
-        ///     instead.
-        /// </summary>
-        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
-        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
-        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
-        /// <param name="source"> The source query. </param>
-        /// <param name="navigationPropertyPath">
-        ///     A lambda expression representing the navigation property to be included (<c>t => t.Property1</c>).
-        /// </param>
-        /// <returns>
-        ///     A new query with the related data included.
-        /// </returns>
-        [Obsolete(message: "Use overload that takes an IEnumerable<> navigation property instead.")]
-        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
-            [NotNull] IIncludableQueryable<TEntity, ICollection<TPreviousProperty>> source,
-            [NotNull] Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
-            where TEntity : class
-            => ThenInclude((IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>>)source, navigationPropertyPath);
-
-        /// <summary>
         ///     Specifies additional related data to be further included based on a related type that was just included.
         /// </summary>
         /// <example>

--- a/src/EFCore/Metadata/INavigation.cs
+++ b/src/EFCore/Metadata/INavigation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the entity type that this property belongs to.
         /// </summary>
-        new IEntityType DeclaringEntityType { get; }
+        IEntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.

--- a/src/EFCore/Metadata/IProperty.cs
+++ b/src/EFCore/Metadata/IProperty.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the entity type that this property belongs to.
         /// </summary>
-        new IEntityType DeclaringEntityType { get; }
+        IEntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this property can contain null.

--- a/src/EFCore/Metadata/IPropertyBase.cs
+++ b/src/EFCore/Metadata/IPropertyBase.cs
@@ -14,12 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public interface IPropertyBase : IAnnotatable
     {
         /// <summary>
-        ///     Gets the entity type that this property belongs to.
-        /// </summary>
-        [Obsolete("Use DeclaringType, IProperty.DeclaringEntityType, or INavigation.DeclaringEntityType.")]
-        IEntityType DeclaringEntityType { get; }
-
-        /// <summary>
         ///     Gets the name of the property.
         /// </summary>
         string Name { get; }

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -246,8 +246,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, p => new PropertyAccessorsFactory().Create(p));
 
         ITypeBase IPropertyBase.DeclaringType => DeclaringType;
-
-        [Obsolete("Use DeclaringType, IProperty.DeclaringEntityType, or INavigation.DeclaringEntityType.")]
-        IEntityType IPropertyBase.DeclaringEntityType => (IEntityType)DeclaringType;
     }
 }

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,574 +1,579 @@
-[
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.DatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkServicesBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.Extensions.DependencyInjection.IServiceCollection>",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SensitiveDataLogger<T0> : Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<T0>",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DatabaseErrorLogState",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DatabaseProvider<T0, T1> : Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider where T0 : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices, class where T1 : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension, class",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public enum Microsoft.EntityFrameworkCore.Infrastructure.CoreEventId",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger : Microsoft.Extensions.Logging.ILogger",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<T0> : Microsoft.Extensions.Logging.ILogger<T0>, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel get_Model()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "System.String get_Name()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "System.Type get_ClrType()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
-    "MemberId": "Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices GetProviderServices(System.IServiceProvider serviceProvider)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public enum Microsoft.EntityFrameworkCore.Metadata.ValueGenerated",
-    "MemberId": "OnAddOrUpdate = 2",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorCache : Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache",
-    "MemberId": "protected .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector get_ConcurrencyDetector()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IChangeDetector> get_ChangeDetector()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> get_StateManager()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ICoreConventionSetBuilder coreConventionSetBuilder, Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer modelCustomizer, Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory modelCacheKeyFactory)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory get_ModelCacheKeyFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer get_ModelCustomizer()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IDbSetFinder get_SetFinder()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ICoreConventionSetBuilder get_CoreConventionSetBuilder()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IModel CreateModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "public Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource get_EntityMaterializerSource()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory get_EntityQueryableExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory get_EntityResultFindingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory get_MemberAccessBindingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory get_NavigationRewritingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory get_OrderingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory get_QuerySourceTracingExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor get_SubQueryMemberPushDownExpressionVisitor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor get_TaskBlockingExpressionVisitor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory get_ProjectionExpressionVisitorFactory()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter get_ExpressionPrinter()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor get_QueryAnnotationExtractor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer get_QueryOptimizer()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler get_ResultOperatorHandler()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Query.QueryCompilationContext queryCompilationContext)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "protected virtual System.Void IncludeNavigations(Microsoft.EntityFrameworkCore.Query.IncludeSpecification includeSpecification, System.Type resultType, System.Linq.Expressions.Expression accessorExpression, System.Boolean querySourceRequiresTracking)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "protected virtual System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "protected virtual System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel, System.Collections.Generic.IReadOnlyCollection<Microsoft.EntityFrameworkCore.Query.IncludeSpecification> includeSpecifications)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "protected virtual System.Void OptimizeQueryModel(Remotion.Linq.QueryModel queryModel)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "public static System.Boolean IsPropertyMethod(System.Reflection.MethodInfo methodInfo)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "public static System.Linq.Expressions.Expression CreatePropertyExpression(System.Linq.Expressions.Expression target, Microsoft.EntityFrameworkCore.Metadata.IProperty property)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "public virtual System.Linq.Expressions.Expression BindReadValueMethod(System.Type memberType, System.Linq.Expressions.Expression expression, System.Int32 index)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "public virtual System.Void AddOrUpdateMapping(Remotion.Linq.Clauses.IQuerySource querySource, System.Linq.Expressions.Expression expression)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
-    "MemberId": "public virtual T0 BindNavigationPathPropertyExpression<T0>(System.Linq.Expressions.Expression propertyExpression, System.Func<System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IPropertyBase>, Remotion.Linq.Clauses.IQuerySource, T0> propertyBinder)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.Database : Microsoft.EntityFrameworkCore.Storage.IDatabase",
-    "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.IQueryCompilationContextFactory queryCompilationContextFactory)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<T0> : Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder where T0 : class",
-    "MemberId": "protected override Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder New(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder builder)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ExpressionVisitorBase : Remotion.Linq.Parsing.RelinqExpressionVisitor",
-    "MemberId": "protected override System.Linq.Expressions.Expression VisitExtension(System.Linq.Expressions.Expression node)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ExpressionVisitorBase : Remotion.Linq.Parsing.RelinqExpressionVisitor",
-    "MemberId": "public override System.Linq.Expressions.Expression Visit(System.Linq.Expressions.Expression node)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.ChangeTracking.NavigationEntry : Microsoft.EntityFrameworkCore.ChangeTracking.MemberEntry",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IEntityFinder Finder(System.Type entityType)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder New(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder builder)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasManyBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.Reflection.PropertyInfo navigationProperty)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasManyBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.String navigationName)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasOneBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.Reflection.PropertyInfo navigationProperty)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
-    "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasOneBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.String navigationName)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategy : Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy",
-    "MemberId": "protected virtual Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> get_Logger()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ResultOperatorHandler : Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.ModelCacheKeyFactory : Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.ModelCustomizer : Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer",
-    "MemberId": "public .ctor()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> logger)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext",
-    "MemberId": "public virtual Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> get_Logger()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.CompiledQueryCacheKeyGenerator : Microsoft.EntityFrameworkCore.Query.ICompiledQueryCacheKeyGenerator",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.Extensions.Logging.ILogger logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.ILinqOperatorProvider linqOperatorProvider, System.Type contextType, System.Boolean trackQueryResults)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
-    "MemberId": "public virtual Microsoft.Extensions.Logging.ILogger get_Logger()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder builder, Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType declaringEntityType, Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder HasForeignKey<T0>(params System.String[] foreignKeyPropertyNames) where T0 : class",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder HasPrincipalKey<T0>(params System.String[] keyPropertyNames) where T0 : class",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public struct Microsoft.EntityFrameworkCore.Query.EntityLoadInfo",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.ValueBuffer valueBuffer, System.Func<Microsoft.EntityFrameworkCore.Storage.ValueBuffer, System.Object> materializer)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorSelector",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache cache)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public struct Microsoft.EntityFrameworkCore.Storage.ValueBuffer",
-    "MemberId": "public .ctor(System.Collections.Generic.IList<System.Object> values)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public struct Microsoft.EntityFrameworkCore.Storage.ValueBuffer",
-    "MemberId": "public .ctor(System.Collections.Generic.IList<System.Object> values, System.Int32 offset)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public .ctor(System.Func<Microsoft.EntityFrameworkCore.Query.Internal.IQueryBuffer> queryBufferFactory, Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> stateManager, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryContext",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> get_StateManager()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsBuilderInfrastructure",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder ConfigureWarnings(System.Action<Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder> warningsConfigurationBuilderAction)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsBuilderInfrastructure",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder EnableSensitiveDataLogging()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> : Microsoft.EntityFrameworkCore.DbContextOptionsBuilder where T0 : Microsoft.EntityFrameworkCore.DbContext",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> ConfigureWarnings(System.Action<Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder> warningsConfigurationBuilderAction)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> : Microsoft.EntityFrameworkCore.DbContextOptionsBuilder where T0 : Microsoft.EntityFrameworkCore.DbContext",
-    "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> EnableSensitiveDataLogging()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "System.Boolean get_RequiresValueGenerator()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "System.Void set_RequiresValueGenerator(System.Boolean value)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
-    "MemberId": "System.Boolean get_RequiresValueGenerator()",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "System.Void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IModel : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IEntityType definingEntityType)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType get_DefiningEntityType()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "System.Linq.Expressions.LambdaExpression get_QueryFilter()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
-    "MemberId": "System.String get_DefiningNavigationName()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Infrastructure.IModelValidator validator)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType AddDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType AddDelegatedIdentityEntityType(System.Type clrType, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType RemoveDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_AfterSaveBehavior()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_BeforeSaveBehavior()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "System.Void set_AfterSaveBehavior(Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior value)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
-    "MemberId": "System.Void set_BeforeSaveBehavior(Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior value)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_AfterSaveBehavior()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
-    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_BeforeSaveBehavior()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "System.Boolean ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "System.Int64 GetServiceProviderHashCode()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
-    "MemberId": "System.Void Validate(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IForeignKey : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
-    "MemberId": "System.Boolean get_IsOwnership()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "System.Boolean get_IsOwnership()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
-    "MemberId": "System.Void set_IsOwnership(System.Boolean value)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction : System.IDisposable",
-    "MemberId": "System.Guid get_TransactionId()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
-    "MemberId": "System.Linq.Expressions.LambdaExpression get_QueryFilter()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
-    "MemberId": "System.Void set_QueryFilter(System.Linq.Expressions.LambdaExpression value)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
-    "MemberId": "System.String get_InvariantName()",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDesignTimeServices",
-    "Kind": "Removal"
-  },
-  {
-    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.DesignTimeProviderServicesAttribute : System.Attribute",
-    "Kind": "Removal"
-  }
-]
+  [
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.DatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkServicesBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.Extensions.DependencyInjection.IServiceCollection>",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SensitiveDataLogger<T0> : Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<T0>",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DatabaseErrorLogState",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DatabaseProvider<T0, T1> : Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider where T0 : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices, class where T1 : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension, class",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public enum Microsoft.EntityFrameworkCore.Infrastructure.CoreEventId",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDesignTimeServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger : Microsoft.Extensions.Logging.ILogger",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger<T0> : Microsoft.Extensions.Logging.ILogger<T0>, Microsoft.EntityFrameworkCore.Infrastructure.ISensitiveDataLogger",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.DesignTimeProviderServicesAttribute : System.Attribute",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IPropertyBase : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType get_DeclaringEntityType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel get_Model()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "System.String get_Name()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "System.Type get_ClrType()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices GetProviderServices(System.IServiceProvider serviceProvider)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public enum Microsoft.EntityFrameworkCore.Metadata.ValueGenerated",
+      "MemberId": "OnAddOrUpdate = 2",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorCache : Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache",
+      "MemberId": "protected .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector get_ConcurrencyDetector()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IChangeDetector> get_ChangeDetector()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.QueryContextFactory : Microsoft.EntityFrameworkCore.Query.IQueryContextFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> get_StateManager()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Internal.IDbSetFinder setFinder, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ICoreConventionSetBuilder coreConventionSetBuilder, Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer modelCustomizer, Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory modelCacheKeyFactory)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory get_ModelCacheKeyFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer get_ModelCustomizer()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IDbSetFinder get_SetFinder()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.ICoreConventionSetBuilder get_CoreConventionSetBuilder()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.IModel CreateModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "public Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Internal.IModelValidator validator)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource get_EntityMaterializerSource()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory get_EntityQueryableExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory get_EntityResultFindingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory get_MemberAccessBindingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory get_NavigationRewritingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory get_OrderingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory get_QuerySourceTracingExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor get_SubQueryMemberPushDownExpressionVisitor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor get_TaskBlockingExpressionVisitor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory get_ProjectionExpressionVisitorFactory()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter get_ExpressionPrinter()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor get_QueryAnnotationExtractor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer get_QueryOptimizer()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorFactory : Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler get_ResultOperatorHandler()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter, Microsoft.EntityFrameworkCore.Query.QueryCompilationContext queryCompilationContext)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "protected virtual System.Void IncludeNavigations(Microsoft.EntityFrameworkCore.Query.IncludeSpecification includeSpecification, System.Type resultType, System.Linq.Expressions.Expression accessorExpression, System.Boolean querySourceRequiresTracking)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "protected virtual System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "protected virtual System.Void IncludeNavigations(Remotion.Linq.QueryModel queryModel, System.Collections.Generic.IReadOnlyCollection<Microsoft.EntityFrameworkCore.Query.IncludeSpecification> includeSpecifications)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "protected virtual System.Void OptimizeQueryModel(Remotion.Linq.QueryModel queryModel)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "public static System.Boolean IsPropertyMethod(System.Reflection.MethodInfo methodInfo)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "public static System.Linq.Expressions.Expression CreatePropertyExpression(System.Linq.Expressions.Expression target, Microsoft.EntityFrameworkCore.Metadata.IProperty property)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "public virtual System.Linq.Expressions.Expression BindReadValueMethod(System.Type memberType, System.Linq.Expressions.Expression expression, System.Int32 index)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "public virtual System.Void AddOrUpdateMapping(Remotion.Linq.Clauses.IQuerySource querySource, System.Linq.Expressions.Expression expression)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor : Remotion.Linq.QueryModelVisitorBase",
+      "MemberId": "public virtual T0 BindNavigationPathPropertyExpression<T0>(System.Linq.Expressions.Expression propertyExpression, System.Func<System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IPropertyBase>, Remotion.Linq.Clauses.IQuerySource, T0> propertyBinder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.Database : Microsoft.EntityFrameworkCore.Storage.IDatabase",
+      "MemberId": "protected .ctor(Microsoft.EntityFrameworkCore.Query.IQueryCompilationContextFactory queryCompilationContextFactory)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<T0> : Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder where T0 : class",
+      "MemberId": "protected override Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder New(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder builder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ExpressionVisitorBase : Remotion.Linq.Parsing.RelinqExpressionVisitor",
+      "MemberId": "protected override System.Linq.Expressions.Expression VisitExtension(System.Linq.Expressions.Expression node)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.ExpressionVisitorBase : Remotion.Linq.Parsing.RelinqExpressionVisitor",
+      "MemberId": "public override System.Linq.Expressions.Expression Visit(System.Linq.Expressions.Expression node)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.ChangeTracking.NavigationEntry : Microsoft.EntityFrameworkCore.ChangeTracking.MemberEntry",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Internal.IEntityFinder Finder(System.Type entityType)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder New(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder builder)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasManyBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.Reflection.PropertyInfo navigationProperty)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasManyBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.String navigationName)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasOneBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.Reflection.PropertyInfo navigationProperty)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalEntityTypeBuilder>",
+      "MemberId": "protected virtual Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder HasOneBuilder(Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType, System.String navigationName)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategy : Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy",
+      "MemberId": "protected virtual Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> get_Logger()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.ResultOperatorHandler : Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.ModelCacheKeyFactory : Microsoft.EntityFrameworkCore.Infrastructure.IModelCacheKeyFactory",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.ModelCustomizer : Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> logger)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ExecutionStrategyContext",
+      "MemberId": "public virtual Microsoft.Extensions.Logging.ILogger<Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy> get_Logger()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.CompiledQueryCacheKeyGenerator : Microsoft.EntityFrameworkCore.Query.ICompiledQueryCacheKeyGenerator",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.Extensions.Logging.ILogger logger, Microsoft.EntityFrameworkCore.Query.IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.ILinqOperatorProvider linqOperatorProvider, System.Type contextType, System.Boolean trackQueryResults)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
+      "MemberId": "public virtual Microsoft.Extensions.Logging.ILogger get_Logger()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder builder, Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType declaringEntityType, Microsoft.EntityFrameworkCore.Metadata.Internal.EntityType relatedEntityType)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder HasForeignKey<T0>(params System.String[] foreignKeyPropertyNames) where T0 : class",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder HasPrincipalKey<T0>(params System.String[] keyPropertyNames) where T0 : class",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public struct Microsoft.EntityFrameworkCore.Query.EntityLoadInfo",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.ValueBuffer valueBuffer, System.Func<Microsoft.EntityFrameworkCore.Storage.ValueBuffer, System.Object> materializer)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.ValueGeneration.ValueGeneratorSelector : Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorSelector",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.ValueGeneration.IValueGeneratorCache cache)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public struct Microsoft.EntityFrameworkCore.Storage.ValueBuffer",
+      "MemberId": "public .ctor(System.Collections.Generic.IList<System.Object> values)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public struct Microsoft.EntityFrameworkCore.Storage.ValueBuffer",
+      "MemberId": "public .ctor(System.Collections.Generic.IList<System.Object> values, System.Int32 offset)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public .ctor(System.Func<Microsoft.EntityFrameworkCore.Query.Internal.IQueryBuffer> queryBufferFactory, Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> stateManager, Microsoft.EntityFrameworkCore.Internal.IConcurrencyDetector concurrencyDetector)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryContext",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Internal.LazyRef<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager> get_StateManager()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsBuilderInfrastructure",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder ConfigureWarnings(System.Action<Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder> warningsConfigurationBuilderAction)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsBuilderInfrastructure",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder EnableSensitiveDataLogging()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> : Microsoft.EntityFrameworkCore.DbContextOptionsBuilder where T0 : Microsoft.EntityFrameworkCore.DbContext",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> ConfigureWarnings(System.Action<Microsoft.EntityFrameworkCore.Infrastructure.WarningsConfigurationBuilder> warningsConfigurationBuilderAction)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> : Microsoft.EntityFrameworkCore.DbContextOptionsBuilder where T0 : Microsoft.EntityFrameworkCore.DbContext",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<T0> EnableSensitiveDataLogging()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Boolean get_RequiresValueGenerator()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Void set_RequiresValueGenerator(System.Boolean value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
+      "MemberId": "System.Boolean get_RequiresValueGenerator()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "System.Void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IModel : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IEntityType definingEntityType)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IEntityType get_DefiningEntityType()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "System.Linq.Expressions.LambdaExpression get_QueryFilter()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "System.String get_DefiningNavigationName()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IModel GetModel(Microsoft.EntityFrameworkCore.DbContext context, Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IConventionSetBuilder conventionSetBuilder, Microsoft.EntityFrameworkCore.Infrastructure.IModelValidator validator)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType AddDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType AddDelegatedIdentityEntityType(System.Type clrType, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType FindDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType RemoveDelegatedIdentityEntityType(System.String name, System.String definingNavigationName, Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType definingEntityType)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_AfterSaveBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_BeforeSaveBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Void set_AfterSaveBehavior(Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableProperty : Microsoft.EntityFrameworkCore.Metadata.IProperty, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Void set_BeforeSaveBehavior(Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_AfterSaveBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IProperty : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.PropertyValueBehavior get_BeforeSaveBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "System.Boolean ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "System.Int64 GetServiceProviderHashCode()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "System.Void Validate(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IForeignKey : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "System.Boolean get_IsOwnership()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "System.Boolean get_IsOwnership()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "System.Void set_IsOwnership(System.Boolean value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction : System.IDisposable",
+      "MemberId": "System.Guid get_TransactionId()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+      "MemberId": "System.Linq.Expressions.LambdaExpression get_QueryFilter()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+      "MemberId": "System.Void set_QueryFilter(System.Linq.Expressions.LambdaExpression value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
+      "MemberId": "System.String get_InvariantName()",
+      "Kind": "Addition"
+    }
+  ]

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
@@ -81,11 +81,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 return result;
             }
 
-            int IRelationalCommand.ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            {
-                throw new System.NotImplementedException();
-            }
-
             public Task<int> ExecuteNonQueryAsync(
                 IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
             {
@@ -98,11 +93,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                     throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
                 }
                 return result;
-            }
-
-            Task<int> IRelationalCommand.ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new System.NotImplementedException();
             }
 
             public object ExecuteScalar(
@@ -119,11 +109,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 return result;
             }
 
-            object IRelationalCommand.ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            {
-                throw new System.NotImplementedException();
-            }
-
             public async Task<object> ExecuteScalarAsync(
                 IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
             {
@@ -136,11 +121,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                     throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
                 }
                 return result;
-            }
-
-            Task<object> IRelationalCommand.ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new System.NotImplementedException();
             }
 
             public RelationalDataReader ExecuteReader(
@@ -157,11 +137,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 return result;
             }
 
-            RelationalDataReader IRelationalCommand.ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            {
-                throw new System.NotImplementedException();
-            }
-
             public async Task<RelationalDataReader> ExecuteReaderAsync(
                 IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = new CancellationToken())
             {
@@ -174,11 +149,6 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                     throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
                 }
                 return result;
-            }
-
-            Task<RelationalDataReader> IRelationalCommand.ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new System.NotImplementedException();
             }
 
             private int? PreExecution(IRelationalConnection connection)

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -228,30 +228,10 @@ namespace Microsoft.EntityFrameworkCore
                 return 0;
             }
 
-            int IRelationalCommand.ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-            {
-                throw new NotImplementedException();
-            }
-
             public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                 => Task.FromResult(0);
 
-            Task<int> IRelationalCommand.ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
-            Task<object> IRelationalCommand.ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
             public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
-            {
-                throw new NotImplementedException();
-            }
-
-            RelationalDataReader IRelationalCommand.ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
             {
                 throw new NotImplementedException();
             }
@@ -261,17 +241,7 @@ namespace Microsoft.EntityFrameworkCore
                 throw new NotImplementedException();
             }
 
-            Task<RelationalDataReader> IRelationalCommand.ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
             public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
-            {
-                throw new NotImplementedException();
-            }
-
-            object IRelationalCommand.ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
             {
                 throw new NotImplementedException();
             }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -235,17 +235,7 @@ namespace Microsoft.EntityFrameworkCore
                     throw new NotImplementedException();
                 }
 
-                int IRelationalCommand.ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-                {
-                    throw new NotImplementedException();
-                }
-
                 public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
-                {
-                    throw new NotImplementedException();
-                }
-
-                Task<int> IRelationalCommand.ExecuteNonQueryAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
                 {
                     throw new NotImplementedException();
                 }
@@ -253,35 +243,15 @@ namespace Microsoft.EntityFrameworkCore
                 public object ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
                     => Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize);
 
-                object IRelationalCommand.ExecuteScalar(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-                {
-                    throw new NotImplementedException();
-                }
-
                 public Task<object> ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
                     => Task.FromResult<object>(Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize));
-
-                Task<object> IRelationalCommand.ExecuteScalarAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
-                {
-                    throw new NotImplementedException();
-                }
 
                 public RelationalDataReader ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
                 {
                     throw new NotImplementedException();
                 }
 
-                RelationalDataReader IRelationalCommand.ExecuteReader(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection)
-                {
-                    throw new NotImplementedException();
-                }
-
                 public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, CancellationToken cancellationToken = default(CancellationToken))
-                {
-                    throw new NotImplementedException();
-                }
-
-                Task<RelationalDataReader> IRelationalCommand.ExecuteReaderAsync(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues, bool manageConnection, CancellationToken cancellationToken)
                 {
                     throw new NotImplementedException();
                 }


### PR DESCRIPTION
These things were made obsolete for binary compat in 1.1 releases. They can now be removed.

Issue #8490
