### PR TITLE
Ignore TypeMapping annotations when generating model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -259,7 +259,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             GenerateFluentApiForAnnotation(ref annotations, CoreAnnotationNames.MaxLengthAnnotation, nameof(PropertyBuilder.HasMaxLength), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, CoreAnnotationNames.UnicodeAnnotation, nameof(PropertyBuilder.IsUnicode), stringBuilder);
 
-            IgnoreAnnotations(annotations, CoreAnnotationNames.ValueGeneratorFactoryAnnotation);
+            IgnoreAnnotations(
+                annotations, 
+                CoreAnnotationNames.ValueGeneratorFactoryAnnotation,
+                RelationalAnnotationNames.TypeMapping);
 
             GenerateAnnotations(annotations, stringBuilder);
         }

--- a/src/EFCore.Relational.Design.Specification.Tests/Migrations/ModelSnapshotTest.cs
+++ b/src/EFCore.Relational.Design.Specification.Tests/Migrations/ModelSnapshotTest.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
@@ -728,7 +729,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotTest+Enti
             Test(
                 builder =>
                     {
-                        builder.Entity<EntityWithOneProperty>().Property<int>("Id").HasAnnotation("AnnotationName", "AnnotationValue");
+                        builder.Entity<EntityWithOneProperty>()
+                            .Property<int>("Id")
+                            .HasAnnotation("AnnotationName", "AnnotationValue")
+                            .HasAnnotation(RelationalAnnotationNames.TypeMapping, new RelationalTypeMapping("int", typeof(int)));
+
                         builder.Ignore<EntityWithTwoProperties>();
                     },
                GetHeading() + @"


### PR DESCRIPTION
Adding to the exclusion list since they cannot be serialized.
