### PR TITLE
Update SqlServerTypeMapper to no longer allow char mappings

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/LikeTranslator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         private static readonly MethodInfo _methodInfoWithEscape
             = typeof(DbFunctionsExtensions).GetRuntimeMethod(
                 nameof(DbFunctionsExtensions.Like),
-                new[] { typeof(DbFunctions), typeof(string), typeof(string), typeof(char) });
+                new[] { typeof(DbFunctions), typeof(string), typeof(string), typeof(string) });
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Specification.Tests/DbFunctionsTestBase.cs
+++ b/src/EFCore.Specification.Tests/DbFunctionsTestBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateContext())
             {
-                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "!%", '!'));
+                var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "!%", "!"));
                 Assert.Equal(0, count);
             }
         }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -138,9 +138,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { "xml", _xml }
                 };
 
-            // Note: sbyte, ushort, uint and ulong type mappings are not supported by SQL Server.
+            // Note: sbyte, ushort, uint, char and ulong type mappings are not supported by SQL Server.
             // We would need the type conversions feature to allow this to work - see https://github.com/aspnet/EntityFramework/issues/242.
-            // char mapping is included but only temporarily - see https://github.com/aspnet/EntityFramework/issues/8656
             _clrTypeMappings
                 = new Dictionary<Type, RelationalTypeMapping>
                 {
@@ -152,7 +151,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { typeof(byte), _byte },
                     { typeof(double), _double },
                     { typeof(DateTimeOffset), _datetimeoffset },
-                    { typeof(char), new CharTypeMapping("int") },
                     { typeof(short), _short },
                     { typeof(float), _real },
                     { typeof(decimal), _decimal },

--- a/test/EFCore.SqlServer.FunctionalTests/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbFunctionsSqlServerTest.cs
@@ -44,7 +44,7 @@ WHERE [c].[ContactName] LIKE [c].[ContactName]",
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]
-WHERE [c].[ContactName] LIKE N'!%' ESCAPE '!'",
+WHERE [c].[ContactName] LIKE N'!%' ESCAPE N'!'",
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 var columns = (await testStore.QueryAsync<string>(
                     "SELECT TABLE_NAME + '.' + COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'Blogs' ORDER BY TABLE_NAME, COLUMN_NAME")).ToArray();
-                Assert.Equal(15, columns.Length);
+                Assert.Equal(14, columns.Length);
 
                 Assert.Equal(
                     new[]
@@ -359,7 +359,6 @@ namespace Microsoft.EntityFrameworkCore
                             "Blogs.AndChew (varbinary)",
                             "Blogs.AndRow (timestamp)",
                             "Blogs.Cheese (nvarchar)",
-                            "Blogs.CupOfChar (int)",
                             "Blogs.ErMilan (int)",
                             "Blogs.Fuse (smallint)",
                             "Blogs.George (bit)",
@@ -627,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal("Blogs", tables.Single());
 
                     var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Blogs'");
-                    Assert.Equal(15, columns.Count());
+                    Assert.Equal(14, columns.Count());
                     Assert.True(columns.Any(c => c == "Blogs.Key1"));
                     Assert.True(columns.Any(c => c == "Blogs.Key2"));
                     Assert.True(columns.Any(c => c == "Blogs.Cheese"));
@@ -636,7 +635,6 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.True(columns.Any(c => c == "Blogs.TheGu"));
                     Assert.True(columns.Any(c => c == "Blogs.NotFigTime"));
                     Assert.True(columns.Any(c => c == "Blogs.ToEat"));
-                    Assert.True(columns.Any(c => c == "Blogs.CupOfChar"));
                     Assert.True(columns.Any(c => c == "Blogs.OrNothing"));
                     Assert.True(columns.Any(c => c == "Blogs.Fuse"));
                     Assert.True(columns.Any(c => c == "Blogs.WayRound"));
@@ -816,7 +814,6 @@ namespace Microsoft.EntityFrameworkCore
             public Guid TheGu { get; set; }
             public DateTime NotFigTime { get; set; }
             public byte ToEat { get; set; }
-            public char CupOfChar { get; set; }
             public double OrNothing { get; set; }
             public short Fuse { get; set; }
             public long WayRound { get; set; }

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal("int", GetTypeMapping(typeof(int)).StoreType);
             Assert.Equal("datetime2", GetTypeMapping(typeof(DateTime)).StoreType);
             Assert.Equal("uniqueidentifier", GetTypeMapping(typeof(Guid)).StoreType);
-            Assert.Equal("int", GetTypeMapping(typeof(char)).StoreType);
             Assert.Equal("tinyint", GetTypeMapping(typeof(byte)).StoreType);
             Assert.Equal("float", GetTypeMapping(typeof(double)).StoreType);
             Assert.Equal("bit", GetTypeMapping(typeof(bool)).StoreType);
@@ -37,7 +36,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal("int", GetTypeMapping(typeof(int?)).StoreType);
             Assert.Equal("datetime2", GetTypeMapping(typeof(DateTime?)).StoreType);
             Assert.Equal("uniqueidentifier", GetTypeMapping(typeof(Guid?)).StoreType);
-            Assert.Equal("int", GetTypeMapping(typeof(char?)).StoreType);
             Assert.Equal("tinyint", GetTypeMapping(typeof(byte?)).StoreType);
             Assert.Equal("float", GetTypeMapping(typeof(double?)).StoreType);
             Assert.Equal("bit", GetTypeMapping(typeof(bool?)).StoreType);
@@ -59,9 +57,8 @@ namespace Microsoft.EntityFrameworkCore
             ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(uint)).StoreType);
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "uint"), ex.Message);
 
-            //TODO: We should uncomment this once issue https://github.com/aspnet/EntityFramework/issues/8656 is fixed
-            // ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(char)).StoreType);
-            // Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "char"), ex.Message);
+            ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(char)).StoreType);
+            Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "char"), ex.Message);
 
             ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(ulong)).StoreType);
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "ulong"), ex.Message);
@@ -88,7 +85,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(DbType.Binary, GetTypeMapping(typeof(byte[])).DbType);
             Assert.Null(GetTypeMapping(typeof(TimeSpan)).DbType);
             Assert.Equal(DbType.Guid, GetTypeMapping(typeof(Guid)).DbType);
-            Assert.Null(GetTypeMapping(typeof(char)).DbType);
             Assert.Equal(DbType.Byte, GetTypeMapping(typeof(byte)).DbType);
             Assert.Null(GetTypeMapping(typeof(double)).DbType);
             Assert.Null(GetTypeMapping(typeof(bool)).DbType);
@@ -106,7 +102,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(DbType.Binary, GetTypeMapping(typeof(byte[])).DbType);
             Assert.Null(GetTypeMapping(typeof(TimeSpan?)).DbType);
             Assert.Equal(DbType.Guid, GetTypeMapping(typeof(Guid?)).DbType);
-            Assert.Null(GetTypeMapping(typeof(char?)).DbType);
             Assert.Equal(DbType.Byte, GetTypeMapping(typeof(byte?)).DbType);
             Assert.Null(GetTypeMapping(typeof(double?)).DbType);
             Assert.Null(GetTypeMapping(typeof(bool?)).DbType);

--- a/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -27,12 +27,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("Long"), entityType));
             Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("Short"), entityType));
             Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("Byte"), entityType));
-            Assert.IsType<TemporaryCharValueGenerator>(selector.Select(entityType.FindProperty("Char"), entityType));
             Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
             Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
             Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
             Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
-            Assert.IsType<TemporaryCharValueGenerator>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
             Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("Decimal"), entityType));
             Assert.IsType<StringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
@@ -69,12 +67,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<long>>(selector.Select(entityType.FindProperty("Long"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<short>>(selector.Select(entityType.FindProperty("Short"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<byte>>(selector.Select(entityType.FindProperty("Byte"), entityType));
-            Assert.IsType<SqlServerSequenceHiLoValueGenerator<char>>(selector.Select(entityType.FindProperty("Char"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<int>>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<long>>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<short>>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<byte>>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
-            Assert.IsType<SqlServerSequenceHiLoValueGenerator<char>>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
             Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("Decimal"), entityType));
             Assert.IsType<StringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
@@ -143,12 +139,10 @@ namespace Microsoft.EntityFrameworkCore
             public long Long { get; set; }
             public short Short { get; set; }
             public byte Byte { get; set; }
-            public char Char { get; set; }
             public int? NullableInt { get; set; }
             public long? NullableLong { get; set; }
             public short? NullableShort { get; set; }
             public byte? NullableByte { get; set; }
-            public char? NullableChar { get; set; }
             public string String { get; set; }
             public Guid Guid { get; set; }
             public byte[] Binary { get; set; }

--- a/test/EFCore.Tests/DbFunctionsTest.cs
+++ b/test/EFCore.Tests/DbFunctionsTest.cs
@@ -90,25 +90,25 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Like_when_escaping()
         {
-            Assert.True(_functions.Like("50%", "%!%", '!'));
-            Assert.True(_functions.Like("50%", "50!%", '!'));
-            Assert.True(_functions.Like("50%", "__!%", '!'));
-            Assert.True(_functions.Like("_%_%_%", "!_!%!_!%!_!%", '!'));
+            Assert.True(_functions.Like("50%", "%!%", "!"));
+            Assert.True(_functions.Like("50%", "50!%", "!"));
+            Assert.True(_functions.Like("50%", "__!%", "!"));
+            Assert.True(_functions.Like("_%_%_%", "!_!%!_!%!_!%", "!"));
 
-            Assert.False(_functions.Like("abc", "!%", '!'));
-            Assert.False(_functions.Like("50%abc", "50!%", '!'));
+            Assert.False(_functions.Like("abc", "!%", "!"));
+            Assert.False(_functions.Like("50%abc", "50!%", "!"));
         }
 
         [Fact]
         public void Like_when_escaping_with_regex_char()
         {
-            Assert.True(_functions.Like("50%", "%|%", '|'));
-            Assert.True(_functions.Like("50%", "50|%", '|'));
-            Assert.True(_functions.Like("50%", "__|%", '|'));
-            Assert.True(_functions.Like("_%_%_%", "|_|%|_|%|_|%", '|'));
+            Assert.True(_functions.Like("50%", "%|%", "|"));
+            Assert.True(_functions.Like("50%", "50|%", "|"));
+            Assert.True(_functions.Like("50%", "__|%", "|"));
+            Assert.True(_functions.Like("_%_%_%", "|_|%|_|%|_|%", "|"));
 
-            Assert.False(_functions.Like("abc", "|%", '|'));
-            Assert.False(_functions.Like("50%abc", "50|%", '|'));
+            Assert.False(_functions.Like("abc", "|%", "|"));
+            Assert.False(_functions.Like("50%abc", "50|%", "|"));
         }
 
         [Fact]


### PR DESCRIPTION
Which requires we also update treatment of `LIKE` to treat the escape character as a string.

This addresses issue #8656 for preview2. We may want to revisit our approach after that as we have not addressed the wider issue e.g. being able to construct a `DbParameter` for a character arg. 