### PR TITLE
Add EventId, LogLevel, and message generation for event payloads

### DIFF
--- a/src/EFCore.Design/Diagnostics/DesignEventId.cs
+++ b/src/EFCore.Design/Diagnostics/DesignEventId.cs
@@ -45,92 +45,197 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
-        ///     Removing a migration without checking the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Removing a migration without checking the database.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationDesignEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationForceRemove = MakeMigrationsId(Id.MigrationForceRemove);
 
         /// <summary>
-        ///     Removing migration.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Removing migration.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationDesignEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationRemoving = MakeMigrationsId(Id.MigrationRemoving);
 
         /// <summary>
-        ///     A migration file was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         A migration file was not found.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationFileNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationFileNotFound = MakeMigrationsId(Id.MigrationFileNotFound);
 
         /// <summary>
-        ///     A metadata file was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         A metadata file was not found.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationFileNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationMetadataFileNotFound = MakeMigrationsId(Id.MigrationMetadataFileNotFound);
 
         /// <summary>
-        ///     A manual migration deletion was detected.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         A manual migration deletion was detected.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationDesignEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationManuallyDeleted = MakeMigrationsId(Id.MigrationManuallyDeleted);
 
         /// <summary>
-        ///     Removing model snapshot.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Removing model snapshot.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ModelSnapshotFileNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SnapshotRemoving = MakeMigrationsId(Id.SnapshotRemoving);
 
         /// <summary>
-        ///     No model snapshot file named was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         No model snapshot file named was found.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ModelSnapshotFileNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SnapshotFileNotFound = MakeMigrationsId(Id.SnapshotFileNotFound);
 
         /// <summary>
-        ///     Writing model snapshot to file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Writing model snapshot to file.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ScaffoldedMigrationEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SnapshotWriting = MakeMigrationsId(Id.SnapshotWriting);
 
         /// <summary>
-        ///     Reusing namespace of a type.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Reusing namespace of a type.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ResourceReusedEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId NamespaceReusing = MakeMigrationsId(Id.NamespaceReusing);
 
         /// <summary>
-        ///     Reusing directory for a file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Reusing directory for a file.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ResourceReusedEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId DirectoryReusing = MakeMigrationsId(Id.DirectoryReusing);
 
         /// <summary>
-        ///     Reverting model snapshot.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Reverting model snapshot.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ModelSnapshotFileNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SnapshotReverting = MakeMigrationsId(Id.SnapshotReverting);
 
         /// <summary>
-        ///     Writing migration to file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Writing migration to file.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ScaffoldedMigrationEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId MigrationWriting = MakeMigrationsId(Id.MigrationWriting);
 
         /// <summary>
-        ///     Resuing model snapshot name.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         Resuing model snapshot name.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="SnapshotNameEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SnapshotNameReusing = MakeMigrationsId(Id.SnapshotNameReusing);
 
         /// <summary>
-        ///     An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationOperationsEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId DestructiveOperation = MakeMigrationsId(Id.DestructiveOperation);
 
         /// <summary>
-        ///     The namespace contains migrations for a different context.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     <para>
+        ///         The namespace contains migrations for a different context.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="NamespaceEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId ForeignMigrations = MakeMigrationsId(Id.ForeignMigrations);
     }

--- a/src/EFCore.Design/Diagnostics/MigrationDesignEventData.cs
+++ b/src/EFCore.Design/Diagnostics/MigrationDesignEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated <see cref="Migrations.Migration" />.
+    /// </summary>
+    public class MigrationDesignEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="migration"> The <see cref="Migration" />. </param>
+        public MigrationDesignEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Migration migration)
+            : base(eventDefinition, messageGenerator)
+        {
+            Migration = migration;
+        }
+
+        /// <summary>
+        ///     The <see cref="Migration" />.
+        /// </summary>
+        public virtual Migration Migration { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/MigrationFileNameEventData.cs
+++ b/src/EFCore.Design/Diagnostics/MigrationFileNameEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated <see cref="Migrations.Migration" /> and file name.
+    /// </summary>
+    public class MigrationFileNameEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="migration"> The <see cref="Migration" />. </param>
+        /// <param name="fileName"> The file name. </param>
+        public MigrationFileNameEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Migration migration,
+            [NotNull] string fileName)
+            : base(eventDefinition, messageGenerator)
+        {
+            Migration = migration;
+            FileName = fileName;
+        }
+
+        /// <summary>
+        ///     The <see cref="Migration" />.
+        /// </summary>
+        public virtual Migration Migration { get; }
+
+        /// <summary>
+        ///     The file name.
+        /// </summary>
+        public virtual string FileName { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/MigrationOperationsEventData.cs
+++ b/src/EFCore.Design/Diagnostics/MigrationOperationsEventData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     associated <see cref="MigrationOperation" />s.
+    /// </summary>
+    public class MigrationOperationsEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="operations"> The operations. </param>
+        public MigrationOperationsEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IEnumerable<MigrationOperation> operations)
+            : base(eventDefinition, messageGenerator)
+        {
+            Operations = operations;
+        }
+
+        /// <summary>
+        ///     The operations.
+        /// </summary>
+        public virtual IEnumerable<MigrationOperation> Operations { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/ModelSnapshotFileNameEventData.cs
+++ b/src/EFCore.Design/Diagnostics/ModelSnapshotFileNameEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated <see cref="ModelSnapshot" /> and file name.
+    /// </summary>
+    public class ModelSnapshotFileNameEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="snapshot"> The <see cref="ModelSnapshot" />. </param>
+        /// <param name="fileName"> The file name. </param>
+        public ModelSnapshotFileNameEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] ModelSnapshot snapshot,
+            [NotNull] string fileName)
+            : base(eventDefinition, messageGenerator)
+        {
+            Snapshot = snapshot;
+            FileName = fileName;
+        }
+
+        /// <summary>
+        ///     The <see cref="ModelSnapshot" />.
+        /// </summary>
+        public virtual ModelSnapshot Snapshot { get; }
+
+        /// <summary>
+        ///     The file name.
+        /// </summary>
+        public virtual string FileName { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/NamespaceEventData.cs
+++ b/src/EFCore.Design/Diagnostics/NamespaceEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated namespace.
+    /// </summary>
+    public class NamespaceEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="namespace"> The namespace. </param>
+        public NamespaceEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] string @namespace)
+            : base(eventDefinition, messageGenerator)
+        {
+            Namespace = @namespace;
+        }
+
+        /// <summary>
+        ///     The namespace.
+        /// </summary>
+        public virtual string Namespace { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/ResourceReusedEventData.cs
+++ b/src/EFCore.Design/Diagnostics/ResourceReusedEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that identify
+    ///     a resource such as a name or filename that is being re-used.
+    /// </summary>
+    public class ResourceReusedEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="resourceName"> The resource name. </param>
+        public ResourceReusedEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] string resourceName)
+            : base(eventDefinition, messageGenerator)
+        {
+            ResourceName = resourceName;
+        }
+
+        /// <summary>
+        ///     The resource name.
+        /// </summary>
+        public virtual string ResourceName { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/ScaffoldedMigrationEventData.cs
+++ b/src/EFCore.Design/Diagnostics/ScaffoldedMigrationEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Design;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated <see cref="Migrations.Design.ScaffoldedMigration" /> and file name.
+    /// </summary>
+    public class ScaffoldedMigrationEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="scaffoldedMigration"> The <see cref="Migrations.Design.ScaffoldedMigration" />. </param>
+        /// <param name="fileName"> The file name. </param>
+        public ScaffoldedMigrationEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] ScaffoldedMigration scaffoldedMigration,
+            [NotNull] string fileName)
+            : base(eventDefinition, messageGenerator)
+        {
+            ScaffoldedMigration = scaffoldedMigration;
+            FileName = fileName;
+        }
+
+        /// <summary>
+        ///     The <see cref="Migrations.Design.ScaffoldedMigration" />.
+        /// </summary>
+        public virtual ScaffoldedMigration ScaffoldedMigration { get; }
+
+        /// <summary>
+        ///     The file name.
+        /// </summary>
+        public virtual string FileName { get; }
+    }
+}

--- a/src/EFCore.Design/Diagnostics/SnapshotNameEventData.cs
+++ b/src/EFCore.Design/Diagnostics/SnapshotNameEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an associated snapshot name.
+    /// </summary>
+    public class SnapshotNameEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="snapshotName"> The snapshot name. </param>
+        public SnapshotNameEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] string snapshotName)
+            : base(eventDefinition, messageGenerator)
+        {
+            SnapshotName = snapshotName;
+        }
+
+        /// <summary>
+        ///     The snapshot name.
+        /// </summary>
+        public virtual string SnapshotName { get; }
+    }
+}

--- a/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
+++ b/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -38,11 +37,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        MigrationNamespace = migrationNamespace
-                    });
+                    new NamespaceEventData(
+                        definition,
+                        ForeignMigrations,
+                        migrationNamespace));
             }
+        }
+
+        private static string ForeignMigrations(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (NamespaceEventData)payload;
+            return d.GenerateMessage(p.Namespace);
         }
 
         /// <summary>
@@ -63,11 +69,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        LastModelSnapshotName = lastModelSnapshotName
-                    });
+                    new SnapshotNameEventData(
+                        definition,
+                        SnapshotNameReusing,
+                        lastModelSnapshotName));
             }
+        }
+
+        private static string SnapshotNameReusing(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (SnapshotNameEventData)payload;
+            return d.GenerateMessage(p.SnapshotName);
         }
 
         /// <summary>
@@ -86,10 +99,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Operations = (ICollection<MigrationOperation>)operations.ToList()
-                    });
+                    new MigrationOperationsEventData(
+                        definition,
+                        (d, p) => ((EventDefinition)d).GenerateMessage(),
+                        operations));
             }
         }
 
@@ -115,11 +128,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Migration = migration
-                    });
+                    new MigrationDesignEventData(
+                        definition,
+                        MigrationForceRemove,
+                        migration));
             }
+        }
+
+        private static string MigrationForceRemove(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (MigrationDesignEventData)payload;
+            return d.GenerateMessage(p.Migration.GetId());
         }
 
         /// <summary>
@@ -144,11 +164,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Migration = migration
-                    });
+                    new MigrationDesignEventData(
+                        definition,
+                        MigrationRemoving,
+                        migration));
             }
+        }
+
+        private static string MigrationRemoving(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (MigrationDesignEventData)payload;
+            return d.GenerateMessage(p.Migration.GetId());
         }
 
         /// <summary>
@@ -175,12 +202,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Migration = migration,
-                        FileName = fileName
-                    });
+                    new MigrationFileNameEventData(
+                        definition,
+                        MigrationFileNotFound,
+                        migration,
+                        fileName));
             }
+        }
+
+        private static string MigrationFileNotFound(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (MigrationFileNameEventData)payload;
+            return d.GenerateMessage(p.FileName, p.Migration.GetType().ShortDisplayName());
         }
 
         /// <summary>
@@ -200,12 +234,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Migration = migration,
-                        FileName = fileName
-                    });
+                    new MigrationFileNameEventData(
+                        definition,
+                        MigrationMetadataFileNotFound,
+                        migration,
+                        fileName));
             }
+        }
+
+        private static string MigrationMetadataFileNotFound(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (MigrationFileNameEventData)payload;
+            return d.GenerateMessage(p.FileName);
         }
 
         /// <summary>
@@ -224,10 +265,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Migration = migration
-                    });
+                    new MigrationDesignEventData(
+                        definition,
+                        (d, p) => ((EventDefinition)d).GenerateMessage(),
+                        migration));
             }
         }
 
@@ -248,11 +289,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        ModelSnapshot = modelSnapshot,
-                        FileName = fileName
-                    });
+                    new ModelSnapshotFileNameEventData(
+                        definition,
+                        (d, p) => ((EventDefinition)d).GenerateMessage(),
+                        modelSnapshot,
+                        fileName));
             }
         }
 
@@ -280,12 +321,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        ModelSnapshot = modelSnapshot,
-                        FileName = fileName
-                    });
+                    new ModelSnapshotFileNameEventData(
+                        definition,
+                        SnapshotFileNotFound,
+                        modelSnapshot,
+                        fileName));
             }
+        }
+
+        private static string SnapshotFileNotFound(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (ModelSnapshotFileNameEventData)payload;
+            return d.GenerateMessage(p.FileName, p.Snapshot.GetType().ShortDisplayName());
         }
 
         /// <summary>
@@ -305,11 +353,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        ModelSnapshot = modelSnapshot,
-                        FileName = fileName
-                    });
+                    new ModelSnapshotFileNameEventData(
+                        definition,
+                        (d, p) => ((EventDefinition)d).GenerateMessage(),
+                        modelSnapshot,
+                        fileName));
             }
         }
 
@@ -330,12 +378,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        ScaffoldedMigration = scaffoldedMigration,
-                        FileName = fileName
-                    });
+                    new ScaffoldedMigrationEventData(
+                        definition,
+                        MigrationWriting,
+                        scaffoldedMigration,
+                        fileName));
             }
+        }
+
+        private static string MigrationWriting(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (ScaffoldedMigrationEventData)payload;
+            return d.GenerateMessage(p.FileName);
         }
 
         /// <summary>
@@ -355,12 +410,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        ScaffoldedMigration = scaffoldedMigration,
-                        FileName = fileName
-                    });
+                    new ScaffoldedMigrationEventData(
+                        definition,
+                        SnapshotWriting,
+                        scaffoldedMigration,
+                        fileName));
             }
+        }
+
+        private static string SnapshotWriting(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (ScaffoldedMigrationEventData)payload;
+            return d.GenerateMessage(p.FileName);
         }
 
         /// <summary>
@@ -383,11 +445,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Type = type
-                    });
+                    new ResourceReusedEventData(
+                        definition,
+                        NamespaceReusing,
+                        type.ShortDisplayName()));
             }
+        }
+
+        private static string NamespaceReusing(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (ResourceReusedEventData)payload;
+            return d.GenerateMessage(p.ResourceName);
         }
 
         /// <summary>
@@ -406,11 +475,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        FileName = fileName
-                    });
+                    new ResourceReusedEventData(
+                        definition,
+                        DirectoryReusing,
+                        fileName));
             }
+        }
+
+        private static string DirectoryReusing(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (ResourceReusedEventData)payload;
+            return d.GenerateMessage(p.ResourceName);
         }
     }
 }

--- a/src/EFCore.InMemory/Diagnostics/InMemoryEventId.cs
+++ b/src/EFCore.InMemory/Diagnostics/InMemoryEventId.cs
@@ -34,8 +34,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
 
         /// <summary>
-        ///     Changes were saved to the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///     <para>
+        ///         Changes were saved to the database.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="EventDataBase" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId TransactionIgnoredWarning = MakeTransactionId(Id.TransactionIgnoredWarning);
 
@@ -43,8 +50,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
-        ///     A transaction operation was requested, but ignored because in-memory does not support transactions.
-        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     <para>
+        ///         A transaction operation was requested, but ignored because in-memory does not support transactions.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="SaveChangesEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId ChangesSaved = MakeUpdateId(Id.ChangesSaved);
     }

--- a/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
@@ -5,7 +5,6 @@ using System;
 using System.Data.Common;
 using System.Diagnostics;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
@@ -18,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command">
         ///     The <see cref="DbCommand" />.
         /// </param>
@@ -33,6 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
+        /// <param name="logParameterValues">
+        ///     Indicates whether or not the application allows logging of parameter values.
+        /// </param>
         /// <param name="startTime">
         ///     The start time of this event.
         /// </param>
@@ -40,14 +44,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public CommandEndEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
             bool async,
+            bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(command, executeMethod, commandId, connectionId, async, startTime)
+            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime)
             => Duration = duration;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
@@ -16,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command">
         ///     The <see cref="DbCommand" /> that was executing when it failed.
         /// </param>
@@ -34,6 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
+        /// <param name="logParameterValues">
+        ///     Indicates whether or not the application allows logging of parameter values.
+        /// </param>
         /// <param name="startTime">
         ///     The start time of this event.
         /// </param>
@@ -41,15 +46,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public CommandErrorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
             [NotNull] Exception exception,
             bool async,
+            bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(command, executeMethod, commandId, connectionId, async, startTime, duration) 
+            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime, duration) 
             => Exception = exception;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/CommandEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEventData.cs
@@ -5,7 +5,6 @@ using System;
 using System.Data.Common;
 using System.Diagnostics;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
@@ -13,11 +12,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///     The <see cref="DiagnosticSource" /> event payload for
     ///     <see cref="RelationalEventId" /> command events.
     /// </summary>
-    public class CommandEventData
+    public class CommandEventData : EventDataBase
     {
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command">
         ///     The <see cref="DbCommand" />.
         /// </param>
@@ -33,22 +34,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
+        /// <param name="logParameterValues">
+        ///     Indicates whether or not the application allows logging of parameter values.
+        /// </param>
         /// <param name="startTime">
         ///     The start time of this event.
         /// </param>
         public CommandEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
             bool async,
+            bool logParameterValues,
             DateTimeOffset startTime)
+            : base(eventDefinition, messageGenerator)
         {
             Command = command;
             CommandId = commandId;
             ConnectionId = connectionId;
             ExecuteMethod = executeMethod;
             IsAsync = async;
+            LogParameterValues = logParameterValues;
             StartTime = startTime;
         }
 
@@ -76,6 +85,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     Indicates whether or not the operation is being executed asyncronously.
         /// </summary>
         public virtual bool IsAsync { get; }
+
+        /// <summary>
+        ///     Indicates whether or not the application allows logging of parameter values.
+        /// </summary>
+        public virtual bool LogParameterValues { get; }
 
         /// <summary>
         ///     The start time of this event.

--- a/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
@@ -16,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command">
         ///     The <see cref="DbCommand" /> that was executing when it failed.
         /// </param>
@@ -34,6 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async">
         ///     Indicates whether or not the command was executed asyncronously.
         /// </param>
+        /// <param name="logParameterValues">
+        ///     Indicates whether or not the application allows logging of parameter values.
+        /// </param>
         /// <param name="startTime">
         ///     The start time of this event.
         /// </param>
@@ -41,15 +46,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public CommandExecutedEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
             Guid connectionId,
             [CanBeNull] object result,
             bool async,
+            bool logParameterValues,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(command, executeMethod, commandId, connectionId, async, startTime, duration)
+            : base(eventDefinition, messageGenerator, command, executeMethod, commandId, connectionId, async, logParameterValues, startTime, duration)
             => Result = result;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/ConnectionEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionEndEventData.cs
@@ -17,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="connection">
         ///     The <see cref="DbConnection" />.
         /// </param>
@@ -33,12 +35,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public ConnectionEndEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbConnection connection,
             Guid connectionId,
             bool async,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(connection, connectionId, async, startTime)
+            : base(eventDefinition, messageGenerator, connection, connectionId, async, startTime)
             => Duration = duration;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/ConnectionErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionErrorEventData.cs
@@ -16,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="connection">
         ///     The <see cref="DbConnection" />.
         /// </param>
@@ -35,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public ConnectionErrorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbConnection connection,
             Guid connectionId,
             [NotNull] Exception exception,
             bool async,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(connection, connectionId, async, startTime, duration) 
+            : base(eventDefinition, messageGenerator, connection, connectionId, async, startTime, duration) 
             => Exception = exception;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/ConnectionEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/ConnectionEventData.cs
@@ -12,11 +12,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///     The <see cref="DiagnosticSource" /> event payload base class for
     ///     <see cref="RelationalEventId" /> connection events.
     /// </summary>
-    public class ConnectionEventData
+    public class ConnectionEventData : EventDataBase
     {
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="connection">
         ///     The <see cref="DbConnection" />.
         /// </param>
@@ -30,10 +32,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The start time of this event.
         /// </param>
         public ConnectionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbConnection connection,
             Guid connectionId,
             bool async,
             DateTimeOffset startTime)
+            : base(eventDefinition, messageGenerator)
         {
             Connection = connection;
             ConnectionId = connectionId;

--- a/src/EFCore.Relational/Diagnostics/DataReaderDisposingEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/DataReaderDisposingEventData.cs
@@ -11,11 +11,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     /// <summary>
     ///     <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderDisposing" />.
     /// </summary>
-    public class DataReaderDisposingEventData
+    public class DataReaderDisposingEventData : EventDataBase
     {
         /// <summary>
         ///     Constructs a <see cref="DiagnosticSource" /> event payload for <see cref="RelationalEventId.DataReaderDisposing" />.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="command">
         ///     The <see cref="DbCommand" /> that created the reader.
         /// </param>
@@ -38,6 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public DataReaderDisposingEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader dataReader,
             Guid commandId,
@@ -45,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             int recordsAffected,
             DateTimeOffset startTime,
             TimeSpan duration)
+            : base(eventDefinition, messageGenerator)
         {
             Command = command;
             DataReader = dataReader;

--- a/src/EFCore.Relational/Diagnostics/EntityTypeSchemaEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/EntityTypeSchemaEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     The <see cref="DiagnosticSource" /> event payload base class for events that
+    ///     reference an entity type and a schema
+    /// </summary>
+    public class EntityTypeSchemaEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="entityType"> The entity type. </param>
+        /// <param name="schema"> The schema. </param>
+        public EntityTypeSchemaEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IEntityType entityType,
+            [NotNull] string schema)
+            : base(eventDefinition, messageGenerator)
+        {
+            EntityType = entityType;
+            Schema = schema;
+        }
+
+        /// <summary>
+        ///     The entity type.
+        /// </summary>
+        public virtual IEntityType EntityType { get; }
+
+        /// <summary>
+        ///     The schema.
+        /// </summary>
+        public virtual string Schema { get; }
+    }
+}

--- a/src/EFCore.Relational/Diagnostics/MigrationEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigrationEventData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -16,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="migrator">
         ///     The <see cref="IMigrator" /> in use.
         /// </param>
@@ -23,9 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The <see cref="Migration" /> being processed.
         /// </param>
         public MigrationEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration)
-            : base(migrator)
+            : base(eventDefinition, messageGenerator, migrator)
         {
             Migration = migration;
         }

--- a/src/EFCore.Relational/Diagnostics/MigrationScriptingEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigrationScriptingEventData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -16,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="migrator">
         ///     The <see cref="IMigrator" /> in use.
         /// </param>
@@ -32,12 +35,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     Indicates whether or not the script is idempotent.
         /// </param>
         public MigrationScriptingEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration,
             [CanBeNull] string fromMigration,
             [CanBeNull] string toMigration,
             bool idempotent)
-            : base(migrator, migration)
+            : base(eventDefinition, messageGenerator, migrator, migration)
         {
             FromMigration = fromMigration;
             ToMigration = toMigration;

--- a/src/EFCore.Relational/Diagnostics/MigratorConnectionEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigratorConnectionEventData.cs
@@ -18,6 +18,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="migrator">
         ///     The <see cref="IMigrator" /> in use.
         /// </param>
@@ -28,10 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     A correlation ID that identifies the <see cref="DbConnection" /> instance being used.
         /// </param>
         public MigratorConnectionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] IMigrator migrator,
             [NotNull] DbConnection connection,
             Guid connectionId)
-            : base(migrator)
+            : base(eventDefinition, messageGenerator, migrator)
         {
             Connection = connection;
             ConnectionId = connectionId;

--- a/src/EFCore.Relational/Diagnostics/MigratorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigratorEventData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -11,15 +12,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///     The <see cref="DiagnosticSource" /> event payload for
     ///     <see cref="RelationalEventId" /> migration events.
     /// </summary>
-    public class MigratorEventData
+    public class MigratorEventData : EventDataBase
     {
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="migrator">
         ///     The <see cref="IMigrator" /> in use.
         /// </param>
-        public MigratorEventData([NotNull] IMigrator migrator)
+        public MigratorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IMigrator migrator)
+            : base(eventDefinition, messageGenerator)
         {
             Migrator = migrator;
         }

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -357,6 +357,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     <para>
         ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
         ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryModelExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId QueryClientEvaluationWarning = MakeQueryId(Id.QueryClientEvaluationWarning);
 
@@ -366,6 +369,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         ///     <para>
         ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="BinaryExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
         ///     </para>
         /// </summary>
         public static readonly EventId QueryPossibleUnintendedUseOfEqualsWarning = MakeQueryId(Id.QueryPossibleUnintendedUseOfEqualsWarning);
@@ -379,6 +385,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         ///     <para>
         ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
         ///     </para>
         /// </summary>
         public static readonly EventId ModelValidationKeyDefaultValueWarning = MakeValidationId(Id.ModelValidationKeyDefaultValueWarning);

--- a/src/EFCore.Relational/Diagnostics/SequenceEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/SequenceEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     The <see cref="DiagnosticSource" /> event payload base class for events that
+    ///     reference a sequence.
+    /// </summary>
+    public class SequenceEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="sequence"> The sequence. </param>
+        public SequenceEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] ISequence sequence)
+            : base(eventDefinition, messageGenerator)
+        {
+            Sequence = sequence;
+        }
+
+        /// <summary>
+        ///     The sequence.
+        /// </summary>
+        public virtual ISequence Sequence { get; }
+    }
+}

--- a/src/EFCore.Relational/Diagnostics/TransactionEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionEndEventData.cs
@@ -17,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="transaction">
         ///     The <see cref="DbTransaction" />.
         /// </param>
@@ -33,12 +35,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public TransactionEndEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
             Guid connectionId,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(transaction, transactionId, connectionId, startTime) 
+            : base(eventDefinition, messageGenerator, transaction, transactionId, connectionId, startTime) 
             => Duration = duration;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/TransactionErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionErrorEventData.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="transaction">
         ///     The <see cref="DbTransaction" />.
         /// </param>
@@ -36,6 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The duration this event.
         /// </param>
         public TransactionErrorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
             Guid connectionId,
@@ -43,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             [NotNull] Exception exception,
             DateTimeOffset startTime,
             TimeSpan duration)
-            : base(transaction, transactionId, connectionId, startTime, duration)
+            : base(eventDefinition, messageGenerator, transaction, transactionId, connectionId, startTime, duration)
         {
             Action = action;
             Exception = exception;

--- a/src/EFCore.Relational/Diagnostics/TransactionEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/TransactionEventData.cs
@@ -12,11 +12,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     ///     The <see cref="DiagnosticSource" /> event payload base class for
     ///     <see cref="RelationalEventId" /> transaction events.
     /// </summary>
-    public class TransactionEventData
+    public class TransactionEventData : EventDataBase
     {
         /// <summary>
         ///     Constructs the event payload.
         /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
         /// <param name="transaction">
         ///     The <see cref="DbTransaction" />.
         /// </param>
@@ -30,10 +32,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The start time of this event.
         /// </param>
         public TransactionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
             Guid connectionId,
             DateTimeOffset startTime)
+            : base(eventDefinition, messageGenerator)
         {
             Transaction = transaction;
             TransactionId = transactionId;

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -32,14 +32,28 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
-        ///     No explicit type for a decimal column.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     <para>
+        ///         No explicit type for a decimal column.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId DecimalTypeDefaultWarning = MakeValidationId(Id.DecimalTypeDefaultWarning);
 
         /// <summary>
-        ///     A byte property is set up to use a SQL Server identity column.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     <para>
+        ///         A byte property is set up to use a SQL Server identity column.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId ByteIdentityColumnWarning = MakeValidationId(Id.ByteIdentityColumnWarning);
     }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -35,11 +34,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Property = property
-                    });
+                    new PropertyEventData(
+                        definition,
+                        DecimalTypeDefaultWarning,
+                        property));
             }
+        }
+
+        private static string DecimalTypeDefaultWarning(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (PropertyEventData)payload;
+            return d.GenerateMessage(
+                p.Property.Name,
+                p.Property.DeclaringEntityType.DisplayName());
         }
 
         /// <summary>
@@ -62,11 +70,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Property = property
-                    });
+                    new PropertyEventData(
+                        definition,
+                        ByteIdentityColumnWarning,
+                        property));
             }
+        }
+
+        private static string ByteIdentityColumnWarning(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (PropertyEventData)payload;
+            return d.GenerateMessage(
+                p.Property.Name,
+                p.Property.DeclaringEntityType.DisplayName());
         }
     }
 }

--- a/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
+++ b/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
@@ -32,14 +32,28 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
-        ///     A schema was configured for an entity type, but SQLite does not support schemas.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     <para>
+        ///         A schema was configured for an entity type, but SQLite does not support schemas.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="EntityTypeSchemaEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SchemaConfiguredWarning = MakeValidationId(Id.SchemaConfiguredWarning);
 
         /// <summary>
-        ///     A sequence was configured for an entity type, but SQLite does not support sequences.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     <para>
+        ///         A sequence was configured for an entity type, but SQLite does not support sequences.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="SequenceEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SequenceConfiguredWarning = MakeValidationId(Id.SequenceConfiguredWarning);
     }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -32,12 +31,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        EntityType = entityType,
-                        Schema = schema
-                    });
+                    new EntityTypeSchemaEventData(
+                        definition,
+                        SchemaConfiguredWarning,
+                        entityType,
+                        schema));
             }
+        }
+
+        private static string SchemaConfiguredWarning(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (EntityTypeSchemaEventData)payload;
+            return d.GenerateMessage(
+                p.EntityType.DisplayName(),
+                p.Schema);
         }
 
         /// <summary>
@@ -56,11 +64,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 diagnostics.DiagnosticSource.Write(
                     definition.EventId.Name,
-                    new
-                    {
-                        Sequence = sequence
-                    });
+                    new SequenceEventData(
+                        definition,
+                        SequenceConfiguredWarning,
+                        sequence));
             }
+        }
+
+        private static string SequenceConfiguredWarning(EventDefinitionBase definition, EventDataBase payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (SequenceEventData)payload;
+            return d.GenerateMessage(p.Sequence.Name);
         }
     }
 }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -335,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore
             }
             catch (Exception exception)
             {
-                _updateLogger.SaveChangesFailed(GetType(), exception);
+                _updateLogger.SaveChangesFailed(this, exception);
 
                 throw;
             }
@@ -407,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore
             }
             catch (Exception exception)
             {
-                _updateLogger.SaveChangesFailed(GetType(), exception);
+                _updateLogger.SaveChangesFailed(this, exception);
 
                 throw;
             }

--- a/src/EFCore/Diagnostics/BinaryExpressionEventData.cs
+++ b/src/EFCore/Diagnostics/BinaryExpressionEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a query expression.
+    /// </summary>
+    public class BinaryExpressionEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="left"> The left <see cref="Expression" />. </param>
+        /// <param name="right"> The right <see cref="Expression" />. </param>
+        public BinaryExpressionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Expression left,
+            [NotNull] Expression right)
+            : base(eventDefinition, messageGenerator)
+        {
+            Left = left;
+            Right = right;
+        }
+
+        /// <summary>
+        ///     The left <see cref="Expression" />.
+        /// </summary>
+        public virtual Expression Left { get; }
+
+        /// <summary>
+        ///     The right <see cref="Expression" />.
+        /// </summary>
+        public virtual Expression Right { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -48,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The lower-bound for event IDs used only by database provider design-time and tooling.
         /// </summary>
         public const int ProviderDesignBaseId = 350000;
-        
+
         // Warning: These values must not change between releases.
         // Only add new values to the end of sections, never in the middle.
         // Try to use <Noun><Verb> naming and be consistent with existing names.
@@ -69,9 +68,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             PossibleUnintendedCollectionNavigationNullComparisonWarning,
             PossibleUnintendedReferenceComparisonWarning,
 
-            // Model validation events
-            ModelValidationShadowKeyWarning = CoreBaseId + 300,
-
             // Infrastucture events
             SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
             ServiceProviderCreated,
@@ -82,8 +78,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
-        ///     An error occurred while attempting to save changes to the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     <para>
+        ///         An error occurred while attempting to save changes to the database.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="DbContextErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SaveChangesFailed = MakeUpdateId(Id.SaveChangesFailed);
 
@@ -91,94 +94,176 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
 
         /// <summary>
-        ///     An error occurred while processing the results of a query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         An error occurred while processing the results of a query.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="DbContextTypeErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId QueryIterationFailed = MakeQueryId(Id.QueryIterationFailed);
 
         /// <summary>
-        ///     A query model is being compiled.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A query model is being compiled.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryModelEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId QueryModelCompiling = MakeQueryId(Id.QueryModelCompiling);
 
         /// <summary>
-        ///     A query uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A query uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryModelEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId RowLimitingOperationWithoutOrderByWarning = MakeQueryId(Id.RowLimitingOperationWithoutOrderByWarning);
 
         /// <summary>
-        ///     A query uses First/FirstOrDefault operation without OrderBy and filter which may lead to unpredictable results.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A query uses First/FirstOrDefault operation without OrderBy and filter which may lead to unpredictable results.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryModelEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId FirstWithoutOrderByAndFilterWarning = MakeQueryId(Id.FirstWithoutOrderByAndFilterWarning);
 
         /// <summary>
-        ///     A query model was optimized.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A query model was optimized.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryModelEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId QueryModelOptimized = MakeQueryId(Id.QueryModelOptimized);
 
         /// <summary>
-        ///     A navigation was included in the query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A navigation was included in the query.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="IncludeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId NavigationIncluded = MakeQueryId(Id.NavigationIncluded);
 
         /// <summary>
-        ///     A navigation was ignored while compiling a query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A navigation was ignored while compiling a query.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="IncludeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId IncludeIgnoredWarning = MakeQueryId(Id.IncludeIgnoredWarning);
 
         /// <summary>
-        ///     A query is planned for execution.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         A query is planned for execution.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId QueryExecutionPlanned = MakeQueryId(Id.QueryExecutionPlanned);
 
         /// <summary>
-        ///     Possible uninteded comparison of collection navigation to null.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         Possible uninteded comparison of collection navigation to null.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="NavigationPathEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId PossibleUnintendedCollectionNavigationNullComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedCollectionNavigationNullComparisonWarning);
 
         /// <summary>
-        ///     Possible uninteded reference comparison.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     <para>
+        ///         Possible uninteded reference comparison.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="BinaryExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId PossibleUnintendedReferenceComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedReferenceComparisonWarning);
-
-        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
-        private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
-
-        /// <summary>
-        ///     A warning during model validation indicating a key is configured on shadow properties.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
-        /// </summary>
-        public static readonly EventId ModelValidationShadowKeyWarning = MakeValidationId(Id.ModelValidationShadowKeyWarning);
 
         private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
         private static EventId MakeInfraId(Id id) => new EventId((int)id, _infraPrefix + id);
 
         /// <summary>
-        ///     A warning indicating that sensitive data logging is enabled and may be logged.
-        ///     This event may be in different categories depending on where sensitive data is being logged.
+        ///     <para>
+        ///         A warning indicating that sensitive data logging is enabled and may be logged.
+        ///     </para>
+        ///     <para>
+        ///         This event may be in different categories depending on where sensitive data is being logged.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="EventDataBase" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId SensitiveDataLoggingEnabledWarning = MakeInfraId(Id.SensitiveDataLoggingEnabledWarning);
 
         /// <summary>
-        ///     A service provider was created for internal use by Entity Framework.
-        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     <para>
+        ///         A service provider was created for internal use by Entity Framework.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ServiceProviderEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId ServiceProviderCreated = MakeInfraId(Id.ServiceProviderCreated);
 
         /// <summary>
-        ///     Many service proviers were created in a single app domain.
-        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     <para>
+        ///         Many service proviers were created in a single app domain.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ServiceProvidersEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
         /// </summary>
         public static readonly EventId ManyServiceProvidersCreatedWarning = MakeInfraId(Id.ManyServiceProvidersCreatedWarning);
     }

--- a/src/EFCore/Diagnostics/DbContextErrorEventData.cs
+++ b/src/EFCore/Diagnostics/DbContextErrorEventData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for error events that reference
+    ///     a <see cref="DbContext" />.
+    /// </summary>
+    public class DbContextErrorEventData : DbContextEventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="context"> The current <see cref="DbContext" />. </param>
+        /// <param name="exception"> The exception that triggered this event. </param>
+        public DbContextErrorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] DbContext context,
+            [NotNull] Exception exception)
+            : base(eventDefinition, messageGenerator, context)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        ///     The exception that triggered this event.
+        /// </summary>
+        public virtual Exception Exception { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/DbContextEventData.cs
+++ b/src/EFCore/Diagnostics/DbContextEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that reference
+    ///     a <see cref="DbContext" />.
+    /// </summary>
+    public class DbContextEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="context"> The current <see cref="DbContext" />. </param>
+        public DbContextEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] DbContext context)
+            : base(eventDefinition, messageGenerator)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        ///     The current <see cref="DbContext" />.
+        /// </summary>
+        public virtual DbContext Context { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/DbContextTypeErrorEventData.cs
+++ b/src/EFCore/Diagnostics/DbContextTypeErrorEventData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for error events that reference
+    ///     a <see cref="DbContext" /> type.
+    /// </summary>
+    public class DbContextTypeErrorEventData : DbContextTypeEventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="contextType"> The type of the current <see cref="DbContext" />. </param>
+        /// <param name="exception"> The exception that triggered this event. </param>
+        public DbContextTypeErrorEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Type contextType,
+            [NotNull] Exception exception)
+            : base(eventDefinition, messageGenerator, contextType)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        ///     The exception that triggered this event.
+        /// </summary>
+        public virtual Exception Exception { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/DbContextTypeEventData.cs
+++ b/src/EFCore/Diagnostics/DbContextTypeEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that reference
+    ///     a <see cref="DbContext" /> type.
+    /// </summary>
+    public class DbContextTypeEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="contextType"> The current <see cref="DbContext" />. </param>
+        public DbContextTypeEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Type contextType)
+            : base(eventDefinition, messageGenerator)
+        {
+            ContextType = contextType;
+        }
+
+        /// <summary>
+        ///     The current <see cref="DbContext" />.
+        /// </summary>
+        public virtual Type ContextType { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/EventDataBase.cs
+++ b/src/EFCore/Diagnostics/EventDataBase.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A base class for all Entity Framework <see cref="DiagnosticSource" /> event payloads.
+    /// </summary>
+    public class EventDataBase
+    {
+        private readonly EventDefinitionBase _eventDefinition;
+        private readonly Func<EventDefinitionBase, EventDataBase, string> _messageGenerator;
+
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        public EventDataBase(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator)
+        {
+            _eventDefinition = eventDefinition;
+            _messageGenerator = messageGenerator;
+        }
+
+        /// <summary>
+        ///     The <see cref="EventId" /> that defines the message ID and name.
+        /// </summary>
+        public virtual EventId EventId => _eventDefinition.EventId;
+
+        /// <summary>
+        ///     The <see cref="LogLevel" /> that would be used to log message for this event.
+        /// </summary>
+        public virtual LogLevel LogLevel => _eventDefinition.Level;
+
+        /// <summary>
+        ///     A logger message describing this event.
+        /// </summary>
+        /// <returns> A logger message describing this event. </returns>
+        public override string ToString() => _messageGenerator(_eventDefinition, this);
+    }
+}

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics

--- a/src/EFCore/Diagnostics/IncludeEventData.cs
+++ b/src/EFCore/Diagnostics/IncludeEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     an <see cref="EntityFrameworkQueryableExtensions.Include{TEntity,TProperty}" /> specification.
+    /// </summary>
+    public class IncludeEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="includeSpecification"> The Include specification. </param>
+        public IncludeEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] string includeSpecification)
+            : base(eventDefinition, messageGenerator)
+        {
+            IncludeSpecification = includeSpecification;
+        }
+
+        /// <summary>
+        ///     The <see cref="EntityFrameworkQueryableExtensions.Include{TEntity,TProperty}" /> specification.
+        /// </summary>
+        public virtual string IncludeSpecification { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/NavigationPathEventData.cs
+++ b/src/EFCore/Diagnostics/NavigationPathEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a navigation property.
+    /// </summary>
+    public class NavigationPathEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="navigationPath"> The navigation property. </param>
+        public NavigationPathEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] string navigationPath)
+            : base(eventDefinition, messageGenerator)
+        {
+            NavigationPath = navigationPath;
+        }
+
+        /// <summary>
+        ///     The navigation property.
+        /// </summary>
+        public virtual string NavigationPath { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/PropertyEventData.cs
+++ b/src/EFCore/Diagnostics/PropertyEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a property.
+    /// </summary>
+    public class PropertyEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="property"> The property. </param>
+        public PropertyEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IProperty property)
+            : base(eventDefinition, messageGenerator)
+        {
+            Property = property;
+        }
+
+        /// <summary>
+        ///     The property.
+        /// </summary>
+        public virtual IProperty Property { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/QueryExpressionEventData.cs
+++ b/src/EFCore/Diagnostics/QueryExpressionEventData.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a query expression.
+    /// </summary>
+    public class QueryExpressionEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="queryExpression"> The <see cref="Expression" />. </param>
+        /// <param name="expressionPrinter"> An <see cref="IExpressionPrinter" /> that can be used to render the <see cref="Expression" />. </param>
+        public QueryExpressionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] Expression queryExpression,
+            [NotNull] IExpressionPrinter expressionPrinter)
+            : base(eventDefinition, messageGenerator)
+        {
+            Expression = queryExpression;
+            ExpressionPrinter = expressionPrinter;
+        }
+
+        /// <summary>
+        ///     The <see cref="Expression" />.
+        /// </summary>
+        public virtual Expression Expression { get; }
+
+        /// <summary>
+        ///     An <see cref="IExpressionPrinter" /> that can be used to render the <see cref="Expression" />.
+        /// </summary>
+        public virtual IExpressionPrinter ExpressionPrinter { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/QueryModelEventData.cs
+++ b/src/EFCore/Diagnostics/QueryModelEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Remotion.Linq;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a query model.
+    /// </summary>
+    public class QueryModelEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="queryModel"> The <see cref="QueryModel" />. </param>
+        public QueryModelEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] QueryModel queryModel)
+            : base(eventDefinition, messageGenerator)
+        {
+            QueryModel = queryModel;
+        }
+
+        /// <summary>
+        ///     The <see cref="QueryModel" />.
+        /// </summary>
+        public virtual QueryModel QueryModel { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/QueryModelExpressionEventData.cs
+++ b/src/EFCore/Diagnostics/QueryModelExpressionEventData.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Remotion.Linq;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a query model and an expression.
+    /// </summary>
+    public class QueryModelExpressionEventData : QueryModelEventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="queryModel"> The <see cref="QueryModel" />. </param>
+        /// <param name="expression"> The expression. </param>
+        public QueryModelExpressionEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] QueryModel queryModel,
+            [NotNull] object expression)
+            : base(eventDefinition, messageGenerator, queryModel)
+        {
+            Expression = expression;
+        }
+
+        /// <summary>
+        ///     The expression.
+        /// </summary>
+        public virtual object Expression { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/SaveChangesEventData.cs
+++ b/src/EFCore/Diagnostics/SaveChangesEventData.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Update;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that
+    ///     specify the enties being saved and the rows affected.
+    /// </summary>
+    public class SaveChangesEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="entries"> Entries for the entities being saved. </param>
+        /// <param name="rowsAffected"> The rows affected. </param>
+        public SaveChangesEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IEnumerable<IUpdateEntry> entries,
+            int rowsAffected)
+            : base(eventDefinition, messageGenerator)
+        {
+            Entries = entries;
+            RowsAffected = rowsAffected;
+        }
+
+        /// <summary>
+        ///     Entries for the entities being saved.
+        /// </summary>
+        public virtual IEnumerable<IUpdateEntry> Entries { get; }
+
+        /// <summary>
+        ///     The rows affected.
+        /// </summary>
+        public virtual int RowsAffected { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/ServiceProviderEventData.cs
+++ b/src/EFCore/Diagnostics/ServiceProviderEventData.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that reference
+    ///     a <see cref="IServiceProvider" /> container.
+    /// </summary>
+    public class ServiceProviderEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="serviceProvider"> The <see cref="IServiceProvider" />. </param>
+        public ServiceProviderEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] IServiceProvider serviceProvider)
+            : base(eventDefinition, messageGenerator)
+        {
+            ServiceProvider = serviceProvider;
+        }
+
+        /// <summary>
+        ///     The <see cref="IServiceProvider" />.
+        /// </summary>
+        public virtual IServiceProvider ServiceProvider { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/ServiceProvidersEventData.cs
+++ b/src/EFCore/Diagnostics/ServiceProvidersEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that reference
+    ///     multiple <see cref="IServiceProvider" /> containers.
+    /// </summary>
+    public class ServiceProvidersEventData : EventDataBase
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="serviceProviders"> The <see cref="IServiceProvider" />s. </param>
+        public ServiceProvidersEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventDataBase, string> messageGenerator,
+            [NotNull] ICollection<IServiceProvider> serviceProviders)
+            : base(eventDefinition, messageGenerator)
+        {
+            ServiceProviders = serviceProviders;
+        }
+
+        /// <summary>
+        ///     The <see cref="IServiceProvider" />s.
+        /// </summary>
+        public virtual ICollection<IServiceProvider> ServiceProviders { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/WarningsConfiguration.cs
+++ b/src/EFCore/Diagnostics/WarningsConfiguration.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -851,18 +851,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 referencingEntityTypeOrNavigation, referencedEntityTypeOrNavigation, foreignKeyPropertiesWithTypes, primaryKeyPropertiesWithTypes);
 
         /// <summary>
-        ///     The key {key} on entity type '{entityType}' contains properties in shadow state - {shadowProperties}.
-        /// </summary>
-        public static readonly EventDefinition<string, string, string> LogShadowKey
-            = new EventDefinition<string, string, string>(
-                CoreEventId.ModelValidationShadowKeyWarning,
-                LogLevel.Warning,
-                LoggerMessage.Define<string, string, string>(
-                    LogLevel.Warning,
-                    CoreEventId.ModelValidationShadowKeyWarning,
-                    _resourceManager.GetString("LogShadowKey")));
-
-        /// <summary>
         ///     An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.
         /// </summary>
         public static string ExpressionParameterizationException

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -431,10 +431,6 @@
   <data name="ReferencedShadowKey" xml:space="preserve">
     <value>The relationship from '{referencingEntityTypeOrNavigation}' to '{referencedEntityTypeOrNavigation}' with foreign key properties {foreignKeyPropertiesWithTypes} cannot target the primary key {primaryKeyPropertiesWithTypes} because it is not compatible. Configure a principal key or a set of compatible foreign key properties for this relationship.</value>
   </data>
-  <data name="LogShadowKey" xml:space="preserve">
-    <value>The key {key} on entity type '{entityType}' contains properties in shadow state - {shadowProperties}.</value>
-    <comment>Warning CoreEventId.ModelValidationShadowKeyWarning string string string</comment>
-  </data>
   <data name="ExpressionParameterizationException" xml:space="preserve">
     <value>An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.</value>
   </data>

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var fakeFactories = new Dictionary<Type, Func<object>>
             {
                 { typeof(Type), () => typeof(object) },
+                { typeof(DbContext), () => new DbContext(new DbContextOptionsBuilder().UseInMemoryDatabase("D").Options) },
                 { typeof(QueryModel), () => queryModel },
                 { typeof(string), () => "Fake" },
                 { typeof(IExpressionPrinter), () => new ExpressionPrinter() },


### PR DESCRIPTION
Issue #7939

Also adds nominal types for all events other than those in the relational design assemblies. (Since these assemblies are currently being refactored.)

Each event payload now contains all the information needed to create and log the message for the event, including overridden ToString that creates the message.
