### PR TITLE
[POC] for EF.LoggerCategories for #8550

### DIFF
--- a/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
+++ b/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
 
         void IObserver<DiagnosticListener>.OnNext(DiagnosticListener diagnosticListener)
         {
-            if (diagnosticListener.Name == DbLoggerCategory.Root)
+            if (diagnosticListener.Name == EF.LoggerCategories.Root)
             {
                 lock (_sync)
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
                 var eventName = value.Key;
                 var eventData = value.Value;
 
-                Debug.Assert(eventName.StartsWith(DbLoggerCategory.Root, StringComparison.Ordinal));
+                Debug.Assert(eventName.StartsWith(EF.LoggerCategories.Root, StringComparison.Ordinal));
                 Debug.Assert(eventData != null);
 
                 switch (eventData)

--- a/src/EFCore.Design/Design/Internal/OperationLogger.cs
+++ b/src/EFCore.Design/Design/Internal/OperationLogger.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Func<TState, Exception, string> formatter)
         {
             // Only show SQL when verbose
-            if (_categoryName == DbLoggerCategory.Database.Command.Name
+            if (_categoryName == EF.LoggerCategories.Database.Command.Name
                 && eventId.Id == RelationalEventId.CommandExecuted.Id)
             {
                 logLevel = LogLevel.Debug;

--- a/src/EFCore.Design/Diagnostics/DesignEventId.cs
+++ b/src/EFCore.Design/Diagnostics/DesignEventId.cs
@@ -41,96 +41,96 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ForeignMigrations
         }
 
-        private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
+        private static readonly string _migrationsPrefix = EF.LoggerCategories.Migrations.Name + ".";
         private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
         ///     Removing a migration without checking the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationForceRemove = MakeMigrationsId(Id.MigrationForceRemove);
 
         /// <summary>
         ///     Removing migration.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationRemoving = MakeMigrationsId(Id.MigrationRemoving);
 
         /// <summary>
         ///     A migration file was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationFileNotFound = MakeMigrationsId(Id.MigrationFileNotFound);
 
         /// <summary>
         ///     A metadata file was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationMetadataFileNotFound = MakeMigrationsId(Id.MigrationMetadataFileNotFound);
 
         /// <summary>
         ///     A manual migration deletion was detected.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationManuallyDeleted = MakeMigrationsId(Id.MigrationManuallyDeleted);
 
         /// <summary>
         ///     Removing model snapshot.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotRemoving = MakeMigrationsId(Id.SnapshotRemoving);
 
         /// <summary>
         ///     No model snapshot file named was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotFileNotFound = MakeMigrationsId(Id.SnapshotFileNotFound);
 
         /// <summary>
         ///     Writing model snapshot to file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotWriting = MakeMigrationsId(Id.SnapshotWriting);
 
         /// <summary>
         ///     Reusing namespace of a type.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId NamespaceReusing = MakeMigrationsId(Id.NamespaceReusing);
 
         /// <summary>
         ///     Reusing directory for a file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId DirectoryReusing = MakeMigrationsId(Id.DirectoryReusing);
 
         /// <summary>
         ///     Reverting model snapshot.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotReverting = MakeMigrationsId(Id.SnapshotReverting);
 
         /// <summary>
         ///     Writing migration to file.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId MigrationWriting = MakeMigrationsId(Id.MigrationWriting);
 
         /// <summary>
         ///     Resuing model snapshot name.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId SnapshotNameReusing = MakeMigrationsId(Id.SnapshotNameReusing);
 
         /// <summary>
         ///     An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId DestructiveOperation = MakeMigrationsId(Id.DestructiveOperation);
 
         /// <summary>
         ///     The namespace contains migrations for a different context.
-        ///     This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         /// </summary>
         public static readonly EventId ForeignMigrations = MakeMigrationsId(Id.ForeignMigrations);
     }

--- a/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
+++ b/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignMigrations(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] string migrationNamespace)
         {
             var definition = DesignStrings.LogForeignMigrations;
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotNameReusing(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] string lastModelSnapshotName)
         {
             var definition = DesignStrings.LogReusingSnapshotName;
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DestructiveOperation(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IEnumerable<MigrationOperation> operations)
         {
             var definition = DesignStrings.LogDestructiveOperation;
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationForceRemove(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogForceRemoveMigration;
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationRemoving(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogRemovingMigration;
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationFileNotFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Migration migration,
             [NotNull] string fileName)
         {
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationMetadataFileNotFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Migration migration,
             [NotNull] string fileName)
         {
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationManuallyDeleted(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Migration migration)
         {
             var definition = DesignStrings.LogManuallyDeleted;
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotRemoving(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotFileNotFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotReverting(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] ModelSnapshot modelSnapshot,
             [NotNull] string fileName)
         {
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationWriting(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] ScaffoldedMigration scaffoldedMigration,
             [NotNull] string fileName)
         {
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SnapshotWriting(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] ScaffoldedMigration scaffoldedMigration,
             [NotNull] string fileName)
         {
@@ -368,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void NamespaceReusing(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] Type type)
         {
             var definition = DesignStrings.LogReusingNamespace;
@@ -395,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DirectoryReusing(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] string fileName)
         {
             var definition = DesignStrings.LogReusingDirectory;

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private readonly IMigrationsIdGenerator _idGenerator;
         private readonly MigrationsCodeGenerator _migrationCodeGenerator;
         private readonly IHistoryRepository _historyRepository;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Migrations> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Migrations> _logger;
         private readonly string _activeProvider;
 
         public MigrationsScaffolder(
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             [NotNull] IMigrationsIdGenerator idGenerator,
             [NotNull] MigrationsCodeGenerator migrationCodeGenerator,
             [NotNull] IHistoryRepository historyRepository,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Migrations> logger,
             [NotNull] IDatabaseProvider databaseProvider)
         {
             Check.NotNull(currentContext, nameof(currentContext));

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<EntityTypeWriter>()
                 .AddSingleton<CodeWriter, StringBuilderCodeWriter>()
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
-                .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root))
+                .AddSingleton<DiagnosticSource>(new DiagnosticListener(EF.LoggerCategories.Root))
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>));
     }
 }

--- a/src/EFCore.InMemory/Diagnostics/InMemoryEventId.cs
+++ b/src/EFCore.InMemory/Diagnostics/InMemoryEventId.cs
@@ -30,21 +30,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ChangesSaved = CoreEventId.ProviderBaseId + 100
         }
 
-        private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
+        private static readonly string _transactionPrefix = EF.LoggerCategories.Database.Transaction.Name + ".";
         private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
 
         /// <summary>
         ///     Changes were saved to the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         /// </summary>
         public static readonly EventId TransactionIgnoredWarning = MakeTransactionId(Id.TransactionIgnoredWarning);
 
-        private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
+        private static readonly string _updatePrefix = EF.LoggerCategories.Update.Name + ".";
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
         ///     A transaction operation was requested, but ignored because in-memory does not support transactions.
-        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Update" /> category.
         /// </summary>
         public static readonly EventId ChangesSaved = MakeUpdateId(Id.ChangesSaved);
     }

--- a/src/EFCore.InMemory/Extensions/Internal/InMemoryLoggerExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/Internal/InMemoryLoggerExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionIgnoredWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics)
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics)
         {
             var definition = InMemoryStrings.LogTransactionsNotSupported;
 
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ChangesSaved(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Update> diagnostics,
             [NotNull] IEnumerable<IUpdateEntry> entries,
             int rowsAffected)
         {

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -38,6 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);
+        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries, [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Update> updateLogger);
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class InMemoryDatabase : Database, IInMemoryDatabase
     {
         private readonly IInMemoryStore _store;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Update> _updateLogger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] DatabaseDependencies dependencies,
             [NotNull] IInMemoryStoreCache storeCache,
             [NotNull] IDbContextOptions options,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Update> updateLogger)
             : base(dependencies)
         {
             Check.NotNull(storeCache, nameof(storeCache));

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public virtual int ExecuteTransaction(
             IEnumerable<IUpdateEntry> entries,
-            IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
+            IDiagnosticsLogger<EF.LoggerCategories.Update> updateLogger)
         {
             var rowsAffected = 0;
 

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -15,10 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     {
         private static readonly InMemoryTransaction _stubTransaction = new InMemoryTransaction();
 
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> _logger;
 
         public InMemoryTransactionManager(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger)
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> logger)
         {
             Check.NotNull(logger, nameof(logger));
 

--- a/src/EFCore.Relational.Design/Diagnostics/RelationalDesignEventId.cs
+++ b/src/EFCore.Relational.Design/Diagnostics/RelationalDesignEventId.cs
@@ -58,186 +58,186 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             SequenceFound
         }
 
-        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = EF.LoggerCategories.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     The database is missing a schema.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingSchemaWarning = MakeScaffoldingId(Id.MissingSchemaWarning);
 
         /// <summary>
         ///     The database is missing a table.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingTableWarning = MakeScaffoldingId(Id.MissingTableWarning);
 
         /// <summary>
         ///     The database has an unnamed sequence.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceNotNamedWarning = MakeScaffoldingId(Id.SequenceNotNamedWarning);
 
         /// <summary>
         ///     The database has a sequence of a type that is not supported.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceTypeNotSupportedWarning = MakeScaffoldingId(Id.SequenceTypeNotSupportedWarning);
 
         /// <summary>
         ///     An entity type could not be generated.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId UnableToGenerateEntityTypeWarning = MakeScaffoldingId(Id.UnableToGenerateEntityTypeWarning);
 
         /// <summary>
         ///     A column type could not be mapped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnTypeNotMappedWarning = MakeScaffoldingId(Id.ColumnTypeNotMappedWarning);
 
         /// <summary>
         ///     A table is missing a primary key.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId MissingPrimaryKeyWarning = MakeScaffoldingId(Id.MissingPrimaryKeyWarning);
 
         /// <summary>
         ///     Columns in a primary key were not mapped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId PrimaryKeyColumnsNotMappedWarning = MakeScaffoldingId(Id.PrimaryKeyColumnsNotMappedWarning);
 
         /// <summary>
         ///     Columns in an index were not mapped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnsNotMappedWarning = MakeScaffoldingId(Id.IndexColumnsNotMappedWarning);
 
         /// <summary>
         ///     A foreign key references a missing table.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingTableWarning);
 
         /// <summary>
         ///     A foreign key references a missing table at the principal end.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingPrincipalTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingPrincipalTableWarning);
 
         /// <summary>
         ///     A foreign key references a table that was not mapped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesNotMappedTableWarning = MakeScaffoldingId(Id.ForeignKeyReferencesNotMappedTableWarning);
 
         /// <summary>
         ///     Columns in a foreign key were not mapped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnsNotMappedWarning = MakeScaffoldingId(Id.ForeignKeyColumnsNotMappedWarning);
 
         /// <summary>
         ///     A foreign key references missing prinicpal key columns.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyReferencesMissingPrincipalKeyWarning = MakeScaffoldingId(Id.ForeignKeyReferencesMissingPrincipalKeyWarning);
 
         /// <summary>
         ///     A principal key contains nullable columns.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalEndContainsNullableColumnsWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalEndContainsNullableColumnsWarning);
 
         /// <summary>
         ///     A foreign key is not named.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyNotNamedWarning = MakeScaffoldingId(Id.ForeignKeyNotNamedWarning);
 
         /// <summary>
         ///     A foreign key column was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyColumnMissingWarning);
 
         /// <summary>
         ///     A column referenced by a foreign key constraint was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalColumnMissingWarning);
 
         /// <summary>
         ///     A foreign key column was not named.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnNotNamedWarning = MakeScaffoldingId(Id.ForeignKeyColumnNotNamedWarning);
 
         /// <summary>
         ///     A column is not named. 
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnNotNamedWarning = MakeScaffoldingId(Id.ColumnNotNamedWarning);
 
         /// <summary>
         ///     An index is not named. 
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexNotNamedWarning = MakeScaffoldingId(Id.IndexNotNamedWarning);
 
         /// <summary>
         ///     The table referened by an index was not found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexTableMissingWarning = MakeScaffoldingId(Id.IndexTableMissingWarning);
 
         /// <summary>
         ///     An index column was not named.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnNotNamedWarning = MakeScaffoldingId(Id.IndexColumnNotNamedWarning);
 
         /// <summary>
         ///     A table was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TableFound = MakeScaffoldingId(Id.TableFound);
 
         /// <summary>
         ///     A table was skipped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TableSkipped = MakeScaffoldingId(Id.TableSkipped);
 
         /// <summary>
         ///     A column was skipped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnSkipped = MakeScaffoldingId(Id.ColumnSkipped);
 
         /// <summary>
         ///     An index was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexFound = MakeScaffoldingId(Id.IndexFound);
 
         /// <summary>
         ///     An index was skipped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnFound = MakeScaffoldingId(Id.IndexColumnFound);
 
         /// <summary>
         ///     A column of an index was skipped.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId IndexColumnSkipped = MakeScaffoldingId(Id.IndexColumnSkipped);
 
         /// <summary>
         ///     A sequence was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceFound = MakeScaffoldingId(Id.SequenceFound);
     }

--- a/src/EFCore.Relational.Design/Internal/RelationalDesignLoggerExtensions.cs
+++ b/src/EFCore.Relational.Design/Internal/RelationalDesignLoggerExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingSchemaWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string schemaName)
         {
             var definition = RelationalDesignStrings.LogMissingSchema;
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingTableWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogMissingTable;
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics)
         {
             var definition = RelationalDesignStrings.LogSequencesRequireName;
 
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceTypeNotSupportedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string sequenceName,
             [CanBeNull] string dataTypeName)
         {
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void UnableToGenerateEntityTypeWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogUnableToGenerateEntityType;
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnTypeNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingPrimaryKeyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogMissingPrimaryKey;
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PrimaryKeyColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -238,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingTableWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName)
         {
             var definition = RelationalDesignStrings.LogForeignKeyScaffoldErrorPrincipalTableNotFound;
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesNotMappedTableWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [NotNull] string principalTableName)
         {
@@ -286,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [NotNull] IList<string> unmappedColumnNames)
         {
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingPrincipalKeyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string principalEntityTypeName,
             [NotNull] IList<string> principalColumnNames)
@@ -345,7 +345,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyPrincipalEndContainsNullableColumnsWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string indexName,
             [CanBeNull] IList<string> nullablePropertyNames)
@@ -376,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string sequenceName,
             [CanBeNull] string sequenceTypeName,
             bool? cyclic,
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TableFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogFoundTable;
@@ -451,7 +451,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TableSkipped(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogTableNotInSelectionSet;
@@ -474,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnSkipped(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName)
         {
@@ -499,7 +499,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string indexName,
             bool? unique,
@@ -530,7 +530,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogColumnNameEmptyOnTable;
@@ -553,7 +553,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnSkipped(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string indexName,
             [CanBeNull] string columnName)
@@ -580,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogIndexNameEmpty;
@@ -603,7 +603,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexTableMissingWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
         {
@@ -628,7 +628,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
         {
@@ -653,7 +653,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
         {
             var definition = RelationalDesignStrings.LogForeignKeyNameEmpty;
@@ -676,7 +676,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnMissingWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
@@ -703,7 +703,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingPrincipalTableWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName,
             [CanBeNull] string principalTableName)
@@ -730,7 +730,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnNotNamedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
         {
@@ -755,7 +755,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IndexFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName,
             bool? unique)
@@ -782,7 +782,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyPrincipalColumnMissingWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName,
             [CanBeNull] string principalColumnName,

--- a/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         internal const string NavigationNameUniquifyingPattern = "{0}Navigation";
         internal const string SelfReferencingPrincipalEndNavigationNamePattern = "Inverse{0}";
 
-        protected virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
+        protected virtual IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> Logger { get; }
         protected virtual IRelationalTypeMapper TypeMapper { get; }
         protected virtual CandidateNamingService CandidateNamingService { get; }
 
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         private readonly IPluralizer _pluralizer;
 
         public RelationalScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ModelValidationKeyDefaultValueWarning = CoreEventId.RelationalBaseId + 600
         }
 
-        private static readonly string _connectionPrefix = DbLoggerCategory.Database.Connection.Name + ".";
+        private static readonly string _connectionPrefix = EF.LoggerCategories.Database.Connection.Name + ".";
         private static EventId MakeConnectionId(Id id) => new EventId((int)id, _connectionPrefix + id);
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database connection is opening.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database connection has been opened.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database connection is closing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database connection has been closed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A error occurred while opening or using a database connection.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Connection" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId ConnectionError = MakeConnectionId(Id.ConnectionError);
 
-        private static readonly string _sqlPrefix = DbLoggerCategory.Database.Command.Name + ".";
+        private static readonly string _sqlPrefix = EF.LoggerCategories.Database.Command.Name + ".";
         private static EventId MakeCommandId(Id id) => new EventId((int)id, _sqlPrefix + id);
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database command is executing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database command has been executed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandExecutedEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         An error occurred while a database command was executing.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="CommandErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId CommandError = MakeCommandId(Id.CommandError);
 
-        private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
+        private static readonly string _transactionPrefix = EF.LoggerCategories.Database.Transaction.Name + ".";
         private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database transaction has been started.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         Entity Framework started using an already existing database transaction.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database transaction has been committed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database transaction has been rolled back.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEndEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database transaction has been disposed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         An error has occurred while using. committing, or rolling back a database transaction.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="TransactionErrorEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -258,7 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         An application may have expected an ambient transaction to be used when it was actually ignorred.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Transaction" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="ConnectionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -271,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A database data reader has been disposed.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Database.Command" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="DataReaderDisposingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -279,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId DataReaderDisposing = MakeCommandId(Id.DataReaderDisposing);
 
-        private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
+        private static readonly string _migrationsPrefix = EF.LoggerCategories.Migrations.Name + ".";
         private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         Migrations is using a database connection.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigratorConnectionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A migration is being reverted.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -313,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A migration is being applied.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -326,7 +326,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         Migrations is generating a "down" script.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationScriptingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -339,7 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         Migrations is generating an "up" script.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Migrations" /> category.
         ///     </para>
         ///     <para>
         ///         This event uses the <see cref="MigrationScriptingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
@@ -347,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId MigrationGeneratingUpScript = MakeMigrationsId(Id.MigrationGeneratingUpScript);
 
-        private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
+        private static readonly string _queryPrefix = EF.LoggerCategories.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
 
         /// <summary>
@@ -355,7 +355,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         Part of a query is being evaluated on the client instead of on the database server.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId QueryClientEvaluationWarning = MakeQueryId(Id.QueryClientEvaluationWarning);
@@ -365,12 +365,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A query is using equals comparisons in a possibly unintended way.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId QueryPossibleUnintendedUseOfEqualsWarning = MakeQueryId(Id.QueryPossibleUnintendedUseOfEqualsWarning);
 
-        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = EF.LoggerCategories.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         A single database default column value has been set on a key column.
         ///     </para>
         ///     <para>
-        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///         This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         ///     </para>
         /// </summary>
         public static readonly EventId ModelValidationKeyDefaultValueWarning = MakeValidationId(Id.ModelValidationKeyDefaultValueWarning);

--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandExecuting(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId, 
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private static bool ShouldLogParameterValues(
-            IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+            IDiagnosticsLogger<EF.LoggerCategories.Database.Command> diagnostics,
             DbCommand command)
             => command.Parameters.Count > 0
                && diagnostics.ShouldLogSensitiveData();
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandExecuted(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void CommandError(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Command> diagnostics,
             [NotNull] DbCommand command,
             DbCommandMethod executeMethod,
             Guid commandId,
@@ -169,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionOpening(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             bool async)
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionOpened(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             TimeSpan duration,
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionClosing(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime)
         {
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionClosed(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startTime,
             TimeSpan duration)
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ConnectionError(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Connection> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] Exception exception,
             DateTimeOffset startTime,
@@ -341,7 +341,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionStarted(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionUsed(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -399,7 +399,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionCommitted(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionRolledBack(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -457,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionDisposed(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -484,7 +484,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TransactionError(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
             Guid transactionId,
@@ -517,7 +517,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void AmbientTransactionWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> diagnostics,
             [NotNull] IRelationalConnection connection,
             DateTimeOffset startDate)
         {
@@ -542,7 +542,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DataReaderDisposing(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Database.Command> diagnostics,
             [NotNull] IRelationalConnection connection,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader dataReader,
@@ -575,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrateUsingConnection(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] IRelationalConnection connection)
         {
@@ -608,7 +608,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationReverting(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration)
         {
@@ -637,7 +637,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationApplying(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration)
         {
@@ -666,7 +666,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationGeneratingDownScript(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration,
             [CanBeNull] string fromMigration,
@@ -701,7 +701,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MigrationGeneratingUpScript(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Migrations> diagnostics,
             [NotNull] IMigrator migrator,
             [NotNull] Migration migration,
             [CanBeNull] string fromMigration,
@@ -736,7 +736,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryClientEvaluationWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] QueryModel queryModel,
             [NotNull] object expression)
         {
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryPossibleUnintendedUseOfEqualsWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] MethodCallExpression methodCallExpression,
             [NotNull] Expression argument)
         {
@@ -789,7 +789,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ModelValidationKeyDefaultValueWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = RelationalStrings.LogKeyHasDefaultValue;

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         private readonly IMigrationCommandExecutor _migrationCommandExecutor;
         private readonly IRelationalConnection _connection;
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Migrations> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Migrations> _logger;
         private readonly string _activeProvider;
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             [NotNull] IMigrationCommandExecutor migrationCommandExecutor,
             [NotNull] IRelationalConnection connection,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Migrations> logger,
             [NotNull] IDatabaseProvider databaseProvider)
         {
             Check.NotNull(migrationsAssembly, nameof(migrationsAssembly));

--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EqualsTranslator.cs
@@ -17,13 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class EqualsTranslator : IMethodCallTranslator
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public EqualsTranslator([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        public EqualsTranslator([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger)
         {
             Check.NotNull(logger, nameof(logger));
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     </para>
         /// </summary>
         /// <param name="logger"> A logger. </param>
-        public RelationalCompositeMethodCallTranslatorDependencies([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        public RelationalCompositeMethodCallTranslatorDependencies([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger)
         {
             Logger = logger;
         }
@@ -48,14 +48,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Query> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger)
             => new RelationalCompositeMethodCallTranslatorDependencies(logger);
     }
 }

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommand(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
             [NotNull] string commandText,
             [NotNull] IReadOnlyList<IRelationalParameter> parameters)
         {
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
+        protected virtual IDiagnosticsLogger<EF.LoggerCategories.Database.Command> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class RelationalCommandBuilder : IRelationalCommandBuilder
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Command> _logger;
 
         private readonly IndentedStringBuilder _commandTextBuilder = new IndentedStringBuilder();
 
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilder(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
             [NotNull] IRelationalTypeMapper typeMapper)
         {
             Check.NotNull(logger, nameof(logger));
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual IRelationalCommand BuildCore(
-                [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                 [NotNull] string commandText,
                 [NotNull] IReadOnlyList<IRelationalParameter> parameters)
             => new RelationalCommand(

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class RelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Command> _logger;
         private readonly IRelationalTypeMapper _typeMapper;
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalCommandBuilderFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
             [NotNull] IRelationalTypeMapper typeMapper)
         {
             Check.NotNull(logger, nameof(logger));
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual IRelationalCommandBuilder CreateCore(
-                [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                 [NotNull] IRelationalTypeMapper relationalTypeMapper)
             => new RelationalCommandBuilder(
                 logger,

--- a/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -45,8 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="connectionLogger"> The logger to which connection messages will be written. </param>
         public RelationalConnectionDependencies(
             [NotNull] IDbContextOptions contextOptions,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger)
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> transactionLogger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> connectionLogger)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
             Check.NotNull(transactionLogger, nameof(transactionLogger));
@@ -65,13 +65,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger to which transaction messages will be written.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> TransactionLogger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> TransactionLogger { get; }
 
 
         /// <summary>
         ///     The logger to which connection messages will be written.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Database.Connection> ConnectionLogger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> ConnectionLogger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A replacement for the current dependency of this type.
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger)
+        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Connection> connectionLogger)
             => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, connectionLogger);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A replacement for the current dependency of this type.
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger)
+        public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> transactionLogger)
             => new RelationalConnectionDependencies(ContextOptions, transactionLogger, ConnectionLogger);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private readonly DbCommand _command;
         private readonly DbDataReader _reader;
         private readonly Guid _commandId;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Command> _logger;
         private readonly DateTimeOffset _startTime;
         private readonly Stopwatch _stopwatch;
 
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
             Guid commandId,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger)
         {
             Check.NotNull(command, nameof(command));
             Check.NotNull(reader, nameof(reader));

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     {
         private readonly IRelationalConnection _relationalConnection;
         private readonly DbTransaction _dbTransaction;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> _logger;
         private readonly bool _transactionOwned;
 
         private bool _connectionClosed;
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public RelationalTransaction(
             [NotNull] IRelationalConnection connection,
             [NotNull] DbTransaction transaction,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> logger,
             bool transactionOwned)
         {
             Check.NotNull(connection, nameof(connection));

--- a/src/EFCore.Specification.Tests/TestHelpers.cs
+++ b/src/EFCore.Specification.Tests/TestHelpers.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (category.GetTypeInfo().ContainsGenericParameters)
                 {
-                    category = typeof(DbLoggerCategory.Infrastructure);
+                    category = typeof(EF.LoggerCategories.Infrastructure);
                     loggerMethod = loggerMethod.MakeGenericMethod(category);
                 }
 

--- a/src/EFCore.SqlServer.Design/Diagnostics/SqlServerDesignEventId.cs
+++ b/src/EFCore.SqlServer.Design/Diagnostics/SqlServerDesignEventId.cs
@@ -31,36 +31,36 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             DataTypeDoesNotAllowSqlServerIdentityStrategyWarning
         }
 
-        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = EF.LoggerCategories.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnFound = MakeScaffoldingId(Id.ColumnFound);
 
         /// <summary>
         ///     A column of a foreign key was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnFound = MakeScaffoldingId(Id.ForeignKeyColumnFound);
 
         /// <summary>
         ///     A default schema was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId DefaultSchemaFound = MakeScaffoldingId(Id.DefaultSchemaFound);
 
         /// <summary>
         ///     A type alias was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TypeAliasFound = MakeScaffoldingId(Id.TypeAliasFound);
 
         /// <summary>
         ///     The data type does not support the SQL Server identity strategy.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId DataTypeDoesNotAllowSqlServerIdentityStrategyWarning = MakeScaffoldingId(Id.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning);
     }

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerDatabaseModelFactory.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerDatabaseModelFactory([NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
+        public SqlServerDatabaseModelFactory([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
+        public virtual IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> Logger { get; }
 
         private void ResetState()
         {

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerDesignLoggerExtensions.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerDesignLoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName,
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string principalTableName,
@@ -145,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DefaultSchemaFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string schemaName)
         {
             var definition = SqlServerDesignStrings.LogFoundDefaultSchema;
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void TypeAliasFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string typeAliasName,
             [CanBeNull] string systemTypeName)
         {
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DataTypeDoesNotAllowSqlServerIdentityStrategyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string columnName,
             [CanBeNull] string typeName)
         {

--- a/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
+++ b/src/EFCore.SqlServer.Design/Internal/SqlServerScaffoldingModelFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -28,18 +28,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ByteIdentityColumnWarning
         }
 
-        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = EF.LoggerCategories.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     No explicit type for a decimal column.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId DecimalTypeDefaultWarning = MakeValidationId(Id.DecimalTypeDefaultWarning);
 
         /// <summary>
         ///     A byte property is set up to use a SQL Server identity column.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId ByteIdentityColumnWarning = MakeValidationId(Id.ByteIdentityColumnWarning);
     }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerLoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void DecimalTypeDefaultWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = SqlServerStrings.LogDefaultDecimalTypeColumn;
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ByteIdentityColumnWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] IProperty property)
         {
             var definition = SqlServerStrings.LogByteIdentityColumn;

--- a/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
+++ b/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
@@ -28,18 +28,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             SequenceConfiguredWarning
         }
 
-        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = EF.LoggerCategories.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     A schema was configured for an entity type, but SQLite does not support schemas.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId SchemaConfiguredWarning = MakeValidationId(Id.SchemaConfiguredWarning);
 
         /// <summary>
         ///     A sequence was configured for an entity type, but SQLite does not support sequences.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId SequenceConfiguredWarning = MakeValidationId(Id.SequenceConfiguredWarning);
     }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteLoggerExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SchemaConfiguredWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] IEntityType entityType,
             [NotNull] string schema)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceConfiguredWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] ISequence sequence)
         {
             var definition = SqliteStrings.LogSequenceConfigured;

--- a/src/EFCore.Sqlite.Design/Diagnostics/SqliteDesignEventId.cs
+++ b/src/EFCore.Sqlite.Design/Diagnostics/SqliteDesignEventId.cs
@@ -29,24 +29,24 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             SchemasNotSupportedWarning
         }
 
-        private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
+        private static readonly string _scaffoldingPrefix = EF.LoggerCategories.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ColumnFound = MakeScaffoldingId(Id.ColumnFound);
 
         /// <summary>
         ///     A column of a foreign key was found.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyColumnFound = MakeScaffoldingId(Id.ForeignKeyColumnFound);
 
         /// <summary>
         ///     SQLite does not support schemas.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SchemasNotSupportedWarning = MakeScaffoldingId(Id.SchemasNotSupportedWarning);
     }

--- a/src/EFCore.Sqlite.Design/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteDatabaseModelFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqliteDatabaseModelFactory([NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
+        public SqliteDatabaseModelFactory([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IDiagnosticsLogger<DbLoggerCategory.Scaffolding> Logger { get; }
+        public virtual IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> Logger { get; }
 
         private DbConnection _connection;
         private TableSelectionSet _tableSelectionSet;

--- a/src/EFCore.Sqlite.Design/Internal/SqliteDesignLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteDesignLoggerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName,
             [CanBeNull] string dataTypeName,
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             int id,
             [CanBeNull] string principalTableName,
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SchemasNotSupportedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> diagnostics)
         {
             var definition = SqliteDesignStrings.LogUsingSchemaSelectionsWarning;
 

--- a/src/EFCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
+++ b/src/EFCore.Sqlite.Design/Internal/SqliteScaffoldingModelFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqliteScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] CandidateNamingService candidateNamingService,

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore
         private IDbContextDependencies _dbContextDependencies;
         private DatabaseFacade _database;
         private ChangeTracker _changeTracker;
-        private IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
+        private IDiagnosticsLogger<EF.LoggerCategories.Update> _updateLogger;
 
         private IServiceScope _serviceScope;
         private IDbContextPool _dbContextPool;
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 contextServices.Initialize(scopedServiceProvider, options, this);
 
-                _updateLogger = scopedServiceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Update>>();
+                _updateLogger = scopedServiceProvider.GetRequiredService<IDiagnosticsLogger<EF.LoggerCategories.Update>>();
 
                 return contextServices;
             }

--- a/src/EFCore/DbLoggerCategory.cs
+++ b/src/EFCore/DbLoggerCategory.cs
@@ -6,102 +6,106 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    /// <summary>
-    ///     <para>
-    ///         An API for getting logger categories inan Intellisense/tab-completion friedly manner.
-    ///     </para>
-    ///     <para>
-    ///         Get an Entity Framework Core logger category using its Name property. For example,
-    ///         <code>LoggerCategory.Database.Sql.Name</code>.
-    ///     </para>
-    ///     <para>
-    ///         Use these types with <see cref="IDiagnosticsLogger{TLoggerCategory}" /> or
-    ///         <see cref="IDiagnosticsLogger{TLoggerCategory}" /> to create a logger.
-    ///     </para>
-    /// </summary>
-    public static class DbLoggerCategory
+    public static partial class EF
     {
-        /// <summary>
-        ///     The root/prefix for all Entity Framework categories.
-        /// </summary>
-        public const string Root = "Microsoft.EntityFrameworkCore";
 
         /// <summary>
-        ///     Logger categories for messages related to database interactions.
+        ///     <para>
+        ///         An API for getting logger categories in an Intellisense/tab-completion friedly manner.
+        ///     </para>
+        ///     <para>
+        ///         Get an Entity Framework Core logger category using its Name property. For example,
+        ///         <code>LoggerCategory.Database.Sql.Name</code>.
+        ///     </para>
+        ///     <para>
+        ///         Use these types with <see cref="IDiagnosticsLogger{TLoggerCategory}" /> or
+        ///         <see cref="IDiagnosticsLogger{TLoggerCategory}" /> to create a logger.
+        ///     </para>
         /// </summary>
-        public class Database : LoggerCategory<Database>
+        public static class LoggerCategories
         {
             /// <summary>
-            ///     Logger category for messages related to connection operations.
+            ///     The root/prefix for all Entity Framework categories.
             /// </summary>
-            public class Connection : LoggerCategory<Connection>
+            public const string Root = "Microsoft.EntityFrameworkCore";
+
+            /// <summary>
+            ///     Logger categories for messages related to database interactions.
+            /// </summary>
+            public class Database : LoggerCategory<Database>
+            {
+                /// <summary>
+                ///     Logger category for messages related to connection operations.
+                /// </summary>
+                public class Connection : LoggerCategory<Connection>
+                {
+                }
+
+                /// <summary>
+                ///     Logger category for command execution, including SQL sent to the database.
+                /// </summary>
+                public class Command : LoggerCategory<Command>
+                {
+                }
+
+                /// <summary>
+                ///     Logger category for messages related to transaction operations.
+                /// </summary>
+                public class Transaction : LoggerCategory<Transaction>
+                {
+                }
+            }
+
+            /// <summary>
+            ///     Logger category for messages related to <see cref="DbContext.SaveChanges()" />, excluding
+            ///     messages specifically relating to database interactions which are covered by
+            ///     the <see cref="EF.LoggerCategories.Database" /> categories.
+            /// </summary>
+            public class Update : LoggerCategory<Update>
             {
             }
 
             /// <summary>
-            ///     Logger category for command execution, including SQL sent to the database.
+            ///     Logger categories for messages related to model building and metadata.
             /// </summary>
-            public class Command : LoggerCategory<Command>
+            public class Model : LoggerCategory<Model>
+            {
+                /// <summary>
+                ///     Logger category for messages from model validation.
+                /// </summary>
+                public class Validation : LoggerCategory<Validation>
+                {
+                }
+            }
+
+            /// <summary>
+            ///     Logger category for messages related to queries, excluding
+            ///     the generated SQL, which is in the <see cref="Database.Command" /> category.
+            /// </summary>
+            public class Query : LoggerCategory<Query>
             {
             }
 
             /// <summary>
-            ///     Logger category for messages related to transaction operations.
+            ///     Logger category for miscellaneous messages from the Entity Framework infrastructure.
             /// </summary>
-            public class Transaction : LoggerCategory<Transaction>
+            public class Infrastructure : LoggerCategory<Infrastructure>
             {
             }
-        }
 
-        /// <summary>
-        ///     Logger category for messages related to <see cref="DbContext.SaveChanges()" />, excluding
-        ///     messages specifically relating to database interactions which are covered by
-        ///     the <see cref="DbLoggerCategory.Database" /> categories.
-        /// </summary>
-        public class Update : LoggerCategory<Update>
-        {
-        }
-
-        /// <summary>
-        ///     Logger categories for messages related to model building and metadata.
-        /// </summary>
-        public class Model : LoggerCategory<Model>
-        {
             /// <summary>
-            ///     Logger category for messages from model validation.
+            ///     Logger category for messages from scaffolding/reverse engineering.
             /// </summary>
-            public class Validation : LoggerCategory<Validation>
+            public class Scaffolding : LoggerCategory<Scaffolding>
             {
             }
-        }
 
-        /// <summary>
-        ///     Logger category for messages related to queries, excluding
-        ///     the generated SQL, which is in the <see cref="Database.Command" /> category.
-        /// </summary>
-        public class Query : LoggerCategory<Query>
-        {
-        }
-
-        /// <summary>
-        ///     Logger category for miscellaneous messages from the Entity Framework infrastructure.
-        /// </summary>
-        public class Infrastructure : LoggerCategory<Infrastructure>
-        {
-        }
-
-        /// <summary>
-        ///     Logger category for messages from scaffolding/reverse engineering.
-        /// </summary>
-        public class Scaffolding : LoggerCategory<Scaffolding>
-        {
-        }
-
-        /// <summary>
-        ///     Logger category messages from Migrations.
-        /// </summary>
-        public class Migrations : LoggerCategory<Migrations>
-        {
+            /// <summary>
+            ///     Logger category messages from Migrations.
+            /// </summary>
+            public class Migrations : LoggerCategory<Migrations>
+            {
+            }
         }
     }
 }

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -78,90 +78,90 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ManyServiceProvidersCreatedWarning
         }
 
-        private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
+        private static readonly string _updatePrefix = EF.LoggerCategories.Update.Name + ".";
         private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
 
         /// <summary>
         ///     An error occurred while attempting to save changes to the database.
-        ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Update" /> category.
         /// </summary>
         public static readonly EventId SaveChangesFailed = MakeUpdateId(Id.SaveChangesFailed);
 
-        private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
+        private static readonly string _queryPrefix = EF.LoggerCategories.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
 
         /// <summary>
         ///     An error occurred while processing the results of a query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId QueryIterationFailed = MakeQueryId(Id.QueryIterationFailed);
 
         /// <summary>
         ///     A query model is being compiled.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId QueryModelCompiling = MakeQueryId(Id.QueryModelCompiling);
 
         /// <summary>
         ///     A query uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId RowLimitingOperationWithoutOrderByWarning = MakeQueryId(Id.RowLimitingOperationWithoutOrderByWarning);
 
         /// <summary>
         ///     A query uses First/FirstOrDefault operation without OrderBy and filter which may lead to unpredictable results.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId FirstWithoutOrderByAndFilterWarning = MakeQueryId(Id.FirstWithoutOrderByAndFilterWarning);
 
         /// <summary>
         ///     A query model was optimized.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId QueryModelOptimized = MakeQueryId(Id.QueryModelOptimized);
 
         /// <summary>
         ///     A navigation was included in the query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId NavigationIncluded = MakeQueryId(Id.NavigationIncluded);
 
         /// <summary>
         ///     A navigation was ignored while compiling a query.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId IncludeIgnoredWarning = MakeQueryId(Id.IncludeIgnoredWarning);
 
         /// <summary>
         ///     A query is planned for execution.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId QueryExecutionPlanned = MakeQueryId(Id.QueryExecutionPlanned);
 
         /// <summary>
         ///     Possible uninteded comparison of collection navigation to null.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId PossibleUnintendedCollectionNavigationNullComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedCollectionNavigationNullComparisonWarning);
 
         /// <summary>
         ///     Possible uninteded reference comparison.
-        ///     This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Query" /> category.
         /// </summary>
         public static readonly EventId PossibleUnintendedReferenceComparisonWarning
             = MakeQueryId(Id.PossibleUnintendedReferenceComparisonWarning);
 
-        private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
+        private static readonly string _validationPrefix = EF.LoggerCategories.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     A warning during model validation indicating a key is configured on shadow properties.
-        ///     This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Model.Validation" /> category.
         /// </summary>
         public static readonly EventId ModelValidationShadowKeyWarning = MakeValidationId(Id.ModelValidationShadowKeyWarning);
 
-        private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
+        private static readonly string _infraPrefix = EF.LoggerCategories.Infrastructure.Name + ".";
         private static EventId MakeInfraId(Id id) => new EventId((int)id, _infraPrefix + id);
 
         /// <summary>
@@ -172,13 +172,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     A service provider was created for internal use by Entity Framework.
-        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Infrastructure" /> category.
         /// </summary>
         public static readonly EventId ServiceProviderCreated = MakeInfraId(Id.ServiceProviderCreated);
 
         /// <summary>
         ///     Many service proviers were created in a single app domain.
-        ///     This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     This event is in the <see cref="EF.LoggerCategories.Infrastructure" /> category.
         /// </summary>
         public static readonly EventId ManyServiceProvidersCreatedWarning = MakeInfraId(Id.ManyServiceProvidersCreatedWarning);
     }

--- a/src/EFCore/Diagnostics/EventDefinition.cs
+++ b/src/EFCore/Diagnostics/EventDefinition.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>
         public virtual void Log<TLoggerCategory>(

--- a/src/EFCore/Diagnostics/EventDefinition`.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg"> Message argument. </param>
         /// <param name="exception"> Optional exception associated with the event. </param>

--- a/src/EFCore/Diagnostics/EventDefinition``.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Diagnostics/EventDefinition```.cs
+++ b/src/EFCore/Diagnostics/EventDefinition```.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Diagnostics/EventDefinition````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition````.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Diagnostics/EventDefinition`````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition`````.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Diagnostics/EventDefinition``````.cs
+++ b/src/EFCore/Diagnostics/EventDefinition``````.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="arg1"> The first message argument. </param>
         /// <param name="arg2"> The second message argument. </param>

--- a/src/EFCore/Diagnostics/FallbackEventDefinition.cs
+++ b/src/EFCore/Diagnostics/FallbackEventDefinition.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Logs the event, or throws if the event has been configured to be treated as an error.
         /// </summary>
-        /// <typeparam name="TLoggerCategory"> The <see cref="DbLoggerCategory" />. </typeparam>
+        /// <typeparam name="TLoggerCategory"> The <see cref="EF.LoggerCategories" />. </typeparam>
         /// <param name="logger"> The logger to which the event should be logged. </param>
         /// <param name="logAction"> A delegate that will log the message to an <see cref="ILogger" />. </param>
         public virtual void Log<TLoggerCategory>(

--- a/src/EFCore/Diagnostics/LoggerCategory.cs
+++ b/src/EFCore/Diagnostics/LoggerCategory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         private static string ToName(Type loggerCategoryType)
         {
-            const string outerClassName = "." + nameof(DbLoggerCategory);
+            const string outerClassName = "." + nameof(EF.LoggerCategories);
 
             var name = loggerCategoryType.FullName.Replace('+', '.');
             var index = name.IndexOf(outerClassName, StringComparison.Ordinal);

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SaveChangesFailed(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Update> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Update> diagnostics,
             [NotNull] Type contextType,
             [NotNull] Exception exception)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryIterationFailed(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] Type contextType,
             [NotNull] Exception exception)
         {
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryModelCompiling(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogCompilingQueryModel;
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void RowLimitingOperationWithoutOrderByWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogRowLimitingOperationWithoutOrderBy;
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void FirstWithoutOrderByAndFilterWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogFirstWithoutOrderByAndFilter;
@@ -171,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryModelOptimized(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] QueryModel queryModel)
         {
             var definition = CoreStrings.LogOptimizedQueryModel;
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void NavigationIncluded(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] string includeSpecification)
         {
             var definition = CoreStrings.LogIncludingNavigation;
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void QueryExecutionPlanned(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] IExpressionPrinter expressionPrinter,
             [NotNull] Expression queryExecutorExpression)
         {
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void IncludeIgnoredWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] string includeSpecification)
         {
             var definition = CoreStrings.LogIgnoredInclude;
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PossibleUnintendedCollectionNavigationNullComparisonWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] string navigationPath)
         {
             var definition = CoreStrings.LogPossibleUnintendedCollectionNavigationNullComparison;
@@ -325,7 +325,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PossibleUnintendedReferenceComparisonWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Query> diagnostics,
             [NotNull] Expression left,
             [NotNull] Expression right)
         {
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ModelValidationShadowKeyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> diagnostics,
             [NotNull] IEntityType entityType,
             [NotNull] IKey key)
         {
@@ -386,7 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ServiceProviderCreated(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> diagnostics,
             [NotNull] IServiceProvider serviceProvider)
         {
             var definition = CoreStrings.LogServiceProviderCreated;
@@ -409,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ManyServiceProvidersCreatedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+            [NotNull] this IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> diagnostics,
             [NotNull] ICollection<IServiceProvider> serviceProviders)
         {
             var definition = CoreStrings.LogManyServiceProvidersCreated;

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IResettableService, IDbContextTransactionManager>(p => p.GetService<IDbContextTransactionManager>());
 
             ServiceCollectionMap
-                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root));
+                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(EF.LoggerCategories.Root));
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<DatabaseProviderDependencies>()

--- a/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
+++ b/src/EFCore/Infrastructure/ModelValidatorDependencies.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     </para>
         /// </summary>
         /// <param name="logger"> The logger. </param>
-        public ModelValidatorDependencies([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+        public ModelValidatorDependencies([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> logger)
         {
             Check.NotNull(logger, nameof(logger));
 
@@ -54,14 +54,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+        public ModelValidatorDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> logger)
             => new ModelValidatorDependencies(logger);
     }
 }

--- a/src/EFCore/Internal/ServiceProviderCache.cs
+++ b/src/EFCore/Internal/ServiceProviderCache.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                                 .EnsureInitialized(serviceProvider, options);
                         }
 
-                        var logger = serviceProvider.GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>();
+                        var logger = serviceProvider.GetRequiredService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>();
 
                         logger.ServiceProviderCreated(serviceProvider);
 

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -294,9 +294,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private class NondeterministicResultCheckingVisitor : QueryModelVisitorBase
         {
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
 
-            public NondeterministicResultCheckingVisitor([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+            public NondeterministicResultCheckingVisitor([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger)
                 => _logger = logger;
 
             public override void VisitQueryModel(QueryModel queryModel)

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
         private readonly IParameterValues _parameterValues;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
 
         private readonly bool _parameterize;
         private readonly bool _generateContextAccessors;
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         public ParameterExtractingExpressionVisitor(
             [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
             [NotNull] IParameterValues parameterValues,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger,
             bool parameterize,
             bool generateContextAccessors = false)
         {

--- a/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -104,18 +104,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<T> _InterceptExceptions<T>(
-            IAsyncEnumerable<T> source, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
+            IAsyncEnumerable<T> source, Type contextType, IDiagnosticsLogger<EF.LoggerCategories.Query> logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
 
         private sealed class ExceptionInterceptor<T> : IAsyncEnumerable<T>
         {
             private readonly IAsyncEnumerable<T> _innerAsyncEnumerable;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
             private readonly QueryContext _queryContext;
 
             public ExceptionInterceptor(
-                IAsyncEnumerable<T> innerAsyncEnumerable, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
+                IAsyncEnumerable<T> innerAsyncEnumerable, Type contextType, IDiagnosticsLogger<EF.LoggerCategories.Query> logger, QueryContext queryContext)
             {
                 _innerAsyncEnumerable = innerAsyncEnumerable;
                 _contextType = contextType;

--- a/src/EFCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/LinqOperatorProvider.cs
@@ -84,18 +84,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
         private static IEnumerable<T> _InterceptExceptions<T>(
-            IEnumerable<T> source, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
+            IEnumerable<T> source, Type contextType, IDiagnosticsLogger<EF.LoggerCategories.Query> logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
 
         private sealed class ExceptionInterceptor<T> : IEnumerable<T>
         {
             private readonly IEnumerable<T> _innerEnumerable;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
             private readonly QueryContext _queryContext;
 
             public ExceptionInterceptor(
-                IEnumerable<T> innerEnumerable, Type contextType, IDiagnosticsLogger<DbLoggerCategory.Query> logger, QueryContext queryContext)
+                IEnumerable<T> innerEnumerable, Type contextType, IDiagnosticsLogger<EF.LoggerCategories.Query> logger, QueryContext queryContext)
             {
                 _innerEnumerable = innerEnumerable;
                 _contextType = contextType;

--- a/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public QueryCompilationContextDependencies(
             [NotNull] IModel model,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] ICurrentDbContext currentContext)
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Query> Logger { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public QueryCompilationContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        public QueryCompilationContextDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger)
             => new QueryCompilationContextDependencies(
                 Model,
                 logger,

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly ICompiledQueryCache _compiledQueryCache;
         private readonly ICompiledQueryCacheKeyGenerator _compiledQueryCacheKeyGenerator;
         private readonly IDatabase _database;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Query> _logger;
         private readonly INodeTypeProviderFactory _nodeTypeProviderFactory;
 
         private readonly Type _contextType;
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] ICompiledQueryCache compiledQueryCache,
             [NotNull] ICompiledQueryCacheKeyGenerator compiledQueryCacheKeyGenerator,
             [NotNull] IDatabase database,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Query> logger,
             [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
             [NotNull] ICurrentDbContext currentContext)
         {
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Expression query, 
             INodeTypeProvider nodeTypeProvider, 
             IDatabase database, 
-            IDiagnosticsLogger<DbLoggerCategory.Query> logger, 
+            IDiagnosticsLogger<EF.LoggerCategories.Query> logger, 
             Type contextType)
         {
             var queryModel
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         private static Func<QueryContext, Task<TResult>> CreateCompiledSingletonAsyncQuery<TResult>(
-                Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery, IDiagnosticsLogger<DbLoggerCategory.Query> logger, Type contextType)
+                Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery, IDiagnosticsLogger<EF.LoggerCategories.Query> logger, Type contextType)
             => qc => ExecuteSingletonAsyncQuery(qc, compiledQuery, logger, contextType);
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static async Task<TResult> ExecuteSingletonAsyncQuery<TResult>(
             QueryContext queryContext,
             Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery,
-            IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            IDiagnosticsLogger<EF.LoggerCategories.Query> logger,
             Type contextType)
         {
             try

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <value>
         ///     The logger.
         /// </value>
-        public virtual IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
+        public virtual IDiagnosticsLogger<EF.LoggerCategories.Query> Logger { get; }
 
         /// <summary>
         ///     Gets the linq operator provider.

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger for this <see cref="ExecutionStrategy" />.
         /// </summary>
-        protected virtual IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger { get; }
+        protected virtual IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> Logger { get; }
 
         private static readonly AsyncLocal<bool?> _suspended = new AsyncLocal<bool?>();
 

--- a/src/EFCore/Storage/ExecutionStrategyContext.cs
+++ b/src/EFCore/Storage/ExecutionStrategyContext.cs
@@ -37,6 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger for the <see cref="ExecutionStrategy" />.
         /// </summary>
-        public virtual IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger => Dependencies.Logger;
+        public virtual IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> Logger => Dependencies.Logger;
     }
 }

--- a/src/EFCore/Storage/ExecutionStrategyContextDependencies.cs
+++ b/src/EFCore/Storage/ExecutionStrategyContextDependencies.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ExecutionStrategyContextDependencies(
             [NotNull] ICurrentDbContext currentDbContext,
             [CanBeNull] IDbContextOptions options,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
+            [CanBeNull] IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> logger)
         {
             Check.NotNull(currentDbContext, nameof(currentDbContext));
 
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The logger.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger { get; }
+        public IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public ExecutionStrategyContextDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
+        public ExecutionStrategyContextDependencies With([NotNull] IDiagnosticsLogger<EF.LoggerCategories.Infrastructure> logger)
             => new ExecutionStrategyContextDependencies(CurrentDbContext, Options, logger);
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/OperationLoggerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new LoggerProvider(categoryName => new OperationLogger(categoryName, reporter)));
 
-            var logger = loggerFactory.CreateLogger(DbLoggerCategory.Database.Command.Name);
+            var logger = loggerFactory.CreateLogger(EF.LoggerCategories.Database.Command.Name);
             logger.Log<object>(
                 LogLevel.Information,
                 RelationalEventId.CommandExecuted,

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 idGenerator,
                 new CSharpMigrationsGenerator(code, new CSharpMigrationOperationGenerator(code), new CSharpSnapshotGenerator(code)),
                 new MockHistoryRepository(),
-                new DiagnosticsLogger<DbLoggerCategory.Migrations>(
+                new DiagnosticsLogger<EF.LoggerCategories.Migrations>(
                     new LoggerFactory(), 
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),

--- a/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/EFCore.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore
                     () => transactionManager.RollbackTransaction()).Message);
         }
 
-        private class FakeLogger : IDiagnosticsLogger<DbLoggerCategory.Database.Transaction>, ILogger
+        private class FakeLogger : IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction>, ILogger
         {
             public void Log<TState>(
                 LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/EFCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -31,10 +31,10 @@ namespace Microsoft.EntityFrameworkCore
         public RelationalDatabaseModelFactoryTest()
         {
             ILoggerFactory loggerFactory = new TestDesignLoggerFactory();
-            _logger = (TestDesignLoggerFactory.DesignLogger)loggerFactory.CreateLogger(DbLoggerCategory.Scaffolding.Name);
+            _logger = (TestDesignLoggerFactory.DesignLogger)loggerFactory.CreateLogger(EF.LoggerCategories.Scaffolding.Name);
 
             _factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(), 
                     new DiagnosticListener("Fake")));
@@ -903,7 +903,7 @@ namespace Microsoft.EntityFrameworkCore
             };
 
             var factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                     new TestDesignLoggerFactory(),
                     new LoggingOptions(), 
                     new DiagnosticListener("Fake")),
@@ -965,7 +965,7 @@ namespace Microsoft.EntityFrameworkCore
             };
 
             var factory = new FakeScaffoldingModelFactory(
-                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                     new TestDesignLoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),
@@ -994,13 +994,13 @@ namespace Microsoft.EntityFrameworkCore
         public IModel Create(DatabaseModel databaseModel) => CreateFromDatabaseModel(databaseModel);
 
         public FakeScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger)
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger)
             : this(logger, new NullPluralizer())
         {
         }
 
         public FakeScaffoldingModelFactory(
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Scaffolding> logger,
+            [NotNull] IDiagnosticsLogger<EF.LoggerCategories.Scaffolding> logger,
             [NotNull] IPluralizer pluralizer)
             : base(
                 logger,

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandExecutorTest.cs
@@ -299,7 +299,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             string commandText = "Command Text",
             IReadOnlyList<IRelationalParameter> parameters = null)
             => new RelationalCommand(
-                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                 commandText,
                 parameters ?? new IRelationalParameter[0]);
     }

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -117,7 +117,7 @@ Statement3
         private MigrationCommandListBuilder CreateBuilder()
             => new MigrationCommandListBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -667,8 +667,8 @@ namespace Microsoft.EntityFrameworkCore
         protected override ModelValidator CreateModelValidator()
             => new RelationalModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == EF.LoggerCategories.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Builds_simple_command()
         {
             var commandBuilder = new RelationalCommandBuilder(
-                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                 new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
 
             var command = commandBuilder.Build();
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Build_command_with_parameter()
         {
             var commandBuilder = new RelationalCommandBuilder(
-                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                 new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
 
             commandBuilder.ParameterBuilder.AddParameter(

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -901,7 +901,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Command>(
                     new ListLoggerFactory(log),
                     new FakeLoggingOptions(false),
                     new DiagnosticListener("Fake")),
@@ -955,7 +955,7 @@ Logged Command",
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Command>(
                     new ListLoggerFactory(log),
                     new FakeLoggingOptions(true),
                     new DiagnosticListener("Fake")),
@@ -1009,7 +1009,7 @@ Logged Command",
             var diagnostic = new List<Tuple<string, object>>();
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Command>(
                     new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
@@ -1077,7 +1077,7 @@ Logged Command",
             var fakeConnection = new FakeRelationalConnection(options);
 
             var relationalCommand = CreateRelationalCommand(
-                new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Command>(
                     new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
@@ -1162,11 +1162,11 @@ Logged Command",
         }
 
         private IRelationalCommand CreateRelationalCommand(
-            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger = null,
+            IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger = null,
             string commandText = "Command Text",
             IReadOnlyList<IRelationalParameter> parameters = null)
             => new RelationalCommand(
-                logger ?? new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                logger ?? new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                 commandText,
                 parameters ?? new IRelationalParameter[0]);
     }

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var transaction = new RelationalTransaction(
                 connection,
                 dbTransaction,
-                new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Transaction>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")),

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -19,11 +19,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
             : base(
                 new RelationalConnectionDependencies(
                     options,
-                    new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Database.Transaction>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener")),
-                    new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener"))))

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 IUpdateSqlGenerator sqlGenerator = null)
                 : base(
                     new RelationalCommandBuilderFactory(
-                        new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                        new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                         new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
                     new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                     sqlGenerator ?? new FakeSqlGenerator(

--- a/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFixture.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
             TestStore.ExecuteNonQuery(createSql);
 
             return new SqlServerDatabaseModelFactory(
-                    new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                         TestDesignLoggerFactory,
                         new LoggingOptions(),
                         new DiagnosticListener("Fake")))

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerDatabaseCleaner.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/SqlServerDatabaseCleaner.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
     {
         protected override IInternalDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
             => new SqlServerDatabaseModelFactory(
-                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")));

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalCommandBuilderFactory.cs
@@ -14,11 +14,11 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 {
     public class TestRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
+        private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Command> _logger;
         private readonly IRelationalTypeMapper _typeMapper;
 
         public TestRelationalCommandBuilderFactory(
-            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
             IRelationalTypeMapper typeMapper)
         {
             _logger = logger;
@@ -30,10 +30,10 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
         private class TestRelationalCommandBuilder : IRelationalCommandBuilder
         {
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _logger;
+            private readonly IDiagnosticsLogger<EF.LoggerCategories.Database.Command> _logger;
 
             public TestRelationalCommandBuilder(
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                 IRelationalTypeMapper typeMapper)
             {
                 _logger = logger;
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             private readonly RelationalCommand _realRelationalCommand;
 
             public TestRelationalCommand(
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                 string commandText,
                 IReadOnlyList<IRelationalParameter> parameters)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Utilities/TestRelationalTransaction.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 new RelationalTransaction(
                     connection,
                     transaction,
-                    new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Database.Transaction>(
                         loggerFactory, new LoggingOptions(), diagnosticSource),
                     transactionOwned))
         {

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var typeMapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
 
             var commandBuilderFactory = new RelationalCommandBuilderFactory(
-                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                 typeMapper);
 
             return new SqlServerHistoryRepository(

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -80,11 +80,11 @@ namespace Microsoft.EntityFrameworkCore
 
             return new RelationalConnectionDependencies(
                 options,
-                new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Transaction>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener")),
-                new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
+                new DiagnosticsLogger<EF.LoggerCategories.Database.Connection>(
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener")));

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -215,8 +215,8 @@ namespace Microsoft.EntityFrameworkCore
         protected override ModelValidator CreateModelValidator()
             => new SqlServerModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == EF.LoggerCategories.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new SqlServerTypeMapper(
                         new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new SqlServerTypeMapper(
                         new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         {
             var batch = new SqlServerModificationCommandBatch(
                 new RelationalCommandBuilderFactory(
-                    new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                    new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                     new SqlServerTypeMapper(new RelationalTypeMapperDependencies())),
                 new SqlServerSqlGenerationHelper(
                     new RelationalSqlGenerationHelperDependencies()),

--- a/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore
         private class BadDataCommandBuilderFactory : RelationalCommandBuilderFactory
         {
             public BadDataCommandBuilderFactory(
-                IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                 IRelationalTypeMapper typeMapper)
                 : base(logger, typeMapper)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore
             public object[] Values { private get; set; }
 
             protected override IRelationalCommandBuilder CreateCore(
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                    IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                     IRelationalTypeMapper relationalTypeMapper)
                 => new BadDataRelationalCommandBuilder(
                     logger, relationalTypeMapper, Values);
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore
                 private readonly object[] _values;
 
                 public BadDataRelationalCommandBuilder(
-                    IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                    IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                     IRelationalTypeMapper typeMapper,
                     object[] values)
                     : base(logger, typeMapper)
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 protected override IRelationalCommand BuildCore(
-                        IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                        IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                         string commandText,
                         IReadOnlyList<IRelationalParameter> parameters)
                     => new BadDataRelationalCommand(logger, commandText, parameters, _values);
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore
                     private readonly object[] _values;
 
                     public BadDataRelationalCommand(
-                        IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+                        IDiagnosticsLogger<EF.LoggerCategories.Database.Command> logger,
                         string commandText,
                         IReadOnlyList<IRelationalParameter> parameters,
                         object[] values)

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCleaner.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override IInternalDatabaseModelFactory CreateDatabaseModelFactory(ILoggerFactory loggerFactory)
             => new SqliteDatabaseModelFactory(
-                new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                new DiagnosticsLogger<EF.LoggerCategories.Scaffolding>(
                     loggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("Fake")));

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     new SqliteMigrationsSqlGenerator(
                         new MigrationsSqlGeneratorDependencies(
                             new RelationalCommandBuilderFactory(
-                                new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
+                                new FakeDiagnosticsLogger<EF.LoggerCategories.Database.Command>(),
                                 typeMapper),
                             new SqliteSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                             typeMapper)),

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -74,8 +74,8 @@ namespace Microsoft.EntityFrameworkCore
         protected override ModelValidator CreateModelValidator()
             => new SqliteModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
+                    new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
+                        new ListLoggerFactory(Log, l => l == EF.LoggerCategories.Model.Validation.Name),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -2274,7 +2274,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContextWithOC1A())
@@ -2304,8 +2304,8 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
-                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
+                Assert.Contains(EF.LoggerCategories.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContextWithOC1B(loggerFactory, memoryCache))
@@ -2332,7 +2332,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
@@ -2370,8 +2370,8 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
-                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
+                Assert.Contains(EF.LoggerCategories.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContextWithOC3A(options))
@@ -2398,7 +2398,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2434,7 +2434,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2466,7 +2466,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var context = new ConstructorTestContext1A(options))
@@ -2504,8 +2504,8 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
-                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
+                Assert.Contains(EF.LoggerCategories.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new ConstructorTestContext1A(options))
@@ -2538,7 +2538,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2570,7 +2570,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var context = new DbContext(options))
@@ -2608,8 +2608,8 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
-                Assert.Contains(DbLoggerCategory.Infrastructure.Name, loggerFactory.CreatedLoggers);
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
+                Assert.Contains(EF.LoggerCategories.Infrastructure.Name, loggerFactory.CreatedLoggers);
             }
 
             using (var context = new DbContext(options))
@@ -2642,7 +2642,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.Same(options, context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 Assert.Same(singleton[0], internalServiceProivder.GetService<IInMemoryStoreCache>());
                 Assert.Same(singleton[1], internalServiceProivder.GetService<ILoggerFactory>());
@@ -2679,7 +2679,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -2721,7 +2721,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(loggerFactory, context.GetService<ILoggerFactory>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2762,7 +2762,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 appSingleton = context.GetService<SomeAppService>();
                 Assert.NotNull(appSingleton);
@@ -2810,7 +2810,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2846,7 +2846,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2887,7 +2887,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2925,7 +2925,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -2967,7 +2967,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3003,7 +3003,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3043,7 +3043,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3085,7 +3085,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3123,7 +3123,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3165,7 +3165,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3201,7 +3201,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3244,7 +3244,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
                 Assert.NotNull(options = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3281,7 +3281,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
                 Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             using (var serviceScope = appServiceProivder
@@ -3332,7 +3332,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3407,7 +3407,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3462,7 +3462,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3527,7 +3527,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3581,7 +3581,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3649,7 +3649,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
             Assert.NotNull(context1.Model);
@@ -3699,7 +3699,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3773,7 +3773,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
 
-                Assert.NotNull(context1.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context1.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
                 context1.Dispose();
                 Assert.Throws<ObjectDisposedException>(() => context1.Model);
@@ -3806,7 +3806,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(p))
                 .BuildServiceProvider();
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
             using (var serviceScope = appServiceProivder
                 .GetRequiredService<IServiceScopeFactory>()
@@ -3815,10 +3815,10 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
                 _ = context.Model;
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             }
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
         }
 
         [Fact]
@@ -3833,7 +3833,7 @@ namespace Microsoft.EntityFrameworkCore
                         .UseLoggerFactory(loggerFactory = new WrappingLoggerFactory(p.GetService<ILoggerFactory>())))
                 .BuildServiceProvider();
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
             Assert.Null(loggerFactory);
 
             using (var serviceScope = appServiceProivder
@@ -3843,13 +3843,13 @@ namespace Microsoft.EntityFrameworkCore
                 var context = serviceScope.ServiceProvider.GetService<DbContext>();
                 _ = context.Model;
 
-                Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
+                Assert.NotNull(context.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
 
-                Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+                Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == EF.LoggerCategories.Infrastructure.Name));
             }
 
-            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
-            Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+            Assert.NotNull(appServiceProivder.GetService<IDiagnosticsLogger<EF.LoggerCategories.Infrastructure>>());
+            Assert.Equal(1, loggerFactory.CreatedLoggers.Count(n => n == EF.LoggerCategories.Infrastructure.Name));
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -15,19 +15,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [Fact]
         public void Can_filter_for_messages_of_one_category()
         {
-            FilterTest(c => c == DbLoggerCategory.Database.Command.Name, "SQL1", "SQL2");
+            FilterTest(c => c == EF.LoggerCategories.Database.Command.Name, "SQL1", "SQL2");
         }
 
         [Fact]
         public void Can_filter_for_messages_of_one_subcategory()
         {
-            FilterTest(c => c.StartsWith(DbLoggerCategory.Database.Name), "DB1", "SQL1", "DB2", "SQL2");
+            FilterTest(c => c.StartsWith(EF.LoggerCategories.Database.Name), "DB1", "SQL1", "DB2", "SQL2");
         }
 
         [Fact]
         public void Can_filter_for_all_EF_messages()
         {
-            FilterTest(c => c.StartsWith(DbLoggerCategory.Root), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
+            FilterTest(c => c.StartsWith(EF.LoggerCategories.Root), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
         }
 
         [Fact]
@@ -43,9 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             loggerFactory.AddProvider(loggerProvider);
 
-            var dbLogger = new DiagnosticsLogger<DbLoggerCategory.Database>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
-            var sqlLogger = new DiagnosticsLogger<DbLoggerCategory.Database.Command>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
-            var queryLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var dbLogger = new DiagnosticsLogger<EF.LoggerCategories.Database>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var sqlLogger = new DiagnosticsLogger<EF.LoggerCategories.Database.Command>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
+            var queryLogger = new DiagnosticsLogger<EF.LoggerCategories.Query>(loggerFactory, new LoggingOptions(), new DiagnosticListener("Fake"));
             var randomLogger = loggerFactory.CreateLogger("Random");
 
             dbLogger.Logger.LogInformation(1, "DB1");

--- a/test/EFCore.Tests/Infrastructure/LoggerCategoryTest.cs
+++ b/test/EFCore.Tests/Infrastructure/LoggerCategoryTest.cs
@@ -10,33 +10,33 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [Fact]
         public void Logger_categories_have_the_correct_names()
         {
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database", DbLoggerCategory.Database.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Command", DbLoggerCategory.Database.Command.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Connection", DbLoggerCategory.Database.Connection.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Transaction", DbLoggerCategory.Database.Transaction.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Infrastructure", DbLoggerCategory.Infrastructure.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Migrations", DbLoggerCategory.Migrations.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Scaffolding", DbLoggerCategory.Scaffolding.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Model", DbLoggerCategory.Model.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Model.Validation", DbLoggerCategory.Model.Validation.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Query", DbLoggerCategory.Query.Name);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Update", DbLoggerCategory.Update.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database", EF.LoggerCategories.Database.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Command", EF.LoggerCategories.Database.Command.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Connection", EF.LoggerCategories.Database.Connection.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Database.Transaction", EF.LoggerCategories.Database.Transaction.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Infrastructure", EF.LoggerCategories.Infrastructure.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Migrations", EF.LoggerCategories.Migrations.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Scaffolding", EF.LoggerCategories.Scaffolding.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Model", EF.LoggerCategories.Model.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Model.Validation", EF.LoggerCategories.Model.Validation.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Query", EF.LoggerCategories.Query.Name);
+            Assert.Equal("Microsoft.EntityFrameworkCore.Update", EF.LoggerCategories.Update.Name);
         }
 
         [Fact]
         public void DbLoggerCategory_instances_generate_the_correct_names()
         {
-            Assert.Equal(DbLoggerCategory.Database.Name, new DbLoggerCategory.Database());
-            Assert.Equal(DbLoggerCategory.Database.Command.Name, new DbLoggerCategory.Database.Command());
-            Assert.Equal(DbLoggerCategory.Database.Connection.Name, new DbLoggerCategory.Database.Connection());
-            Assert.Equal(DbLoggerCategory.Database.Transaction.Name, new DbLoggerCategory.Database.Transaction());
-            Assert.Equal(DbLoggerCategory.Infrastructure.Name, new DbLoggerCategory.Infrastructure());
-            Assert.Equal(DbLoggerCategory.Migrations.Name, new DbLoggerCategory.Migrations());
-            Assert.Equal(DbLoggerCategory.Scaffolding.Name, new DbLoggerCategory.Scaffolding());
-            Assert.Equal(DbLoggerCategory.Model.Name, new DbLoggerCategory.Model());
-            Assert.Equal(DbLoggerCategory.Model.Validation.Name, new DbLoggerCategory.Model.Validation());
-            Assert.Equal(DbLoggerCategory.Query.Name, new DbLoggerCategory.Query());
-            Assert.Equal(DbLoggerCategory.Update.Name, new DbLoggerCategory.Update());
+            Assert.Equal(EF.LoggerCategories.Database.Name, new EF.LoggerCategories.Database());
+            Assert.Equal(EF.LoggerCategories.Database.Command.Name, new EF.LoggerCategories.Database.Command());
+            Assert.Equal(EF.LoggerCategories.Database.Connection.Name, new EF.LoggerCategories.Database.Connection());
+            Assert.Equal(EF.LoggerCategories.Database.Transaction.Name, new EF.LoggerCategories.Database.Transaction());
+            Assert.Equal(EF.LoggerCategories.Infrastructure.Name, new EF.LoggerCategories.Infrastructure());
+            Assert.Equal(EF.LoggerCategories.Migrations.Name, new EF.LoggerCategories.Migrations());
+            Assert.Equal(EF.LoggerCategories.Scaffolding.Name, new EF.LoggerCategories.Scaffolding());
+            Assert.Equal(EF.LoggerCategories.Model.Name, new EF.LoggerCategories.Model());
+            Assert.Equal(EF.LoggerCategories.Model.Validation.Name, new EF.LoggerCategories.Model.Validation());
+            Assert.Equal(EF.LoggerCategories.Query.Name, new EF.LoggerCategories.Query());
+            Assert.Equal(EF.LoggerCategories.Update.Name, new EF.LoggerCategories.Update());
         }
     }
 }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -106,15 +106,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         protected ModelValidatorTest()
         {
             Log = new List<Tuple<LogLevel, string>>();
-            Logger = new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
-                new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
+            Logger = new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
+                new ListLoggerFactory(Log, l => l == EF.LoggerCategories.Model.Validation.Name),
                 new LoggingOptions(),
                 new DiagnosticListener("Fake"));
         }
 
         protected List<Tuple<LogLevel, string>> Log { get; }
 
-        protected IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
+        protected IDiagnosticsLogger<EF.LoggerCategories.Model.Validation> Logger { get; }
 
         protected virtual void VerifyWarning(string expectedMessage, IModel model)
         {

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1586,7 +1586,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var modelValidator = new CoreModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))));

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -626,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
         }
 
-        private class FakeLogger : IDiagnosticsLogger<DbLoggerCategory.Model.Validation>, ILogger
+        private class FakeLogger : IDiagnosticsLogger<EF.LoggerCategories.Model.Validation>, ILogger
         {
             public void Log<TState>(
                 LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = ((IInfrastructure<InternalModelBuilder>)ModelBuilder).Instance.Validate();
                 new CoreModelValidator(
                         new ModelValidatorDependencies(
-                            new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                            new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
                                 new LoggerFactory(),
                                 new LoggingOptions(),
                                 new DiagnosticListener("Fake"))))

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         private readonly CoreModelValidator _coreModelValidator
             = new CoreModelValidator(
                 new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
+                    new DiagnosticsLogger<EF.LoggerCategories.Model.Validation>(
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))));

--- a/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
+++ b/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private IDbContextTransaction _currentTransaction;
 
         public TestInMemoryTransactionManager(
-            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger)
+            IDiagnosticsLogger<EF.LoggerCategories.Database.Transaction> logger)
             : base(logger)
         {
         }


### PR DESCRIPTION
Not to be merged. Just trying a simple approach that nests DbLoggerCategory into EF. This doesn't allow for extensibility but we are not sure if that matters a log. We could add an `Other` cateogory for any events that don't feet existing ones. 