### PR TITLE
Revert back to parameter logging format from v1 and update test baselines

### DIFF
--- a/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
+++ b/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             builder
                 .Append(name)
-                .Append(": ");
+                .Append("=");
 
             FormatParameterValue(builder, value);
 
@@ -128,6 +128,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private static void FormatParameterValue(StringBuilder builder, object parameterValue)
         {
+            builder.Append('\'');
+
             if (parameterValue?.GetType() != typeof(byte[]))
             {
                 builder.Append(Convert.ToString(parameterValue, CultureInfo.InvariantCulture));
@@ -147,6 +149,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     builder.Append(buffer[i].ToString("X2", CultureInfo.InvariantCulture));
                 }
             }
+
+            builder.Append('\'');
         }
 
         private static bool IsNormalDbType(DbType dbType, Type clrType)

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -933,7 +933,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             foreach (var item in log)
             {
                 Assert.EndsWith(
-                    @"[Parameters=[FirstParameter: ?], CommandType='0', CommandTimeout='30']
+                    @"[Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']
 Logged Command",
                     item.Item2.Replace(Environment.NewLine, FileLineEnding));
             }
@@ -989,7 +989,7 @@ Logged Command",
             foreach (var item in log.Skip(1))
             {
                 Assert.EndsWith(
-                    @"[Parameters=[FirstParameter: 17], CommandType='0', CommandTimeout='30']
+                    @"[Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']
 Logged Command",
                     item.Item2.Replace(Environment.NewLine, FileLineEnding));
             }

--- a/test/EFCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Utilities/RelationalLoggerExtensionsTest.cs
@@ -18,12 +18,12 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             var longerShortArray = shortArray.Concat(shortArray).ToArray();
 
             Assert.Equal(
-                "@param: 0x2020EC21EA3A6940A2DD08002B30309D",
+                "@param='0x2020EC21EA3A6940A2DD08002B30309D'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", shortArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0));
 
             Assert.Equal(
-                "@param: 0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D",
+                "@param='0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", longerShortArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0));
         }
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             var longArray = shortArray.Concat(shortArray).Concat(shortArray).ToArray();
 
             Assert.Equal(
-                "@param: 0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...",
+                "@param='0x2020EC21EA3A6940A2DD08002B30309D2020EC21EA3A6940A2DD08002B30309D...'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", longArray, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0));
         }
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_string_parameter()
         {
             Assert.Equal(
-                "@param: Muffin",
+                "@param='Muffin'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Input, DbType.String, true, 0, 0, 0));
         }
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Format_parameter_with_direction()
         {
             Assert.Equal(
-                "@param: Muffin (Direction = Output)",
+                "@param='Muffin' (Direction = Output)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Output, DbType.String, true, 0, 0, 0));
         }
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_non_nullable_string_parameter()
         {
             Assert.Equal(
-                "@param: Muffin (Nullable = false)",
+                "@param='Muffin' (Nullable = false)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Input, DbType.String, false, 0, 0, 0));
         }
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_non_unicode_string_parameter()
         {
             Assert.Equal(
-                "@param: Muffin (DbType = AnsiString)",
+                "@param='Muffin' (DbType = AnsiString)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0));
         }
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_non_unicode_non_nullable_string_parameter()
         {
             Assert.Equal(
-                "@param: Muffin (Nullable = false) (DbType = AnsiString)",
+                "@param='Muffin' (Nullable = false) (DbType = AnsiString)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 0, 0, 0));
         }
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_non_unicode_non_nullable_sized_string_parameter()
         {
             Assert.Equal(
-                "@param: Muffin (Nullable = false) (Size = 100) (DbType = AnsiString)",
+                "@param='Muffin' (Nullable = false) (Size = 100) (DbType = AnsiString)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "Muffin", true, ParameterDirection.Input, DbType.AnsiString, false, 100, 0, 0));
         }
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_null_string_parameter()
         {
             Assert.Equal(
-                "@param:  (DbType = String)",
+                "@param='' (DbType = String)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", null, true, ParameterDirection.Input, DbType.String, true, 0, 0, 0));
         }
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_null_non_unicode_string_parameter()
         {
             Assert.Equal(
-                "@param:  (DbType = AnsiString)",
+                "@param='' (DbType = AnsiString)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", null, true, ParameterDirection.Input, DbType.AnsiString, true, 0, 0, 0));
         }
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_string_parameter()
         {
             Assert.Equal(
-                "@param: ?",
+                "@param='?'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.String, true, 0, 0, 0));
         }
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_non_nullable_string_parameter()
         {
             Assert.Equal(
-                "@param: ?",
+                "@param='?'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.String, false, 0, 0, 0));
         }
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_int_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", 777, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0));
         }
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_nullable_int_parameter()
         {
             Assert.Equal(
-                "@param: 777 (Nullable = true)",
+                "@param='777' (Nullable = true)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", 777, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0));
         }
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_int_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", 777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_int_parameter_with_no_type()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", 777, true, ParameterDirection.Input, 0, false, 0, 0, 0));
         }
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_null_nullable_int_parameter()
         {
             Assert.Equal(
-                "@param:  (DbType = Int32)",
+                "@param='' (DbType = Int32)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", null, true, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0));
         }
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_int_parameter()
         {
             Assert.Equal(
-                "@param: ?",
+                "@param='?'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0));
         }
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_nullable_int_parameter()
         {
             Assert.Equal(
-                "@param: ?",
+                "@param='?'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0));
         }
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_short_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (short)777, true, ParameterDirection.Input, DbType.Int16, false, 0, 0, 0));
         }
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_short_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (short)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_long_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (long)777, true, ParameterDirection.Input, DbType.Int64, false, 0, 0, 0));
         }
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_long_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (long)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_byte_parameter()
         {
             Assert.Equal(
-                "@param: 77",
+                "@param='77'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (byte)77, true, ParameterDirection.Input, DbType.Byte, false, 0, 0, 0));
         }
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_byte_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 77 (DbType = VarNumeric)",
+                "@param='77' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (byte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -251,7 +251,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_uint_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (uint)777, true, ParameterDirection.Input, DbType.UInt32, false, 0, 0, 0));
         }
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_uint_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (uint)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_ushort_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (ushort)777, true, ParameterDirection.Input, DbType.UInt16, false, 0, 0, 0));
         }
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_ushort_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (ushort)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_ulong_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (ulong)777, true, ParameterDirection.Input, DbType.UInt64, false, 0, 0, 0));
         }
@@ -296,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_ulong_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (ulong)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -305,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sbyte_parameter()
         {
             Assert.Equal(
-                "@param: 77",
+                "@param='77'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (sbyte)77, true, ParameterDirection.Input, DbType.SByte, false, 0, 0, 0));
         }
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sbyte_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 77 (DbType = VarNumeric)",
+                "@param='77' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (sbyte)77, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -323,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_binary_parameter()
         {
             Assert.Equal(
-                "@param: 0x0102",
+                "@param='0x0102'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Binary, true, 0, 0, 0));
         }
@@ -332,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_binary_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 0x0102 (DbType = Object)",
+                "@param='0x0102' (DbType = Object)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new byte[] { 1, 2 }, true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0));
         }
@@ -341,7 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_bool_parameter()
         {
             Assert.Equal(
-                "@param: True",
+                "@param='True'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", true, true, ParameterDirection.Input, DbType.Boolean, false, 0, 0, 0));
         }
@@ -350,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_bool_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: True (DbType = Int32)",
+                "@param='True' (DbType = Int32)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", true, true, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0));
         }
@@ -359,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_decimal_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (decimal)777, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 0));
         }
@@ -368,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_decimal_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (decimal)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -377,7 +377,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_decimal_parameter_with_precision()
         {
             Assert.Equal(
-                "@param: 77.7 (Precision = 18)",
+                "@param='77.7' (Precision = 18)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 0));
         }
@@ -386,7 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_decimal_parameter_with_scale()
         {
             Assert.Equal(
-                "@param: 77.7 (Scale = 2)",
+                "@param='77.7' (Scale = 2)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 0, 2));
         }
@@ -395,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_decimal_parameter_with_precision_and_scale()
         {
             Assert.Equal(
-                "@param: 77.7 (Precision = 18) (Scale = 2)",
+                "@param='77.7' (Precision = 18) (Scale = 2)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (decimal)77.7, true, ParameterDirection.Input, DbType.Decimal, false, 0, 18, 2));
         }
@@ -404,7 +404,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_double_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (double)777, true, ParameterDirection.Input, DbType.Double, false, 0, 0, 0));
         }
@@ -413,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_double_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (double)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -422,7 +422,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_float_parameter()
         {
             Assert.Equal(
-                "@param: 777",
+                "@param='777'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (float)777, true, ParameterDirection.Input, DbType.Single, false, 0, 0, 0));
         }
@@ -431,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_float_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 777 (DbType = VarNumeric)",
+                "@param='777' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", (float)777, true, ParameterDirection.Input, DbType.VarNumeric, false, 0, 0, 0));
         }
@@ -440,7 +440,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_Guid_parameter()
         {
             Assert.Equal(
-                "@param: 304afb2a-8b8c-49ac-996e-8561f7559a3f",
+                "@param='304afb2a-8b8c-49ac-996e-8561f7559a3f'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
                     true, ParameterDirection.Input, DbType.Guid, false, 0, 0, 0));
@@ -450,7 +450,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_Guid_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 304afb2a-8b8c-49ac-996e-8561f7559a3f (DbType = Binary)",
+                "@param='304afb2a-8b8c-49ac-996e-8561f7559a3f' (DbType = Binary)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", Guid.Parse("304afb2a-8b8c-49ac-996e-8561f7559a3f"),
                     true, ParameterDirection.Input, DbType.Binary, false, 0, 0, 0));
@@ -460,7 +460,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_object_parameter()
         {
             Assert.Equal(
-                "@param: System.Object",
+                "@param='System.Object'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new object(), true, ParameterDirection.Input, DbType.Object, true, 0, 0, 0));
         }
@@ -469,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_object_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: System.Object (DbType = VarNumeric)",
+                "@param='System.Object' (DbType = VarNumeric)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new object(), true, ParameterDirection.Input, DbType.VarNumeric, true, 0, 0, 0));
         }
@@ -478,7 +478,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_DateTime_parameter()
         {
             Assert.Equal(
-                "@param: 09/03/1973 00:00:00",
+                "@param='09/03/1973 00:00:00'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime2, false, 0, 0, 0));
         }
@@ -487,7 +487,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_DateTime_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 09/03/1973 00:00:00 (DbType = DateTime)",
+                "@param='09/03/1973 00:00:00' (DbType = DateTime)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new DateTime(1973, 9, 3), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0));
         }
@@ -496,7 +496,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_DateTimeOffset_parameter()
         {
             Assert.Equal(
-                "@param: 09/03/1973 00:00:00 -08:00",
+                "@param='09/03/1973 00:00:00 -08:00'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
                     true, ParameterDirection.Input, DbType.DateTimeOffset, false, 0, 0, 0));
@@ -506,7 +506,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_DateTimeOffset_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: 09/03/1973 00:00:00 -08:00 (DbType = Date)",
+                "@param='09/03/1973 00:00:00 -08:00' (DbType = Date)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new DateTimeOffset(new DateTime(1973, 9, 3), new TimeSpan(-8, 0, 0)),
                     true, ParameterDirection.Input, DbType.Date, false, 0, 0, 0));
@@ -516,7 +516,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_TimeSpan_parameter()
         {
             Assert.Equal(
-                "@param: -08:00:00",
+                "@param='-08:00:00'",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.Time, false, 0, 0, 0));
         }
@@ -525,7 +525,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_TimeSpan_parameter_with_unusual_type()
         {
             Assert.Equal(
-                "@param: -08:00:00 (DbType = DateTime)",
+                "@param='-08:00:00' (DbType = DateTime)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", new TimeSpan(-8, 0, 0), true, ParameterDirection.Input, DbType.DateTime, false, 0, 0, 0));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -67,7 +67,7 @@ WHERE [e].[Time] = '00:01:02'",
 
                 Assert.Equal(0, results.Count);
                 Assert.Equal(
-                    @"@__timeSpan_0: 02:01:00
+                    @"@__timeSpan_0='02:01:00'
 
 SELECT [e].[Int]
 FROM [MappedNullableDataTypes] AS [e]
@@ -323,36 +323,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 77
-@p1: 78
-@p2: 0x5D5E5F60 (Nullable = false) (Size = 8000)
-@p3: True
-@p4: Your (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p5: strong (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p6: 01/02/2015 10:11:12 (DbType = DateTime)
-@p7: 01/02/2019 14:11:12 (DbType = DateTime)
-@p8: 01/02/2017 12:11:12
-@p9: 01/02/2016 11:11:12 +00:00
-@p10: 102.2
-@p11: 101.1
-@p12: 85.5
-@p13: 83.3
-@p14: 0x61626364 (Nullable = false) (Size = 8000)
-@p15: 81.1
-@p16: help (Nullable = false) (Size = 4000)
-@p17: anyone! (Nullable = false) (Size = 4000)
-@p18: Gumball Rules OK! (Nullable = false) (Size = 4000)
-@p19: 103.3
-@p20: don't (Nullable = false) (Size = 4000)
-@p21: 84.4
-@p22: 01/02/2018 13:11:12 (DbType = DateTime)
-@p23: 79
-@p24: 82.2
-@p25: Gumball Rules! (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p26: 11:15:12
-@p27: 80 (Size = 1)
-@p28: 0x595A5B5C (Nullable = false) (Size = 8000)
-@p29: C (Nullable = false) (Size = 8000) (DbType = AnsiString)",
+                @"@p0='77'
+@p1='78'
+@p2='0x5D5E5F60' (Nullable = false) (Size = 8000)
+@p3='True'
+@p4='Your' (Nullable = false) (Size = 8000) (DbType = AnsiString)
+@p5='strong' (Nullable = false) (Size = 8000) (DbType = AnsiString)
+@p6='01/02/2015 10:11:12' (DbType = DateTime)
+@p7='01/02/2019 14:11:12' (DbType = DateTime)
+@p8='01/02/2017 12:11:12'
+@p9='01/02/2016 11:11:12 +00:00'
+@p10='102.2'
+@p11='101.1'
+@p12='85.5'
+@p13='83.3'
+@p14='0x61626364' (Nullable = false) (Size = 8000)
+@p15='81.1'
+@p16='help' (Nullable = false) (Size = 4000)
+@p17='anyone!' (Nullable = false) (Size = 4000)
+@p18='Gumball Rules OK!' (Nullable = false) (Size = 4000)
+@p19='103.3'
+@p20='don't' (Nullable = false) (Size = 4000)
+@p21='84.4'
+@p22='01/02/2018 13:11:12' (DbType = DateTime)
+@p23='79'
+@p24='82.2'
+@p25='Gumball Rules!' (Nullable = false) (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12'
+@p27='80' (Size = 1)
+@p28='0x595A5B5C' (Nullable = false) (Size = 8000)
+@p29='C' (Nullable = false) (Size = 8000) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -445,36 +445,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 77
-@p1: 78 (Nullable = true)
-@p2: 0x5D5E5F60 (Size = 8000)
-@p3: True (Nullable = true)
-@p4: Your (Size = 8000) (DbType = AnsiString)
-@p5: strong (Size = 8000) (DbType = AnsiString)
-@p6: 01/02/2015 10:11:12 (Nullable = true) (DbType = DateTime)
-@p7: 01/02/2019 14:11:12 (Nullable = true) (DbType = DateTime)
-@p8: 01/02/2017 12:11:12 (Nullable = true)
-@p9: 01/02/2016 11:11:12 +00:00 (Nullable = true)
-@p10: 102.2 (Nullable = true)
-@p11: 101.1 (Nullable = true)
-@p12: 85.5 (Nullable = true)
-@p13: 83.3 (Nullable = true)
-@p14: 0x61626364 (Size = 8000)
-@p15: 81.1 (Nullable = true)
-@p16: help (Size = 4000)
-@p17: anyone! (Size = 4000)
-@p18: Gumball Rules OK! (Size = 4000)
-@p19: 103.3 (Nullable = true)
-@p20: don't (Size = 4000)
-@p21: 84.4 (Nullable = true)
-@p22: 01/02/2018 13:11:12 (Nullable = true) (DbType = DateTime)
-@p23: 79 (Nullable = true)
-@p24: 82.2 (Nullable = true)
-@p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
-@p26: 11:15:12 (Nullable = true)
-@p27: 80 (Nullable = true) (Size = 1)
-@p28: 0x595A5B5C (Size = 8000)
-@p29: C (Size = 8000) (DbType = AnsiString)",
+                @"@p0='77'
+@p1='78' (Nullable = true)
+@p2='0x5D5E5F60' (Size = 8000)
+@p3='True' (Nullable = true)
+@p4='Your' (Size = 8000) (DbType = AnsiString)
+@p5='strong' (Size = 8000) (DbType = AnsiString)
+@p6='01/02/2015 10:11:12' (Nullable = true) (DbType = DateTime)
+@p7='01/02/2019 14:11:12' (Nullable = true) (DbType = DateTime)
+@p8='01/02/2017 12:11:12' (Nullable = true)
+@p9='01/02/2016 11:11:12 +00:00' (Nullable = true)
+@p10='102.2' (Nullable = true)
+@p11='101.1' (Nullable = true)
+@p12='85.5' (Nullable = true)
+@p13='83.3' (Nullable = true)
+@p14='0x61626364' (Size = 8000)
+@p15='81.1' (Nullable = true)
+@p16='help' (Size = 4000)
+@p17='anyone!' (Size = 4000)
+@p18='Gumball Rules OK!' (Size = 4000)
+@p19='103.3' (Nullable = true)
+@p20='don't' (Size = 4000)
+@p21='84.4' (Nullable = true)
+@p22='01/02/2018 13:11:12' (Nullable = true) (DbType = DateTime)
+@p23='79' (Nullable = true)
+@p24='82.2' (Nullable = true)
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12' (Nullable = true)
+@p27='80' (Nullable = true) (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -564,36 +564,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 78
-@p1:  (DbType = Int64)
-@p2:  (Size = 8000) (DbType = Binary)
-@p3:  (DbType = String)
-@p4:  (Size = 8000)
-@p5:  (Size = 8000)
-@p6:  (DbType = DateTime)
-@p7:  (DbType = DateTime)
-@p8:  (DbType = DateTime2)
-@p9:  (DbType = String)
-@p10:  (DbType = String)
-@p11:  (DbType = String)
-@p12:  (DbType = String)
-@p13:  (DbType = String)
-@p14:  (Size = 8000) (DbType = Binary)
-@p15:  (DbType = String)
-@p16:  (Size = 4000) (DbType = String)
-@p17:  (Size = 4000) (DbType = String)
-@p18:  (Size = 4000) (DbType = String)
-@p19:  (DbType = String)
-@p20:  (Size = 4000) (DbType = String)
-@p21:  (DbType = String)
-@p22:  (DbType = DateTime)
-@p23:  (DbType = Int16)
-@p24:  (DbType = String)
-@p25:  (Size = 8000)
-@p26:  (DbType = String)
-@p27:  (DbType = Byte)
-@p28:  (Size = 8000) (DbType = Binary)
-@p29:  (Size = 8000)",
+                @"@p0='78'
+@p1='' (DbType = Int64)
+@p2='' (Size = 8000) (DbType = Binary)
+@p3='' (DbType = String)
+@p4='' (Size = 8000)
+@p5='' (Size = 8000)
+@p6='' (DbType = DateTime)
+@p7='' (DbType = DateTime)
+@p8='' (DbType = DateTime2)
+@p9='' (DbType = String)
+@p10='' (DbType = String)
+@p11='' (DbType = String)
+@p12='' (DbType = String)
+@p13='' (DbType = String)
+@p14='' (Size = 8000) (DbType = Binary)
+@p15='' (DbType = String)
+@p16='' (Size = 4000) (DbType = String)
+@p17='' (Size = 4000) (DbType = String)
+@p18='' (Size = 4000) (DbType = String)
+@p19='' (DbType = String)
+@p20='' (Size = 4000) (DbType = String)
+@p21='' (DbType = String)
+@p22='' (DbType = DateTime)
+@p23='' (DbType = Int16)
+@p24='' (DbType = String)
+@p25='' (Size = 8000)
+@p26='' (DbType = String)
+@p27='' (DbType = Byte)
+@p28='' (Size = 8000) (DbType = Binary)
+@p29='' (Size = 8000)",
                 parameters);
 
             using (var context = CreateContext())
@@ -648,20 +648,20 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 77
-@p1: 0x0A0B0C (Size = 3)
-@p2: 0x0C0D0E (Size = 3)
-@p3: Wor (Size = 3) (DbType = AnsiStringFixedLength)
-@p4: Thr (Size = 3) (DbType = AnsiString)
-@p5: Lon (Size = 3) (DbType = AnsiStringFixedLength)
-@p6: Let (Size = 3) (DbType = AnsiString)
-@p7: The (Size = 3)
-@p8: Squ (Size = 3) (DbType = StringFixedLength)
-@p9: Col (Size = 3)
-@p10: Won (Size = 3) (DbType = StringFixedLength)
-@p11: Int (Size = 3)
-@p12: 0x0B0C0D (Size = 3)
-@p13: Tha (Size = 3) (DbType = AnsiString)",
+                @"@p0='77'
+@p1='0x0A0B0C' (Size = 3)
+@p2='0x0C0D0E' (Size = 3)
+@p3='Wor' (Size = 3) (DbType = AnsiStringFixedLength)
+@p4='Thr' (Size = 3) (DbType = AnsiString)
+@p5='Lon' (Size = 3) (DbType = AnsiStringFixedLength)
+@p6='Let' (Size = 3) (DbType = AnsiString)
+@p7='The' (Size = 3)
+@p8='Squ' (Size = 3) (DbType = StringFixedLength)
+@p9='Col' (Size = 3)
+@p10='Won' (Size = 3) (DbType = StringFixedLength)
+@p11='Int' (Size = 3)
+@p12='0x0B0C0D' (Size = 3)
+@p13='Tha' (Size = 3) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -719,20 +719,20 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 78
-@p1:  (Size = 3) (DbType = Binary)
-@p2:  (Size = 3) (DbType = Binary)
-@p3:  (Size = 3) (DbType = AnsiStringFixedLength)
-@p4:  (Size = 3)
-@p5:  (Size = 3) (DbType = AnsiStringFixedLength)
-@p6:  (Size = 3)
-@p7:  (Size = 3) (DbType = String)
-@p8:  (Size = 3) (DbType = StringFixedLength)
-@p9:  (Size = 3) (DbType = String)
-@p10:  (Size = 3) (DbType = StringFixedLength)
-@p11:  (Size = 3) (DbType = String)
-@p12:  (Size = 3) (DbType = Binary)
-@p13:  (Size = 3)",
+                @"@p0='78'
+@p1='' (Size = 3) (DbType = Binary)
+@p2='' (Size = 3) (DbType = Binary)
+@p3='' (Size = 3) (DbType = AnsiStringFixedLength)
+@p4='' (Size = 3)
+@p5='' (Size = 3) (DbType = AnsiStringFixedLength)
+@p6='' (Size = 3)
+@p7='' (Size = 3) (DbType = String)
+@p8='' (Size = 3) (DbType = StringFixedLength)
+@p9='' (Size = 3) (DbType = String)
+@p10='' (Size = 3) (DbType = StringFixedLength)
+@p11='' (Size = 3) (DbType = String)
+@p12='' (Size = 3) (DbType = Binary)
+@p13='' (Size = 3)",
                 parameters);
 
             using (var context = CreateContext())
@@ -771,14 +771,14 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 77
-@p1: 01/02/2017 12:11:12
-@p2: 01/02/2016 11:11:12 +00:00
-@p3: 102.2
-@p4: 101.1
-@p5: 85.5
-@p6: 83.3
-@p7: 103.3",
+                @"@p0='77'
+@p1='01/02/2017 12:11:12'
+@p2='01/02/2016 11:11:12 +00:00'
+@p3='102.2'
+@p4='101.1'
+@p5='85.5'
+@p6='83.3'
+@p7='103.3'",
                 parameters);
 
             using (var context = CreateContext())
@@ -824,10 +824,10 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 77
-@p1: 102.2
-@p2: 101.1
-@p3: 103.3",
+                @"@p0='77'
+@p1='102.2'
+@p2='101.1'
+@p3='103.3'",
                 parameters);
 
             using (var context = CreateContext())
@@ -865,36 +865,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 78
-@p1: 0x5D5E5F60 (Size = 8000)
-@p2: True
-@p3: Your (Size = 8000) (DbType = AnsiString)
-@p4: strong (Size = 8000) (DbType = AnsiString)
-@p5: 01/02/2015 10:11:12 (DbType = DateTime)
-@p6: 01/02/2019 14:11:12 (DbType = DateTime)
-@p7: 01/02/2017 12:11:12
-@p8: 01/02/2016 11:11:12 +00:00
-@p9: 102.2
-@p10: 101.1
-@p11: 85.5
-@p12: 83.3
-@p13: 0x61626364 (Size = 8000)
-@p14: 77
-@p15: 81.1
-@p16: help (Size = 4000)
-@p17: anyone! (Size = 4000)
-@p18: Gumball Rules OK! (Size = 4000)
-@p19: 103.3
-@p20: don't (Size = 4000)
-@p21: 84.4
-@p22: 01/02/2018 13:11:12 (DbType = DateTime)
-@p23: 79
-@p24: 82.2
-@p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
-@p26: 11:15:12
-@p27: 80 (Size = 1)
-@p28: 0x595A5B5C (Size = 8000)
-@p29: C (Size = 8000) (DbType = AnsiString)",
+                @"@p0='78'
+@p1='0x5D5E5F60' (Size = 8000)
+@p2='True'
+@p3='Your' (Size = 8000) (DbType = AnsiString)
+@p4='strong' (Size = 8000) (DbType = AnsiString)
+@p5='01/02/2015 10:11:12' (DbType = DateTime)
+@p6='01/02/2019 14:11:12' (DbType = DateTime)
+@p7='01/02/2017 12:11:12'
+@p8='01/02/2016 11:11:12 +00:00'
+@p9='102.2'
+@p10='101.1'
+@p11='85.5'
+@p12='83.3'
+@p13='0x61626364' (Size = 8000)
+@p14='77'
+@p15='81.1'
+@p16='help' (Size = 4000)
+@p17='anyone!' (Size = 4000)
+@p18='Gumball Rules OK!' (Size = 4000)
+@p19='103.3'
+@p20='don't' (Size = 4000)
+@p21='84.4'
+@p22='01/02/2018 13:11:12' (DbType = DateTime)
+@p23='79'
+@p24='82.2'
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12'
+@p27='80' (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -984,36 +984,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 78 (Nullable = true)
-@p1: 0x5D5E5F60 (Size = 8000)
-@p2: True (Nullable = true)
-@p3: Your (Size = 8000) (DbType = AnsiString)
-@p4: strong (Size = 8000) (DbType = AnsiString)
-@p5: 01/02/2015 10:11:12 (Nullable = true) (DbType = DateTime)
-@p6: 01/02/2019 14:11:12 (Nullable = true) (DbType = DateTime)
-@p7: 01/02/2017 12:11:12 (Nullable = true)
-@p8: 01/02/2016 11:11:12 +00:00 (Nullable = true)
-@p9: 102.2 (Nullable = true)
-@p10: 101.1 (Nullable = true)
-@p11: 85.5 (Nullable = true)
-@p12: 83.3 (Nullable = true)
-@p13: 0x61626364 (Size = 8000)
-@p14: 77 (Nullable = true)
-@p15: 81.1 (Nullable = true)
-@p16: help (Size = 4000)
-@p17: anyone! (Size = 4000)
-@p18: Gumball Rules OK! (Size = 4000)
-@p19: 103.3 (Nullable = true)
-@p20: don't (Size = 4000)
-@p21: 84.4 (Nullable = true)
-@p22: 01/02/2018 13:11:12 (Nullable = true) (DbType = DateTime)
-@p23: 79 (Nullable = true)
-@p24: 82.2 (Nullable = true)
-@p25: Gumball Rules! (Size = 8000) (DbType = AnsiString)
-@p26: 11:15:12 (Nullable = true)
-@p27: 80 (Nullable = true) (Size = 1)
-@p28: 0x595A5B5C (Size = 8000)
-@p29: C (Size = 8000) (DbType = AnsiString)",
+                @"@p0='78' (Nullable = true)
+@p1='0x5D5E5F60' (Size = 8000)
+@p2='True' (Nullable = true)
+@p3='Your' (Size = 8000) (DbType = AnsiString)
+@p4='strong' (Size = 8000) (DbType = AnsiString)
+@p5='01/02/2015 10:11:12' (Nullable = true) (DbType = DateTime)
+@p6='01/02/2019 14:11:12' (Nullable = true) (DbType = DateTime)
+@p7='01/02/2017 12:11:12' (Nullable = true)
+@p8='01/02/2016 11:11:12 +00:00' (Nullable = true)
+@p9='102.2' (Nullable = true)
+@p10='101.1' (Nullable = true)
+@p11='85.5' (Nullable = true)
+@p12='83.3' (Nullable = true)
+@p13='0x61626364' (Size = 8000)
+@p14='77' (Nullable = true)
+@p15='81.1' (Nullable = true)
+@p16='help' (Size = 4000)
+@p17='anyone!' (Size = 4000)
+@p18='Gumball Rules OK!' (Size = 4000)
+@p19='103.3' (Nullable = true)
+@p20='don't' (Size = 4000)
+@p21='84.4' (Nullable = true)
+@p22='01/02/2018 13:11:12' (Nullable = true) (DbType = DateTime)
+@p23='79' (Nullable = true)
+@p24='82.2' (Nullable = true)
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12' (Nullable = true)
+@p27='80' (Nullable = true) (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -1103,36 +1103,36 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0:  (DbType = Int64)
-@p1:  (Size = 8000) (DbType = Binary)
-@p2:  (DbType = String)
-@p3:  (Size = 8000)
-@p4:  (Size = 8000)
-@p5:  (DbType = DateTime)
-@p6:  (DbType = DateTime)
-@p7:  (DbType = DateTime2)
-@p8:  (DbType = String)
-@p9:  (DbType = String)
-@p10:  (DbType = String)
-@p11:  (DbType = String)
-@p12:  (DbType = String)
-@p13:  (Size = 8000) (DbType = Binary)
-@p14: 78 (Nullable = true)
-@p15:  (DbType = String)
-@p16:  (Size = 4000) (DbType = String)
-@p17:  (Size = 4000) (DbType = String)
-@p18:  (Size = 4000) (DbType = String)
-@p19:  (DbType = String)
-@p20:  (Size = 4000) (DbType = String)
-@p21:  (DbType = String)
-@p22:  (DbType = DateTime)
-@p23:  (DbType = Int16)
-@p24:  (DbType = String)
-@p25:  (Size = 8000)
-@p26:  (DbType = String)
-@p27:  (DbType = Byte)
-@p28:  (Size = 8000) (DbType = Binary)
-@p29:  (Size = 8000)",
+                @"@p0='' (DbType = Int64)
+@p1='' (Size = 8000) (DbType = Binary)
+@p2='' (DbType = String)
+@p3='' (Size = 8000)
+@p4='' (Size = 8000)
+@p5='' (DbType = DateTime)
+@p6='' (DbType = DateTime)
+@p7='' (DbType = DateTime2)
+@p8='' (DbType = String)
+@p9='' (DbType = String)
+@p10='' (DbType = String)
+@p11='' (DbType = String)
+@p12='' (DbType = String)
+@p13='' (Size = 8000) (DbType = Binary)
+@p14='78' (Nullable = true)
+@p15='' (DbType = String)
+@p16='' (Size = 4000) (DbType = String)
+@p17='' (Size = 4000) (DbType = String)
+@p18='' (Size = 4000) (DbType = String)
+@p19='' (DbType = String)
+@p20='' (Size = 4000) (DbType = String)
+@p21='' (DbType = String)
+@p22='' (DbType = DateTime)
+@p23='' (DbType = Int16)
+@p24='' (DbType = String)
+@p25='' (Size = 8000)
+@p26='' (DbType = String)
+@p27='' (DbType = Byte)
+@p28='' (Size = 8000) (DbType = Binary)
+@p29='' (Size = 8000)",
                 parameters);
 
             using (var context = CreateContext())
@@ -1188,20 +1188,20 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 0x0A0B0C (Size = 3)
-@p1: 0x0C0D0E (Size = 3)
-@p2: Wor (Size = 3) (DbType = AnsiStringFixedLength)
-@p3: Thr (Size = 3) (DbType = AnsiString)
-@p4: Lon (Size = 3) (DbType = AnsiStringFixedLength)
-@p5: Let (Size = 3) (DbType = AnsiString)
-@p6: 77
-@p7: The (Size = 3)
-@p8: Squ (Size = 3) (DbType = StringFixedLength)
-@p9: Col (Size = 3)
-@p10: Won (Size = 3) (DbType = StringFixedLength)
-@p11: Int (Size = 3)
-@p12: 0x0B0C0D (Size = 3)
-@p13: Tha (Size = 3) (DbType = AnsiString)",
+                @"@p0='0x0A0B0C' (Size = 3)
+@p1='0x0C0D0E' (Size = 3)
+@p2='Wor' (Size = 3) (DbType = AnsiStringFixedLength)
+@p3='Thr' (Size = 3) (DbType = AnsiString)
+@p4='Lon' (Size = 3) (DbType = AnsiStringFixedLength)
+@p5='Let' (Size = 3) (DbType = AnsiString)
+@p6='77'
+@p7='The' (Size = 3)
+@p8='Squ' (Size = 3) (DbType = StringFixedLength)
+@p9='Col' (Size = 3)
+@p10='Won' (Size = 3) (DbType = StringFixedLength)
+@p11='Int' (Size = 3)
+@p12='0x0B0C0D' (Size = 3)
+@p13='Tha' (Size = 3) (DbType = AnsiString)",
                 parameters);
 
             using (var context = CreateContext())
@@ -1259,20 +1259,20 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0:  (Size = 3) (DbType = Binary)
-@p1:  (Size = 3) (DbType = Binary)
-@p2:  (Size = 3) (DbType = AnsiStringFixedLength)
-@p3:  (Size = 3)
-@p4:  (Size = 3) (DbType = AnsiStringFixedLength)
-@p5:  (Size = 3)
-@p6: 78
-@p7:  (Size = 3) (DbType = String)
-@p8:  (Size = 3) (DbType = StringFixedLength)
-@p9:  (Size = 3) (DbType = String)
-@p10:  (Size = 3) (DbType = StringFixedLength)
-@p11:  (Size = 3) (DbType = String)
-@p12:  (Size = 3) (DbType = Binary)
-@p13:  (Size = 3)",
+                @"@p0='' (Size = 3) (DbType = Binary)
+@p1='' (Size = 3) (DbType = Binary)
+@p2='' (Size = 3) (DbType = AnsiStringFixedLength)
+@p3='' (Size = 3)
+@p4='' (Size = 3) (DbType = AnsiStringFixedLength)
+@p5='' (Size = 3)
+@p6='78'
+@p7='' (Size = 3) (DbType = String)
+@p8='' (Size = 3) (DbType = StringFixedLength)
+@p9='' (Size = 3) (DbType = String)
+@p10='' (Size = 3) (DbType = StringFixedLength)
+@p11='' (Size = 3) (DbType = String)
+@p12='' (Size = 3) (DbType = Binary)
+@p13='' (Size = 3)",
                 parameters);
 
             using (var context = CreateContext())
@@ -1311,14 +1311,14 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 01/02/2017 12:11:12
-@p1: 01/02/2016 11:11:12 +00:00
-@p2: 102.2
-@p3: 101.1
-@p4: 85.5
-@p5: 83.3
-@p6: 77
-@p7: 103.3",
+                @"@p0='01/02/2017 12:11:12'
+@p1='01/02/2016 11:11:12 +00:00'
+@p2='102.2'
+@p3='101.1'
+@p4='85.5'
+@p5='83.3'
+@p6='77'
+@p7='103.3'",
                 parameters);
 
             using (var context = CreateContext())
@@ -1365,10 +1365,10 @@ WHERE [e].[Time] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0: 102.2
-@p1: 101.1
-@p2: 77
-@p3: 103.3",
+                @"@p0='102.2'
+@p1='101.1'
+@p2='77'
+@p3='103.3'",
                 parameters);
 
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CompiledQuerySqlServerTest.cs
@@ -57,13 +57,13 @@ FROM [Customers] AS [c]",
             base.Query_with_single_parameter();
 
             Assert.Equal(
-                @"@__customerID: ALFKI (Size = 450)
+                @"@__customerID='ALFKI' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @__customerID
 
-@__customerID: ANATR (Size = 450)
+@__customerID='ANATR' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -76,13 +76,13 @@ WHERE [c].[CustomerID] = @__customerID",
             base.First_query_with_single_parameter();
 
             Assert.Equal(
-                @"@__customerID: ALFKI (Size = 450)
+                @"@__customerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @__customerID
 
-@__customerID: ANATR (Size = 450)
+@__customerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -95,13 +95,13 @@ WHERE [c].[CustomerID] = @__customerID",
             base.Query_with_two_parameters();
 
             Assert.Equal(
-                @"@__customerID: ALFKI (Size = 450)
+                @"@__customerID='ALFKI' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @__customerID
 
-@__customerID: ANATR (Size = 450)
+@__customerID='ANATR' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -114,13 +114,13 @@ WHERE [c].[CustomerID] = @__customerID",
             base.Query_with_three_parameters();
 
             Assert.Equal(
-                @"@__customerID: ALFKI (Size = 450)
+                @"@__customerID='ALFKI' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = @__customerID
 
-@__customerID: ANATR (Size = 450)
+@__customerID='ANATR' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1330,8 +1330,8 @@ WHERE (
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK].[Date], [e.OneToOne_Required_FK].[Level1_Optional_Id], [e.OneToOne_Required_FK].[Level1_Required_Id], [e.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1339,8 +1339,8 @@ LEFT JOIN [Level2] AS [e.OneToOne_Required_FK] ON [e].[Id] = [e.OneToOne_Require
 ORDER BY [e].[Name], [e.OneToOne_Required_FK].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                     //
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e.OneToOne_Required_FK.OneToMany_Optional].[Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToMany_Optional].[Name], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Required_FK.OneToMany_Optional]
@@ -1356,8 +1356,8 @@ INNER JOIN (
 ) AS [t0] ON [e.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t0].[Id]
 ORDER BY [t0].[Name], [t0].[Id]",
                     //
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e.OneToOne_Required_FK.OneToMany_Required].[Id], [e.OneToOne_Required_FK.OneToMany_Required].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToMany_Required].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToMany_Required].[Name], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Required_FK.OneToMany_Required]
@@ -1382,8 +1382,8 @@ ORDER BY [t2].[Name], [t2].[Id]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [e.OneToOne_Required_FK].[Id], [e.OneToOne_Required_FK].[Date], [e.OneToOne_Required_FK].[Level1_Optional_Id], [e.OneToOne_Required_FK].[Level1_Required_Id], [e.OneToOne_Required_FK].[Name], [e.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Optional_FK].[Id], [e.OneToOne_Optional_FK].[Date], [e.OneToOne_Optional_FK].[Level1_Optional_Id], [e.OneToOne_Optional_FK].[Level1_Required_Id], [e.OneToOne_Optional_FK].[Name], [e.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1392,8 +1392,8 @@ LEFT JOIN [Level2] AS [e.OneToOne_Optional_FK] ON [e].[Id] = [e.OneToOne_Optiona
 ORDER BY [e].[Name], [e.OneToOne_Optional_FK].[Id], [e.OneToOne_Required_FK].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                     //
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e.OneToOne_Required_FK.OneToMany_Required].[Id], [e.OneToOne_Required_FK.OneToMany_Required].[Level2_Optional_Id], [e.OneToOne_Required_FK.OneToMany_Required].[Level2_Required_Id], [e.OneToOne_Required_FK.OneToMany_Required].[Name], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Optional_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_Self_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Required_FK.OneToMany_Required].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Required_FK.OneToMany_Required]
@@ -1410,8 +1410,8 @@ INNER JOIN (
 ) AS [t2] ON [e.OneToOne_Required_FK.OneToMany_Required].[OneToMany_Required_InverseId] = [t2].[Id]
 ORDER BY [t2].[Name], [t2].[Id0], [t2].[Id]",
                     //
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e.OneToOne_Optional_FK.OneToMany_Optional].[Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [e.OneToOne_Optional_FK.OneToMany_Optional].[Name], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [e.OneToOne_Optional_FK.OneToMany_Optional]
@@ -1437,8 +1437,8 @@ ORDER BY [t0].[Name], [t0].[Id]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e].[Id], [e].[Date], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [e.OneToOne_Optional_FK].[Id], [e.OneToOne_Optional_FK].[Date], [e.OneToOne_Optional_FK].[Level1_Optional_Id], [e.OneToOne_Optional_FK].[Level1_Required_Id], [e.OneToOne_Optional_FK].[Name], [e.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK].[OneToOne_Optional_SelfId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[Level2_Optional_Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[Level2_Required_Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[Name], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
@@ -1447,8 +1447,8 @@ LEFT JOIN [Level3] AS [e.OneToOne_Optional_FK.OneToOne_Required_FK] ON [e.OneToO
 ORDER BY [e].[Name], [e.OneToOne_Optional_FK.OneToOne_Required_FK].[Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                     //
-                    @"@__p_0: 0
-@__p_1: 10
+                    @"@__p_0='0'
+@__p_1='10'
 
 SELECT [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[Level3_Optional_Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[Level3_Required_Id], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[Name], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [Level4] AS [e.OneToOne_Optional_FK.OneToOne_Required_FK.OneToMany_Optional]
@@ -1691,7 +1691,7 @@ ORDER BY [l3].[Level2_Required_Id]");
             base.Order_by_key_of_projected_navigation_doesnt_get_optimized_into_FK_access_subquery();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse.OneToOne_Required_FK_Inverse].[Name]
 FROM [Level3] AS [l3]
@@ -1705,7 +1705,7 @@ ORDER BY [l3].[Level2_Required_Id]");
             base.Order_by_key_of_anonymous_type_projected_navigation_doesnt_get_optimized_into_FK_access_subquery();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [l3.OneToOne_Required_FK_Inverse].[Id], [l3.OneToOne_Required_FK_Inverse].[Date], [l3.OneToOne_Required_FK_Inverse].[Level1_Optional_Id], [l3.OneToOne_Required_FK_Inverse].[Level1_Required_Id], [l3.OneToOne_Required_FK_Inverse].[Name], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_PK_InverseId], [l3.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId], [l3].[Name] AS [name0]
 FROM [Level3] AS [l3]
@@ -1718,7 +1718,7 @@ ORDER BY [l3].[Level2_Required_Id]");
             base.Optional_navigation_take_optional_navigation();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [l1.OneToOne_Optional_FK.OneToOne_Optional_FK].[Name]
 FROM [Level1] AS [l1]
@@ -1732,7 +1732,7 @@ ORDER BY [l1.OneToOne_Optional_FK].[Id]");
             base.Projection_select_correct_table_from_subquery_when_materialization_is_not_required();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [l2].[Name]
 FROM [Level2] AS [l2]
@@ -1745,7 +1745,7 @@ WHERE [l2.OneToOne_Required_FK_Inverse].[Name] = N'L1 03'");
             base.Projection_select_correct_table_with_anonymous_projection_in_subquery();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId], [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l2]
@@ -1759,7 +1759,7 @@ WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')");
             base.Projection_select_correct_table_in_subquery_when_materialization_is_not_required_in_multiple_joins();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [l1].[Name]
 FROM [Level2] AS [l2]
@@ -1773,7 +1773,7 @@ WHERE ([l1].[Name] = N'L1 03') AND ([l3].[Name] = N'L3 08')");
             base.Where_predicate_on_optional_reference_navigation();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [l1].[Name]
 FROM [Level1] AS [l1]
@@ -2196,7 +2196,7 @@ WHERE 1 IN (
 FROM [Level1] AS [l1]
 WHERE [l1].[Id] < 3",
                 //
-                @"@_outer_Id: 1
+                @"@_outer_Id='1'
 
 SELECT [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id], [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id]
 FROM [Level2] AS [l20]
@@ -2204,7 +2204,7 @@ LEFT JOIN [Level3] AS [l2.OneToOne_Optional_FK0] ON [l20].[Id] = [l2.OneToOne_Op
 LEFT JOIN [Level4] AS [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0] ON [l2.OneToOne_Optional_FK0].[Id] = [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Level3_Optional_Id]
 WHERE @_outer_Id = [l20].[OneToMany_Optional_InverseId]",
                 //
-                @"@_outer_Id: 2
+                @"@_outer_Id='2'
 
 SELECT [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id], [l2.OneToOne_Optional_FK.OneToOne_Optional_FK0].[Id]
 FROM [Level2] AS [l20]
@@ -2439,7 +2439,7 @@ ORDER BY [l1_outer].[Id]");
             base.GroupJoin_on_left_side_being_a_subquery();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [l1].[Id], [l1.OneToOne_Optional_FK].[Name] AS [Brand]
 FROM [Level1] AS [l1]
@@ -2452,7 +2452,7 @@ ORDER BY [l1.OneToOne_Optional_FK].[Name], [l1].[Id]");
             base.GroupJoin_on_right_side_being_a_subquery();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [l2].[Id], [t].[Name]
 FROM [Level2] AS [l2]
@@ -2616,7 +2616,7 @@ ORDER BY [l1].[Id]");
             base.Optional_navigation_in_subquery_with_unrelated_projection();
 
             AssertSql(
-                @"@__p_0: 15
+                @"@__p_0='15'
 
 SELECT TOP(@__p_0) [l1].[Id]
 FROM [Level1] AS [l1]
@@ -2629,7 +2629,7 @@ WHERE ([l1.OneToOne_Optional_FK].[Name] <> N'Foo') OR [l1.OneToOne_Optional_FK].
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection();
 
             AssertSql(
-                @"@__p_0: 15
+                @"@__p_0='15'
 
 SELECT TOP(@__p_0) [l1].[Id]
 FROM [Level1] AS [l1]
@@ -2667,7 +2667,7 @@ WHERE ([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL");
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection4();
 
             AssertSql(
-                @"@__p_0: 20
+                @"@__p_0='20'
 
 SELECT DISTINCT TOP(@__p_0) [l1].[Id]
 FROM [Level1] AS [l1]
@@ -2711,8 +2711,8 @@ WHERE (
             base.Where_on_multilevel_reference_in_subquery_with_outer_projection();
 
             AssertSql(
-                @"@__p_0: 0
-@__p_1: 10
+                @"@__p_0='0'
+@__p_1='10'
 
 SELECT [l3].[Name]
 FROM [Level3] AS [l3]
@@ -2748,7 +2748,7 @@ INNER JOIN [Level2] AS [l2] ON (([l1].[OneToMany_Optional_Self_InverseId] = [l2]
             base.Navigation_filter_navigation_grouping_ordering_by_group_key();
 
             AssertSql(
-                @"@__level1Id_0: 1
+                @"@__level1Id_0='1'
 
 SELECT [l20].[Id], [l20].[Date], [l20].[Level1_Optional_Id], [l20].[Level1_Required_Id], [l20].[Name], [l20].[OneToMany_Optional_InverseId], [l20].[OneToMany_Optional_Self_InverseId], [l20].[OneToMany_Required_InverseId], [l20].[OneToMany_Required_Self_InverseId], [l20].[OneToOne_Optional_PK_InverseId], [l20].[OneToOne_Optional_SelfId], [l2.OneToMany_Required_Self_Inverse0].[Name]
 FROM [Level2] AS [l20]
@@ -2762,7 +2762,7 @@ ORDER BY [l2.OneToMany_Required_Self_Inverse0].[Name]");
             base.Nested_group_join_with_take();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [l2_outer].[Name]
 FROM (

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -154,20 +154,20 @@ SELECT TOP(1) [r].[UniqueNo], [r].[MaxLengthProperty], [r].[Name], [r].[RowVersi
 FROM [Sample] AS [r]
 WHERE [r].[UniqueNo] = 1
 
-@p2: 1
-@p0: ModifiedData (Nullable = false) (Size = 4000)
-@p1: 00000000-0000-0000-0003-000000000001
-@p3: 00000001-0000-0000-0000-000000000001
+@p2='1'
+@p0='ModifiedData' (Nullable = false) (Size = 4000)
+@p1='00000000-0000-0000-0003-000000000001'
+@p3='00000001-0000-0000-0000-000000000001'
 
 SET NOCOUNT ON;
 UPDATE [Sample] SET [Name] = @p0, [RowVersion] = @p1
 WHERE [UniqueNo] = @p2 AND [RowVersion] = @p3;
 SELECT @@ROWCOUNT;
 
-@p2: 1
-@p0: ChangedData (Nullable = false) (Size = 4000)
-@p1: 00000000-0000-0000-0002-000000000001
-@p3: 00000001-0000-0000-0000-000000000001
+@p2='1'
+@p0='ChangedData' (Nullable = false) (Size = 4000)
+@p1='00000000-0000-0000-0002-000000000001'
+@p3='00000001-0000-0000-0000-000000000001'
 
 SET NOCOUNT ON;
 UPDATE [Sample] SET [Name] = @p0, [RowVersion] = @p1
@@ -180,9 +180,9 @@ SELECT @@ROWCOUNT;",
         {
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
-            Assert.Equal(@"@p0:  (Size = 10) (DbType = String)
-@p1: Third (Nullable = false) (Size = 4000)
-@p2: 00000000-0000-0000-0000-000000000003
+            Assert.Equal(@"@p0='' (Size = 10) (DbType = String)
+@p1='Third' (Nullable = false) (Size = 4000)
+@p2='00000000-0000-0000-0000-000000000003'
 
 SET NOCOUNT ON;
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
@@ -197,9 +197,9 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.MaxLengthAttribute_throws_while_inserting_value_longer_than_max_length();
 
-            Assert.Equal(@"@p0: Short (Size = 10)
-@p1: ValidString (Nullable = false) (Size = 4000)
-@p2: 00000000-0000-0000-0000-000000000001
+            Assert.Equal(@"@p0='Short' (Size = 10)
+@p1='ValidString' (Nullable = false) (Size = 4000)
+@p2='00000000-0000-0000-0000-000000000001'
 
 SET NOCOUNT ON;
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
@@ -208,9 +208,9 @@ SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();
 
-@p0: VeryVeryVeryVeryVeryVeryLongString (Size = -1)
-@p1: ValidString (Nullable = false) (Size = 4000)
-@p2: 00000000-0000-0000-0000-000000000002
+@p0='VeryVeryVeryVeryVeryVeryLongString' (Size = -1)
+@p1='ValidString' (Nullable = false) (Size = 4000)
+@p2='00000000-0000-0000-0000-000000000002'
 
 SET NOCOUNT ON;
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
@@ -225,11 +225,11 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p1: Book1 (Nullable = false) (Size = 450)
+            Assert.Contains(@"@p1='Book1' (Nullable = false) (Size = 450)
 ",
                 Sql);
 
-            Assert.Contains(@"@p1:  (Nullable = false) (Size = 450) (DbType = String)
+            Assert.Contains(@"@p1='' (Nullable = false) (Size = 450) (DbType = String)
 ",
                 Sql);
         }
@@ -238,9 +238,9 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
-            Assert.Equal(@"@p0:  (Size = 10) (DbType = String)
-@p1: ValidString (Nullable = false) (Size = 4000)
-@p2: 00000000-0000-0000-0000-000000000001
+            Assert.Equal(@"@p0='' (Size = 10) (DbType = String)
+@p1='ValidString' (Nullable = false) (Size = 4000)
+@p2='00000000-0000-0000-0000-000000000001'
 
 SET NOCOUNT ON;
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
@@ -249,9 +249,9 @@ SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();
 
-@p0:  (Size = 10) (DbType = String)
-@p1:  (Nullable = false) (Size = 4000) (DbType = String)
-@p2: 00000000-0000-0000-0000-000000000002
+@p0='' (Size = 10) (DbType = String)
+@p1='' (Nullable = false) (Size = 4000) (DbType = String)
+@p2='00000000-0000-0000-0000-000000000002'
 
 SET NOCOUNT ON;
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
@@ -266,7 +266,7 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.StringLengthAttribute_throws_while_inserting_value_longer_than_max_length();
 
-            Assert.Equal(@"@p0: ValidString (Size = 16)
+            Assert.Equal(@"@p0='ValidString' (Size = 16)
 
 SET NOCOUNT ON;
 INSERT INTO [Two] ([Data])
@@ -275,7 +275,7 @@ SELECT [Id], [Timestamp]
 FROM [Two]
 WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
 
-@p0: ValidButLongString (Size = -1)
+@p0='ValidButLongString' (Size = -1)
 
 SET NOCOUNT ON;
 INSERT INTO [Two] ([Data])

--- a/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Count_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
@@ -44,7 +44,7 @@ FROM [Products] AS [p]");
             base.Materialized_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -56,8 +56,8 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Find();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
-@__get_Item_0: ALFKI (Size = 450)
+                @"@__TenantPrefix_0='B' (Size = 4000)
+@__get_Item_0='ALFKI' (Size = 450)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -69,7 +69,7 @@ WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNa
             base.Materialized_query_parameter();
 
             AssertSql(
-                @"@__TenantPrefix_0: F (Size = 4000)
+                @"@__TenantPrefix_0='F' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -81,13 +81,13 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Materialized_query_parameter_new_context();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')",
                 //
-                @"@__TenantPrefix_0: T (Size = 4000)
+                @"@__TenantPrefix_0='T' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -99,7 +99,7 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Projection_query_parameter();
 
             AssertSql(
-                @"@__TenantPrefix_0: F (Size = 4000)
+                @"@__TenantPrefix_0='F' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -111,7 +111,7 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Projection_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -123,14 +123,14 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Include_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@__TenantPrefix_1: B (Size = 4000)
+                @"@__TenantPrefix_1='B' (Size = 4000)
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -165,7 +165,7 @@ ORDER BY [t].[CustomerID]");
             base.Included_many_to_one_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]
@@ -198,7 +198,7 @@ WHERE [o].[Quantity] > 50");
             base.Navs_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -222,7 +222,7 @@ WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNa
             }
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
+                @"@__TenantPrefix_0='B' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
@@ -236,15 +236,15 @@ WHERE ([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNam
             base.Compiled_query();
 
             AssertSql(
-                @"@__TenantPrefix_0: B (Size = 4000)
-@__customerID: BERGS (Size = 450)
+                @"@__TenantPrefix_0='B' (Size = 4000)
+@__customerID='BERGS' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([c].[CustomerID] = @__customerID)",
                 //
-                @"@__TenantPrefix_0: B (Size = 4000)
-@__customerID: BLAUS (Size = 450)
+                @"@__TenantPrefix_0='B' (Size = 4000)
+@__customerID='BLAUS' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Find_int_key_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
+                @"@__get_Item_0='77'
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
@@ -87,7 +87,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
             base.Returns_null_for_int_key_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 99
+                @"@__get_Item_0='99'
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
@@ -108,7 +108,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
             base.Find_string_key_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: Cat (Size = 450)
+                @"@__get_Item_0='Cat' (Size = 450)
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [StringKey] AS [e]
@@ -121,7 +121,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
             base.Returns_null_for_string_key_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: Fox (Size = 450)
+                @"@__get_Item_0='Fox' (Size = 450)
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [StringKey] AS [e]
@@ -142,8 +142,8 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
             base.Find_composite_key_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
-@__get_Item_1: Dog (Size = 450)
+                @"@__get_Item_0='77'
+@__get_Item_1='Dog' (Size = 450)
 
 SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
 FROM [CompositeKey] AS [e]
@@ -156,8 +156,8 @@ WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
             base.Returns_null_for_composite_key_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
-@__get_Item_1: Fox (Size = 450)
+                @"@__get_Item_0='77'
+@__get_Item_1='Fox' (Size = 450)
 
 SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
 FROM [CompositeKey] AS [e]
@@ -178,7 +178,7 @@ WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
             base.Find_base_type_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
+                @"@__get_Item_0='77'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -191,7 +191,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
             base.Returns_null_for_base_type_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 99
+                @"@__get_Item_0='99'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -212,7 +212,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
             base.Find_derived_type_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 78
+                @"@__get_Item_0='78'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -225,7 +225,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
             base.Returns_null_for_derived_type_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 99
+                @"@__get_Item_0='99'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -238,7 +238,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
             base.Find_base_type_using_derived_set_tracked();
 
             Assert.Equal(
-                @"@__get_Item_0: 88
+                @"@__get_Item_0='88'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -251,7 +251,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
             base.Find_base_type_using_derived_set_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
+                @"@__get_Item_0='77'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -272,7 +272,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
             base.Find_derived_using_base_set_type_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 78
+                @"@__get_Item_0='78'
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
@@ -293,7 +293,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
             base.Find_shadow_key_from_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 77
+                @"@__get_Item_0='77'
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [ShadowKey] AS [e]
@@ -306,7 +306,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
             base.Returns_null_for_shadow_key_not_in_store();
 
             Assert.Equal(
-                @"@__get_Item_0: 99
+                @"@__get_Item_0='99'
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [ShadowKey] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -131,8 +131,8 @@ WHERE [c].[CustomerID] = [o].[CustomerID]");
             base.From_sql_queryable_multiple_composed_with_closure_parameters();
 
             AssertSql(
-                @"@__8__locals1_startDate_1: 01/01/1997 00:00:00
-@__8__locals1_endDate_2: 01/01/1998 00:00:00
+                @"@__8__locals1_startDate_1='01/01/1997 00:00:00'
+@__8__locals1_endDate_2='01/01/1998 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -149,9 +149,9 @@ WHERE [c].[CustomerID] = [o].[CustomerID]");
             base.From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@__8__locals1_startDate_1: 01/01/1997 00:00:00
-@__8__locals1_endDate_2: 01/01/1998 00:00:00
+                @"@p0='London' (Size = 4000)
+@__8__locals1_startDate_1='01/01/1997 00:00:00'
+@__8__locals1_endDate_2='01/01/1998 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -162,9 +162,9 @@ CROSS JOIN (
 ) AS [o]
 WHERE [c].[CustomerID] = [o].[CustomerID]",
                 //
-                @"@p0: Berlin (Size = 4000)
-@__8__locals1_startDate_1: 04/01/1998 00:00:00
-@__8__locals1_endDate_2: 05/01/1998 00:00:00
+                @"@p0='Berlin' (Size = 4000)
+@__8__locals1_startDate_1='04/01/1998 00:00:00'
+@__8__locals1_endDate_2='05/01/1998 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -204,8 +204,8 @@ WHERE [c].[City] = N'London'");
             base.From_sql_queryable_with_parameters();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -215,8 +215,8 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
             base.From_sql_queryable_with_parameters_inline();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -226,8 +226,8 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
             base.From_sql_queryable_with_parameters_interpolated();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -237,8 +237,8 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
             base.From_sql_queryable_with_parameters_inline_interpolated();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -248,9 +248,9 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
             base.From_sql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: 01/01/1997 00:00:00
-@p2: 01/01/1998 00:00:00
+                @"@p0='London' (Size = 4000)
+@p1='01/01/1997 00:00:00'
+@p2='01/01/1998 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -261,9 +261,9 @@ CROSS JOIN (
 ) AS [o]
 WHERE [c].[CustomerID] = [o].[CustomerID]",
                 //
-                @"@p0: Berlin (Size = 4000)
-@p1: 04/01/1998 00:00:00
-@p2: 05/01/1998 00:00:00
+                @"@p0='Berlin' (Size = 4000)
+@p1='04/01/1998 00:00:00'
+@p2='05/01/1998 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -280,7 +280,7 @@ WHERE [c].[CustomerID] = [o].[CustomerID]");
             base.From_sql_queryable_with_null_parameter();
 
             AssertSql(
-                @"@p0:  (Nullable = false) (DbType = String)
+                @"@p0='' (Nullable = false) (DbType = String)
 
 SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL AND @p0 IS NULL)");
         }
@@ -290,8 +290,8 @@ SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL 
             base.From_sql_queryable_with_parameters_and_closure();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@__contactTitle_1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@__contactTitle_1='Sales Representative' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
@@ -315,13 +315,13 @@ WHERE [c].[ContactTitle] = @__contactTitle_1");
             base.From_sql_queryable_with_parameters_cache_key_includes_parameters();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1",
                 //
-                @"@p0: Madrid (Size = 4000)
-@p1: Accounting Manager (Size = 4000)
+                @"@p0='Madrid' (Size = 4000)
+@p1='Accounting Manager' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -422,7 +422,7 @@ WHERE ([c].[ContactName] = [c].[CompanyName]) OR ([c].[ContactName] IS NULL AND 
             base.From_sql_with_dbParameter();
 
             AssertSql(
-                @"@city: London (Nullable = false) (Size = 6)
+                @"@city='London' (Nullable = false) (Size = 6)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @city");
         }
@@ -432,13 +432,13 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @city");
             base.From_sql_with_dbParameter_mixed();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@title: Sales Representative (Nullable = false) (Size = 20)
+                @"@p0='London' (Size = 4000)
+@title='Sales Representative' (Nullable = false) (Size = 20)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @title",
                 //
-                @"@city: London (Nullable = false) (Size = 6)
-@p1: Sales Representative (Size = 4000)
+                @"@city='London' (Nullable = false) (Size = 6)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p1");
         }
@@ -448,11 +448,11 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p1");
             base.From_sql_with_db_parameters_called_multiple_times();
 
             AssertSql(
-                @"@id: ALFKI (Nullable = false) (Size = 5)
+                @"@id='ALFKI' (Nullable = false) (Size = 5)
 
 SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @id",
                 //
-                @"@id: ALFKI (Nullable = false) (Size = 5)
+                @"@id='ALFKI' (Nullable = false) (Size = 5)
 
 SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @id");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
             base.From_sql_queryable_stored_procedure_with_parameter();
 
             Assert.Equal(
-                @"@p0: ALFKI (Size = 4000)
+                @"@p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql);
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
             base.From_sql_queryable_stored_procedure_with_parameter_composed();
 
             Assert.Equal(
-                @"@p0: ALFKI (Size = 4000)
+                @"@p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
                 Sql);

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -568,7 +568,7 @@ WHERE [w].[AmmunitionType] IS NULL");
             base.Where_nullable_enum_with_non_nullable_parameter();
 
             AssertSql(
-                @"@__ammunitionType_0: Cartridge
+                @"@__ammunitionType_0='Cartridge'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -580,7 +580,7 @@ WHERE [w].[AmmunitionType] = @__ammunitionType_0");
             base.Where_nullable_enum_with_nullable_parameter();
 
             AssertSql(
-                @"@__ammunitionType_0: Cartridge (Nullable = true)
+                @"@__ammunitionType_0='Cartridge' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -657,7 +657,7 @@ WHERE ([w].[AmmunitionType] & NULL) > 0");
             base.Where_bitwise_and_nullable_enum_with_non_nullable_parameter();
 
             AssertSql(
-                @"@__ammunitionType_0: Cartridge
+                @"@__ammunitionType_0='Cartridge'
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -670,13 +670,13 @@ WHERE ([w].[AmmunitionType] & @__ammunitionType_0) > 0");
             base.Where_bitwise_and_nullable_enum_with_nullable_parameter();
 
             AssertSql(
-                @"@__ammunitionType_0: Cartridge (Nullable = true)
+                @"@__ammunitionType_0='Cartridge' (Nullable = true)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE ([w].[AmmunitionType] & @__ammunitionType_0) > 0",
                 //
-                @"@__ammunitionType_0:  (DbType = Int32)
+                @"@__ammunitionType_0='' (DbType = Int32)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -811,7 +811,7 @@ ORDER BY [x0].[Nickname], [x0].[SquadId]");
             base.Where_enum_has_flag_with_non_nullable_parameter();
 
             AssertSql(
-                @"@__parameter_0: Corporal
+                @"@__parameter_0='Corporal'
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
@@ -823,7 +823,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & @__paramet
             base.Where_has_flag_with_nullable_parameter();
 
             AssertSql(
-                @"@__parameter_0: Corporal (Nullable = true)
+                @"@__parameter_0='Corporal' (Nullable = true)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
@@ -891,8 +891,8 @@ WHERE [w].[IsAutomatic] = 1");
             base.Select_comparison_with_null();
 
             AssertSql(
-                @"@__ammunitionType_1: Cartridge (Nullable = true)
-@__ammunitionType_0: Cartridge (Nullable = true)
+                @"@__ammunitionType_1='Cartridge' (Nullable = true)
+@__ammunitionType_0='Cartridge' (Nullable = true)
 
 SELECT [w].[Id], CASE
     WHEN [w].[AmmunitionType] = @__ammunitionType_1
@@ -1530,7 +1530,7 @@ FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)
 ORDER BY [g].[Nickname]",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
 
 SELECT TOP(1) [t0].[IsAutomatic]
 FROM (
@@ -1539,7 +1539,7 @@ FROM (
     WHERE @_outer_FullName = [w0].[OwnerFullName]
 ) AS [t0]",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
 
 SELECT TOP(1) [t0].[IsAutomatic]
 FROM (
@@ -1559,7 +1559,7 @@ FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)
 ORDER BY [g].[Nickname]",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
 
 SELECT TOP(2) [t0].[IsAutomatic]
 FROM (
@@ -1568,7 +1568,7 @@ FROM (
     WHERE (CHARINDEX(N'Lancer', [w0].[Name]) > 0) AND (@_outer_FullName = [w0].[OwnerFullName])
 ) AS [t0]",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
 
 SELECT TOP(2) [t0].[IsAutomatic]
 FROM (
@@ -1621,15 +1621,15 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[HasSoulPatch] = 1)
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
-@_outer_FullName1: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
+@_outer_FullName1='Damon Baird' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
-@_outer_FullName1: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
+@_outer_FullName1='Marcus Fenix' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -1645,15 +1645,15 @@ WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[Own
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
-@_outer_FullName1: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
+@_outer_FullName1='Damon Baird' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE (@_outer_FullName = [w].[OwnerFullName]) AND (@_outer_FullName1 = [w].[OwnerFullName])",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
-@_outer_FullName1: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
+@_outer_FullName1='Marcus Fenix' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -1791,7 +1791,7 @@ WHERE 'Unknown' = [c].[Location]");
             base.Non_unicode_parameter_is_used_for_non_unicode_column();
 
             AssertSql(
-                @"@__value_0: Unknown (Size = 100) (DbType = AnsiString)
+                @"@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
 
 SELECT [c].[Name], [c].[Location]
 FROM [City] AS [c]
@@ -2419,13 +2419,13 @@ WHERE ([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL");
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[CityOrBirthName] IN (N'Ephyra', N'Hanover')",
                 //
-                @"@_outer_FullName: Augustus Cole (Size = 450)
+                @"@_outer_FullName='Augustus Cole' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND (@_outer_FullName = [w].[OwnerFullName])",
                 //
-                @"@_outer_FullName: Dominic Santiago (Size = 450)
+                @"@_outer_FullName='Dominic Santiago' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -2441,15 +2441,15 @@ WHERE (([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL) AND (@_outer_FullName = 
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] = N'Officer'",
                 //
-                @"@_outer_Nickname: Baird (Size = 4000)
-@_outer_SquadId: 1
+                @"@_outer_Nickname='Baird' (Size = 4000)
+@_outer_SquadId='1'
 
 SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
 FROM [Gear] AS [r]
 WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom')) AND ((@_outer_Nickname = [r].[LeaderNickname]) AND (@_outer_SquadId = [r].[LeaderSquadId]))",
                 //
-                @"@_outer_Nickname: Marcus (Size = 4000)
-@_outer_SquadId: 1
+                @"@_outer_Nickname='Marcus' (Size = 4000)
+@_outer_SquadId='1'
 
 SELECT [r].[Nickname], [r].[SquadId], [r].[AssignedCityName], [r].[CityOrBirthName], [r].[Discriminator], [r].[FullName], [r].[HasSoulPatch], [r].[LeaderNickname], [r].[LeaderSquadId], [r].[Rank]
 FROM [Gear] AS [r]
@@ -2464,7 +2464,7 @@ WHERE ([r].[Discriminator] IN (N'Officer', N'Gear') AND ([r].[Nickname] <> N'Dom
                 @"SELECT [t].[GearNickName]
 FROM [CogTag] AS [t]",
                 //
-                @"@_outer_GearNickName: Paduk (Size = 450)
+                @"@_outer_GearNickName='Paduk' (Size = 450)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
@@ -2474,25 +2474,25 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[Nickname] IS NULL",
                 //
-                @"@_outer_GearNickName: Baird (Size = 450)
+                @"@_outer_GearNickName='Baird' (Size = 450)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
                 //
-                @"@_outer_GearNickName: Dom (Size = 450)
+                @"@_outer_GearNickName='Dom' (Size = 450)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
                 //
-                @"@_outer_GearNickName: Cole Train (Size = 450)
+                @"@_outer_GearNickName='Cole Train' (Size = 450)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
                 //
-                @"@_outer_GearNickName: Marcus (Size = 450)
+                @"@_outer_GearNickName='Marcus' (Size = 450)
 
 SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
@@ -2582,7 +2582,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
             base.DateTimeOffset_Date_works();
 
             AssertSql(
-                @"@__Date_0: 01/01/0001 00:00:00
+                @"@__Date_0='01/01/0001 00:00:00'
 
 SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
 FROM [Mission] AS [m]
@@ -2946,7 +2946,7 @@ ORDER BY [g0].[Rank]");
             base.Subquery_with_result_operator_is_not_lifted();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [t].[FullName]
 FROM (
@@ -2976,13 +2976,13 @@ FROM [Weapon] AS [w]");
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -2998,19 +2998,19 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 0)",
                 //
-                @"@_outer_FullName: Augustus Cole (Size = 450)
+                @"@_outer_FullName='Augustus Cole' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Dominic Santiago (Size = 450)
+                @"@_outer_FullName='Dominic Santiago' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Garron Paduk (Size = 450)
+                @"@_outer_FullName='Garron Paduk' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -3026,19 +3026,19 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 0)",
                 //
-                @"@_outer_FullName: Augustus Cole (Size = 450)
+                @"@_outer_FullName='Augustus Cole' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Dominic Santiago (Size = 450)
+                @"@_outer_FullName='Dominic Santiago' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Garron Paduk (Size = 450)
+                @"@_outer_FullName='Garron Paduk' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
@@ -3054,15 +3054,15 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] = N'Officer'",
                 //
-                @"@_outer_Nickname: Baird (Size = 4000)
-@_outer_SquadId: 1
+                @"@_outer_Nickname='Baird' (Size = 4000)
+@_outer_SquadId='1'
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
 WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g0].[LeaderNickname]) AND (@_outer_SquadId = [g0].[LeaderSquadId]))",
                 //
-                @"@_outer_Nickname: Marcus (Size = 4000)
-@_outer_SquadId: 1
+                @"@_outer_Nickname='Marcus' (Size = 4000)
+@_outer_SquadId='1'
 
 SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gear] AS [g0]
@@ -3078,31 +3078,31 @@ WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g0
 FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
                 //
-                @"@_outer_FullName1: Damon Baird (Size = 450)
+                @"@_outer_FullName1='Damon Baird' (Size = 450)
 
 SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapon] AS [w0]
 WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
                 //
-                @"@_outer_FullName1: Augustus Cole (Size = 450)
+                @"@_outer_FullName1='Augustus Cole' (Size = 450)
 
 SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapon] AS [w0]
 WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
                 //
-                @"@_outer_FullName1: Dominic Santiago (Size = 450)
+                @"@_outer_FullName1='Dominic Santiago' (Size = 450)
 
 SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapon] AS [w0]
 WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
                 //
-                @"@_outer_FullName1: Marcus Fenix (Size = 450)
+                @"@_outer_FullName1='Marcus Fenix' (Size = 450)
 
 SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapon] AS [w0]
 WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
                 //
-                @"@_outer_FullName1: Garron Paduk (Size = 450)
+                @"@_outer_FullName1='Garron Paduk' (Size = 450)
 
 SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
 FROM [Weapon] AS [w0]
@@ -3112,13 +3112,13 @@ WHERE @_outer_FullName1 = [w0].[OwnerFullName]",
 FROM [Gear] AS [o]
 WHERE ([o].[Discriminator] = N'Officer') AND ([o].[HasSoulPatch] = 1)",
                 //
-                @"@_outer_FullName: Damon Baird (Size = 450)
+                @"@_outer_FullName='Damon Baird' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE @_outer_FullName = [w].[OwnerFullName]",
                 //
-                @"@_outer_FullName: Marcus Fenix (Size = 450)
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
 
 SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -109,14 +109,14 @@ ORDER BY [t].[CustomerID] DESC");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 OFFSET @__p_0 ROWS",
                     //
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -137,13 +137,13 @@ ORDER BY [t].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                     //
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -163,16 +163,16 @@ ORDER BY [t].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 10
-@__p_1: 5
+                    @"@__p_0='10'
+@__p_1='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                     //
-                    @"@__p_0: 10
-@__p_1: 5
+                    @"@__p_0='10'
+@__p_1='5'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -406,13 +406,13 @@ ORDER BY [t].[City], [t].[CustomerID]");
             base.Include_collection_order_by_non_key_with_take(useString);
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactTitle], [c].[CustomerID]",
                 //
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -431,14 +431,14 @@ ORDER BY [t].[ContactTitle], [t].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactTitle], [c].[CustomerID]
 OFFSET @__p_0 ROWS",
                     //
-                    @"@__p_0: 10
+                    @"@__p_0='10'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -703,7 +703,7 @@ ORDER BY [t].[CustomerID]");
             base.Include_collection_on_additional_from_clause(useString);
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM (
@@ -714,7 +714,7 @@ FROM (
 CROSS JOIN [Customers] AS [c2]
 ORDER BY [c2].[CustomerID]",
                 //
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c2.Orders].[OrderID], [c2.Orders].[CustomerID], [c2.Orders].[EmployeeID], [c2.Orders].[OrderDate]
 FROM [Orders] AS [c2.Orders]
@@ -737,7 +737,7 @@ ORDER BY [t1].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -753,7 +753,7 @@ CROSS JOIN (
 ) AS [t0]
 ORDER BY [t].[CustomerID], [t0].[CustomerID]",
                     //
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [c1.Orders].[OrderID], [c1.Orders].[CustomerID], [c1.Orders].[EmployeeID], [c1.Orders].[OrderDate]
 FROM [Orders] AS [c1.Orders]
@@ -773,7 +773,7 @@ INNER JOIN (
 ) AS [t3] ON [c1.Orders].[CustomerID] = [t3].[CustomerID]
 ORDER BY [t3].[CustomerID]",
                     //
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [c2.Orders].[OrderID], [c2.Orders].[CustomerID], [c2.Orders].[EmployeeID], [c2.Orders].[OrderDate]
 FROM [Orders] AS [c2.Orders]
@@ -802,8 +802,8 @@ ORDER BY [t6].[CustomerID0], [t6].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_1: 1
-@__p_0: 2
+                    @"@__p_1='1'
+@__p_0='2'
 
 SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -819,8 +819,8 @@ CROSS JOIN (
 ) AS [t0]
 ORDER BY [t].[CustomerID], [t0].[CustomerID]",
                     //
-                    @"@__p_1: 1
-@__p_0: 2
+                    @"@__p_1='1'
+@__p_0='2'
 
 SELECT [c1.Orders].[OrderID], [c1.Orders].[CustomerID], [c1.Orders].[EmployeeID], [c1.Orders].[OrderDate]
 FROM [Orders] AS [c1.Orders]
@@ -844,8 +844,8 @@ INNER JOIN (
 ) AS [t4] ON [c1.Orders].[CustomerID] = [t4].[CustomerID]
 ORDER BY [t4].[CustomerID]",
                     //
-                    @"@__p_1: 1
-@__p_0: 2
+                    @"@__p_1='1'
+@__p_0='2'
 
 SELECT [c2.Orders].[OrderID], [c2.Orders].[CustomerID], [c2.Orders].[EmployeeID], [c2.Orders].[OrderDate]
 FROM [Orders] AS [c2.Orders]
@@ -918,7 +918,7 @@ ORDER BY [t].[City], [t].[CustomerID]");
             base.Include_collection_on_additional_from_clause2(useString);
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -936,8 +936,8 @@ CROSS JOIN [Customers] AS [c2]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 1
-@__p_1: 2
+                    @"@__p_0='1'
+@__p_1='2'
 
 SELECT [od.Order].[CustomerID]
 FROM [Order Details] AS [od]
@@ -955,8 +955,8 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_1: 1
-@__p_0: 2
+                    @"@__p_1='1'
+@__p_0='2'
 
 SELECT TOP(@__p_1) [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -972,8 +972,8 @@ CROSS JOIN (
 ) AS [t0]
 ORDER BY [t].[CustomerID]",
                     //
-                    @"@__p_1: 1
-@__p_0: 2
+                    @"@__p_1='1'
+@__p_0='2'
 
 SELECT [c1.Orders].[OrderID], [c1.Orders].[CustomerID], [c1.Orders].[EmployeeID], [c1.Orders].[OrderDate]
 FROM [Orders] AS [c1.Orders]
@@ -1027,7 +1027,7 @@ INNER JOIN [Orders] AS [o.Order] ON [o].[OrderID] = [o.Order].[OrderID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [o1.Customer].[CustomerID], [o1.Customer].[Address], [o1.Customer].[City], [o1.Customer].[CompanyName], [o1.Customer].[ContactName], [o1.Customer].[ContactTitle], [o1.Customer].[Country], [o1.Customer].[Fax], [o1.Customer].[Phone], [o1.Customer].[PostalCode], [o1.Customer].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [o2.Customer].[CustomerID], [o2.Customer].[Address], [o2.Customer].[City], [o2.Customer].[CompanyName], [o2.Customer].[ContactName], [o2.Customer].[ContactTitle], [o2.Customer].[Country], [o2.Customer].[Fax], [o2.Customer].[Phone], [o2.Customer].[PostalCode], [o2.Customer].[Region]
 FROM (
@@ -1053,7 +1053,7 @@ LEFT JOIN [Customers] AS [o2.Customer] ON [t0].[CustomerID] = [o2.Customer].[Cus
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [o1.Customer].[CustomerID], [o1.Customer].[Address], [o1.Customer].[City], [o1.Customer].[CompanyName], [o1.Customer].[ContactName], [o1.Customer].[ContactTitle], [o1.Customer].[Country], [o1.Customer].[Fax], [o1.Customer].[Phone], [o1.Customer].[PostalCode], [o1.Customer].[Region], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM (
@@ -1078,7 +1078,7 @@ CROSS JOIN (
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 2
+                    @"@__p_0='2'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [o2.Customer].[CustomerID], [o2.Customer].[Address], [o2.Customer].[City], [o2.Customer].[CompanyName], [o2.Customer].[ContactName], [o2.Customer].[ContactTitle], [o2.Customer].[Country], [o2.Customer].[Fax], [o2.Customer].[Phone], [o2.Customer].[PostalCode], [o2.Customer].[Region]
 FROM (
@@ -1206,13 +1206,13 @@ LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[Custom
             base.Include_collection_as_no_tracking2(useString);
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -1238,13 +1238,13 @@ FROM [Orders] AS [o]");
             base.Include_with_take(useString);
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[City] DESC, [c].[CustomerID]",
                 //
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -1263,14 +1263,14 @@ ORDER BY [t].[City] DESC, [t].[CustomerID]");
             if (SupportsOffset)
             {
                 AssertSql(
-                    @"@__p_0: 80
+                    @"@__p_0='80'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 ORDER BY [c].[ContactName], [c].[CustomerID]
 OFFSET @__p_0 ROWS",
                     //
-                    @"@__p_0: 80
+                    @"@__p_0='80'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -337,13 +337,13 @@ WHERE [k].[Discriminator] = N'Kiwi'");
 FROM [Country] AS [c]
 WHERE [c].[Id] = 1",
                 //
-                @"@p0: Apteryx owenii (Nullable = false) (Size = 100)
-@p1: 1
-@p2: Kiwi (Nullable = false) (Size = 4000)
-@p3: Little spotted kiwi (Size = 4000)
-@p4:  (Size = 100) (DbType = String)
-@p5: True
-@p6: North
+                @"@p0='Apteryx owenii' (Nullable = false) (Size = 100)
+@p1='1'
+@p2='Kiwi' (Nullable = false) (Size = 4000)
+@p3='Little spotted kiwi' (Size = 4000)
+@p4='' (Size = 100) (DbType = String)
+@p5='True'
+@p6='North'
 
 SET NOCOUNT ON;
 INSERT INTO [Animal] ([Species], [CountryId], [Discriminator], [Name], [EagleId], [IsFlightless], [FoundOn])
@@ -353,8 +353,8 @@ VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6);",
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
                 //
-                @"@p1: Apteryx owenii (Nullable = false) (Size = 100)
-@p0: Aquila chrysaetos canadensis (Size = 100)
+                @"@p1='Apteryx owenii' (Nullable = false) (Size = 100)
+@p0='Aquila chrysaetos canadensis' (Size = 100)
 
 SET NOCOUNT ON;
 UPDATE [Animal] SET [EagleId] = @p0
@@ -365,7 +365,7 @@ SELECT @@ROWCOUNT;",
 FROM [Animal] AS [k]
 WHERE ([k].[Discriminator] = N'Kiwi') AND (RIGHT([k].[Species], LEN(N'owenii')) = N'owenii')",
                 //
-                @"@p0: Apteryx owenii (Nullable = false) (Size = 100)
+                @"@p0='Apteryx owenii' (Nullable = false) (Size = 100)
 
 SET NOCOUNT ON;
 DELETE FROM [Animal]

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -44,7 +44,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -61,7 +61,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -78,7 +78,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -95,7 +95,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -112,7 +112,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id]
 FROM [SinglePkToPk] AS [e]
@@ -129,7 +129,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -146,7 +146,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -163,7 +163,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -180,7 +180,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -197,7 +197,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -214,7 +214,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id]
 FROM [SinglePkToPk] AS [e]
@@ -283,7 +283,7 @@ WHERE 0 = 1",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -300,7 +300,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -317,7 +317,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -334,7 +334,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -351,7 +351,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -368,7 +368,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -385,7 +385,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -402,7 +402,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -485,7 +485,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -502,7 +502,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -519,7 +519,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -536,7 +536,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -553,7 +553,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -570,7 +570,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id]
 FROM [SinglePkToPk] AS [e]
@@ -587,7 +587,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -604,7 +604,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -621,7 +621,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -638,7 +638,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -655,7 +655,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -672,7 +672,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -689,7 +689,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -706,7 +706,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -723,7 +723,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -740,7 +740,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -757,7 +757,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -774,7 +774,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -791,7 +791,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -808,7 +808,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -825,7 +825,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 787
+                    @"@__get_Item_0='787'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -842,7 +842,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 767 (Nullable = true)
+                    @"@__get_Item_0='767' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -903,7 +903,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
@@ -920,7 +920,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -937,7 +937,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -954,7 +954,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
@@ -971,7 +971,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildAk] AS [e]
@@ -988,7 +988,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1005,7 +1005,7 @@ WHERE [e].[AlternateId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1022,7 +1022,7 @@ WHERE [e].[AlternateId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [SingleAk] AS [e]
@@ -1039,7 +1039,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildAk] AS [e]
@@ -1056,7 +1056,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1073,7 +1073,7 @@ WHERE [e].[AlternateId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1090,7 +1090,7 @@ WHERE [e].[AlternateId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
+                    @"@__get_Item_0='Root' (Size = 450)
 
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [SingleAk] AS [e]
@@ -1159,7 +1159,7 @@ WHERE 0 = 1",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildShadowFk] AS [e]
@@ -1176,7 +1176,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1193,7 +1193,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1210,7 +1210,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [SingleShadowFk] AS [e]
@@ -1227,7 +1227,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildShadowFk] AS [e]
@@ -1244,7 +1244,7 @@ WHERE [e].[ParentId] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1261,7 +1261,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707
+                    @"@__get_Item_0='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1278,7 +1278,7 @@ WHERE [e].[Id] = @__get_Item_0",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: 707 (Nullable = true)
+                    @"@__get_Item_0='707' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [SingleShadowFk] AS [e]
@@ -1347,8 +1347,8 @@ WHERE 0 = 1",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707 (Nullable = true)
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [ChildCompositeKey] AS [e]
@@ -1365,8 +1365,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1383,8 +1383,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
 
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1401,8 +1401,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707 (Nullable = true)
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [SingleCompositeKey] AS [e]
@@ -1419,8 +1419,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707 (Nullable = true)
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
 
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [ChildCompositeKey] AS [e]
@@ -1437,8 +1437,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1455,8 +1455,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
 
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
@@ -1473,8 +1473,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
             if (!async)
             {
                 Assert.Equal(
-                    @"@__get_Item_0: Root (Size = 450)
-@__get_Item_1: 707 (Nullable = true)
+                    @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
 
 SELECT TOP(2) [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [SingleCompositeKey] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -642,7 +642,7 @@ WHERE [e].[NullableStringA] IS NULL");
             base.Compare_nullable_with_non_null_parameter_not_equal();
 
             AssertSql(
-                @"@__prm_0: Foo (Size = 4000)
+                @"@__prm_0='Foo' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -724,7 +724,7 @@ WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
             base.Where_multiple_ands_with_nullable_parameter_and_constant();
 
             AssertSql(
-                @"@__prm3_2: Blah (Size = 4000)
+                @"@__prm3_2='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -736,7 +736,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo', @__prm3_2) AND [e].[NullableStringA]
             base.Where_multiple_ands_with_nullable_parameter_and_constant_not_optimized();
 
             AssertSql(
-                @"@__prm3_2: Blah (Size = 4000)
+                @"@__prm3_2='Blah' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -876,7 +876,7 @@ WHERE ((CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0) OR ([e].[Nu
             base.Where_conditional_search_condition_in_result();
 
             AssertSql(
-                @"@__prm_0: True
+                @"@__prm_0='True'
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -888,7 +888,7 @@ WHERE CASE
     END ELSE CAST(0 AS BIT)
 END = 1",
                 //
-                @"@__prm_0: True
+                @"@__prm_0='True'
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -906,8 +906,8 @@ END = 1");
             base.Where_nested_conditional_search_condition_in_result();
 
             AssertSql(
-                @"@__prm1_0: True
-@__prm2_1: False
+                @"@__prm1_0='True'
+@__prm2_1='False'
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -980,7 +980,7 @@ WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)");
             base.Where_equal_using_relational_null_semantics_with_parameter();
 
             AssertSql(
-                @"@__prm_0:  (DbType = String)
+                @"@__prm_0='' (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -1012,7 +1012,7 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
             base.Where_not_equal_using_relational_null_semantics_with_parameter();
 
             AssertSql(
-                @"@__prm_0:  (DbType = String)
+                @"@__prm_0='' (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -1034,13 +1034,13 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
             base.Where_comparison_null_constant_and_null_parameter();
 
             AssertSql(
-                @"@__prm_0:  (Size = 4000) (DbType = String)
+                @"@__prm_0='' (Size = 4000) (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE @__prm_0 IS NULL",
                 //
-                @"@__prm_0:  (Size = 4000) (DbType = String)
+                @"@__prm_0='' (Size = 4000) (DbType = String)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -1052,13 +1052,13 @@ WHERE @__prm_0 IS NOT NULL");
             base.Where_comparison_null_constant_and_nonnull_parameter();
 
             AssertSql(
-                @"@__prm_0: Foo (Size = 4000)
+                @"@__prm_0='Foo' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
 WHERE @__prm_0 IS NULL",
                 //
-                @"@__prm_0: Foo (Size = 4000)
+                @"@__prm_0='Foo' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]
@@ -1107,7 +1107,7 @@ WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
             base.Switching_parameter_value_to_null_produces_different_cache_entry();
 
             AssertSql(
-                @"@__prm_0: Foo (Size = 4000)
+                @"@__prm_0='Foo' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [NullSemanticsEntity1] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -735,8 +735,8 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
                     ctx.Customers.Where(c => c.FirstName == firstName && c.LastName == details.LastName).ToList();
 
                     const string expectedSql
-                        = @"@__firstName_0: Foo (Size = 450)
-@__8__locals1_details_LastName_1: Bar (Size = 450)
+                        = @"@__firstName_0='Foo' (Size = 450)
+@__8__locals1_details_LastName_1='Bar' (Size = 450)
 
 SELECT [c].[FirstName], [c].[LastName]
 FROM [Customer] AS [c]

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -146,7 +146,7 @@ WHERE CHARINDEX(N'Sea', [o.Customer].[City]) > 0");
             base.Select_Where_Navigation_Deep();
 
             AssertSql(
-                @"@__p_0: 1
+                @"@__p_0='1'
 
 SELECT TOP(@__p_0) [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
@@ -161,19 +161,19 @@ ORDER BY [od].[OrderID], [od].[ProductID]");
             base.Take_Select_Navigation();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -185,7 +185,7 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             base.Select_collection_FirstOrDefault_project_single_column1();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) (
     SELECT TOP(1) [o].[CustomerID]
@@ -201,7 +201,7 @@ ORDER BY [c].[CustomerID]");
             base.Select_collection_FirstOrDefault_project_single_column2();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) (
     SELECT TOP(1) [o].[CustomerID]
@@ -217,19 +217,19 @@ ORDER BY [c].[CustomerID]");
             base.Select_collection_FirstOrDefault_project_anonymous_type();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [o].[CustomerID], [o].[OrderID]
 FROM [Orders] AS [o]
@@ -241,19 +241,19 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             base.Select_collection_FirstOrDefault_project_entity();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -267,21 +267,21 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
             {
                 AssertSql(
-                    @"@__p_0: 20
+                    @"@__p_0='20'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 OFFSET @__p_0 ROWS",
                     //
-                    @"@_outer_CustomerID: FAMIA (Size = 450)
+                    @"@_outer_CustomerID='FAMIA' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                     //
-                    @"@_outer_CustomerID: FISSA (Size = 450)
+                    @"@_outer_CustomerID='FISSA' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -482,25 +482,25 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -517,37 +517,37 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 WHERE [o].[CustomerID] = N'ALFKI'",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
@@ -639,13 +639,13 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
 WHERE @_outer_CustomerID = [o0].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o0]
@@ -674,13 +674,13 @@ WHERE NOT EXISTS (
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -828,13 +828,13 @@ WHERE (
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -851,28 +851,28 @@ FROM [Customers] AS [e]
 WHERE [e].[CustomerID] LIKE N'A' + N'%' AND (LEFT([e].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [e].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
 WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
 WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
 LEFT JOIN [Customers] AS [e.Customer] ON [e0].[CustomerID] = [e.Customer].[CustomerID]
 WHERE [e0].[OrderID] IN (10643, 10692, 10702, 10835, 10952, 11011) AND (@_outer_CustomerID = [e0].[CustomerID])",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT TOP(1) [e.Customer].[CustomerID], [e.Customer].[Address], [e.Customer].[City], [e.Customer].[CompanyName], [e.Customer].[ContactName], [e.Customer].[ContactTitle], [e.Customer].[Country], [e.Customer].[Fax], [e.Customer].[Phone], [e.Customer].[PostalCode], [e.Customer].[Region]
 FROM [Orders] AS [e0]
@@ -1056,7 +1056,7 @@ ORDER BY [c].[CustomerID]",
                 @"SELECT [o4].[OrderID]
 FROM [Orders] AS [o4]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o2].[OrderID]
 FROM [Orders] AS [o2]
@@ -1065,7 +1065,7 @@ WHERE @_outer_CustomerID = [o2].[CustomerID]",
                 @"SELECT [o4].[OrderID]
 FROM [Orders] AS [o4]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [o2].[OrderID]
 FROM [Orders] AS [o2]
@@ -1158,28 +1158,28 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_CustomerID = [o].[CustomerID]
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -1192,7 +1192,7 @@ ORDER BY [o].[OrderID]");
             base.Project_single_scalar_value_subquery_in_query_with_optional_navigation_works();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [o].[OrderID], (
     SELECT TOP(1) [od].[OrderID]

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Lifting_when_subquery_nested_order_by_anonymous();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [c1_Orders].[OrderID], [c1_Orders].[CustomerID], [c1_Orders].[EmployeeID], [c1_Orders].[OrderDate], [t0].[CustomerID]
 FROM [Orders] AS [c1_Orders]
@@ -46,7 +46,7 @@ INNER JOIN (
 
             // TODO: Avoid unnecessary pushdown of subquery. See Issue#8094
             AssertContainsSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [t0].[CustomerID]
 FROM (
@@ -122,7 +122,7 @@ WHERE [e].[EmployeeID] = 1");
             base.Local_array();
 
             AssertSql(
-                @"@__get_Item_0: ALFKI (Size = 450)
+                @"@__get_Item_0='ALFKI' (Size = 450)
 
 SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -144,7 +144,7 @@ WHERE [c].[CustomerID] = [c].[CustomerID]");
             base.Entity_equality_local();
 
             AssertSql(
-                @"@__local_0_CustomerID: ANATR (Nullable = false) (Size = 450)
+                @"@__local_0_CustomerID='ANATR' (Nullable = false) (Size = 450)
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -267,7 +267,7 @@ WHERE [e1].[FirstName] = (
             base.Where_query_composition_is_null();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -275,7 +275,7 @@ FROM (
     FROM [Employees] AS [e]
 ) AS [t]",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
 FROM [Employees] AS [e2]
@@ -285,7 +285,7 @@ WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
 FROM [Employees] AS [e2]
 WHERE [e2].[EmployeeID] IS NULL",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
 FROM [Employees] AS [e2]
@@ -297,7 +297,7 @@ WHERE [e2].[EmployeeID] = @_outer_ReportsTo");
             base.Where_query_composition_is_null();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -305,7 +305,7 @@ FROM (
     FROM [Employees] AS [e]
 ) AS [t]",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
 FROM [Employees] AS [e2]
@@ -315,7 +315,7 @@ WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
 FROM [Employees] AS [e2]
 WHERE [e2].[EmployeeID] IS NULL",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
 FROM [Employees] AS [e2]
@@ -327,7 +327,7 @@ WHERE [e2].[EmployeeID] = @_outer_ReportsTo");
             base.Where_query_composition_entity_equality_one_element_SingleOrDefault();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -335,7 +335,7 @@ FROM (
     FROM [Employees] AS [e]
 ) AS [t]",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e20].[EmployeeID]
 FROM [Employees] AS [e20]
@@ -345,7 +345,7 @@ WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
 FROM [Employees] AS [e20]
 WHERE [e20].[EmployeeID] IS NULL",
                 //
-                @"@_outer_ReportsTo: 2 (Nullable = true)
+                @"@_outer_ReportsTo='2' (Nullable = true)
 
 SELECT TOP(2) [e20].[EmployeeID]
 FROM [Employees] AS [e20]
@@ -371,7 +371,7 @@ WHERE (
             base.Where_query_composition_entity_equality_no_elements_SingleOrDefault();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -425,7 +425,7 @@ WHERE (
             base.Where_query_composition2();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -451,7 +451,7 @@ ORDER BY [e0].[EmployeeID]");
             base.Where_query_composition2_FirstOrDefault();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -470,7 +470,7 @@ WHERE [t].[FirstName] = (
             base.Where_query_composition2_FirstOrDefault_with_anonymous();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -510,20 +510,20 @@ WHERE [e].[Title] = (
             base.Select_Subquery_Single();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [od].[OrderID]
 FROM [Order Details] AS [od]
 ORDER BY [od].[ProductID], [od].[OrderID]",
                 //
-                @"@_outer_OrderID: 10285
+                @"@_outer_OrderID='10285'
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @_outer_OrderID = [o].[OrderID]
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_OrderID: 10294
+                @"@_outer_OrderID='10294'
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -540,25 +540,25 @@ ORDER BY [o].[OrderID]");
 FROM [Order Details] AS [od]
 WHERE [od].[OrderID] = 10344",
                 //
-                @"@_outer_OrderID: 10344
+                @"@_outer_OrderID='10344'
 
 SELECT TOP(2) [o0].[CustomerID]
 FROM [Orders] AS [o0]
 WHERE @_outer_OrderID = [o0].[OrderID]",
                 //
-                @"@_outer_CustomerID1: WHITC (Size = 450)
+                @"@_outer_CustomerID1='WHITC' (Size = 450)
 
 SELECT TOP(2) [c2].[City]
 FROM [Customers] AS [c2]
 WHERE @_outer_CustomerID1 = [c2].[CustomerID]",
                 //
-                @"@_outer_OrderID: 10344
+                @"@_outer_OrderID='10344'
 
 SELECT TOP(2) [o0].[CustomerID]
 FROM [Orders] AS [o0]
 WHERE @_outer_OrderID = [o0].[OrderID]",
                 //
-                @"@_outer_CustomerID1: WHITC (Size = 450)
+                @"@_outer_CustomerID1='WHITC' (Size = 450)
 
 SELECT TOP(2) [c2].[City]
 FROM [Customers] AS [c2]
@@ -570,7 +570,7 @@ WHERE @_outer_CustomerID1 = [c2].[CustomerID]");
             base.Select_Where_Subquery_Deep_First();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
@@ -590,7 +590,7 @@ WHERE (
             base.Select_Where_Subquery_Equality();
 
             AssertSql(
-                @"@__p_0: 1
+                @"@__p_0='1'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
@@ -606,14 +606,14 @@ FROM (
     ORDER BY [od0].[OrderID]
 ) AS [t1]",
                 //
-                @"@_outer_CustomerID2: VINET (Size = 450)
+                @"@_outer_CustomerID2='VINET' (Size = 450)
 
 SELECT TOP(1) [c3].[Country]
 FROM [Customers] AS [c3]
 WHERE [c3].[CustomerID] = @_outer_CustomerID2
 ORDER BY [c3].[CustomerID]",
                 //
-                @"@_outer_OrderID1: 10248
+                @"@_outer_OrderID1='10248'
 
 SELECT TOP(1) [c4].[Country]
 FROM [Orders] AS [o20]
@@ -621,14 +621,14 @@ INNER JOIN [Customers] AS [c4] ON [o20].[CustomerID] = [c4].[CustomerID]
 WHERE [o20].[OrderID] = @_outer_OrderID1
 ORDER BY [o20].[OrderID], [c4].[CustomerID]",
                 //
-                @"@_outer_CustomerID2: VINET (Size = 450)
+                @"@_outer_CustomerID2='VINET' (Size = 450)
 
 SELECT TOP(1) [c3].[Country]
 FROM [Customers] AS [c3]
 WHERE [c3].[CustomerID] = @_outer_CustomerID2
 ORDER BY [c3].[CustomerID]",
                 //
-                @"@_outer_OrderID1: 10248
+                @"@_outer_OrderID1='10248'
 
 SELECT TOP(1) [c4].[Country]
 FROM [Orders] AS [o20]
@@ -642,7 +642,7 @@ ORDER BY [o20].[OrderID], [c4].[CustomerID]");
             base.Where_subquery_anon();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
 FROM (
@@ -660,7 +660,7 @@ CROSS JOIN (
             base.Where_subquery_anon_nested();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
 FROM (
@@ -696,7 +696,7 @@ WHERE EXISTS (
             base.Where_subquery_correlated_client_eval();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -705,31 +705,31 @@ FROM (
 ) AS [t]
 ORDER BY [t].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
 WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
 WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
 WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
 WHERE @_outer_CustomerID = [c2].[CustomerID]",
                 //
-                @"@_outer_CustomerID: BERGS (Size = 450)
+                @"@_outer_CustomerID='BERGS' (Size = 450)
 
 SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
 FROM [Customers] AS [c2]
@@ -762,7 +762,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
@@ -772,7 +772,7 @@ SELECT CASE
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
@@ -782,7 +782,7 @@ SELECT CASE
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
@@ -792,7 +792,7 @@ SELECT CASE
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT CASE
     WHEN EXISTS (
@@ -850,7 +850,7 @@ ORDER BY [order0].[OrderID]");
             base.Where_simple_closure();
 
             AssertSql(
-                @"@__city_0: London (Size = 4000)
+                @"@__city_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -871,7 +871,7 @@ FROM [Customers] AS [c]");
             base.Where_simple_closure_constant();
 
             AssertSql(
-                @"@__predicate_0: True
+                @"@__predicate_0='True'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -887,13 +887,13 @@ WHERE @__predicate_0 = 1");
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] IS NULL",
                 //
-                @"@__reportsTo_0: 5 (Nullable = true)
+                @"@__reportsTo_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__reportsTo_0",
                 //
-                @"@__reportsTo_0: 2 (Nullable = true)
+                @"@__reportsTo_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -905,13 +905,13 @@ WHERE [e].[ReportsTo] = @__reportsTo_0");
             base.Where_simple_closure_via_query_cache_nullable_type();
 
             AssertSql(
-                @"@__reportsTo_0: 2 (Nullable = true)
+                @"@__reportsTo_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__reportsTo_0",
                 //
-                @"@__reportsTo_0: 5 (Nullable = true)
+                @"@__reportsTo_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -927,13 +927,13 @@ WHERE [e].[ReportsTo] IS NULL");
             base.Where_new_instance_field_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__InstanceFieldValue_0: London (Size = 4000)
+                @"@__InstanceFieldValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__InstanceFieldValue_0",
                 //
-                @"@__InstanceFieldValue_0: Seattle (Size = 4000)
+                @"@__InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -945,13 +945,13 @@ WHERE [c].[City] = @__InstanceFieldValue_0");
             base.Where_nested_property_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_Nested_InstancePropertyValue_0: London (Size = 4000)
+                @"@__city_Nested_InstancePropertyValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0",
                 //
-                @"@__city_Nested_InstancePropertyValue_0: Seattle (Size = 4000)
+                @"@__city_Nested_InstancePropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -963,13 +963,13 @@ WHERE [c].[City] = @__city_Nested_InstancePropertyValue_0");
             base.Where_nested_field_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_Nested_InstanceFieldValue_0: London (Size = 4000)
+                @"@__city_Nested_InstanceFieldValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0",
                 //
-                @"@__city_Nested_InstanceFieldValue_0: Seattle (Size = 4000)
+                @"@__city_Nested_InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -981,13 +981,13 @@ WHERE [c].[City] = @__city_Nested_InstanceFieldValue_0");
             base.Where_static_property_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__StaticPropertyValue_0: London (Size = 4000)
+                @"@__StaticPropertyValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__StaticPropertyValue_0",
                 //
-                @"@__StaticPropertyValue_0: Seattle (Size = 4000)
+                @"@__StaticPropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -999,13 +999,13 @@ WHERE [c].[City] = @__StaticPropertyValue_0");
             base.Where_property_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_InstancePropertyValue_0: London (Size = 4000)
+                @"@__city_InstancePropertyValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_InstancePropertyValue_0",
                 //
-                @"@__city_InstancePropertyValue_0: Seattle (Size = 4000)
+                @"@__city_InstancePropertyValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1017,13 +1017,13 @@ WHERE [c].[City] = @__city_InstancePropertyValue_0");
             base.Where_static_field_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__StaticFieldValue_0: London (Size = 4000)
+                @"@__StaticFieldValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__StaticFieldValue_0",
                 //
-                @"@__StaticFieldValue_0: Seattle (Size = 4000)
+                @"@__StaticFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1035,13 +1035,13 @@ WHERE [c].[City] = @__StaticFieldValue_0");
             base.Where_field_access_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_InstanceFieldValue_0: London (Size = 4000)
+                @"@__city_InstanceFieldValue_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_InstanceFieldValue_0",
                 //
-                @"@__city_InstanceFieldValue_0: Seattle (Size = 4000)
+                @"@__city_InstanceFieldValue_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1053,13 +1053,13 @@ WHERE [c].[City] = @__city_InstanceFieldValue_0");
             base.Where_method_call_closure_via_query_cache();
 
             AssertSql(
-                @"@__GetCity_0: London (Size = 4000)
+                @"@__GetCity_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__GetCity_0",
                 //
-                @"@__GetCity_0: Seattle (Size = 4000)
+                @"@__GetCity_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1071,13 +1071,13 @@ WHERE [c].[City] = @__GetCity_0");
             base.Where_method_call_nullable_type_reverse_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_NullableInt_0: 1 (Nullable = true)
+                @"@__city_NullableInt_0='1' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] > @__city_NullableInt_0",
                 //
-                @"@__city_NullableInt_0: 5 (Nullable = true)
+                @"@__city_NullableInt_0='5' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -1089,13 +1089,13 @@ WHERE [e].[EmployeeID] > @__city_NullableInt_0");
             base.Where_method_call_nullable_type_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_Int_0: 2
+                @"@__city_Int_0='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__city_Int_0",
                 //
-                @"@__city_Int_0: 5
+                @"@__city_Int_0='5'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -1107,13 +1107,13 @@ WHERE [e].[ReportsTo] = @__city_Int_0");
             base.Where_simple_closure_via_query_cache();
 
             AssertSql(
-                @"@__city_0: London (Size = 4000)
+                @"@__city_0='London' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[City] = @__city_0",
                 //
-                @"@__city_0: Seattle (Size = 4000)
+                @"@__city_0='Seattle' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1125,7 +1125,7 @@ WHERE [c].[City] = @__city_0");
             base.Where_subquery_closure_via_query_cache();
 
             AssertSql(
-                @"@__customerID_0: ALFKI (Size = 450)
+                @"@__customerID_0='ALFKI' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1134,7 +1134,7 @@ WHERE EXISTS (
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] = [c].[CustomerID]))",
                 //
-                @"@__customerID_0: ANATR (Size = 450)
+                @"@__customerID_0='ANATR' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1273,7 +1273,7 @@ WHERE ([o].[CustomerID] <> N'ALFKI') OR [o].[CustomerID] IS NULL");
             base.OrderBy_client_Take();
 
             AssertSql(
-                @"@__p_1: 10
+                @"@__p_1='10'
 
 SELECT TOP(@__p_1) [o].[EmployeeID], [o].[City], [o].[Country], [o].[FirstName], [o].[ReportsTo], [o].[Title]
 FROM [Employees] AS [o]
@@ -1648,7 +1648,7 @@ FROM (
             base.Skip();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1662,7 +1662,7 @@ OFFSET @__p_0 ROWS");
             base.Skip_no_orderby();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1676,8 +1676,8 @@ OFFSET @__p_0 ROWS");
             base.Skip_Take();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1691,8 +1691,8 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             base.Join_Customers_Orders_Skip_Take();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [c].[ContactName], [o].[OrderID]
 FROM [Customers] AS [c]
@@ -1707,8 +1707,8 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT ([c].[ContactName] + N' ') + [c].[ContactTitle] AS [Contact], [o].[OrderID]
 FROM [Customers] AS [c]
@@ -1723,8 +1723,8 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [o].[OrderID], [ca].[CustomerID] AS [CustomerIDA], [cb].[CustomerID] AS [CustomerIDB], [ca].[ContactName] AS [ContactNameA], [cb].[ContactName] AS [ContactNameB]
 FROM [Orders] AS [o]
@@ -1740,8 +1740,8 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             base.Take_Skip();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].*
 FROM (
@@ -1759,8 +1759,8 @@ OFFSET @__p_1 ROWS");
             base.Take_Skip_Distinct();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -1781,8 +1781,8 @@ FROM (
             base.Take_Skip_Distinct_Caching();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -1796,8 +1796,8 @@ FROM (
     OFFSET @__p_1 ROWS
 ) AS [t0]",
                 //
-                @"@__p_0: 15
-@__p_1: 10
+                @"@__p_0='15'
+@__p_1='10'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -1822,7 +1822,7 @@ FROM (
             base.Take_Distinct_Count();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT COUNT(*)
 FROM (
@@ -1839,7 +1839,7 @@ FROM (
             base.Take_Where_Distinct_Count();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT COUNT(*)
 FROM (
@@ -1904,7 +1904,7 @@ FROM [Customers] AS [c3]");
             base.Queryable_simple_anonymous_projection_subquery();
 
             AssertSql(
-                @"@__p_0: 91
+                @"@__p_0='91'
 
 SELECT TOP(@__p_0) [c].[City]
 FROM [Customers] AS [c]");
@@ -1915,7 +1915,7 @@ FROM [Customers] AS [c]");
             base.Queryable_simple_anonymous_subquery();
 
             AssertSql(
-                @"@__p_0: 91
+                @"@__p_0='91'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]");
@@ -1926,7 +1926,7 @@ FROM [Customers] AS [c]");
             base.Take_simple();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1938,7 +1938,7 @@ ORDER BY [c].[CustomerID]");
             base.Take_simple_parameterized();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -1950,7 +1950,7 @@ ORDER BY [c].[CustomerID]");
             base.Take_simple_projection();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT TOP(@__p_0) [c].[City]
 FROM [Customers] AS [c]
@@ -1962,7 +1962,7 @@ ORDER BY [c].[CustomerID]");
             base.Take_subquery_projection();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT TOP(@__p_0) [c].[City]
 FROM [Customers] AS [c]
@@ -1974,7 +1974,7 @@ ORDER BY [c].[CustomerID]");
             base.OrderBy_Take_Count();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT COUNT(*)
 FROM (
@@ -1989,7 +1989,7 @@ FROM (
             base.Take_OrderBy_Count();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT COUNT(*)
 FROM (
@@ -2265,7 +2265,7 @@ FROM [Products] AS [p]");
             base.Select_scalar_primitive_after_take();
 
             AssertSql(
-                @"@__p_0: 9
+                @"@__p_0='9'
 
 SELECT TOP(@__p_0) [e].[EmployeeID]
 FROM [Employees] AS [e]");
@@ -2285,7 +2285,7 @@ FROM [Customers] AS [c]");
             base.Select_local();
 
             AssertSql(
-                @"@__x_0: 10
+                @"@__x_0='10'
 
 SELECT @__x_0
 FROM [Customers] AS [c]");
@@ -2421,7 +2421,7 @@ WHERE ([c].[CustomerID] = N'ALFKI') AND ((
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(1) [o0].[CustomerID]
 FROM [Orders] AS [o0]
@@ -2541,7 +2541,7 @@ WHERE 0 = 1");
             base.Where_equals_using_int_overload_on_mismatched_types();
 
             AssertSql(
-                @"@__shortPrm_0: 1 (DbType = Int32)
+                @"@__shortPrm_0='1' (DbType = Int32)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -2553,13 +2553,13 @@ WHERE [e].[EmployeeID] = @__shortPrm_0");
             base.Where_equals_on_mismatched_types_int_nullable_int();
 
             AssertSql(
-                @"@__intPrm_0: 2
+                @"@__intPrm_0='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE [e].[ReportsTo] = @__intPrm_0",
                 //
-                @"@__intPrm_0: 2
+                @"@__intPrm_0='2'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -2615,13 +2615,13 @@ WHERE 0 = 1");
             base.Where_equals_on_matched_nullable_int_types();
 
             AssertSql(
-                @"@__nullableIntPrm_0: 2 (Nullable = true)
+                @"@__nullableIntPrm_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
 WHERE @__nullableIntPrm_0 = [e].[ReportsTo]",
                 //
-                @"@__nullableIntPrm_0: 2 (Nullable = true)
+                @"@__nullableIntPrm_0='2' (Nullable = true)
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
@@ -2657,7 +2657,7 @@ WHERE CAST(LEN([c].[City]) AS int) = 6");
             base.Where_datetime_date_component();
 
             AssertSql(
-                @"@__myDatetime_0: 05/04/1998 00:00:00
+                @"@__myDatetime_0='05/04/1998 00:00:00'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -2759,7 +2759,7 @@ WHERE DATEPART(millisecond, [o].[OrderDate]) = 88");
             base.Where_datetime_now();
 
             AssertSql(
-                @"@__myDatetime_0: 04/10/2015 00:00:00
+                @"@__myDatetime_0='04/10/2015 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2771,7 +2771,7 @@ WHERE GETDATE() <> @__myDatetime_0");
             base.Where_datetime_utcnow();
 
             AssertSql(
-                @"@__myDatetime_0: 04/10/2015 00:00:00
+                @"@__myDatetime_0='04/10/2015 00:00:00'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -2905,8 +2905,8 @@ WHERE [c].[City] IN (N'London', N'Berlin', N'Seattle', N'Lisboa')");
             base.Where_select_many_or_with_parameter();
 
             AssertSql(
-                @"@__london_0: London (Size = 4000)
-@__lisboa_1: Lisboa (Size = 4000)
+                @"@__london_0='London' (Size = 4000)
+@__lisboa_1='Lisboa' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
@@ -3005,7 +3005,7 @@ WHERE [c].[City] = N'London'");
             base.SelectMany_mixed();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -3048,7 +3048,7 @@ FROM (
             base.SelectMany_simple_subquery();
 
             AssertSql(
-                @"@__p_0: 9
+                @"@__p_0='9'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
@@ -3219,7 +3219,7 @@ CROSS JOIN [Employees] AS [e]");
             base.Client_Join_select_many();
 
             AssertContainsSql(
-                @"@__p_1: 2
+                @"@__p_1='2'
 
 SELECT [t0].[EmployeeID], [t0].[City], [t0].[Country], [t0].[FirstName], [t0].[ReportsTo], [t0].[Title]
 FROM (
@@ -3227,7 +3227,7 @@ FROM (
     FROM [Employees] AS [e0]
 ) AS [t0]",
                 //
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[ReportsTo], [t].[Title]
 FROM (
@@ -3291,7 +3291,7 @@ FROM [Customers] AS [c]");
             base.Join_customers_orders_with_subquery_with_take();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c].[ContactName], [t].[OrderID]
 FROM [Customers] AS [c]
@@ -3321,7 +3321,7 @@ FROM [Customers] AS [c]");
             base.Join_customers_orders_with_subquery_anonymous_property_method_with_take();
 
             AssertContainsSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
@@ -3353,7 +3353,7 @@ FROM [Customers] AS [c]");
             base.Join_customers_orders_with_subquery_predicate_with_take();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [c].[ContactName], [t].[OrderID]
 FROM [Customers] AS [c]
@@ -3614,7 +3614,7 @@ LEFT JOIN [Orders] AS [o] ON [e].[EmployeeID] = [o].[EmployeeID]");
             base.GroupJoin_DefaultIfEmpty3();
 
             AssertSql(
-                @"@__p_0: 1
+                @"@__p_0='1'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -3749,7 +3749,7 @@ ORDER BY [c].[City]");
             base.GroupJoin_simple_subquery();
 
             AssertSql(
-                @"@__p_0: 4
+                @"@__p_0='4'
 
 SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM [Customers] AS [c]
@@ -3776,7 +3776,7 @@ ORDER BY [c].[CustomerID]");
             base.GroupJoin_customers_orders_count_preserves_ordering();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -3869,7 +3869,7 @@ CROSS APPLY (
             base.Take_with_single();
 
             AssertSql(
-                @"@__p_0: 1
+                @"@__p_0='1'
 
 SELECT TOP(2) [t].*
 FROM (
@@ -3885,7 +3885,7 @@ ORDER BY [t].[CustomerID]");
             base.Take_with_single_select_many();
 
             AssertSql(
-                @"@__p_0: 1
+                @"@__p_0='1'
 
 SELECT TOP(2) [t].*
 FROM (
@@ -3933,8 +3933,8 @@ FROM [Customers] AS [c]");
             base.Skip_Take_Any();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT CASE
     WHEN EXISTS (
@@ -3952,8 +3952,8 @@ END");
             base.Skip_Take_All();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT CASE
     WHEN NOT EXISTS (
@@ -4101,7 +4101,7 @@ ORDER BY [t].[CustomerID]");
             base.Take_Distinct();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -4116,7 +4116,7 @@ FROM (
             base.Distinct_Take();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT TOP(@__p_0) [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
@@ -4131,7 +4131,7 @@ ORDER BY [t].[OrderID]");
             base.Distinct_Take_Count();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT COUNT(*)
 FROM (
@@ -4265,7 +4265,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             base.Where_ternary_boolean_condition_true();
 
             AssertSql(
-                @"@__flag_0: True
+                @"@__flag_0='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4277,7 +4277,7 @@ WHERE ((@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> 1) AND 
             base.Where_ternary_boolean_condition_false();
 
             AssertSql(
-                @"@__flag_0: False
+                @"@__flag_0='False'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4289,8 +4289,8 @@ WHERE ((@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> 1) AND 
             base.Where_ternary_boolean_condition_with_another_condition();
 
             AssertSql(
-                @"@__productId_0: 15
-@__flag_1: True
+                @"@__productId_0='15'
+@__flag_1='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4302,7 +4302,7 @@ WHERE ([p].[ProductID] < @__productId_0) AND (((@__flag_1 = 1) AND ([p].[UnitsIn
             base.Where_ternary_boolean_condition_with_false_as_result_true();
 
             AssertSql(
-                @"@__flag_0: True
+                @"@__flag_0='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4314,7 +4314,7 @@ WHERE (@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)");
             base.Where_ternary_boolean_condition_with_false_as_result_false();
 
             AssertSql(
-                @"@__flag_0: False
+                @"@__flag_0='False'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4326,7 +4326,7 @@ WHERE (@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)");
             base.Where_concat_string_int_comparison1();
 
             AssertSql(
-                @"@__i_0: 10
+                @"@__i_0='10'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -4338,7 +4338,7 @@ WHERE ([c].[CustomerID] + CAST(@__i_0 AS nvarchar(max))) = [c].[CompanyName]");
             base.Where_concat_string_int_comparison2();
 
             AssertSql(
-                @"@__i_0: 10
+                @"@__i_0='10'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -4350,8 +4350,8 @@ WHERE (CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID]) = [c].[CompanyName]");
             base.Where_concat_string_int_comparison3();
 
             AssertSql(
-                @"@__i_0: 10
-@__j_1: 21
+                @"@__i_0='10'
+@__j_1='21'
 
 SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
@@ -4363,7 +4363,7 @@ WHERE (((CAST(@__i_0 + 20 AS nvarchar(max)) + [c].[CustomerID]) + CAST(@__j_1 AS
             base.Where_primitive();
 
             AssertSql(
-                @"@__p_0: 9
+                @"@__p_0='9'
 
 SELECT [t].[EmployeeID]
 FROM (
@@ -4510,7 +4510,7 @@ END");
             base.Where_bool_parameter();
 
             AssertSql(
-                @"@__prm_0: True
+                @"@__prm_0='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4522,7 +4522,7 @@ WHERE @__prm_0 = 1");
             base.Where_bool_parameter_compared_to_binary_expression();
 
             AssertSql(
-                @"@__prm_0: True
+                @"@__prm_0='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4537,7 +4537,7 @@ END <> @__prm_0");
             base.Where_bool_member_and_parameter_compared_to_binary_expression_nested();
 
             AssertSql(
-                @"@__prm_0: True
+                @"@__prm_0='True'
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
@@ -4749,7 +4749,7 @@ WHERE ([c].[ContactName] LIKE [c].[ContactName] + N'%' AND (LEFT([c].[ContactNam
             base.String_StartsWith_MethodCall();
 
             AssertSql(
-                @"@__LocalMethod1_0: M (Size = 4000)
+                @"@__LocalMethod1_0='M' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4791,7 +4791,7 @@ WHERE (RIGHT([c].[ContactName], LEN([c].[ContactName])) = [c].[ContactName]) OR 
             base.String_EndsWith_MethodCall();
 
             AssertSql(
-                @"@__LocalMethod2_0: m (Size = 4000)
+                @"@__LocalMethod2_0='m' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4839,7 +4839,7 @@ WHERE (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0) OR ([c].[ContactName
                 entryCount: 34);
 
             AssertSql(
-                @"@__LocalMethod1_0: M (Size = 4000)
+                @"@__LocalMethod1_0='M' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4911,37 +4911,37 @@ WHERE [c].[CustomerID] >= N'ALFKI'");
             base.String_compare_with_parameter();
 
             AssertSql(
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] > @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] < @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] >= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4976,7 +4976,7 @@ WHERE [c].[CustomerID] = N'M' + [c].[CustomerID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <> UPPER([c].[CustomerID])",
                 //
-                @"@__ToUpper_0: ALF (Size = 4000)
+                @"@__ToUpper_0='ALF' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -4990,7 +4990,7 @@ WHERE [c].[CustomerID] <= N'M' + [c].[CustomerID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] > UPPER([c].[CustomerID])",
                 //
-                @"@__ToUpper_0: ALF (Size = 4000)
+                @"@__ToUpper_0='ALF' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -5076,37 +5076,37 @@ WHERE [c].[CustomerID] >= N'ALFKI'");
             base.String_compare_to_with_parameter();
 
             AssertSql(
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] > @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] < @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] >= @__customer_CustomerID_0",
                 //
-                @"@__customer_CustomerID_0: ALFKI (Size = 4000)
+                @"@__customer_CustomerID_0='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -5141,7 +5141,7 @@ WHERE [c].[CustomerID] = N'M' + [c].[CustomerID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] <> UPPER([c].[CustomerID])",
                 //
-                @"@__ToUpper_0: ALF (Size = 4000)
+                @"@__ToUpper_0='ALF' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -5155,7 +5155,7 @@ WHERE [c].[CustomerID] <= N'M' + [c].[CustomerID]",
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] > UPPER([c].[CustomerID])",
                 //
-                @"@__ToUpper_0: ALF (Size = 4000)
+                @"@__ToUpper_0='ALF' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -5211,7 +5211,7 @@ WHERE ABS([od].[UnitPrice]) > 10.0");
             base.Where_math_abs_uncorrelated();
 
             AssertSql(
-                @"@__Abs_0: 10
+                @"@__Abs_0='10'
 
 SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
@@ -5253,7 +5253,7 @@ WHERE FLOOR([od].[UnitPrice]) > 10.0");
             base.Where_query_composition4();
 
             AssertSql(
-                @"@__p_0: 2
+                @"@__p_0='2'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -5783,42 +5783,42 @@ FROM [Customers] AS [c]
 WHERE [c].[City] = N'London'
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: BSBEV (Size = 450)
+                @"@_outer_CustomerID='BSBEV' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: CONSH (Size = 450)
+                @"@_outer_CustomerID='CONSH' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: EASTC (Size = 450)
+                @"@_outer_CustomerID='EASTC' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: NORTS (Size = 450)
+                @"@_outer_CustomerID='NORTS' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
 ORDER BY [o].[OrderID]",
                 //
-                @"@_outer_CustomerID: SEVES (Size = 450)
+                @"@_outer_CustomerID='SEVES' (Size = 450)
 
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
@@ -5835,25 +5835,25 @@ ORDER BY [o].[OrderID]");
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT TOP(3) [o].[OrderDate] AS [Date]
 FROM [Orders] AS [o]
 WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT TOP(3) [o].[OrderDate] AS [Date]
 FROM [Orders] AS [o]
 WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT TOP(3) [o].[OrderDate] AS [Date]
 FROM [Orders] AS [o]
 WHERE ([o].[OrderID] < 10500) AND (@_outer_CustomerID = [o].[CustomerID])",
                 //
-                @"@_outer_CustomerID: AROUT (Size = 450)
+                @"@_outer_CustomerID='AROUT' (Size = 450)
 
 SELECT TOP(3) [o].[OrderDate] AS [Date]
 FROM [Orders] AS [o]
@@ -5956,28 +5956,28 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
                 //
-                @"@_outer_CustomerID1: ALFKI (Size = 450)
+                @"@_outer_CustomerID1='ALFKI' (Size = 450)
 
 SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o2]
 WHERE @_outer_CustomerID1 = [o2].[CustomerID]
 ORDER BY [o2].[OrderID]",
                 //
-                @"@_outer_CustomerID1: ANATR (Size = 450)
+                @"@_outer_CustomerID1='ANATR' (Size = 450)
 
 SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o2]
 WHERE @_outer_CustomerID1 = [o2].[CustomerID]
 ORDER BY [o2].[OrderID]",
                 //
-                @"@_outer_CustomerID1: ANTON (Size = 450)
+                @"@_outer_CustomerID1='ANTON' (Size = 450)
 
 SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o2]
 WHERE @_outer_CustomerID1 = [o2].[CustomerID]
 ORDER BY [o2].[OrderID]",
                 //
-                @"@_outer_CustomerID1: AROUT (Size = 450)
+                @"@_outer_CustomerID1='AROUT' (Size = 450)
 
 SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
 FROM [Orders] AS [o2]
@@ -6078,7 +6078,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
             base.Select_correlated_subquery_projection();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[CustomerID]
 FROM (
@@ -6087,19 +6087,19 @@ FROM (
 ) AS [t]
 ORDER BY [t].[CustomerID]",
                 //
-                @"@_outer_CustomerID: ALFKI (Size = 450)
+                @"@_outer_CustomerID='ALFKI' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = @_outer_CustomerID",
                 //
-                @"@_outer_CustomerID: ANATR (Size = 450)
+                @"@_outer_CustomerID='ANATR' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = @_outer_CustomerID",
                 //
-                @"@_outer_CustomerID: ANTON (Size = 450)
+                @"@_outer_CustomerID='ANTON' (Size = 450)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -6111,7 +6111,7 @@ WHERE [o].[CustomerID] = @_outer_CustomerID");
             base.Select_correlated_subquery_ordered();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]",
@@ -6385,13 +6385,13 @@ WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')");
             base.Contains_with_local_list_inline_closure_mix();
 
             AssertSql(
-                @"@__id_0: ALFKI (Size = 450)
+                @"@__id_0='ALFKI' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ABCDE', @__id_0)",
                 //
-                @"@__id_0: ANATR (Size = 450)
+                @"@__id_0='ANATR' (Size = 450)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -6483,7 +6483,7 @@ WHERE 1 = 1");
             base.Contains_top_level();
 
             AssertSql(
-                @"@__p_0: ALFKI (Size = 4000)
+                @"@__p_0='ALFKI' (Size = 4000)
 
 SELECT CASE
     WHEN @__p_0 IN (
@@ -6509,7 +6509,7 @@ ORDER BY [c].[CustomerID]");
             base.Substring_with_closure();
 
             AssertSql(
-                @"@__start_0: 2
+                @"@__start_0='2'
 
 SELECT TOP(1) SUBSTRING([c].[ContactName], @__start_0 + 1, 3)
 FROM [Customers] AS [c]
@@ -6654,8 +6654,8 @@ WHERE COALESCE([c].[CompanyName], [c].[ContactName]) = N'The Big Cheese'");
             base.Take_skip_null_coalesce_operator();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -6675,7 +6675,7 @@ FROM (
             base.Select_take_null_coalesce_operator();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], N'ZZ') AS [Region]
 FROM [Customers] AS [c]
@@ -6688,8 +6688,8 @@ ORDER BY [Region]");
             base.Select_take_skip_null_coalesce_operator();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].*
 FROM (
@@ -6707,8 +6707,8 @@ OFFSET @__p_1 ROWS");
             base.Select_take_skip_null_coalesce_operator2();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].*
 FROM (
@@ -6726,8 +6726,8 @@ OFFSET @__p_1 ROWS");
             base.Select_take_skip_null_coalesce_operator3();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].*
 FROM (
@@ -6773,7 +6773,7 @@ ORDER BY [Id]");
             base.DateTime_parse_is_parameterized();
 
             AssertSql(
-                @"@__Parse_0: 01/01/1998 12:00:00
+                @"@__Parse_0='01/01/1998 12:00:00'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -6839,8 +6839,8 @@ FROM [Orders] AS [o]");
             base.Environment_newline_is_funcletized();
 
             AssertSql(
-                @"@__NewLine_0: 
- (Size = 4000)
+                @"@__NewLine_0='
+' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -7088,8 +7088,8 @@ ORDER BY [c].[CustomerID]");
             base.Parameter_extraction_short_circuits_1();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0: 7
-@__dateFilter_Value_Year_1: 1996
+                @"@__dateFilter_Value_Month_0='7'
+@__dateFilter_Value_Year_1='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -7105,8 +7105,8 @@ WHERE [o].[OrderID] < 10400");
             base.Parameter_extraction_short_circuits_2();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0: 7
-@__dateFilter_Value_Year_1: 1996
+                @"@__dateFilter_Value_Month_0='7'
+@__dateFilter_Value_Year_1='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -7122,8 +7122,8 @@ WHERE 0 = 1");
             base.Parameter_extraction_short_circuits_3();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0: 7
-@__dateFilter_Value_Year_1: 1996
+                @"@__dateFilter_Value_Month_0='7'
+@__dateFilter_Value_Year_1='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -7138,7 +7138,7 @@ FROM [Orders] AS [o]");
             base.Subquery_member_pushdown_does_not_change_original_subquery_model();
 
             AssertSql(
-                @"@__p_0: 3
+                @"@__p_0='3'
 
 SELECT [t].[CustomerID], [t].[OrderID]
 FROM (
@@ -7147,37 +7147,37 @@ FROM (
     ORDER BY [o].[OrderID]
 ) AS [t]",
                 //
-                @"@_outer_CustomerID: VINET (Size = 450)
+                @"@_outer_CustomerID='VINET' (Size = 450)
 
 SELECT TOP(2) [c0].[City]
 FROM [Customers] AS [c0]
 WHERE [c0].[CustomerID] = @_outer_CustomerID",
                 //
-                @"@_outer_CustomerID: TOMSP (Size = 450)
+                @"@_outer_CustomerID='TOMSP' (Size = 450)
 
 SELECT TOP(2) [c0].[City]
 FROM [Customers] AS [c0]
 WHERE [c0].[CustomerID] = @_outer_CustomerID",
                 //
-                @"@_outer_CustomerID: HANAR (Size = 450)
+                @"@_outer_CustomerID='HANAR' (Size = 450)
 
 SELECT TOP(2) [c0].[City]
 FROM [Customers] AS [c0]
 WHERE [c0].[CustomerID] = @_outer_CustomerID",
                 //
-                @"@_outer_CustomerID1: TOMSP (Size = 450)
+                @"@_outer_CustomerID1='TOMSP' (Size = 450)
 
 SELECT TOP(2) [c2].[City]
 FROM [Customers] AS [c2]
 WHERE [c2].[CustomerID] = @_outer_CustomerID1",
                 //
-                @"@_outer_CustomerID1: VINET (Size = 450)
+                @"@_outer_CustomerID1='VINET' (Size = 450)
 
 SELECT TOP(2) [c2].[City]
 FROM [Customers] AS [c2]
 WHERE [c2].[CustomerID] = @_outer_CustomerID1",
                 //
-                @"@_outer_CustomerID1: HANAR (Size = 450)
+                @"@_outer_CustomerID1='HANAR' (Size = 450)
 
 SELECT TOP(2) [c2].[City]
 FROM [Customers] AS [c2]
@@ -7273,8 +7273,8 @@ WHERE [o].[OrderDate] IS NOT NULL");
             base.Select_expression_date_add_milliseconds_large_number_divided();
 
             AssertSql(
-                @"@__millisecondsPerDay_1: 86400000
-@__millisecondsPerDay_0: 86400000
+                @"@__millisecondsPerDay_1='86400000'
+@__millisecondsPerDay_0='86400000'
 
 SELECT DATEADD(millisecond, DATEPART(millisecond, [o].[OrderDate]) % @__millisecondsPerDay_1, DATEADD(day, DATEPART(millisecond, [o].[OrderDate]) / @__millisecondsPerDay_0, [o].[OrderDate])) AS [OrderDate]
 FROM [Orders] AS [o]
@@ -7286,7 +7286,7 @@ WHERE [o].[OrderDate] IS NOT NULL");
             base.Select_expression_references_are_updated_correctly_with_subquery();
 
             AssertSql(
-                @"@__nextYear_0: 2017
+                @"@__nextYear_0='2017'
 
 SELECT [t].[c]
 FROM (
@@ -7376,8 +7376,8 @@ WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t2].[OrderI
             base.OrderBy_skip_take();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 8
+                @"@__p_0='5'
+@__p_1='8'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -7391,9 +7391,9 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
             base.OrderBy_skip_take_take();
 
             AssertSql(
-                @"@__p_2: 3
-@__p_0: 5
-@__p_1: 8
+                @"@__p_2='3'
+@__p_0='5'
+@__p_1='8'
 
 SELECT TOP(@__p_2) [t].*
 FROM (
@@ -7411,11 +7411,11 @@ ORDER BY [t].[ContactTitle], [t].[ContactName]");
             base.OrderBy_skip_take_take_take_take();
 
             AssertSql(
-                @"@__p_4: 5
-@__p_3: 8
-@__p_2: 10
-@__p_0: 5
-@__p_1: 15
+                @"@__p_4='5'
+@__p_3='8'
+@__p_2='10'
+@__p_0='5'
+@__p_1='15'
 
 SELECT TOP(@__p_4) [t1].*
 FROM (
@@ -7441,11 +7441,11 @@ ORDER BY [t1].[ContactTitle], [t1].[ContactName]");
             base.OrderBy_skip_take_skip_take_skip();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
-@__p_2: 2
-@__p_3: 8
-@__p_4: 5
+                @"@__p_0='5'
+@__p_1='15'
+@__p_2='2'
+@__p_3='8'
+@__p_4='5'
 
 SELECT [t0].*
 FROM (
@@ -7469,8 +7469,8 @@ OFFSET @__p_4 ROWS");
             base.OrderBy_skip_take_distinct();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
+                @"@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -7487,7 +7487,7 @@ FROM (
             base.OrderBy_coalesce_take_distinct();
 
             AssertSql(
-                @"@__p_0: 15
+                @"@__p_0='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -7503,8 +7503,8 @@ FROM (
             base.OrderBy_coalesce_skip_take_distinct();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
+                @"@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -7522,9 +7522,9 @@ FROM (
             base.OrderBy_coalesce_skip_take_distinct_take();
 
             AssertSql(
-                @"@__p_2: 5
-@__p_0: 5
-@__p_1: 15
+                @"@__p_2='5'
+@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT TOP(@__p_2) [t].*
 FROM (
@@ -7541,9 +7541,9 @@ FROM (
             base.OrderBy_skip_take_distinct_orderby_take();
 
             AssertSql(
-                @"@__p_2: 8
-@__p_0: 5
-@__p_1: 15
+                @"@__p_2='8'
+@__p_0='5'
+@__p_1='15'
 
 SELECT TOP(@__p_2) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -7966,8 +7966,8 @@ ORDER BY (
             base.Include_with_orderby_skip_preserves_ordering();
 
             AssertSql(
-                @"@__p_0: 40
-@__p_1: 5
+                @"@__p_0='40'
+@__p_1='5'
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -7975,8 +7975,8 @@ WHERE [c].[CustomerID] <> N'VAFFE'
 ORDER BY [c].[City], [c].[CustomerID]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY",
                 //
-                @"@__p_0: 40
-@__p_1: 5
+                @"@__p_0='40'
+@__p_1='5'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -8046,7 +8046,7 @@ WHERE (
             base.Select_take_average();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT AVG(CAST([t].[OrderID] AS float))
 FROM (
@@ -8061,7 +8061,7 @@ FROM (
             base.Select_take_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -8075,7 +8075,7 @@ FROM (
             base.Select_orderBy_take_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -8090,7 +8090,7 @@ FROM (
             base.Select_take_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -8104,7 +8104,7 @@ FROM (
             base.Select_orderBy_take_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -8119,7 +8119,7 @@ FROM (
             base.Select_take_max();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MAX([t].[OrderID])
 FROM (
@@ -8134,7 +8134,7 @@ FROM (
             base.Select_take_min();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MIN([t].[OrderID])
 FROM (
@@ -8149,7 +8149,7 @@ FROM (
             base.Select_take_sum();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT SUM([t].[OrderID])
 FROM (
@@ -8164,7 +8164,7 @@ FROM (
             base.Select_skip_average();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT AVG(CAST([t].[OrderID] AS float))
 FROM (
@@ -8180,7 +8180,7 @@ FROM (
             base.Select_skip_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -8196,7 +8196,7 @@ FROM (
             base.Select_orderBy_skip_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -8212,7 +8212,7 @@ FROM (
             base.Select_skip_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -8228,7 +8228,7 @@ FROM (
             base.Select_orderBy_skip_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -8244,7 +8244,7 @@ FROM (
             base.Select_skip_max();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MAX([t].[OrderID])
 FROM (
@@ -8260,7 +8260,7 @@ FROM (
             base.Select_skip_min();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MIN([t].[OrderID])
 FROM (
@@ -8276,7 +8276,7 @@ FROM (
             base.Select_skip_sum();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT SUM([t].[OrderID])
 FROM (

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Skip();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -45,7 +45,7 @@ WHERE [t].[__RowNumber__] > @__p_0");
             base.Skip_no_orderby();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -60,8 +60,8 @@ WHERE [t].[__RowNumber__] > @__p_0");
             base.Skip_Take();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -76,8 +76,8 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             base.Join_Customers_Orders_Skip_Take();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].[ContactName], [t].[OrderID]
 FROM (
@@ -93,8 +93,8 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].[Contact], [t].[OrderID]
 FROM (
@@ -110,8 +110,8 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t].[OrderID], [t].[CustomerIDA], [t].[CustomerIDB], [t].[ContactNameA], [t].[ContactNameB]
 FROM (
@@ -128,8 +128,8 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             base.Take_Skip();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t0].*
 FROM (
@@ -148,8 +148,8 @@ WHERE [t0].[__RowNumber__] > @__p_1");
             base.Take_Skip_Distinct();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -171,8 +171,8 @@ FROM (
             base.Take_skip_null_coalesce_operator();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT DISTINCT [t0].*
 FROM (
@@ -194,8 +194,8 @@ FROM (
             base.Select_take_skip_null_coalesce_operator();
 
             AssertSql(
-                @"@__p_0: 10
-@__p_1: 5
+                @"@__p_0='10'
+@__p_1='5'
 
 SELECT [t0].*
 FROM (
@@ -230,7 +230,7 @@ WHERE CHARINDEX(N'M', [c].[ContactName]) > 0");
                 entryCount: 34);
 
             AssertSql(
-                @"@__LocalMethod1_0: M (Size = 4000)
+                @"@__LocalMethod1_0='M' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -242,8 +242,8 @@ WHERE (CHARINDEX(@__LocalMethod1_0, [c].[ContactName]) > 0) OR (@__LocalMethod1_
             base.OrderBy_skip_take();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 8
+                @"@__p_0='5'
+@__p_1='8'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM (
@@ -258,9 +258,9 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
             base.OrderBy_skip_take_take();
 
             AssertSql(
-                @"@__p_2: 3
-@__p_0: 5
-@__p_1: 8
+                @"@__p_2='3'
+@__p_0='5'
+@__p_1='8'
 
 SELECT TOP(@__p_2) [t].*
 FROM (
@@ -279,11 +279,11 @@ ORDER BY [t].[ContactTitle], [t].[ContactName]");
             base.OrderBy_skip_take_take_take_take();
 
             AssertSql(
-                @"@__p_4: 5
-@__p_3: 8
-@__p_2: 10
-@__p_0: 5
-@__p_1: 15
+                @"@__p_4='5'
+@__p_3='8'
+@__p_2='10'
+@__p_0='5'
+@__p_1='15'
 
 SELECT TOP(@__p_4) [t1].*
 FROM (
@@ -310,11 +310,11 @@ ORDER BY [t1].[ContactTitle], [t1].[ContactName]");
             base.OrderBy_skip_take_skip_take_skip();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
-@__p_2: 2
-@__p_3: 8
-@__p_4: 5
+                @"@__p_0='5'
+@__p_1='15'
+@__p_2='2'
+@__p_3='8'
+@__p_4='5'
 
 SELECT [t3].*
 FROM (
@@ -343,8 +343,8 @@ WHERE [t3].[__RowNumber__2] > @__p_4");
             base.OrderBy_skip_take_distinct();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
+                @"@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -362,7 +362,7 @@ FROM (
             base.OrderBy_coalesce_take_distinct();
 
             AssertSql(
-                @"@__p_0: 15
+                @"@__p_0='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -377,8 +377,8 @@ FROM (
             base.OrderBy_coalesce_skip_take_distinct();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 15
+                @"@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT [t].*
 FROM (
@@ -396,9 +396,9 @@ FROM (
             base.OrderBy_coalesce_skip_take_distinct_take();
 
             AssertSql(
-                @"@__p_2: 5
-@__p_0: 5
-@__p_1: 15
+                @"@__p_2='5'
+@__p_0='5'
+@__p_1='15'
 
 SELECT DISTINCT TOP(@__p_2) [t].*
 FROM (
@@ -416,9 +416,9 @@ FROM (
             base.OrderBy_skip_take_distinct_orderby_take();
 
             AssertSql(
-                @"@__p_2: 8
-@__p_0: 5
-@__p_1: 15
+                @"@__p_2='8'
+@__p_0='5'
+@__p_1='15'
 
 SELECT TOP(@__p_2) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -440,8 +440,8 @@ ORDER BY [t0].[ContactTitle]");
             base.Skip_Take_Any();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT CASE
     WHEN EXISTS (
@@ -460,8 +460,8 @@ END");
             base.Skip_Take_All();
 
             AssertSql(
-                @"@__p_0: 5
-@__p_1: 10
+                @"@__p_0='5'
+@__p_1='10'
 
 SELECT CASE
     WHEN NOT EXISTS (
@@ -481,8 +481,8 @@ END");
             base.Include_with_orderby_skip_preserves_ordering();
 
             AssertSql(
-                @"@__p_0: 40
-@__p_1: 5
+                @"@__p_0='40'
+@__p_1='5'
 
 SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
@@ -492,8 +492,8 @@ FROM (
 ) AS [t0]
 WHERE ([t0].[__RowNumber__] > @__p_0) AND ([t0].[__RowNumber__] <= (@__p_0 + @__p_1))",
                 //
-                @"@__p_0: 40
-@__p_1: 5
+                @"@__p_0='40'
+@__p_1='5'
 
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
@@ -514,7 +514,7 @@ ORDER BY [t].[City], [t].[CustomerID]");
             base.GroupJoin_customers_orders_count_preserves_ordering();
 
             AssertSql(
-                @"@__p_0: 5
+                @"@__p_0='5'
 
 SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (
@@ -532,7 +532,7 @@ ORDER BY [t].[City], [t].[CustomerID]");
             base.Select_take_average();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT AVG(CAST([t].[OrderID] AS float))
 FROM (
@@ -547,7 +547,7 @@ FROM (
             base.Select_take_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -561,7 +561,7 @@ FROM (
             base.Select_orderBy_take_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -576,7 +576,7 @@ FROM (
             base.Select_take_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -590,7 +590,7 @@ FROM (
             base.Select_orderBy_take_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -605,7 +605,7 @@ FROM (
             base.Select_take_max();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MAX([t].[OrderID])
 FROM (
@@ -620,7 +620,7 @@ FROM (
             base.Select_take_min();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MIN([t].[OrderID])
 FROM (
@@ -635,7 +635,7 @@ FROM (
             base.Select_take_sum();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT SUM([t].[OrderID])
 FROM (
@@ -650,7 +650,7 @@ FROM (
             base.Select_skip_average();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT AVG(CAST([t].[OrderID] AS float))
 FROM (
@@ -668,7 +668,7 @@ FROM (
             base.Select_skip_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -686,7 +686,7 @@ FROM (
             base.Select_orderBy_skip_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT(*)
 FROM (
@@ -704,7 +704,7 @@ FROM (
             base.Select_skip_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -722,7 +722,7 @@ FROM (
             base.Select_orderBy_skip_long_count();
 
             AssertSql(
-                @"@__p_0: 7
+                @"@__p_0='7'
 
 SELECT COUNT_BIG(*)
 FROM (
@@ -740,7 +740,7 @@ FROM (
             base.Select_skip_max();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MAX([t].[OrderID])
 FROM (
@@ -758,7 +758,7 @@ FROM (
             base.Select_skip_min();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT MIN([t].[OrderID])
 FROM (
@@ -776,7 +776,7 @@ FROM (
             base.Select_skip_sum();
 
             AssertSql(
-                @"@__p_0: 10
+                @"@__p_0='10'
 
 SELECT SUM([t].[OrderID])
 FROM (

--- a/test/EFCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Executes_stored_procedure_with_parameter();
 
             AssertSql(
-                @"@CustomerID: ALFKI (Nullable = false) (Size = 5)
+                @"@CustomerID='ALFKI' (Nullable = false) (Size = 5)
 
 [dbo].[CustOrderHist] @CustomerID");
         }
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Executes_stored_procedure_with_generated_parameter();
 
             AssertSql(
-                @"@p0: ALFKI (Size = 4000)
+                @"@p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0");
         }
@@ -49,8 +49,8 @@ namespace Microsoft.EntityFrameworkCore
             base.Query_with_parameters();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -60,8 +60,8 @@ SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @
             base.Query_with_parameters_interpolated();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -71,8 +71,8 @@ SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @
             await base.Query_with_parameters_async();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
@@ -82,8 +82,8 @@ SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @
             await base.Query_with_parameters_interpolated_async();
 
             AssertSql(
-                @"@p0: London (Size = 4000)
-@p1: Sales Representative (Size = 4000)
+                @"@p0='London' (Size = 4000)
+@p1='Sales Representative' (Size = 4000)
 
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(3, loggingFactory.SqlStatements.Count);
                     Assert.Contains("SELECT", loggingFactory.SqlStatements[0]);
                     Assert.Contains("SELECT", loggingFactory.SqlStatements[1]);
-                    Assert.Contains("@p0: " + deletedId, loggingFactory.SqlStatements[2]);
+                    Assert.Contains("@p0='" + deletedId, loggingFactory.SqlStatements[2]);
                     Assert.Contains("DELETE", loggingFactory.SqlStatements[2]);
                     Assert.Contains("UPDATE", loggingFactory.SqlStatements[2]);
                     Assert.Contains("INSERT", loggingFactory.SqlStatements[2]);

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -108,19 +108,19 @@ FROM ""Sample"" AS ""r""
 WHERE ""r"".""UniqueNo"" = 1
 LIMIT 1
 
-@p2: 1 (DbType = String)
-@p0: ModifiedData (Nullable = false)
-@p1: 00000000-0000-0000-0003-000000000001 (DbType = String)
-@p3: 00000001-0000-0000-0000-000000000001 (DbType = String)
+@p2='1' (DbType = String)
+@p0='ModifiedData' (Nullable = false)
+@p1='00000000-0000-0000-0003-000000000001' (DbType = String)
+@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
 
 UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
 WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
 SELECT changes();
 
-@p2: 1 (DbType = String)
-@p0: ChangedData (Nullable = false)
-@p1: 00000000-0000-0000-0002-000000000001 (DbType = String)
-@p3: 00000001-0000-0000-0000-000000000001 (DbType = String)
+@p2='1' (DbType = String)
+@p0='ChangedData' (Nullable = false)
+@p1='00000000-0000-0000-0002-000000000001' (DbType = String)
+@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
 
 UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
 WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
@@ -132,9 +132,9 @@ SELECT changes();",
         {
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
-            Assert.Contains(@"@p0:  (DbType = String)
-@p1: Third (Nullable = false)
-@p2: 00000000-0000-0000-0000-000000000003 (DbType = String)
+            Assert.Contains(@"@p0='' (DbType = String)
+@p1='Third' (Nullable = false)
+@p2='00000000-0000-0000-0000-000000000003' (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);
@@ -157,11 +157,11 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p1: Book1 (Nullable = false)
+            Assert.Contains(@"@p1='Book1' (Nullable = false)
 ",
                 Sql);
 
-            Assert.Contains(@"@p1:  (Nullable = false) (DbType = String)
+            Assert.Contains(@"@p1='' (Nullable = false) (DbType = String)
 ",
                 Sql);
         }
@@ -170,9 +170,9 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p0:  (DbType = String)
-@p1: ValidString (Nullable = false)
-@p2: 00000000-0000-0000-0000-000000000001 (DbType = String)
+            Assert.Contains(@"@p0='' (DbType = String)
+@p1='ValidString' (Nullable = false)
+@p2='00000000-0000-0000-0000-000000000001' (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);
@@ -181,9 +181,9 @@ FROM ""Sample""
 WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
                 Sql);
 
-            Assert.Contains(@"@p0:  (DbType = String)
-@p1:  (Nullable = false) (DbType = String)
-@p2: 00000000-0000-0000-0000-000000000002 (DbType = String)
+            Assert.Contains(@"@p0='' (DbType = String)
+@p1='' (Nullable = false) (DbType = String)
+@p2='00000000-0000-0000-0000-000000000002' (DbType = String)
 
 INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
 VALUES (@p0, @p1, @p2);


### PR DESCRIPTION
Issue #8456

We previously used a different format for parameter logging in our tests when compared to product code logging. Now we use the same format everywhere. This change updates the product format back to what it was, and updates the test baselines to reflect this.
