### PR TITLE
Rename DbLoggerCategory.Root to DbLoggerCategory.Name

### DIFF
--- a/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
+++ b/src/EFCore.ApplicationInsights/DiagnosticEventForwarder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
 
         void IObserver<DiagnosticListener>.OnNext(DiagnosticListener diagnosticListener)
         {
-            if (diagnosticListener.Name == DbLoggerCategory.Root)
+            if (diagnosticListener.Name == DbLoggerCategory.Name)
             {
                 lock (_sync)
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.ApplicationInsights
                 var eventName = value.Key;
                 var eventData = value.Value;
 
-                Debug.Assert(eventName.StartsWith(DbLoggerCategory.Root, StringComparison.Ordinal));
+                Debug.Assert(eventName.StartsWith(DbLoggerCategory.Name, StringComparison.Ordinal));
                 Debug.Assert(eventData != null);
 
                 switch (eventData)

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<EntityTypeWriter>()
                 .AddSingleton<CodeWriter, StringBuilderCodeWriter>()
                 .AddSingleton<ILoggingOptions, LoggingOptions>()
-                .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root))
+                .AddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name))
                 .AddSingleton(typeof(IDiagnosticsLogger<>), typeof(DiagnosticsLogger<>));
     }
 }

--- a/src/EFCore/DbLoggerCategory.cs
+++ b/src/EFCore/DbLoggerCategory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     The root/prefix for all Entity Framework categories.
         /// </summary>
-        public const string Root = "Microsoft.EntityFrameworkCore";
+        public const string Name = "Microsoft.EntityFrameworkCore";
 
         /// <summary>
         ///     Logger categories for messages related to database interactions.

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IResettableService, IDbContextTransactionManager>(p => p.GetService<IDbContextTransactionManager>());
 
             ServiceCollectionMap
-                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Root));
+                .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<DatabaseProviderDependencies>()

--- a/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DiagnosticsLoggerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [Fact]
         public void Can_filter_for_all_EF_messages()
         {
-            FilterTest(c => c.StartsWith(DbLoggerCategory.Root), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
+            FilterTest(c => c.StartsWith(DbLoggerCategory.Name), "DB1", "SQL1", "Query1", "DB2", "SQL2", "Query2");
         }
 
         [Fact]


### PR DESCRIPTION
To better align with other category Name properties.
