### PR TITLE
Throw when a property is made optional if it's contained in a key created explicitly.

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -39,6 +39,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     foreach (var key in Metadata.GetContainingKeys().ToList())
                     {
+                        if (configurationSource == ConfigurationSource.Explicit
+                            && key.GetConfigurationSource() == ConfigurationSource.Explicit)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.KeyPropertyCannotBeNullable(Metadata.Name, Metadata.DeclaringEntityType.DisplayName(), Property.Format(key.Properties)));
+                        }
+
                         var removed = key.DeclaringEntityType.Builder.RemoveKey(key, configurationSource);
                         Debug.Assert(removed.HasValue);
                     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -801,6 +801,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entityType, propertyType);
 
         /// <summary>
+        ///     The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because it has been included in a key {key}.
+        /// </summary>
+        public static string KeyPropertyCannotBeNullable([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key)
+            => string.Format(
+                GetString("KeyPropertyCannotBeNullable", nameof(property), nameof(entityType), nameof(key)),
+                property, entityType, key);
+
+        /// <summary>
         ///     An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.
         /// </summary>
         public static string RecursiveOnModelCreating
@@ -1743,7 +1751,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogPossibleUnintendedReferenceComparison")));
 
         /// <summary>
-        ///     The same entity is being tracked as different delegated identity entity types '{diet1}' and '{diet2}'. If a property value changes it will result in two store changes, which might not be the desired outcome. 
+        ///     The same entity is being tracked as different delegated identity entity types '{diet1}' and '{diet2}'. If a property value changes it will result in two store changes, which might not be the desired outcome.
         /// </summary>
         public static readonly EventDefinition<string, string> LogDuplicateDietInstance
             = new EventDefinition<string, string>(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -410,6 +410,9 @@
   <data name="CannotBeNullable" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
   </data>
+  <data name="KeyPropertyCannotBeNullable" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because it has been included in a key {key}.</value>
+  </data>
   <data name="RecursiveOnModelCreating" xml:space="preserve">
     <value>An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.</value>
   </data>
@@ -771,7 +774,7 @@
     <comment>Warning CoreEventId.PossibleUnintendedReferenceComparisonWarning object object</comment>
   </data>
   <data name="LogDuplicateDietInstance" xml:space="preserve">
-    <value>The same entity is being tracked as different delegated identity entity types '{diet1}' and '{diet2}'. If a property value changes it will result in two store changes, which might not be the desired outcome. </value>
-    <comment>Warning CoreEventId.DuplicateDietInstance string string</comment>
+    <value>The same entity is being tracked as different delegated identity entity types '{diet1}' and '{diet2}'. If a property value changes it will result in two store changes, which might not be the desired outcome.</value>
+    <comment>Warning CoreEventId.DuplicateDietInstanceWarning string string</comment>
   </data>
 </root>

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -476,6 +476,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [Fact]
+            public virtual void Key_properties_cannot_be_made_optional()
+            {
+                Assert.Equal(CoreStrings.KeyPropertyCannotBeNullable(nameof(Quarks.Down), nameof(Quarks), "{'" + nameof(Quarks.Down) + "'}"),
+                    Assert.Throws<InvalidOperationException>(() =>
+                        CreateModelBuilder().Entity<Quarks>(b =>
+                            {
+                                b.HasAlternateKey(e => new { e.Down });
+                                b.Property(e => e.Down).IsRequired(false);
+                            })).Message);
+            }
+
+            [Fact]
             public virtual void Non_nullable_properties_cannot_be_made_optional()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #6919
