### PR TITLE
Fix to #8584 - Query: reuse include pipeline for queries projecting uncomposed collection navigations

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -308,6 +308,38 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override void Project_collection_navigation()
+        {
+        }
+
+        public override void Project_collection_navigation_nested()
+        {
+        }
+
+        public override void Project_collection_navigation_using_ef_property()
+        {
+        }
+
+        public override void Project_collection_navigation_nested_anonymous()
+        {
+        }
+
+        public override void Project_collection_navigation_count()
+        {
+        }
+
+        public override void Project_collection_navigation_composed()
+        {
+        }
+
+        public override void Project_collection_and_root_entity()
+        {
+        }
+
+        public override void Project_collection_and_include()
+        {
+        }
+
         protected override IQueryable<Level1> GetExpectedLevelOne()
             => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 

--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3292,6 +3292,177 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalFact]
+        public virtual void Project_collection_navigation()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select l1.OneToMany_Optional,
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_nested()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select l1.OneToOne_Optional_FK.OneToMany_Optional,
+                l1s => from l1 in l1s
+                       select Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional),
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_using_ef_property()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select EF.Property<ICollection<Level3>>(
+                           EF.Property<Level2>(
+                               l1,
+                               "OneToOne_Optional_FK"),
+                           "OneToMany_Optional"),
+                l1s => from l1 in l1s
+                       select Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional),
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_nested_anonymous()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1.Id, l1.OneToOne_Optional_FK.OneToMany_Optional },
+                l1s => from l1 in l1s
+                       select new { l1.Id, OneToMany_Optional = Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional) },
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.Id, a.Id);
+
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a.OneToMany_Optional)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e.OneToMany_Optional)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_count()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1.Id, l1.OneToOne_Optional_FK.OneToMany_Optional.Count },
+                l1s => from l1 in l1s
+                       select new
+                       {
+                           l1.Id,
+                           Count = MaybeScalar(
+                           l1.OneToOne_Optional_FK,
+                           () => MaybeScalar<int>(
+                               l1.OneToOne_Optional_FK.OneToMany_Optional,
+                               () => l1.OneToOne_Optional_FK.OneToMany_Optional.Count)) ?? 0
+                       },
+                elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_composed()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       where l1.Id < 3
+                       select new { l1.Id, collection = l1.OneToMany_Optional.Where(l2 => l2.Name != "Foo") },
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+
+                    var actualCollection = new List<Level2>();
+                    foreach (var actualElement in a.collection)
+                    {
+                        actualCollection.Add(actualElement);
+                    }
+
+                    Assert.Equal(((IEnumerable<Level2>)e.collection).Count(), actualCollection.Count);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_and_root_entity()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1, l1.OneToMany_Optional },
+                elementSorter: e => e.l1.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.l1.Id, a.l1.Id);
+
+                    var actualCollection = new List<Level2>();
+                    foreach (var actualElement in a.OneToMany_Optional)
+                    {
+                        actualCollection.Add(actualElement);
+                    }
+
+                    Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional).Count(), actualCollection.Count);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_and_include()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s.Include(l => l.OneToMany_Optional)
+                       select new { l1, l1.OneToMany_Optional },
+                elementSorter: e => e.l1.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.l1.Id, a.l1.Id);
+
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a.OneToMany_Optional)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional).Count(), actualCollection.Count);
+                    });
+        }
+
         private static TResult Maybe<TResult>(object caller, Func<TResult> expression) where TResult : class
         {
             if (caller == null)

--- a/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -429,7 +429,8 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
                         }
-                    });
+                    },
+                entryCount: 34);
         }
 
         [ConditionalFact]
@@ -448,7 +449,8 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
                         }
-                    });
+                    },
+                entryCount: 7);
         }
 
         [ConditionalFact]

--- a/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual object Create(IEnumerable<object> values)
+        public virtual object Create()
         {
             if (_createCollection == null)
             {
@@ -92,13 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     _propertyName, typeof(TEntity).ShortDisplayName(), typeof(TCollection).ShortDisplayName()));
             }
 
-            var collection = (ICollection<TElement>)_createCollection();
-            foreach (TElement value in values)
-            {
-                collection.Add(value);
-            }
-
-            return collection;
+            return _createCollection();
         }
 
         /// <summary>

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -12,13 +12,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators;
 using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
@@ -230,6 +233,137 @@ namespace Microsoft.EntityFrameworkCore.Query
                     QueryContextParameter);
 
         /// <summary>
+        /// Rewrites collection navigation projections so that they can be handled by the Include pipeline.
+        /// </summary>
+        /// <param name="queryModel"> The query. </param>
+        protected virtual void RewriteProjectedCollectionNavigationsToIncludes([NotNull] QueryModel queryModel)
+        {
+            var collectionNavigationIncludeRewriter = new CollectionNavigationIncludeExpressionRewriter(this);
+            queryModel.SelectClause.Selector = collectionNavigationIncludeRewriter.Visit(queryModel.SelectClause.Selector);
+            _queryCompilationContext.QueryAnnotations =
+                new ReadOnlyCollection<IQueryAnnotation>(
+                    _queryCompilationContext.QueryAnnotations
+                        .Concat(collectionNavigationIncludeRewriter.CollectionNavigationIncludeResultOperators)
+                        .ToList());
+        }
+
+        private class CollectionNavigationIncludeExpressionRewriter : ExpressionVisitorBase
+        {
+            private readonly EntityQueryModelVisitor _queryModelVisitor;
+
+            public List<IQueryAnnotation> CollectionNavigationIncludeResultOperators { get; }
+
+            public CollectionNavigationIncludeExpressionRewriter(
+                EntityQueryModelVisitor queryModelVisitor)
+            {
+                _queryModelVisitor = queryModelVisitor;
+                CollectionNavigationIncludeResultOperators = new List<IQueryAnnotation>();
+            }
+
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                var result = _queryModelVisitor.BindNavigationPathPropertyExpression(
+                    node,
+                    (ps, qs) => RewritePropertyAccess(node, ps, qs));
+
+                return result ?? base.VisitMember(node);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                Expression result = null;
+                if (node.Method.IsEFPropertyMethod())
+                {
+                    result = _queryModelVisitor.BindNavigationPathPropertyExpression(
+                        node,
+                        (ps, qs) => RewritePropertyAccess(node, ps, qs));
+                }
+
+                return result ?? base.VisitMethodCall(node);
+            }
+
+            private Expression RewritePropertyAccess(
+                Expression expression, 
+                IReadOnlyList<IPropertyBase> properties, 
+                IQuerySource querySource)
+            {
+                if (querySource != null 
+                    && properties.Count > 0 
+                    && properties.All(p => p is INavigation) 
+                    && properties[properties.Count - 1] is INavigation lastNavigation 
+                    && lastNavigation.IsCollection())
+                {
+                    CollectionNavigationIncludeResultOperators.Add(
+                        new IncludeResultOperator(properties.Select(p => p.Name), new QuerySourceReferenceExpression(querySource)));
+
+                    var navigationMethodInfo = _navigationMethodInfo.MakeGenericMethod(querySource.ItemType, expression.Type);
+                    var parameter = Expression.Parameter(querySource.ItemType, "prm");
+                    var body = new CollectionNavigationIncludeReplacingExpressionVisitor(querySource, parameter).Visit(expression);
+                    var emptyCollection = lastNavigation.GetCollectionAccessor().Create();
+
+                    return Expression.Call(
+                        navigationMethodInfo,
+                        new QuerySourceReferenceExpression(querySource),
+                        new SuppressNavigationRewriteExpression(
+                            Expression.Lambda(
+                                Expression.Coalesce(body, Expression.Constant(emptyCollection)),
+                                parameter)));
+                }
+
+                return expression;
+            }
+
+            private class CollectionNavigationIncludeReplacingExpressionVisitor : ExpressionVisitorBase
+            {
+                private readonly IQuerySource _querySource;
+                private readonly Expression _replacementExpression;
+
+                public CollectionNavigationIncludeReplacingExpressionVisitor(IQuerySource querySource, Expression replacementExpression)
+                {
+                    _querySource = querySource;
+                    _replacementExpression = replacementExpression;
+                }
+
+                protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression expression)
+                    => expression.ReferencedQuerySource == _querySource
+                        ? _replacementExpression
+                        : expression;
+
+                protected override Expression VisitMember(MemberExpression memberExpression)
+                {
+                    var newExpression = Visit(memberExpression.Expression);
+                    var newMemberExpression = memberExpression.Update(newExpression);
+
+                    return new NullConditionalExpression(newExpression, newMemberExpression);
+                }
+
+                protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+                {
+                    if (methodCallExpression.Method.IsEFPropertyMethod())
+                    {
+                        var propertyName = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                        var memberExpression = Expression.Property(methodCallExpression.Arguments[0], propertyName);
+
+                        return Visit(memberExpression);
+                    }
+
+                    return base.VisitMethodCall(methodCallExpression);
+                }
+            }
+
+            protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+                => subQueryExpression;
+
+            private static readonly MethodInfo _navigationMethodInfo
+                = typeof(CollectionNavigationIncludeExpressionRewriter).GetTypeInfo()
+                    .GetDeclaredMethod(nameof(_ProjectCollectionNavigation));
+
+            // ReSharper disable once InconsistentNaming
+            private static TResult _ProjectCollectionNavigation<TEntity, TResult>(TEntity entity, Func<TEntity, TResult> accessor)
+                => accessor(entity);
+        }
+
+        /// <summary>
         ///     Populates <see cref="Query.QueryCompilationContext.QueryAnnotations" /> based on annotations found in the query.
         /// </summary>
         /// <param name="queryModel"> The query. </param>
@@ -259,6 +393,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             new NondeterministicResultCheckingVisitor(QueryCompilationContext.Logger).VisitQueryModel(queryModel);
 
             // Rewrite includes/navigations
+
+            RewriteProjectedCollectionNavigationsToIncludes(queryModel);
 
             var includeCompiler = new IncludeCompiler(QueryCompilationContext, _querySourceTracingExpressionVisitorFactory);
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -645,6 +645,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return newExpression;
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitExtension(Expression extensionExpression)
+            => extensionExpression is SuppressNavigationRewriteExpression
+                ? extensionExpression
+                : base.VisitExtension(extensionExpression);
+
         private Expression RewriteNavigationProperties(
             IReadOnlyList<IPropertyBase> properties,
             IQuerySource querySource,

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -768,6 +768,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     VisitNullConditionalEqualExpression(nullConditionalEqualExpression);
                     break;
 
+                case SuppressNavigationRewriteExpression suppressNavigationRewriteExpression:
+                    VisitSuppressNavigationRewriteExpression(suppressNavigationRewriteExpression);
+                    break;
+
                 default:
                     UnhandledExpressionType(extensionExpression);
                     break;
@@ -819,6 +823,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Visit(nullConditionalEqualExpression.OuterKey);
             _stringBuilder.Append(" ?= ");
             Visit(nullConditionalEqualExpression.InnerKey);
+        }
+
+        private void VisitSuppressNavigationRewriteExpression(SuppressNavigationRewriteExpression suppressNavigationRewriteExpression)
+        {
+            _stringBuilder.Append("SuppressNavigationRewrite(");
+            Visit(suppressNavigationRewriteExpression.Operand);
+            _stringBuilder.Append(")");
         }
 
         private void VisitArguments(IList<Expression> arguments, Action<string> appendAction, string lastSeparator = "")

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2958,6 +2958,156 @@ WHERE [l1].[Id] < 3");
                 @"");
         }
 
+        public override void Project_collection_navigation()
+        {
+            base.Project_collection_navigation();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l1.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [Level1] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_nested()
+        {
+            base.Project_collection_navigation_nested();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_using_ef_property()
+        {
+            base.Project_collection_navigation_using_ef_property();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_nested_anonymous()
+        {
+            base.Project_collection_navigation_nested_anonymous();
+
+            AssertSql(
+                @"SELECT [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_count()
+        {
+            base.Project_collection_navigation_count();
+
+            AssertSql(
+                @"SELECT [l1].[Id], (
+    SELECT COUNT(*)
+    FROM [Level3] AS [l]
+    WHERE [l1.OneToOne_Optional_FK].[Id] = [l].[OneToMany_Optional_InverseId]
+) AS [Count]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]");
+        }
+
+        public override void Project_collection_navigation_composed()
+        {
+            base.Project_collection_navigation_composed();
+
+            AssertSql(
+                @"SELECT [l1].[Id]
+FROM [Level1] AS [l1]
+WHERE [l1].[Id] < 3",
+                //
+                @"@_outer_Id='1'
+
+SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+WHERE (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL) AND (@_outer_Id = [l2].[OneToMany_Optional_InverseId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+WHERE (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL) AND (@_outer_Id = [l2].[OneToMany_Optional_InverseId])");
+        }
+
+        public override void Project_collection_and_root_entity()
+        {
+            base.Project_collection_and_root_entity();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l1.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [Level1] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_and_include()
+        {
+            base.Project_collection_and_include();
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+ORDER BY [l].[Id]",
+                //
+                @"SELECT [l.OneToMany_Optional].[Id], [l.OneToMany_Optional].[Date], [l.OneToMany_Optional].[Level1_Optional_Id], [l.OneToMany_Optional].[Level1_Required_Id], [l.OneToMany_Optional].[Name], [l.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l0].[Id]
+    FROM [Level1] AS [l0]
+) AS [t] ON [l.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -477,34 +477,19 @@ WHERE [e].[ReportsTo] IS NULL");
             base.Select_collection_navigation_simple();
 
             AssertSql(
-                @"SELECT [c].[CustomerID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ANATR' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ANTON' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='AROUT' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]");
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override void Select_collection_navigation_multi_part()
@@ -512,46 +497,21 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             base.Select_collection_navigation_multi_part();
 
             AssertSql(
-                @"SELECT [o].[OrderID], [o.Customer].[CustomerID]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o].[CustomerID] = N'ALFKI'",
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o.Customer].[CustomerID]",
                 //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]");
+                @"SELECT [o.Customer.Orders].[OrderID], [o.Customer.Orders].[CustomerID], [o.Customer.Orders].[EmployeeID], [o.Customer.Orders].[OrderDate]
+FROM [Orders] AS [o.Customer.Orders]
+INNER JOIN (
+    SELECT DISTINCT [o.Customer0].[CustomerID]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+    WHERE [o0].[CustomerID] = N'ALFKI'
+) AS [t] ON [o.Customer.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_any()


### PR DESCRIPTION
Currently when projecting collection navigation we produce N+1 queries. This change leverages include pipeline which produces 2 queries instead and joins the result on the client.

We only do this for collection navigation that are not composed on - otherwise, the query that happens after collection navigation would be performed on the client, so it's not clear that would be preferable to N+1.
Also as a side effect, we always materialize root entity (or all intermediate entities in case of multi-level navigation). This is a side effect of reusing Include pipeline, which always expects (and depends on) root element being materialized.

We leverage the include pipeline by performing a simple QM rewrite:

```
from [e] in entities
select new { [e].Id, [e].Reference.Collection }
```

will be translated to:

```
from [e] in entities
select new { [e].Id, _ProjectCollectionNavigation(
  [e], 
  prm => SuppressNavigationRewrite(prm?.Reference?.Collection) ?? new ICollection<Entity>()) }
```
additionally, we generate include result operator for [e].Reference.Collection.

When include pipeline processes the updated QM, it will apply the include on first argument to _ProjectCollectionNavigation.
Implementation of _ProjectCollectionNavigation simply invokes the Func specified as it's second argument (which accesses requested collection navigation), given the root entity (which now has include applied).
