### PR TITLE
Use verbs in convention names and the property names in ConventionSet.

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class DiscriminatorConvention : IBaseTypeConvention
+    public class DiscriminatorConvention : IBaseTypeChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -39,8 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             ValueGeneratorConvention valueGeneratorConvention = new RelationalValueGeneratorConvention();
 
-            ReplaceConvention(conventionSet.BaseEntityTypeSetConventions, valueGeneratorConvention);
-            ReplaceConvention(conventionSet.PrimaryKeySetConventions, valueGeneratorConvention);
+            ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);
+            ReplaceConvention(conventionSet.PrimaryKeyChangedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, valueGeneratorConvention);
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGeneratorConvention);
 
@@ -52,14 +52,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(sharedTableConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(new DiscriminatorConvention());
-            conventionSet.BaseEntityTypeSetConventions.Add(
+            conventionSet.BaseEntityTypeChangedConventions.Add(new DiscriminatorConvention());
+            conventionSet.BaseEntityTypeChangedConventions.Add(
                 new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder));
-            conventionSet.EntityTypeAnnotationSetConventions.Add(sharedTableConvention);
+            conventionSet.EntityTypeAnnotationChangedConventions.Add(sharedTableConvention);
             conventionSet.PropertyFieldChangedConventions.Add(relationalColumnAttributeConvention);
-            conventionSet.PropertyAnnotationSetConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
-            conventionSet.ForeignKeyUniquenessConventions.Add(sharedTableConvention);
-            conventionSet.ForeignKeyOwnershipConventions.Add(sharedTableConvention);
+            conventionSet.PropertyAnnotationChangedConventions.Add((RelationalValueGeneratorConvention)valueGeneratorConvention);
+            conventionSet.ForeignKeyUniquenessChangedConventions.Add(sharedTableConvention);
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(sharedTableConvention);
 
             conventionSet.ModelBuiltConventions.Add(new RelationalTypeMappingConvention(Dependencies.TypeMapper));
 

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTypeMappingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalTypeMappingConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class RelationalTypeMappingConvention : IModelConvention
+    public class RelationalTypeMappingConvention : IModelBuiltConvention
     {
         private readonly IRelationalTypeMapper _typeMapper;
 

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalValueGeneratorConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalValueGeneratorConvention.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
-    public class RelationalValueGeneratorConvention : ValueGeneratorConvention, IPropertyAnnotationSetConvention
+    public class RelationalValueGeneratorConvention : ValueGeneratorConvention, IPropertyAnnotationChangedConvention
     {
         public virtual Annotation Apply(InternalPropertyBuilder propertyBuilder, string name, Annotation annotation, Annotation oldAnnotation)
         {

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -12,10 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class SharedTableConvention :
-        IEntityTypeConvention,
-        IEntityTypeAnnotationSetConvention,
-        IForeignKeyOwnershipConvention,
-        IForeignKeyUniquenessConvention
+        IEntityTypeAddedConvention,
+        IEntityTypeAnnotationChangedConvention,
+        IForeignKeyOwnershipChangedConvention,
+        IForeignKeyUniquenessChangedConvention
     {
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class TableNameFromDbSetConvention : IBaseTypeConvention
+    public class TableNameFromDbSetConvention : IBaseTypeChangedConvention
     {
         private readonly IDictionary<Type, DbSetProperty> _sets;
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerIndexConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerIndexConvention.cs
@@ -11,11 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
     public class SqlServerIndexConvention :
-        IIndexConvention,
-        IIndexUniquenessConvention,
-        IIndexAnnotationSetConvention,
-        IPropertyNullableConvention,
-        IPropertyAnnotationSetConvention
+        IIndexAddedConvention,
+        IIndexUniquenessChangedConvention,
+        IIndexAnnotationChangedConvention,
+        IPropertyNullabilityChangedConvention,
+        IPropertyAnnotationChangedConvention
     {
         private readonly ISqlGenerationHelper _sqlGenerationHelper;
 
@@ -24,10 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             _sqlGenerationHelper = sqlGenerationHelper;
         }
 
-        InternalIndexBuilder IIndexConvention.Apply(InternalIndexBuilder indexBuilder)
+        InternalIndexBuilder IIndexAddedConvention.Apply(InternalIndexBuilder indexBuilder)
             => SetIndexFilter(indexBuilder);
 
-        bool IIndexUniquenessConvention.Apply(InternalIndexBuilder indexBuilder)
+        bool IIndexUniquenessChangedConvention.Apply(InternalIndexBuilder indexBuilder)
         {
             SetIndexFilter(indexBuilder);
             return true;

--- a/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/Internal/SqlServerMemoryOptimizedTablesConvention.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerMemoryOptimizedTablesConvention : IEntityTypeAnnotationSetConvention, IKeyConvention, IIndexConvention
+    public class SqlServerMemoryOptimizedTablesConvention : IEntityTypeAnnotationChangedConvention, IKeyAddedConvention, IIndexAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -31,12 +31,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
 
             ValueGeneratorConvention valueGeneratorConvention = new SqlServerValueGeneratorConvention();
-            ReplaceConvention(conventionSet.BaseEntityTypeSetConventions, valueGeneratorConvention);
+            ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);
 
             var sqlServerInMemoryTablesConvention = new SqlServerMemoryOptimizedTablesConvention();
-            conventionSet.EntityTypeAnnotationSetConventions.Add(sqlServerInMemoryTablesConvention);
+            conventionSet.EntityTypeAnnotationChangedConventions.Add(sqlServerInMemoryTablesConvention);
 
-            ReplaceConvention(conventionSet.PrimaryKeySetConventions, valueGeneratorConvention);
+            ReplaceConvention(conventionSet.PrimaryKeyChangedConventions, valueGeneratorConvention);
 
             conventionSet.KeyAddedConventions.Add(sqlServerInMemoryTablesConvention);
 
@@ -48,14 +48,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             conventionSet.IndexAddedConventions.Add(sqlServerInMemoryTablesConvention);
             conventionSet.IndexAddedConventions.Add(sqlServerIndexConvention);
 
-            conventionSet.IndexUniquenessConventions.Add(sqlServerIndexConvention);
+            conventionSet.IndexUniquenessChangedConventions.Add(sqlServerIndexConvention);
 
-            conventionSet.IndexAnnotationSetConventions.Add(sqlServerIndexConvention);
+            conventionSet.IndexAnnotationChangedConventions.Add(sqlServerIndexConvention);
 
-            conventionSet.PropertyNullableChangedConventions.Add(sqlServerIndexConvention);
+            conventionSet.PropertyNullabilityChangedConventions.Add(sqlServerIndexConvention);
 
-            conventionSet.PropertyAnnotationSetConventions.Add(sqlServerIndexConvention);
-            conventionSet.PropertyAnnotationSetConventions.Add((SqlServerValueGeneratorConvention)valueGeneratorConvention);
+            conventionSet.PropertyAnnotationChangedConventions.Add(sqlServerIndexConvention);
+            conventionSet.PropertyAnnotationChangedConventions.Add((SqlServerValueGeneratorConvention)valueGeneratorConvention);
 
             return conventionSet;
         }

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <summary>
         ///     Conventions to run when an entity type is added to the model.
         /// </summary>
-        public virtual IList<IEntityTypeConvention> EntityTypeAddedConventions { get; } = new List<IEntityTypeConvention>();
+        public virtual IList<IEntityTypeAddedConvention> EntityTypeAddedConventions { get; } = new List<IEntityTypeAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when an entity type is ignored.
@@ -27,20 +27,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IEntityTypeMemberIgnoredConvention> EntityTypeMemberIgnoredConventions { get; } = new List<IEntityTypeMemberIgnoredConvention>();
 
         /// <summary>
-        ///     Conventions to run when the base entity type is set or removed.
+        ///     Conventions to run when the base entity type is changed.
         /// </summary>
-        public virtual IList<IBaseTypeConvention> BaseEntityTypeSetConventions { get; } = new List<IBaseTypeConvention>();
+        public virtual IList<IBaseTypeChangedConvention> BaseEntityTypeChangedConventions { get; } = new List<IBaseTypeChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when an annotation is set or removed on an entity type.
         /// </summary>
-        public virtual IList<IEntityTypeAnnotationSetConvention> EntityTypeAnnotationSetConventions { get; }
-            = new List<IEntityTypeAnnotationSetConvention>();
+        public virtual IList<IEntityTypeAnnotationChangedConvention> EntityTypeAnnotationChangedConventions { get; }
+            = new List<IEntityTypeAnnotationChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when a foreign key is added.
         /// </summary>
-        public virtual IList<IForeignKeyConvention> ForeignKeyAddedConventions { get; } = new List<IForeignKeyConvention>();
+        public virtual IList<IForeignKeyAddedConvention> ForeignKeyAddedConventions { get; } = new List<IForeignKeyAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when a foreign key is removed.
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <summary>
         ///     Conventions to run when a key is added.
         /// </summary>
-        public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
+        public virtual IList<IKeyAddedConvention> KeyAddedConventions { get; } = new List<IKeyAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when a key is removed.
@@ -58,14 +58,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IKeyRemovedConvention> KeyRemovedConventions { get; } = new List<IKeyRemovedConvention>();
 
         /// <summary>
-        ///     Conventions to run when a primary key is configured.
+        ///     Conventions to run when a primary key is changed.
         /// </summary>
-        public virtual IList<IPrimaryKeyConvention> PrimaryKeySetConventions { get; } = new List<IPrimaryKeyConvention>();
+        public virtual IList<IPrimaryKeyChangedConvention> PrimaryKeyChangedConventions { get; } = new List<IPrimaryKeyChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when an index is added.
         /// </summary>
-        public virtual IList<IIndexConvention> IndexAddedConventions { get; } = new List<IIndexConvention>();
+        public virtual IList<IIndexAddedConvention> IndexAddedConventions { get; } = new List<IIndexAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when an index is removed.
@@ -75,32 +75,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <summary>
         ///     Conventions to run when the uniqueness of an index is changed.
         /// </summary>
-        public virtual IList<IIndexUniquenessConvention> IndexUniquenessConventions { get; } = new List<IIndexUniquenessConvention>();
+        public virtual IList<IIndexUniquenessChangedConvention> IndexUniquenessChangedConventions { get; } = new List<IIndexUniquenessChangedConvention>();
 
         /// <summary>
-        ///     Conventions to run when an annotation is set or removed on an index.
+        ///     Conventions to run when an annotation is changed on an index.
         /// </summary>
-        public virtual IList<IIndexAnnotationSetConvention> IndexAnnotationSetConventions { get; } = new List<IIndexAnnotationSetConvention>();
+        public virtual IList<IIndexAnnotationChangedConvention> IndexAnnotationChangedConventions { get; } = new List<IIndexAnnotationChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when the principal end of a relationship is configured.
         /// </summary>
-        public virtual IList<IPrincipalEndConvention> PrincipalEndSetConventions { get; } = new List<IPrincipalEndConvention>();
+        public virtual IList<IPrincipalEndChangedConvention> PrincipalEndChangedConventions { get; } = new List<IPrincipalEndChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when model building is completed.
         /// </summary>
-        public virtual IList<IModelConvention> ModelBuiltConventions { get; } = new List<IModelConvention>();
+        public virtual IList<IModelBuiltConvention> ModelBuiltConventions { get; } = new List<IModelBuiltConvention>();
 
         /// <summary>
         ///     Conventions to run to setup the initial model.
         /// </summary>
-        public virtual IList<IModelConvention> ModelInitializedConventions { get; } = new List<IModelConvention>();
+        public virtual IList<IModelInitializedConvention> ModelInitializedConventions { get; } = new List<IModelInitializedConvention>();
 
         /// <summary>
         ///     Conventions to run when a navigation property is added.
         /// </summary>
-        public virtual IList<INavigationConvention> NavigationAddedConventions { get; } = new List<INavigationConvention>();
+        public virtual IList<INavigationAddedConvention> NavigationAddedConventions { get; } = new List<INavigationAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when a navigation property is removed.
@@ -110,22 +110,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <summary>
         ///     Conventions to run when the uniqueness of a foreign key is changed.
         /// </summary>
-        public virtual IList<IForeignKeyUniquenessConvention> ForeignKeyUniquenessConventions { get; } = new List<IForeignKeyUniquenessConvention>();
+        public virtual IList<IForeignKeyUniquenessChangedConvention> ForeignKeyUniquenessChangedConventions { get; } = new List<IForeignKeyUniquenessChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when the ownership of a foreign key is changed.
         /// </summary>
-        public virtual IList<IForeignKeyOwnershipConvention> ForeignKeyOwnershipConventions { get; } = new List<IForeignKeyOwnershipConvention>();
+        public virtual IList<IForeignKeyOwnershipChangedConvention> ForeignKeyOwnershipChangedConventions { get; } = new List<IForeignKeyOwnershipChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when a property is added.
         /// </summary>
-        public virtual IList<IPropertyConvention> PropertyAddedConventions { get; } = new List<IPropertyConvention>();
+        public virtual IList<IPropertyAddedConvention> PropertyAddedConventions { get; } = new List<IPropertyAddedConvention>();
 
         /// <summary>
         ///     Conventions to run when the nullability of a property is changed.
         /// </summary>
-        public virtual IList<IPropertyNullableConvention> PropertyNullableChangedConventions { get; } = new List<IPropertyNullableConvention>();
+        public virtual IList<IPropertyNullabilityChangedConvention> PropertyNullabilityChangedConventions { get; } = new List<IPropertyNullabilityChangedConvention>();
 
         /// <summary>
         ///     Conventions to run when the field of a property is changed.
@@ -134,8 +134,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             new List<IPropertyFieldChangedConvention>();
 
         /// <summary>
-        ///     Conventions to run when an annotation is set or removed on a property.
+        ///     Conventions to run when an annotation is changed on a property.
         /// </summary>
-        public virtual IList<IPropertyAnnotationSetConvention> PropertyAnnotationSetConventions { get; } = new List<IPropertyAnnotationSetConvention>();
+        public virtual IList<IPropertyAnnotationChangedConvention> PropertyAnnotationChangedConventions { get; } = new List<IPropertyAnnotationChangedConvention>();
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BackingFieldConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class BackingFieldConvention : IPropertyConvention, INavigationConvention
+    public class BackingFieldConvention : IPropertyAddedConvention, INavigationAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class BaseTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeConvention
+    public class BaseTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class CascadeDeleteConvention : IForeignKeyConvention, IPropertyNullableConvention
+    public class CascadeDeleteConvention : IForeignKeyAddedConvention, IPropertyNullabilityChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var entityTypeConvention in _conventionSet.BaseEntityTypeSetConventions)
+                foreach (var entityTypeConvention in _conventionSet.BaseEntityTypeChangedConventions)
                 {
                     if (!entityTypeConvention.Apply(entityTypeBuilder, previousBaseType))
                     {
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var entityTypeAnnotationSetConvention in _conventionSet.EntityTypeAnnotationSetConventions)
+                foreach (var entityTypeAnnotationSetConvention in _conventionSet.EntityTypeAnnotationChangedConventions)
                 {
                     var newAnnotation = entityTypeAnnotationSetConvention.Apply(entityTypeBuilder, name, annotation, oldAnnotation);
                     if (newAnnotation != annotation)
@@ -398,7 +398,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return;
                 }
 
-                foreach (var keyConvention in _conventionSet.PrimaryKeySetConventions)
+                foreach (var keyConvention in _conventionSet.PrimaryKeyChangedConventions)
                 {
                     if (!keyConvention.Apply(entityTypeBuilder, previousPrimaryKey))
                     {
@@ -446,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return false;
                 }
 
-                foreach (var indexUniquenessConvention in _conventionSet.IndexUniquenessConventions)
+                foreach (var indexUniquenessConvention in _conventionSet.IndexUniquenessChangedConventions)
                 {
                     if (!indexUniquenessConvention.Apply(indexBuilder))
                     {
@@ -468,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var indexAnnotationSetConvention in _conventionSet.IndexAnnotationSetConventions)
+                foreach (var indexAnnotationSetConvention in _conventionSet.IndexAnnotationChangedConventions)
                 {
                     var newAnnotation = indexAnnotationSetConvention.Apply(indexBuilder, name, annotation, oldAnnotation);
                     if (newAnnotation != annotation)
@@ -527,7 +527,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var uniquenessConvention in _conventionSet.ForeignKeyUniquenessConventions)
+                foreach (var uniquenessConvention in _conventionSet.ForeignKeyUniquenessChangedConventions)
                 {
                     relationshipBuilder = uniquenessConvention.Apply(relationshipBuilder);
                     if (relationshipBuilder?.Metadata.Builder == null)
@@ -546,7 +546,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var ownershipConvention in _conventionSet.ForeignKeyOwnershipConventions)
+                foreach (var ownershipConvention in _conventionSet.ForeignKeyOwnershipChangedConventions)
                 {
                     relationshipBuilder = ownershipConvention.Apply(relationshipBuilder);
                     if (relationshipBuilder?.Metadata.Builder == null)
@@ -565,7 +565,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var relationshipConvention in _conventionSet.PrincipalEndSetConventions)
+                foreach (var relationshipConvention in _conventionSet.PrincipalEndChangedConventions)
                 {
                     relationshipBuilder = relationshipConvention.Apply(relationshipBuilder);
                     if (relationshipBuilder == null)
@@ -606,7 +606,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return false;
                 }
 
-                foreach (var propertyConvention in _conventionSet.PropertyNullableChangedConventions)
+                foreach (var propertyConvention in _conventionSet.PropertyNullabilityChangedConventions)
                 {
                     if (!propertyConvention.Apply(propertyBuilder))
                     {
@@ -648,7 +648,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     return null;
                 }
 
-                foreach (var propertyAnnotationSetConvention in _conventionSet.PropertyAnnotationSetConventions)
+                foreach (var propertyAnnotationSetConvention in _conventionSet.PropertyAnnotationChangedConventions)
                 {
                     var newAnnotation = propertyAnnotationSetConvention.Apply(propertyBuilder, name, annotation, oldAnnotation);
                     if (newAnnotation != annotation)

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -53,12 +53,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var foreignKeyIndexConvention = new ForeignKeyIndexConvention();
             var valueGeneratorConvention = new ValueGeneratorConvention();
 
-            conventionSet.BaseEntityTypeSetConventions.Add(propertyDiscoveryConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(keyDiscoveryConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(inversePropertyAttributeConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(relationshipDiscoveryConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(foreignKeyIndexConvention);
-            conventionSet.BaseEntityTypeSetConventions.Add(valueGeneratorConvention );
+            conventionSet.BaseEntityTypeChangedConventions.Add(propertyDiscoveryConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(keyDiscoveryConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(inversePropertyAttributeConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(relationshipDiscoveryConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(foreignKeyIndexConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(valueGeneratorConvention );
 
             // An ambiguity might have been resolved
             conventionSet.EntityTypeMemberIgnoredConventions.Add(inversePropertyAttributeConvention);
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
 
-            conventionSet.PrimaryKeySetConventions.Add(valueGeneratorConvention);
+            conventionSet.PrimaryKeyChangedConventions.Add(valueGeneratorConvention);
 
             conventionSet.KeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.KeyAddedConventions.Add(foreignKeyIndexConvention);
@@ -107,8 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyRemovedConventions.Add(valueGeneratorConvention );
             conventionSet.ForeignKeyRemovedConventions.Add(foreignKeyIndexConvention);
 
-            conventionSet.ForeignKeyUniquenessConventions.Add(foreignKeyPropertyDiscoveryConvention);
-            conventionSet.ForeignKeyUniquenessConventions.Add(foreignKeyIndexConvention);
+            conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
@@ -129,11 +129,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.IndexRemovedConventions.Add(foreignKeyIndexConvention);
 
-            conventionSet.IndexUniquenessConventions.Add(foreignKeyIndexConvention);
+            conventionSet.IndexUniquenessChangedConventions.Add(foreignKeyIndexConvention);
 
-            conventionSet.PropertyNullableChangedConventions.Add(cascadeDeleteConvention);
+            conventionSet.PropertyNullabilityChangedConventions.Add(cascadeDeleteConvention);
 
-            conventionSet.PrincipalEndSetConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.PrincipalEndChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.PropertyFieldChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.PropertyFieldChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class DerivedTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeConvention
+    public class DerivedTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public abstract class EntityTypeAttributeConvention<TAttribute> : IEntityTypeConvention
+    public abstract class EntityTypeAttributeConvention<TAttribute> : IEntityTypeAddedConvention
         where TAttribute : Attribute
     {
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ForeignKeyAttributeConvention : IForeignKeyConvention
+    public class ForeignKeyAttributeConvention : IForeignKeyAddedConvention
     {
         private readonly ITypeMapper _typeMapper;
 

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyIndexConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyIndexConvention.cs
@@ -14,15 +14,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ForeignKeyIndexConvention :
-        IForeignKeyConvention,
+        IForeignKeyAddedConvention,
         IForeignKeyRemovedConvention,
-        IForeignKeyUniquenessConvention,
-        IKeyConvention,
+        IForeignKeyUniquenessChangedConvention,
+        IKeyAddedConvention,
         IKeyRemovedConvention,
-        IBaseTypeConvention,
-        IIndexConvention,
+        IBaseTypeChangedConvention,
+        IIndexAddedConvention,
         IIndexRemovedConvention,
-        IIndexUniquenessConvention
+        IIndexUniquenessChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder IForeignKeyUniquenessConvention.Apply(InternalRelationshipBuilder relationshipBuilder)
+        InternalRelationshipBuilder IForeignKeyUniquenessChangedConvention.Apply(InternalRelationshipBuilder relationshipBuilder)
         {
             var foreignKey = relationshipBuilder.Metadata;
             var index = foreignKey.DeclaringEntityType.FindIndex(foreignKey.Properties);
@@ -186,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        bool IIndexUniquenessConvention.Apply(InternalIndexBuilder indexBuilder)
+        bool IIndexUniquenessChangedConvention.Apply(InternalIndexBuilder indexBuilder)
         {
             var index = indexBuilder.Metadata;
             if (index.IsUnique)

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -15,15 +15,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ForeignKeyPropertyDiscoveryConvention :
-        IForeignKeyConvention,
-        INavigationConvention,
-        IPropertyConvention,
-        IPrincipalEndConvention,
+        IForeignKeyAddedConvention,
+        INavigationAddedConvention,
+        IPropertyAddedConvention,
+        IPrincipalEndChangedConvention,
         IPropertyFieldChangedConvention,
-        IForeignKeyUniquenessConvention,
-        IKeyConvention,
+        IForeignKeyUniquenessChangedConvention,
+        IKeyAddedConvention,
         IKeyRemovedConvention,
-        IModelConvention
+        IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -360,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder IForeignKeyUniquenessConvention.Apply(InternalRelationshipBuilder relationshipBuilder)
+        InternalRelationshipBuilder IForeignKeyUniquenessChangedConvention.Apply(InternalRelationshipBuilder relationshipBuilder)
             => Apply(relationshipBuilder);
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/IBaseTypeChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IBaseTypeChangedConvention.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IBaseTypeConvention
+    public interface IBaseTypeChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/IEntityTypeAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IEntityTypeAddedConvention.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,16 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IEntityTypeAnnotationSetConvention
+    public interface IEntityTypeAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Annotation Apply(
-            [NotNull] InternalEntityTypeBuilder entityTypeBuilder,
-            [NotNull] string name,
-            [CanBeNull] Annotation annotation,
-            [CanBeNull] Annotation oldAnnotation);
+        InternalEntityTypeBuilder Apply([NotNull] InternalEntityTypeBuilder entityTypeBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IEntityTypeAnnotationChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IEntityTypeAnnotationChangedConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -10,12 +11,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface INavigationConvention
+    public interface IEntityTypeAnnotationChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] Navigation navigation);
+        Annotation Apply(
+            [NotNull] InternalEntityTypeBuilder entityTypeBuilder,
+            [NotNull] string name,
+            [CanBeNull] Annotation annotation,
+            [CanBeNull] Annotation oldAnnotation);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IForeignKeyAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IForeignKeyAddedConvention.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,16 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IPropertyAnnotationSetConvention
+    public interface IForeignKeyAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Annotation Apply(
-            [NotNull] InternalPropertyBuilder propertyBuilder,
-            [NotNull] string name,
-            [CanBeNull] Annotation annotation,
-            [CanBeNull] Annotation oldAnnotation);
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IForeignKeyOwnershipChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IForeignKeyOwnershipChangedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IIndexConvention
+    public interface IForeignKeyOwnershipChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalIndexBuilder Apply([NotNull] InternalIndexBuilder indexBuilder);
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IForeignKeyUniquenessChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IForeignKeyUniquenessChangedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IModelConvention
+    public interface IForeignKeyUniquenessChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalModelBuilder Apply([NotNull] InternalModelBuilder modelBuilder);
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IIndexAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IIndexAddedConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -9,17 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerValueGenerationStrategyConvention : IModelInitializedConvention
+    public interface IIndexAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
-        {
-            modelBuilder.SqlServer(ConfigurationSource.Convention).ValueGenerationStrategy(SqlServerValueGenerationStrategy.IdentityColumn);
-
-            return modelBuilder;
-        }
+        InternalIndexBuilder Apply([NotNull] InternalIndexBuilder indexBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IIndexAnnotationChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IIndexAnnotationChangedConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -10,12 +11,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IForeignKeyOwnershipConvention
+    public interface IIndexAnnotationChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+        Annotation Apply(
+            [NotNull] InternalIndexBuilder indexBuilder,
+            [NotNull] string name,
+            [CanBeNull] Annotation annotation,
+            [CanBeNull] Annotation oldAnnotation);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IIndexUniquenessChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IIndexUniquenessChangedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IPrincipalEndConvention
+    public interface IIndexUniquenessChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+        bool Apply([NotNull] InternalIndexBuilder indexBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IKeyAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IKeyAddedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IEntityTypeConvention
+    public interface IKeyAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalEntityTypeBuilder Apply([NotNull] InternalEntityTypeBuilder entityTypeBuilder);
+        InternalKeyBuilder Apply([NotNull] InternalKeyBuilder keyBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IModelBuiltConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IModelBuiltConvention.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -11,16 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IIndexAnnotationSetConvention
+    public interface IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Annotation Apply(
-            [NotNull] InternalIndexBuilder indexBuilder,
-            [NotNull] string name,
-            [CanBeNull] Annotation annotation,
-            [CanBeNull] Annotation oldAnnotation);
+        InternalModelBuilder Apply([NotNull] InternalModelBuilder modelBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IModelInitializedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IModelInitializedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IForeignKeyConvention
+    public interface IModelInitializedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+        InternalModelBuilder Apply([NotNull] InternalModelBuilder modelBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/INavigationAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/INavigationAddedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IIndexUniquenessConvention
+    public interface INavigationAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        bool Apply([NotNull] InternalIndexBuilder indexBuilder);
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] Navigation navigation);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IPrimaryKeyChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IPrimaryKeyChangedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IForeignKeyUniquenessConvention
+    public interface IPrimaryKeyChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+        bool Apply([NotNull] InternalEntityTypeBuilder entityTypeBuilder, [CanBeNull] Key previousPrimaryKey);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IPrincipalEndChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IPrincipalEndChangedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IPrimaryKeyConvention
+    public interface IPrincipalEndChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        bool Apply([NotNull] InternalEntityTypeBuilder entityTypeBuilder, [CanBeNull] Key previousPrimaryKey);
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IPropertyAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IPropertyAddedConvention.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IKeyConvention
+    public interface IPropertyAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalKeyBuilder Apply([NotNull] InternalKeyBuilder keyBuilder);
+        InternalPropertyBuilder Apply([NotNull] InternalPropertyBuilder propertyBuilder);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IPropertyAnnotationChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IPropertyAnnotationChangedConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
@@ -10,12 +11,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IPropertyConvention
+    public interface IPropertyAnnotationChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        InternalPropertyBuilder Apply([NotNull] InternalPropertyBuilder propertyBuilder);
+        Annotation Apply(
+            [NotNull] InternalPropertyBuilder propertyBuilder,
+            [NotNull] string name,
+            [CanBeNull] Annotation annotation,
+            [CanBeNull] Annotation oldAnnotation);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/IPropertyNullabilityChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IPropertyNullabilityChangedConvention.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IPropertyNullableConvention
+    public interface IPropertyNullabilityChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/IgnoredMembersValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IgnoredMembersValidationConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class IgnoredMembersValidationConvention : IModelConvention
+    public class IgnoredMembersValidationConvention : IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class KeyAttributeConvention : PropertyAttributeConvention<KeyAttribute>, IModelConvention
+    public class KeyAttributeConvention : PropertyAttributeConvention<KeyAttribute>, IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -16,12 +16,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class KeyDiscoveryConvention :
-        IEntityTypeConvention,
-        IPropertyConvention,
+        IEntityTypeAddedConvention,
+        IPropertyAddedConvention,
         IKeyRemovedConvention,
-        IBaseTypeConvention,
+        IBaseTypeChangedConvention,
         IPropertyFieldChangedConvention,
-        IForeignKeyConvention,
+        IForeignKeyAddedConvention,
         IForeignKeyRemovedConvention
     {
         private const string KeySuffix = "Id";

--- a/src/EFCore/Metadata/Conventions/Internal/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ModelCleanupConvention.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ModelCleanupConvention : IModelConvention
+    public class ModelCleanupConvention : IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -16,10 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public abstract class NavigationAttributeEntityTypeConvention<TAttribute> :
-        IEntityTypeConvention,
+        IEntityTypeAddedConvention,
         IEntityTypeIgnoredConvention,
-        INavigationConvention,
-        IBaseTypeConvention,
+        INavigationAddedConvention,
+        IBaseTypeChangedConvention,
         IEntityTypeMemberIgnoredConvention
         where TAttribute : Attribute
     {

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public abstract class NavigationAttributeNavigationConvention<TAttribute> : INavigationConvention
+    public abstract class NavigationAttributeNavigationConvention<TAttribute> : INavigationAddedConvention
         where TAttribute : Attribute
     {
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class NotMappedMemberAttributeConvention : IEntityTypeConvention
+    public class NotMappedMemberAttributeConvention : IEntityTypeAddedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public abstract class PropertyAttributeConvention<TAttribute> : IPropertyConvention, IPropertyFieldChangedConvention
+    public abstract class PropertyAttributeConvention<TAttribute> : IPropertyAddedConvention, IPropertyFieldChangedConvention
         where TAttribute : Attribute
     {
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class PropertyDiscoveryConvention : IEntityTypeConvention, IBaseTypeConvention
+    public class PropertyDiscoveryConvention : IEntityTypeAddedConvention, IBaseTypeChangedConvention
     {
         private readonly ITypeMapper _typeMapper;
 

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class PropertyMappingValidationConvention : IModelConvention
+    public class PropertyMappingValidationConvention : IModelBuiltConvention
     {
         private readonly ITypeMapper _typeMapper;
 

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -19,11 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class RelationshipDiscoveryConvention :
-        IEntityTypeConvention,
-        IBaseTypeConvention,
+        IEntityTypeAddedConvention,
+        IBaseTypeChangedConvention,
         INavigationRemovedConvention,
         IEntityTypeMemberIgnoredConvention,
-        INavigationConvention
+        INavigationAddedConvention
     {
         private readonly ITypeMapper _typeMapper;
 

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class RelationshipValidationConvention : IModelConvention
+    public class RelationshipValidationConvention : IModelBuiltConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ValueGeneratorConvention.cs
@@ -15,10 +15,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
     public class ValueGeneratorConvention :
-        IPrimaryKeyConvention,
-        IForeignKeyConvention,
+        IPrimaryKeyChangedConvention,
+        IForeignKeyAddedConvention,
         IForeignKeyRemovedConvention,
-        IBaseTypeConvention
+        IBaseTypeChangedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -575,5 +575,80 @@
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDatabaseProvider",
       "MemberId": "System.String get_InvariantName()",
       "Kind": "Addition"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IBaseTypeConvention> get_BaseEntityTypeSetConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IEntityTypeAnnotationSetConvention> get_EntityTypeAnnotationSetConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IEntityTypeConvention> get_EntityTypeAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IForeignKeyConvention> get_ForeignKeyAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IForeignKeyUniquenessConvention> get_ForeignKeyUniquenessConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IIndexConvention> get_IndexAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IIndexUniquenessConvention> get_IndexUniquenessConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IKeyConvention> get_KeyAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IModelConvention> get_ModelBuiltConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IModelConvention> get_ModelInitializedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.INavigationConvention> get_NavigationAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IPrimaryKeyConvention> get_PrimaryKeySetConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IPrincipalEndConvention> get_PrincipalEndSetConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IPropertyConvention> get_PropertyAddedConventions()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet",
+      "MemberId": "public virtual System.Collections.Generic.IList<Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal.IPropertyNullableConvention> get_PropertyNullableChangedConventions()",
+      "Kind": "Removal"
     }
   ]

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Null(builder.Metadata.FindEntityType(typeof(Order)));
         }
 
-        private class EntityTypeConvention : IEntityTypeConvention
+        private class EntityTypeConvention : IEntityTypeAddedConvention
         {
             private readonly bool _terminate;
             private readonly bool _dependent;
@@ -229,12 +229,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new BaseTypeConvention(terminate: false);
-            var convention2 = new BaseTypeConvention(terminate: true);
-            var convention3 = new BaseTypeConvention(terminate: false);
-            conventions.BaseEntityTypeSetConventions.Add(convention1);
-            conventions.BaseEntityTypeSetConventions.Add(convention2);
-            conventions.BaseEntityTypeSetConventions.Add(convention3);
+            var convention1 = new BaseTypeChangedConvention(terminate: false);
+            var convention2 = new BaseTypeChangedConvention(terminate: true);
+            var convention3 = new BaseTypeChangedConvention(terminate: false);
+            conventions.BaseEntityTypeChangedConventions.Add(convention1);
+            conventions.BaseEntityTypeChangedConventions.Add(convention2);
+            conventions.BaseEntityTypeChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions))
                 .Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
@@ -288,12 +288,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class BaseTypeConvention : IBaseTypeConvention
+        private class BaseTypeChangedConvention : IBaseTypeChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<Type> Calls = new List<Type>();
 
-            public BaseTypeConvention(bool terminate)
+            public BaseTypeChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -320,9 +320,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var convention1 = new EntityTypeAnnotationSetConvention(terminate: false);
             var convention2 = new EntityTypeAnnotationSetConvention(terminate: true);
             var convention3 = new EntityTypeAnnotationSetConvention(terminate: false);
-            conventions.EntityTypeAnnotationSetConventions.Add(convention1);
-            conventions.EntityTypeAnnotationSetConventions.Add(convention2);
-            conventions.EntityTypeAnnotationSetConventions.Add(convention3);
+            conventions.EntityTypeAnnotationChangedConventions.Add(convention1);
+            conventions.EntityTypeAnnotationChangedConventions.Add(convention2);
+            conventions.EntityTypeAnnotationChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var entityBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
@@ -376,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             //Assert.Empty(convention3.Calls);
         }
 
-        private class EntityTypeAnnotationSetConvention : IEntityTypeAnnotationSetConvention
+        private class EntityTypeAnnotationSetConvention : IEntityTypeAnnotationChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -547,7 +547,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(entityBuilder.Metadata.GetProperties());
         }
 
-        private class PropertyConvention : IPropertyConvention
+        private class PropertyConvention : IPropertyAddedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -671,12 +671,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new PropertyNullableConvention(false);
-            var convention2 = new PropertyNullableConvention(true);
-            var convention3 = new PropertyNullableConvention(false);
-            conventions.PropertyNullableChangedConventions.Add(convention1);
-            conventions.PropertyNullableChangedConventions.Add(convention2);
-            conventions.PropertyNullableChangedConventions.Add(convention3);
+            var convention1 = new PropertyNullabilityChangedConvention(false);
+            var convention2 = new PropertyNullabilityChangedConvention(true);
+            var convention3 = new PropertyNullabilityChangedConvention(false);
+            conventions.PropertyNullabilityChangedConventions.Add(convention1);
+            conventions.PropertyNullabilityChangedConventions.Add(convention2);
+            conventions.PropertyNullabilityChangedConventions.Add(convention3);
 
             var builder = new ModelBuilder(conventions);
 
@@ -774,12 +774,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class PropertyNullableConvention : IPropertyNullableConvention
+        private class PropertyNullabilityChangedConvention : IPropertyNullabilityChangedConvention
         {
             public readonly List<bool?> Calls = new List<bool?>();
             private readonly bool _terminate;
 
-            public PropertyNullableConvention(bool terminate)
+            public PropertyNullabilityChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -801,12 +801,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new PropertyAnnotationSetConvention(false);
-            var convention2 = new PropertyAnnotationSetConvention(true);
-            var convention3 = new PropertyAnnotationSetConvention(false);
-            conventions.PropertyAnnotationSetConventions.Add(convention1);
-            conventions.PropertyAnnotationSetConventions.Add(convention2);
-            conventions.PropertyAnnotationSetConventions.Add(convention3);
+            var convention1 = new PropertyAnnotationChangedConvention(false);
+            var convention2 = new PropertyAnnotationChangedConvention(true);
+            var convention3 = new PropertyAnnotationChangedConvention(false);
+            conventions.PropertyAnnotationChangedConventions.Add(convention1);
+            conventions.PropertyAnnotationChangedConventions.Add(convention2);
+            conventions.PropertyAnnotationChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
@@ -861,12 +861,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             //Assert.Empty(convention3.Calls);
         }
 
-        private class PropertyAnnotationSetConvention : IPropertyAnnotationSetConvention
+        private class PropertyAnnotationChangedConvention : IPropertyAnnotationChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
 
-            public PropertyAnnotationSetConvention(bool terminate)
+            public PropertyAnnotationChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -934,7 +934,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class KeyConvention : IKeyConvention
+        private class KeyConvention : IKeyAddedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -1022,12 +1022,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new PrimaryKeyConvention(terminate: false);
-            var convention2 = new PrimaryKeyConvention(terminate: true);
-            var convention3 = new PrimaryKeyConvention(terminate: false);
-            conventions.PrimaryKeySetConventions.Add(convention1);
-            conventions.PrimaryKeySetConventions.Add(convention2);
-            conventions.PrimaryKeySetConventions.Add(convention3);
+            var convention1 = new PrimaryKeyChangedConvention(terminate: false);
+            var convention2 = new PrimaryKeyChangedConvention(terminate: true);
+            var convention3 = new PrimaryKeyChangedConvention(terminate: false);
+            conventions.PrimaryKeyChangedConventions.Add(convention1);
+            conventions.PrimaryKeyChangedConventions.Add(convention2);
+            conventions.PrimaryKeyChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
@@ -1086,12 +1086,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Null(entityBuilder.Metadata.GetPrimaryKeyConfigurationSource());
         }
 
-        private class PrimaryKeyConvention : IPrimaryKeyConvention
+        private class PrimaryKeyChangedConvention : IPrimaryKeyChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
 
-            public PrimaryKeyConvention(bool terminate)
+            public PrimaryKeyChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -1153,7 +1153,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class IndexConvention : IIndexConvention
+        private class IndexConvention : IIndexAddedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -1242,9 +1242,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var convention1 = new IndexUniquenessConvention(terminate: false);
             var convention2 = new IndexUniquenessConvention(terminate: true);
             var convention3 = new IndexUniquenessConvention(terminate: false);
-            conventions.IndexUniquenessConventions.Add(convention1);
-            conventions.IndexUniquenessConventions.Add(convention2);
-            conventions.IndexUniquenessConventions.Add(convention3);
+            conventions.IndexUniquenessChangedConventions.Add(convention1);
+            conventions.IndexUniquenessChangedConventions.Add(convention2);
+            conventions.IndexUniquenessChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
@@ -1301,7 +1301,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Same(index, entityBuilder.Metadata.RemoveIndex(index.Properties));
         }
 
-        private class IndexUniquenessConvention : IIndexUniquenessConvention
+        private class IndexUniquenessConvention : IIndexUniquenessChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<bool> Calls = new List<bool>();
@@ -1330,12 +1330,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new IndexAnnotationSetConvention(terminate: false);
-            var convention2 = new IndexAnnotationSetConvention(terminate: true);
-            var convention3 = new IndexAnnotationSetConvention(terminate: false);
-            conventions.IndexAnnotationSetConventions.Add(convention1);
-            conventions.IndexAnnotationSetConventions.Add(convention2);
-            conventions.IndexAnnotationSetConventions.Add(convention3);
+            var convention1 = new IndexAnnotationChangedConvention(terminate: false);
+            var convention2 = new IndexAnnotationChangedConvention(terminate: true);
+            var convention3 = new IndexAnnotationChangedConvention(terminate: false);
+            conventions.IndexAnnotationChangedConventions.Add(convention1);
+            conventions.IndexAnnotationChangedConventions.Add(convention2);
+            conventions.IndexAnnotationChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var indexBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
@@ -1390,12 +1390,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             //Assert.Empty(convention3.Calls);
         }
 
-        private class IndexAnnotationSetConvention : IIndexAnnotationSetConvention
+        private class IndexAnnotationChangedConvention : IIndexAnnotationChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
 
-            public IndexAnnotationSetConvention(bool terminate)
+            public IndexAnnotationChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -1465,7 +1465,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class ForeignKeyConvention : IForeignKeyConvention
+        private class ForeignKeyConvention : IForeignKeyAddedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -1601,7 +1601,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class NavigationConvention : INavigationConvention
+        private class NavigationConvention : INavigationAddedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -1723,12 +1723,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new ForeignKeyUniquenessConvention(terminate: false);
-            var convention2 = new ForeignKeyUniquenessConvention(terminate: true);
-            var convention3 = new ForeignKeyUniquenessConvention(terminate: false);
-            conventions.ForeignKeyUniquenessConventions.Add(convention1);
-            conventions.ForeignKeyUniquenessConventions.Add(convention2);
-            conventions.ForeignKeyUniquenessConventions.Add(convention3);
+            var convention1 = new ForeignKeyUniquenessChangedConvention(terminate: false);
+            var convention2 = new ForeignKeyUniquenessChangedConvention(terminate: true);
+            var convention3 = new ForeignKeyUniquenessChangedConvention(terminate: false);
+            conventions.ForeignKeyUniquenessChangedConventions.Add(convention1);
+            conventions.ForeignKeyUniquenessChangedConventions.Add(convention2);
+            conventions.ForeignKeyUniquenessChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
@@ -1787,12 +1787,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 dependentEntityBuilder.Metadata.RemoveForeignKey(foreignKey.Properties, foreignKey.PrincipalKey, foreignKey.PrincipalEntityType));
         }
 
-        private class ForeignKeyUniquenessConvention : IForeignKeyUniquenessConvention
+        private class ForeignKeyUniquenessChangedConvention : IForeignKeyUniquenessChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<bool> Calls = new List<bool>();
 
-            public ForeignKeyUniquenessConvention(bool terminate)
+            public ForeignKeyUniquenessChangedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -1819,9 +1819,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var convention1 = new ForeignKeyOwnershipConvention(terminate: false);
             var convention2 = new ForeignKeyOwnershipConvention(terminate: true);
             var convention3 = new ForeignKeyOwnershipConvention(terminate: false);
-            conventions.ForeignKeyOwnershipConventions.Add(convention1);
-            conventions.ForeignKeyOwnershipConventions.Add(convention2);
-            conventions.ForeignKeyOwnershipConventions.Add(convention3);
+            conventions.ForeignKeyOwnershipChangedConventions.Add(convention1);
+            conventions.ForeignKeyOwnershipChangedConventions.Add(convention2);
+            conventions.ForeignKeyOwnershipChangedConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
@@ -1880,7 +1880,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 dependentEntityBuilder.Metadata.RemoveForeignKey(foreignKey.Properties, foreignKey.PrincipalKey, foreignKey.PrincipalEntityType));
         }
 
-        private class ForeignKeyOwnershipConvention : IForeignKeyOwnershipConvention
+        private class ForeignKeyOwnershipConvention : IForeignKeyOwnershipChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<bool> Calls = new List<bool>();
@@ -1910,8 +1910,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var convention1 = new PrincipalEndConvention(terminate: false);
             var convention2 = new PrincipalEndConvention(terminate: true);
             var convention3 = new PrincipalEndConvention(terminate: false);
-            conventions.PrincipalEndSetConventions.Add(convention1);
-            conventions.PrincipalEndSetConventions.Add(convention2);
+            conventions.PrincipalEndChangedConventions.Add(convention1);
+            conventions.PrincipalEndChangedConventions.Add(convention2);
             //conventions.PrincipalEndSetConventions.Add(convention3);
 
             var builder = new InternalModelBuilder(new Model(conventions));
@@ -2001,7 +2001,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Empty(convention3.Calls);
         }
 
-        private class PrincipalEndConvention : IPrincipalEndConvention
+        private class PrincipalEndConvention : IPrincipalEndChangedConvention
         {
             private readonly bool _terminate;
             public readonly List<object> Calls = new List<object>();
@@ -2028,9 +2028,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new ModelConvention(terminate: false);
-            var convention2 = new ModelConvention(terminate: true);
-            var convention3 = new ModelConvention(terminate: false);
+            var convention1 = new ModelInitializedConvention(terminate: false);
+            var convention2 = new ModelInitializedConvention(terminate: true);
+            var convention3 = new ModelInitializedConvention(terminate: false);
             conventions.ModelInitializedConventions.Add(convention1);
             conventions.ModelInitializedConventions.Add(convention2);
             conventions.ModelInitializedConventions.Add(convention3);
@@ -2049,12 +2049,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(0, convention3.Calls);
         }
 
-        private class ModelConvention : IModelConvention
+        private class ModelInitializedConvention : IModelInitializedConvention
         {
             private readonly bool _terminate;
             public int Calls;
 
-            public ModelConvention(bool terminate)
+            public ModelInitializedConvention(bool terminate)
             {
                 _terminate = terminate;
             }
@@ -2076,9 +2076,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventions = new ConventionSet();
 
-            var convention1 = new ModelConvention(terminate: false);
-            var convention2 = new ModelConvention(terminate: true);
-            var convention3 = new ModelConvention(terminate: false);
+            var convention1 = new ModelBuiltConvention(terminate: false);
+            var convention2 = new ModelBuiltConvention(terminate: true);
+            var convention3 = new ModelBuiltConvention(terminate: false);
             conventions.ModelBuiltConventions.Add(convention1);
             conventions.ModelBuiltConventions.Add(convention2);
             conventions.ModelBuiltConventions.Add(convention3);
@@ -2097,6 +2097,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.Equal(1, convention1.Calls);
             Assert.Equal(1, convention2.Calls);
             Assert.Equal(0, convention3.Calls);
+        }
+
+        private class ModelBuiltConvention : IModelBuiltConvention
+        {
+            private readonly bool _terminate;
+            public int Calls;
+
+            public ModelBuiltConvention(bool terminate)
+            {
+                _terminate = terminate;
+            }
+
+            public InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+            {
+                Assert.NotNull(modelBuilder.Metadata.Builder);
+
+                Calls++;
+
+                return _terminate ? null : modelBuilder;
+            }
         }
 
         private class Order

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
@@ -994,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 conventions.EntityTypeAddedConventions.Add(new TestModelChangeListener(onEntityAdded));
 
                 var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention(new CoreTypeMapper());
-                conventions.BaseEntityTypeSetConventions.Add(relationshipDiscoveryConvention);
+                conventions.BaseEntityTypeChangedConventions.Add(relationshipDiscoveryConvention);
                 conventions.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
                 conventions.NavigationAddedConventions.Add(relationshipDiscoveryConvention);
                 conventions.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
@@ -1005,7 +1005,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return entityBuilder;
         }
 
-        private class TestModelChangeListener : IEntityTypeConvention
+        private class TestModelChangeListener : IEntityTypeAddedConvention
         {
             private readonly Action<InternalEntityTypeBuilder>[] _onEntityAdded;
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
@@ -446,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventions.ForeignKeyAddedConventions.Add(keyConvention);
             conventions.ForeignKeyRemovedConventions.Add(keyConvention);
-            conventions.PrimaryKeySetConventions.Add(keyConvention);
+            conventions.PrimaryKeyChangedConventions.Add(keyConvention);
 
             return new InternalModelBuilder(new Model(conventions));
         }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Random)));
         }
 
-        private class TestConvention : IEntityTypeConvention
+        private class TestConvention : IEntityTypeAddedConvention
         {
             public bool Applied { get; private set; }
 


### PR DESCRIPTION
Fixes #8672
