### PR TITLE
Support named connection strings when IConfiguration is in the app service provider

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -76,7 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IRelationalResultOperatorHandler), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRelationalConnection), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRelationalDatabaseCreator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
-                { typeof(IHistoryRepository), new ServiceCharacteristics(ServiceLifetime.Scoped) }
+                { typeof(IHistoryRepository), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(INamedConnectionStringResolver), new ServiceCharacteristics(ServiceLifetime.Scoped) }
             };
 
         /// <summary>
@@ -148,6 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<ICompiledQueryCacheKeyGenerator, RelationalCompiledQueryCacheKeyGenerator>();
             TryAdd<IExpressionFragmentTranslator, RelationalCompositeExpressionFragmentTranslator>();
             TryAdd<ISqlTranslatingExpressionVisitorFactory, SqlTranslatingExpressionVisitorFactory>();
+            TryAdd<INamedConnectionStringResolver, NamedConnectionStringResolver>();
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<RelationalCompositeMemberTranslatorDependencies>()

--- a/src/EFCore.Relational/Storage/Internal/INamedConnectionStringResolver.cs
+++ b/src/EFCore.Relational/Storage/Internal/INamedConnectionStringResolver.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface INamedConnectionStringResolver
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        string ResolveConnectionString([NotNull] string connectionString);
+    }
+}

--- a/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolver.cs
+++ b/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolver.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class NamedConnectionStringResolver : INamedConnectionStringResolver
+    {
+        private const string DefaultSection = "ConnectionStrings:";
+
+        private readonly IDbContextOptions _options;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public NamedConnectionStringResolver([NotNull] IDbContextOptions options)
+        {
+            _options = options;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string ResolveConnectionString(string connectionString)
+        {
+            var connectionName = TryGetConnectionName(connectionString);
+
+            if (connectionName == null)
+            {
+                return connectionString;
+            }
+            var configuration = _options.FindExtension<CoreOptionsExtension>()
+                ?.ApplicationServiceProvider
+                ?.GetService<IConfiguration>();
+
+            return configuration?[connectionName]
+                   ?? configuration?[DefaultSection + connectionName]
+                   ?? connectionString;
+        }
+
+        private static string TryGetConnectionName(string connectionString)
+        {
+            var firstEquals = connectionString.IndexOf('=');
+            if (firstEquals < 0)
+            {
+                return null;
+            }
+
+            if (connectionString.IndexOf('=', firstEquals + 1) >= 0)
+            {
+                return null;
+            }
+
+            if (connectionString.Substring(0, firstEquals).Trim().Equals(
+                "name", StringComparison.OrdinalIgnoreCase))
+            {
+                return connectionString.Substring(firstEquals + 1).Trim();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             }
             else if (!string.IsNullOrWhiteSpace(relationalOptions.ConnectionString))
             {
-                _connectionString = relationalOptions.ConnectionString;
+                _connectionString = dependencies.ConnectionStringResolver.ResolveConnectionString(relationalOptions.ConnectionString);
                 _connection = new LazyRef<DbConnection>(CreateDbConnection);
                 _connectionOwned = true;
             }

--- a/test/EFCore.Relational.Tests/Storage/NamedConnectionStringResolverTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/NamedConnectionStringResolverTest.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class NamedConnectionStringResolverTest
+    {
+        [Fact]
+        public void Returns_given_string_if_no_app_service_provider()
+        {
+            var resolver = new NamedConnectionStringResolver(new FakeOptions(null, false));
+
+            Assert.Equal("name=foo", resolver.ResolveConnectionString("name=foo"));
+        }
+
+        [Fact]
+        public void Returns_given_string_if_no_IConfiguration()
+        {
+            var resolver = new NamedConnectionStringResolver(new FakeOptions(null));
+
+            Assert.Equal("name=foo", resolver.ResolveConnectionString("name=foo"));
+        }
+
+        [Fact]
+        public void Returns_given_string_if_IConfiguration_does_not_contain_key()
+        {
+            var resolver = new NamedConnectionStringResolver(new FakeOptions(new ConfigurationBuilder().Build()));
+
+            Assert.Equal("name=foo", resolver.ResolveConnectionString("name=foo"));
+        }
+
+        [Fact]
+        public void Returns_resolved_string_if_IConfiguration_contains_key()
+        {
+            var resolver = new NamedConnectionStringResolver(
+                new FakeOptions(
+                    new ConfigurationBuilder()
+                        .AddInMemoryCollection(
+                            new Dictionary<string, string>
+                            {
+                                { "MyConnectuonString", "Conn1" },
+                                {"ConnectionStrings:DefaultConnection", "Conn2" },
+                                {"ConnectionStrings:MyConnectuonString", "Conn3" }
+                            })
+                        .Build()));
+
+            Assert.Equal("Conn1", resolver.ResolveConnectionString("name=MyConnectuonString"));
+            Assert.Equal("Conn2", resolver.ResolveConnectionString("name=ConnectionStrings:DefaultConnection"));
+            Assert.Equal("Conn2", resolver.ResolveConnectionString("name=DefaultConnection"));
+            Assert.Equal("Conn3", resolver.ResolveConnectionString("name=ConnectionStrings:MyConnectuonString"));
+
+            Assert.Equal("Conn1", resolver.ResolveConnectionString("  NamE = MyConnectuonString   "));
+        }
+
+        [Fact]
+        public void Returns_given_string_named_connection_string_doesnt_match_pattern()
+        {
+            var resolver = new NamedConnectionStringResolver(
+                new FakeOptions(
+                    new ConfigurationBuilder()
+                        .AddInMemoryCollection(
+                            new Dictionary<string, string>
+                            {
+                                { "Nope", "NoThanks" },
+                            })
+                        .Build()));
+
+            Assert.Equal("name=Fox;DataSource=Jimony", resolver.ResolveConnectionString("name=Fox;DataSource=Jimony"));
+            Assert.Equal("DataSource=Jimony", resolver.ResolveConnectionString("DataSource=Jimony"));
+            Assert.Equal("Jimony", resolver.ResolveConnectionString("Jimony"));
+        }
+
+        private class FakeOptions : IDbContextOptions
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public FakeOptions(IConfiguration configuration, bool useServiceProvider = true)
+            {
+                if (useServiceProvider)
+                {
+                    var collection = new ServiceCollection();
+
+                    if (configuration != null)
+                    {
+                        collection.AddSingleton(configuration);
+                    }
+
+                    _serviceProvider = collection.BuildServiceProvider();
+                }
+            }
+
+            public IEnumerable<IDbContextOptionsExtension> Extensions => null;
+
+            public TExtension FindExtension<TExtension>()
+                where TExtension : class, IDbContextOptionsExtension
+            {
+                var coreOptionsExtension = new CoreOptionsExtension();
+
+                if (_serviceProvider != null)
+                {
+                    coreOptionsExtension = coreOptionsExtension.WithApplicationServiceProvider(_serviceProvider);
+                }
+
+                return (TExtension)(object)coreOptionsExtension;
+            }
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
@@ -26,7 +27,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                     new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                         new LoggerFactory(),
                         new LoggingOptions(),
-                        new DiagnosticListener("FakeDiagnosticListener"))))
+                        new DiagnosticListener("FakeDiagnosticListener")),
+                    new NamedConnectionStringResolver(options)))
         {
         }
 

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -87,7 +87,8 @@ namespace Microsoft.EntityFrameworkCore
                 new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
                     new LoggerFactory(),
                     new LoggingOptions(),
-                    new DiagnosticListener("FakeDiagnosticListener")));
+                    new DiagnosticListener("FakeDiagnosticListener")),
+                new NamedConnectionStringResolver(options));
         }
     }
 }


### PR DESCRIPTION
Issue #7185

This change allows code like this:
```C#
.AddDbContext<MyContect>(
   b => b.UseSqlServer("name=ConnectionStrings:DefaultConnection"))

```

Assuming the IConfiguration is found in the same service provider as AddDbContext is used on, then this will find "ConnectionStrings:DefaultConnection" and use it as the connection string.

Should work for all relational providers.
