### PR TITLE
Don't throw when defining an FK in a derived type on a property contained in a key if the property is not value generated

### DIFF
--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -651,11 +651,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            // FKs are not allowed to use properties from inherited keys since this could result in an ambiguous value space
+            // FKs are not allowed to use properties with value generation from inherited keys since this could result in an ambiguous value space
             if (dependentProperties != null
                 && dependentEntityType.BaseType != null)
             {
-                var inheritedKey = dependentProperties.SelectMany(p => p.GetContainingKeys().Where(k => k.DeclaringEntityType != dependentEntityType)).FirstOrDefault();
+                var inheritedKey = dependentProperties.Where(p => p.ValueGenerated != ValueGenerated.Never)
+                    .SelectMany(p => p.GetContainingKeys().Where(k => k.DeclaringEntityType != dependentEntityType)).FirstOrDefault();
                 if (inheritedKey != null)
                 {
                     if (shouldThrow)

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -203,6 +203,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual void SetValueGenerated(ValueGenerated? valueGenerated, ConfigurationSource configurationSource)
         {
+            if (valueGenerated != null
+                && valueGenerated != ValueGenerated.Never
+                && this.IsKey())
+            {
+                var inheritedFk = GetContainingForeignKeys().FirstOrDefault(fk => fk.DeclaringEntityType.BaseType != null);
+                if (inheritedFk != null)
+                {
+                    var key = GetContainingKeys().First();
+                    throw new InvalidOperationException(
+                        CoreStrings.ForeignKeyPropertyInKey(
+                            Name,
+                            inheritedFk.DeclaringEntityType.DisplayName(),
+                            Format(key.Properties),
+                            key.DeclaringEntityType.DisplayName()));
+                }
+            }
+
             _valueGenerated = valueGenerated;
 
             if (valueGenerated == null)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1303,7 +1303,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 dependentEntityType, principalEntityType, entityType);
 
         /// <summary>
-        ///     The property '{property}' cannot be part of a foreign key on '{entityType}' because it is contained in the key {key} defined on a base entity type '{baseEntityType}'.
+        ///     The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {key} defined on a base entity type '{baseEntityType}'.
         /// </summary>
         public static string ForeignKeyPropertyInKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key, [CanBeNull] object baseEntityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -604,7 +604,7 @@
     <value>You are configuring a relationship between '{dependentEntityType}' and '{principalEntityType}' but have specified a foreign key targeting '{entityType}'. The foreign key must be targeting a type that is part of the relationship.</value>
   </data>
   <data name="ForeignKeyPropertyInKey" xml:space="preserve">
-    <value>The property '{property}' cannot be part of a foreign key on '{entityType}' because it is contained in the key {key} defined on a base entity type '{baseEntityType}'.</value>
+    <value>The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {key} defined on a base entity type '{baseEntityType}'.</value>
   </data>
   <data name="KeyPropertyInForeignKey" xml:space="preserve">
     <value>The property '{property}' cannot be part of a key on '{entityType}' because it is contained in a foreign key defined on a derived entity type.</value>

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -1795,6 +1795,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var model = new Model();
             var baseType = model.AddEntityType(typeof(BaseType));
             var idProperty = baseType.GetOrAddProperty(Customer.IdProperty);
+            idProperty.ValueGenerated = ValueGenerated.OnAdd;
             var idProperty2 = baseType.GetOrAddProperty("id2", typeof(int));
             var key = baseType.GetOrAddKey(new[] { idProperty, idProperty2 });
             IMutableEntityType entityType = model.AddEntityType(typeof(Customer));

--- a/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -281,6 +281,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             derivedDependentEntityBuilder.PrimaryKey(new[] { Order.IdProperty }, ConfigurationSource.Convention);
             derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit);
             var idProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
+            idProperty.ValueGenerated = ValueGenerated.OnAdd;
 
             var relationship = derivedDependentEntityBuilder.Relationship(
                 principalEntityBuilder,


### PR DESCRIPTION
Fixes #7181
