### PR TITLE
Remove HasDefaultUnicode/HasDefaultSize properties from TypeMapping

### DIFF
--- a/src/EFCore.Relational/Metadata/Builders/DiscriminatorBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DiscriminatorBuilder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             var baseEntityTypeBuilder = EntityTypeBuilder;
             if (!baseEntityTypeBuilder.Metadata.IsAssignableFrom(entityTypeBuilder.Metadata)
-                && (entityTypeBuilder.HasBaseType(baseEntityTypeBuilder.Metadata, AnnotationsBuilder.ConfigurationSource) == null))
+                && entityTypeBuilder.HasBaseType(baseEntityTypeBuilder.Metadata, AnnotationsBuilder.ConfigurationSource) == null)
             {
                 throw new InvalidOperationException(RelationalStrings.DiscriminatorEntityTypeNotDerived(
                     entityTypeBuilder.Metadata.DisplayName(),

--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
@@ -155,9 +155,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return RemoveDiscriminator();
             }
 
-            return (DiscriminatorProperty != null)
-                   && (DiscriminatorProperty.Name == propertyInfo.Name)
-                   && (DiscriminatorProperty.ClrType == propertyInfo.PropertyType)
+            return DiscriminatorProperty != null
+                   && DiscriminatorProperty.Name == propertyInfo.Name
+                   && DiscriminatorProperty.ClrType == propertyInfo.PropertyType
                 ? DiscriminatorBuilder(null, null)
                 : DiscriminatorBuilder(b => b.Property(propertyInfo, Annotations.ConfigurationSource), null);
         }

--- a/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -8,6 +8,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public static class RelationalPropertyExtensions
     {
         public static bool IsColumnNullable([NotNull] this IProperty property)
-            => (property.DeclaringEntityType.BaseType != null) || property.IsNullable;
+            => property.DeclaringEntityType.BaseType != null || property.IsNullable;
     }
 }

--- a/src/EFCore.Relational/Metadata/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Sequence.cs
@@ -278,8 +278,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                 var end = value.IndexOf('\'', position);
 
-                while ((end + 1 < value.Length)
-                       && (value[end + 1] == '\''))
+                while (end + 1 < value.Length
+                       && value[end + 1] == '\'')
                 {
                     end = value.IndexOf('\'', end + 2);
                 }
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                             : typeof(byte);
 
             private static bool AsBool(string value)
-                => (value != null) && bool.Parse(value);
+                => value != null && bool.Parse(value);
 
             private static void EscapeAndQuote(StringBuilder builder, object value)
             {

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsAssembly.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 () => (
                         from t in Assembly.GetConstructableTypes()
                         where t.IsSubclassOf(typeof(Migration))
-                              && (t.GetCustomAttribute<DbContextAttribute>()?.ContextType == contextType)
+                              && t.GetCustomAttribute<DbContextAttribute>()?.ContextType == contextType
                         let id = t.GetCustomAttribute<MigrationAttribute>()?.Id
                         orderby id
                         select new { Key = id, Element = t })
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 () => (
                         from t in Assembly.GetConstructableTypes()
                         where t.IsSubclassOf(typeof(ModelSnapshot))
-                              && (t.GetCustomAttribute<DbContextAttribute>()?.ContextType == contextType)
+                              && t.GetCustomAttribute<DbContextAttribute>()?.ContextType == contextType
                         select (ModelSnapshot)Activator.CreateInstance(t.AsType()))
                     .FirstOrDefault());
         }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -639,7 +639,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 || !Equals(sourceAnnotations.DefaultValue, targetAnnotations.DefaultValue)
                 || HasDifferences(sourceMigrationsAnnotations, targetMigrationsAnnotations))
             {
-                var isDestructiveChange = (isNullableChanged && isSourceColumnNullable)
+                var isDestructiveChange = isNullableChanged && isSourceColumnNullable
                                           // TODO: Detect type narrowing
                                           || columnTypeChanged;
 
@@ -748,9 +748,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 (s, t) => Diff(s, t, diffContext),
                 t => Add(t, diffContext),
                 s => Remove(s, diffContext),
-                (s, t) => (s.Relational().Name == t.Relational().Name)
+                (s, t) => s.Relational().Name == t.Relational().Name
                           && s.Properties.Select(diffContext.FindTarget).SequenceEqual(t.Properties)
-                          && (s.IsPrimaryKey() == t.IsPrimaryKey())
+                          && s.IsPrimaryKey() == t.IsPrimaryKey()
                           && !HasDifferences(MigrationsAnnotations.For(s), MigrationsAnnotations.For(t)));
 
         /// <summary>
@@ -852,7 +852,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 (s, t) => Diff(s, t, diffContext),
                 t => Add(t, diffContext),
                 s => Remove(s, diffContext),
-                (s, t) => (s.Relational().Name == t.Relational().Name)
+                (s, t) => s.Relational().Name == t.Relational().Name
                           && s.Properties.Select(diffContext.FindTarget).SequenceEqual(t.Properties)
                           && diffContext.FindTarget(diffContext.FindSourceTable(s.PrincipalEntityType))
                             == diffContext.FindTargetTable(t.PrincipalEntityType)
@@ -1049,9 +1049,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 Remove,
                 (s, t) => string.Equals(s.Schema, t.Schema, StringComparison.OrdinalIgnoreCase)
                           && string.Equals(s.Name, t.Name, StringComparison.OrdinalIgnoreCase)
-                          && (s.ClrType == t.ClrType),
+                          && s.ClrType == t.ClrType,
                 (s, t) => string.Equals(s.Name, t.Name, StringComparison.OrdinalIgnoreCase)
-                          && (s.ClrType == t.ClrType));
+                          && s.ClrType == t.ClrType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1085,10 +1085,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var sourceMigrationsAnnotations = MigrationsAnnotations.For(source).ToList();
             var targetMigrationsAnnotations = MigrationsAnnotations.For(target).ToList();
 
-            if ((source.IncrementBy != target.IncrementBy)
-                || (source.MaxValue != target.MaxValue)
-                || (source.MinValue != target.MinValue)
-                || (source.IsCyclic != target.IsCyclic)
+            if (source.IncrementBy != target.IncrementBy
+                || source.MaxValue != target.MaxValue
+                || source.MinValue != target.MinValue
+                || source.IsCyclic != target.IsCyclic
                 || HasDifferences(sourceMigrationsAnnotations, targetMigrationsAnnotations))
             {
                 var alterSequenceOperation = new AlterSequenceOperation
@@ -1228,7 +1228,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             foreach (var annotation in source)
             {
-                var index = unmatched.FindIndex(a => (a.Name == annotation.Name) && Equals(a.Value, annotation.Value));
+                var index = unmatched.FindIndex(a => a.Name == annotation.Name && Equals(a.Value, annotation.Value));
                 if (index == -1)
                 {
                     return true;

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateExpandingVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateExpandingVisitor.cs
@@ -22,10 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var newLeft = Visit(node.Left);
             var newRight = Visit(node.Right);
 
-            if (((node.NodeType == ExpressionType.Equal)
-                 || (node.NodeType == ExpressionType.NotEqual))
-                && (node.Left.Type == typeof(bool))
-                && (node.Right.Type == typeof(bool)))
+            if ((node.NodeType == ExpressionType.Equal
+                 || node.NodeType == ExpressionType.NotEqual)
+                && node.Left.Type == typeof(bool)
+                && node.Right.Type == typeof(bool))
             {
                 var simpleLeft = node.Left.IsSimpleExpression();
                 var simpleRight = node.Right.IsSimpleExpression();

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateNegationExpressionOptimizer.cs
@@ -30,12 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         protected override Expression VisitBinary(BinaryExpression node)
         {
             var currentExpression = node;
-            if ((currentExpression.NodeType == ExpressionType.Equal)
-                || (currentExpression.NodeType == ExpressionType.NotEqual))
+            if (currentExpression.NodeType == ExpressionType.Equal
+                || currentExpression.NodeType == ExpressionType.NotEqual)
             {
                 var leftUnary = currentExpression.Left as UnaryExpression;
-                if ((leftUnary != null)
-                    && (leftUnary.NodeType == ExpressionType.Not))
+                if (leftUnary != null
+                    && leftUnary.NodeType == ExpressionType.Not)
                 {
                     var leftNullable = BuildIsNullExpression(leftUnary.Operand) != null;
                     var rightNullable = BuildIsNullExpression(currentExpression.Right) != null;
@@ -53,8 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
 
                 var rightUnary = currentExpression.Right as UnaryExpression;
-                if ((rightUnary != null)
-                    && (rightUnary.NodeType == ExpressionType.Not))
+                if (rightUnary != null
+                    && rightUnary.NodeType == ExpressionType.Not)
                 {
                     var leftNullable = BuildIsNullExpression(currentExpression.Left) != null;
                     var rightNullable = BuildIsNullExpression(rightUnary) != null;
@@ -92,8 +92,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (node.NodeType == ExpressionType.Not)
             {
                 var innerUnary = node.Operand as UnaryExpression;
-                if ((innerUnary != null)
-                    && (innerUnary.NodeType == ExpressionType.Not))
+                if (innerUnary != null
+                    && innerUnary.NodeType == ExpressionType.Not)
                 {
                     // !(!(a)) => a
                     return Visit(innerUnary.Operand);
@@ -104,8 +104,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 if (innerBinary != null)
                 {
                     Expression result = null;
-                    if ((innerBinary.NodeType == ExpressionType.Equal)
-                        || (innerBinary.NodeType == ExpressionType.NotEqual))
+                    if (innerBinary.NodeType == ExpressionType.Equal
+                        || innerBinary.NodeType == ExpressionType.NotEqual)
                     {
                         // TODO: this is only valid for non-nullable terms, or if null semantics expansion is performed
                         // if user opts-out of the null semantics, we should not apply this rule

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -30,16 +30,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (node.NodeType == ExpressionType.AndAlso)
                 {
-                    if ((constantLeft != null)
-                        && (constantLeft.Type == typeof(bool)))
+                    if (constantLeft != null
+                        && constantLeft.Type == typeof(bool))
                     {
                         // true && a => a
                         // false && a => false
                         return (bool)constantLeft.Value ? newRight : newLeft;
                     }
 
-                    if ((constantRight != null)
-                        && (constantRight.Type == typeof(bool)))
+                    if (constantRight != null
+                        && constantRight.Type == typeof(bool))
                     {
                         // a && true => a
                         // a && false => false
@@ -49,16 +49,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (node.NodeType == ExpressionType.OrElse)
                 {
-                    if ((constantLeft != null)
-                        && (constantLeft.Type == typeof(bool)))
+                    if (constantLeft != null
+                        && constantLeft.Type == typeof(bool))
                     {
                         // true || a => true
                         // false || a => a
                         return (bool)constantLeft.Value ? newLeft : newRight;
                     }
 
-                    if ((constantRight != null)
-                        && (constantRight.Type == typeof(bool)))
+                    if (constantRight != null
+                        && constantRight.Type == typeof(bool))
                     {
                         // a || true => true
                         // a || false => a

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsExpandingVisitor.cs
@@ -22,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var newLeft = Visit(node.Left);
             var newRight = Visit(node.Right);
 
-            if ((node.NodeType == ExpressionType.Equal)
-                || (node.NodeType == ExpressionType.NotEqual))
+            if (node.NodeType == ExpressionType.Equal
+                || node.NodeType == ExpressionType.NotEqual)
             {
                 var leftIsNull = BuildIsNullExpression(newLeft);
                 var leftNullable = leftIsNull != null;
@@ -38,10 +38,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var unwrappedConvertRight = UnwrapConvertExpression(newRight, out conversionResultTypeRight);
 
                 var leftUnary = unwrappedConvertLeft as UnaryExpression;
-                var leftNegated = (leftUnary != null) && (leftUnary.NodeType == ExpressionType.Not);
+                var leftNegated = leftUnary != null && leftUnary.NodeType == ExpressionType.Not;
 
                 var rightUnary = unwrappedConvertRight as UnaryExpression;
-                var rightNegated = (rightUnary != null) && (rightUnary.NodeType == ExpressionType.Not);
+                var rightNegated = rightUnary != null && rightUnary.NodeType == ExpressionType.Not;
 
                 var leftOperand
                     = leftNegated
@@ -122,8 +122,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var unary = expression as UnaryExpression;
 
-            if ((unary != null)
-                && (unary.NodeType == ExpressionType.Convert))
+            if (unary != null
+                && unary.NodeType == ExpressionType.Convert)
             {
                 conversionResultType = unary.Type;
 

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsOptimizedExpandingVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/RelationalNullsOptimizedExpandingVisitor.cs
@@ -31,8 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 return node;
             }
 
-            if ((node.NodeType == ExpressionType.Equal)
-                || (node.NodeType == ExpressionType.NotEqual))
+            if (node.NodeType == ExpressionType.Equal
+                || node.NodeType == ExpressionType.NotEqual)
             {
                 var leftIsNull = BuildIsNullExpression(newLeft);
                 var rightIsNull = BuildIsNullExpression(newRight);
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var leftNullable = leftIsNull != null;
                 var rightNullable = rightIsNull != null;
 
-                if ((node.NodeType == ExpressionType.Equal)
+                if (node.NodeType == ExpressionType.Equal
                     && leftNullable
                     && rightNullable)
                 {
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         Expression.AndAlso(leftIsNull, rightIsNull));
                 }
 
-                if ((node.NodeType == ExpressionType.NotEqual)
+                if (node.NodeType == ExpressionType.NotEqual
                     && (leftNullable || rightNullable))
                 {
                     IsOptimalExpansion = false;

--- a/src/EFCore.Relational/Scaffolding/Metadata/SequenceModel.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/SequenceModel.cs
@@ -20,6 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         public virtual bool? IsCyclic { get; [param: CanBeNull] set; }
 
         public virtual string DisplayName
-            => !string.IsNullOrEmpty(SchemaName) ? (SchemaName + "." + Name) : Name;
+            => !string.IsNullOrEmpty(SchemaName) ? SchemaName + "." + Name : Name;
     }
 }

--- a/src/EFCore.Relational/Scaffolding/Metadata/TableModel.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/TableModel.cs
@@ -21,6 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         public virtual ICollection<ForeignKeyModel> ForeignKeys { get; } = new List<ForeignKeyModel>();
 
         public virtual string DisplayName
-            => !string.IsNullOrEmpty(SchemaName) ? (SchemaName + "." + Name) : Name;
+            => !string.IsNullOrEmpty(SchemaName) ? SchemaName + "." + Name : Name;
     }
 }

--- a/src/EFCore.Relational/Storage/BoolTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/BoolTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="BoolTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public BoolTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
@@ -24,15 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="ByteArrayTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
-        /// <param name="hasNonDefaultSize"> A value indicating whether the size setting has been manually configured to a non-default value. </param>
         public ByteArrayTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null,
-            int? size = null,
-            bool hasNonDefaultSize = false)
-            : base(storeType, dbType, false, size, false, hasNonDefaultSize)
+            int? size = null)
+            : base(storeType, dbType, unicode: false, size: size)
         {
         }
 
@@ -46,8 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => new ByteArrayTypeMapping(
                 storeType,
                 DbType,
-                size,
-                hasNonDefaultSize: size != Size);
+                size);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/ByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="ByteTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/CharTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/CharTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="CharTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public CharTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
@@ -24,11 +24,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="DateTimeOffsetTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
@@ -24,11 +24,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="DateTimeTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
@@ -23,11 +23,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="DecimalTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DecimalTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="DoubleTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/FloatTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/FloatTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="FloatTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public FloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/GuidTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/GuidTypeMapping.cs
@@ -22,11 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="GuidTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public GuidTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/IntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/IntTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="IntTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public IntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/LongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/LongTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="LongTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public LongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -160,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void ClearTransaction()
         {
-            Debug.Assert((_relationalConnection.CurrentTransaction == null) || (_relationalConnection.CurrentTransaction == this));
+            Debug.Assert(_relationalConnection.CurrentTransaction == null || _relationalConnection.CurrentTransaction == this);
 
             _relationalConnection.UseTransaction(null);
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -24,9 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public static RelationalTypeMapping GetMappingForValue(
             [CanBeNull] this IRelationalTypeMapper typeMapper,
             [CanBeNull] object value)
-            => (value == null)
-               || (value == DBNull.Value)
-               || (typeMapper == null)
+            => value == null
+               || value == DBNull.Value
+               || typeMapper == null
                 ? RelationalTypeMapping.NullMapping
                 : typeMapper.GetMapping(value.GetType());
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -34,16 +34,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
-        /// <param name="hasNonDefaultUnicode"> A value indicating whether the Unicode setting has been manually configured to a non-default value. </param>
-        /// <param name="hasNonDefaultSize"> A value indicating whether the size setting has been manually configured to a non-default value. </param>
         public RelationalTypeMapping(
             [NotNull] string storeType,
             [NotNull] Type clrType,
             [CanBeNull] DbType? dbType,
             bool unicode,
-            int? size,
-            bool hasNonDefaultUnicode = false,
-            bool hasNonDefaultSize = false)
+            int? size)
             : this(storeType)
         {
             Check.NotNull(clrType, nameof(clrType));
@@ -52,8 +48,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType = dbType;
             IsUnicode = unicode;
             Size = size;
-            HasNonDefaultUnicode = hasNonDefaultUnicode;
-            HasNonDefaultSize = hasNonDefaultSize;
         }
 
         private RelationalTypeMapping([NotNull] string storeType)
@@ -75,9 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 ClrType,
                 DbType,
                 IsUnicode,
-                size,
-                HasNonDefaultUnicode,
-                hasNonDefaultSize: size != Size);
+                size);
 
         /// <summary>
         ///     Gets the name of the database type.
@@ -103,16 +95,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Gets the size of data the property is configured to store, or null if no size is configured.
         /// </summary>
         public virtual int? Size { get; }
-
-        /// <summary>
-        ///     Gets a value indicating whether the Unicode setting has been manually configured to a non-default value.
-        /// </summary>
-        public virtual bool HasNonDefaultUnicode { get; }
-
-        /// <summary>
-        ///     Gets a value indicating whether the size setting has been manually configured to a non-default value.
-        /// </summary>
-        public virtual bool HasNonDefaultSize { get; }
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.
@@ -176,9 +158,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The generated string.
         /// </returns>
         public virtual string GenerateSqlLiteral([CanBeNull] object value)
-            => (value == null
+            => value == null
                 ? "NULL"
-                : GenerateNonNullSqlLiteral(value));
+                : GenerateNonNullSqlLiteral(value);
 
         /// <summary>
         ///     Generates the SQL representation of a non-null literal value.
@@ -188,6 +170,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The generated string.
         /// </returns>
         protected virtual string GenerateNonNullSqlLiteral([NotNull] object value)
-            => string.Format(CultureInfo.InvariantCulture, SqlLiteralFormatString, Check.NotNull(value, "value"));
+            => string.Format(CultureInfo.InvariantCulture, SqlLiteralFormatString, Check.NotNull(value, nameof(value)));
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping`.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping`.cs
@@ -24,16 +24,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
-        /// <param name="hasNonDefaultUnicode"> A value indicating whether the Unicode setting has been manually configured to a non-default value. </param>
-        /// <param name="hasNonDefaultSize"> A value indicating whether the size setting has been manually configured to a non-default value. </param>
         public RelationalTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType,
             bool unicode,
-            int? size,
-            bool hasNonDefaultUnicode = false,
-            bool hasNonDefaultSize = false)
-            : base(storeType, typeof(T), dbType, unicode, size, hasNonDefaultUnicode, hasNonDefaultSize)
+            int? size)
+            : base(storeType, typeof(T), dbType, unicode, size)
         {
         }
 
@@ -44,10 +40,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns>
         ///     The generated string.
         /// </returns>
-        public override string GenerateSqlLiteral([CanBeNull]object value)
+        public override string GenerateSqlLiteral(object value)
         {
             return value == null
-                ? base.GenerateSqlLiteral(value)
+                ? base.GenerateSqlLiteral(value: null)
+                // This ensures that the Enum type is cast to underlying type
                 : GenerateNonNullSqlLiteral((T)value);
         }
     }

--- a/src/EFCore.Relational/Storage/SByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/SByteTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="SByteTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public SByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/ShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ShortTypeMapping.cs
@@ -22,11 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="ShortTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/StringTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/StringTypeMapping.cs
@@ -39,16 +39,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
-        /// <param name="hasNonDefaultUnicode"> A value indicating whether the Unicode setting has been manually configured to a non-default value. </param>
-        /// <param name="hasNonDefaultSize"> A value indicating whether the size setting has been manually configured to a non-default value. </param>
         public StringTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType,
             bool unicode,
-            int? size,
-            bool hasNonDefaultUnicode = false,
-            bool hasNonDefaultSize = false)
-            : base(storeType, dbType, unicode, size, hasNonDefaultUnicode, hasNonDefaultSize)
+            int? size)
+            : base(storeType, dbType, unicode, size)
         {
         }
 
@@ -63,9 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 storeType,
                 DbType,
                 IsUnicode,
-                size,
-                HasNonDefaultUnicode,
-                hasNonDefaultSize: size != Size);
+                size);
 
         /// <summary>
         ///     Generates the escaped SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
@@ -22,11 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="TimeSpanTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public TimeSpanTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     return other.IndexMap == null;
                 }
 
-                return (other.IndexMap != null)
+                return other.IndexMap != null
                        && IndexMap.SequenceEqual(other.IndexMap);
             }
 

--- a/src/EFCore.Relational/Storage/UIntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UIntTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="UIntTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UIntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/ULongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ULongTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="ULongTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ULongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Storage/UShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UShortTypeMapping.cs
@@ -21,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="UShortTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
-        /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, dbType, unicode: false, size: null, hasNonDefaultUnicode: false, hasNonDefaultSize: false)
+            : base(storeType, dbType, unicode: false, size: null)
         {
         }
 

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 if (!reader.Read())
                 {
                     var expectedRowsAffected = rowsAffected + 1;
-                    while ((++commandIndex < CommandResultSet.Count)
+                    while (++commandIndex < CommandResultSet.Count
                            && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
                     {
                         expectedRowsAffected++;
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 tableModification.PropagateResults(valueBufferFactory.Create(reader));
                 rowsAffected++;
             }
-            while ((++commandIndex < CommandResultSet.Count)
+            while (++commandIndex < CommandResultSet.Count
                    && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet);
 
             return commandIndex;
@@ -186,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 if (!await reader.ReadAsync(cancellationToken))
                 {
                     var expectedRowsAffected = rowsAffected + 1;
-                    while ((++commandIndex < CommandResultSet.Count)
+                    while (++commandIndex < CommandResultSet.Count
                            && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
                     {
                         expectedRowsAffected++;
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 tableModification.PropagateResults(valueBufferFactory.Create(reader));
                 rowsAffected++;
             }
-            while ((++commandIndex < CommandResultSet.Count)
+            while (++commandIndex < CommandResultSet.Count
                    && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet);
 
             return commandIndex;
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         protected virtual int ConsumeResultSetWithoutPropagation(int commandIndex, [NotNull] DbDataReader reader)
         {
             var expectedRowsAffected = 1;
-            while ((++commandIndex < CommandResultSet.Count)
+            while (++commandIndex < CommandResultSet.Count
                    && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
             {
                 Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             int commandIndex, [NotNull] DbDataReader reader, CancellationToken cancellationToken)
         {
             var expectedRowsAffected = 1;
-            while ((++commandIndex < CommandResultSet.Count)
+            while (++commandIndex < CommandResultSet.Count
                    && CommandResultSet[commandIndex - 1] == ResultSetMapping.NotLastInResultSet)
             {
                 Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         public virtual bool UseOriginalValueParameter => IsCondition && IsConcurrencyToken;
 
-        public virtual bool UseCurrentValueParameter => IsWrite || (IsCondition && !IsConcurrencyToken);
+        public virtual bool UseCurrentValueParameter => IsWrite || IsCondition && !IsConcurrencyToken;
 
         public virtual string ParameterName
             => _parameterName ?? (_parameterName = _generateParameterName());

--- a/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
+++ b/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
@@ -53,8 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         public override bool Equals(object obj)
             => !ReferenceEquals(null, obj)
                && (ReferenceEquals(this, obj)
-                   || (obj.GetType() == GetType()
-                       && Equals((KeyValueIndex<TKey>)obj)));
+                   || obj.GetType() == GetType()
+                   && Equals((KeyValueIndex<TKey>)obj));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -140,11 +140,11 @@ namespace Microsoft.EntityFrameworkCore.Update
                     var readValue = entry.IsStoreGenerated(property);
 
                     var writeValue = !readValue
-                                     && ((adding
-                                          && property.BeforeSaveBehavior == PropertySaveBehavior.Save)
-                                         || (!adding
-                                             && property.AfterSaveBehavior == PropertySaveBehavior.Save
-                                             && entry.IsModified(property)));
+                                     && (adding
+                                         && property.BeforeSaveBehavior == PropertySaveBehavior.Save
+                                         || !adding
+                                         && property.AfterSaveBehavior == PropertySaveBehavior.Save
+                                         && entry.IsModified(property));
 
                     if (readValue
                         || writeValue

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1,5 +1,20 @@
 [
   {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public .ctor(System.String storeType, System.Type clrType, System.Nullable<System.Data.DbType> dbType, System.Boolean unicode, System.Nullable<System.Int32> size, System.Boolean hasNonDefaultUnicode = False, System.Boolean hasNonDefaultSize = False)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public virtual System.Boolean get_HasNonDefaultSize()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public virtual System.Boolean get_HasNonDefaultUnicode()",
+    "Kind": "Removal"
+  },
+  {
     "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T0 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<T0, T1> where T1 : Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension",
     "Kind": "Removal"
   },

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDateComponentTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeDateComponentTranslator.cs
@@ -18,9 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MemberExpression memberExpression)
-            => (memberExpression.Expression != null)
+            => memberExpression.Expression != null
                && (memberExpression.Expression.Type == typeof(DateTime) || memberExpression.Expression.Type == typeof(DateTimeOffset))
-               && (memberExpression.Member.Name == nameof(DateTime.Date))
+               && memberExpression.Member.Name == nameof(DateTime.Date)
                 ? new SqlFunctionExpression("CONVERT",
                     memberExpression.Type,
                     new[]

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeNowTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeNowTranslator.cs
@@ -19,8 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MemberExpression memberExpression)
         {
-            if ((memberExpression.Expression == null)
-                && (memberExpression.Member.DeclaringType == typeof(DateTime)))
+            if (memberExpression.Expression == null
+                && memberExpression.Member.DeclaringType == typeof(DateTime))
             {
                 switch (memberExpression.Member.Name)
                 {

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringLengthTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringLengthTranslator.cs
@@ -17,9 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MemberExpression memberExpression)
-            => (memberExpression.Expression != null)
-               && (memberExpression.Expression.Type == typeof(string))
-               && (memberExpression.Member.Name == nameof(string.Length))
+            => memberExpression.Expression != null
+               && memberExpression.Expression.Type == typeof(string)
+               && memberExpression.Member.Name == nameof(string.Length)
                 ? new ExplicitCastExpression(
                     new SqlFunctionExpression("LEN", memberExpression.Type, new[] { memberExpression.Expression }), 
                     typeof(int))

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         {
             if (_methodInfo.Equals(methodCallExpression.Method)
                 // SqlServer LTRIM does not take arguments
-                && (((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0))
+                && ((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0)
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
                 return new SqlFunctionExpression("LTRIM", methodCallExpression.Type, sqlArguments);

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerTableSelectionSetExtensions.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerTableSelectionSetExtensions.cs
@@ -38,8 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         public static bool Allows(this TableSelectionSet tableSelectionSet, [CanBeNull] string schemaName, [NotNull] string tableName)
         {
             if (tableSelectionSet == null
-                || (tableSelectionSet.Schemas.Count == 0
-                    && tableSelectionSet.Tables.Count == 0))
+                || tableSelectionSet.Schemas.Count == 0
+                && tableSelectionSet.Tables.Count == 0)
             {
                 return true;
             }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -210,11 +210,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             //   System.Data.SqlClient.SqlException: Unable to Attach database file as database xxxxxxx.
             // And (Number 5120)
             //   System.Data.SqlClient.SqlException: Unable to open the physical file xxxxxxx.
-            if ((exception.Number == 233
-                 || exception.Number == -2
-                 || exception.Number == 4060
-                 || exception.Number == 1832
-                 || exception.Number == 5120))
+            if (exception.Number == 233
+                || exception.Number == -2
+                || exception.Number == 4060
+                || exception.Number == 1832
+                || exception.Number == 5120)
             {
                 ClearPool();
                 return true;

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -24,10 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             = new SqlServerStringTypeMapping("nvarchar(450)", dbType: null, unicode: true, size: 450);
 
         private readonly SqlServerStringTypeMapping _unboundedAnsiString
-            = new SqlServerStringTypeMapping("varchar(max)", dbType: DbType.AnsiString, unicode: false, size: null, hasNonDefaultUnicode: true);
+            = new SqlServerStringTypeMapping("varchar(max)", dbType: DbType.AnsiString, unicode: false, size: null);
 
         private readonly SqlServerStringTypeMapping _keyAnsiString
-            = new SqlServerStringTypeMapping("varchar(900)", dbType: DbType.AnsiString, unicode: false, size: 900, hasNonDefaultUnicode: true);
+            = new SqlServerStringTypeMapping("varchar(900)", dbType: DbType.AnsiString, unicode: false, size: 900);
 
         private readonly SqlServerByteArrayTypeMapping _unboundedBinary
             = new SqlServerByteArrayTypeMapping("varbinary(max)");
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly ByteTypeMapping _byte = new ByteTypeMapping("tinyint", DbType.Byte);
 
-        private readonly BoolTypeMapping _bool = new BoolTypeMapping("bit", null);
+        private readonly BoolTypeMapping _bool = new BoolTypeMapping("bit");
 
         private readonly SqlServerStringTypeMapping _fixedLengthUnicodeString
             = new SqlServerStringTypeMapping("nchar", dbType: DbType.StringFixedLength, unicode: true, size: null);
@@ -55,10 +55,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             = new SqlServerStringTypeMapping("nvarchar", dbType: null, unicode: true, size: null);
 
         private readonly SqlServerStringTypeMapping _fixedLengthAnsiString
-            = new SqlServerStringTypeMapping("char", dbType: DbType.AnsiStringFixedLength, unicode: false, size: null, hasNonDefaultUnicode: true);
+            = new SqlServerStringTypeMapping("char", dbType: DbType.AnsiStringFixedLength, unicode: false, size: null);
 
         private readonly SqlServerStringTypeMapping _variableLengthAnsiString
-            = new SqlServerStringTypeMapping("varchar", dbType: DbType.AnsiString, unicode: false, size: null, hasNonDefaultUnicode: true);
+            = new SqlServerStringTypeMapping("varchar", dbType: DbType.AnsiString, unicode: false, size: null);
 
         private readonly SqlServerByteArrayTypeMapping _variableLengthBinary = new SqlServerByteArrayTypeMapping("varbinary");
 
@@ -70,17 +70,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly SqlServerDateTimeTypeMapping _datetime2 = new SqlServerDateTimeTypeMapping("datetime2", dbType: DbType.DateTime2);
 
-        private readonly DoubleTypeMapping _double = new DoubleTypeMapping("float", null); // Note: "float" is correct SQL Server type to map to CLR-type double
+        private readonly DoubleTypeMapping _double = new DoubleTypeMapping("float"); // Note: "float" is correct SQL Server type to map to CLR-type double
 
         private readonly SqlServerDateTimeOffsetTypeMapping _datetimeoffset = new SqlServerDateTimeOffsetTypeMapping("datetimeoffset");
 
-        private readonly FloatTypeMapping _real = new FloatTypeMapping("real", null); // Note: "real" is correct SQL Server type to map to CLR-type float
+        private readonly FloatTypeMapping _real = new FloatTypeMapping("real"); // Note: "real" is correct SQL Server type to map to CLR-type float
 
         private readonly GuidTypeMapping _uniqueidentifier = new GuidTypeMapping("uniqueidentifier", DbType.Guid);
 
-        private readonly DecimalTypeMapping _decimal = new DecimalTypeMapping("decimal(18, 2)", null);
+        private readonly DecimalTypeMapping _decimal = new DecimalTypeMapping("decimal(18, 2)");
 
-        private readonly TimeSpanTypeMapping _time = new TimeSpanTypeMapping("time", null);
+        private readonly TimeSpanTypeMapping _time = new TimeSpanTypeMapping("time");
 
         private readonly SqlServerStringTypeMapping _xml = new SqlServerStringTypeMapping("xml", dbType: null, unicode: true);
 
@@ -181,41 +181,36 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             ByteArrayMapper
                 = new ByteArrayRelationalTypeMapper(
-                    8000,
-                    _unboundedBinary,
-                    _unboundedBinary,
-                    _keyBinary,
-                    _rowversion,
-                    size => new SqlServerByteArrayTypeMapping(
+                    maxBoundedLength: 8000,
+                    defaultMapping: _unboundedBinary,
+                    unboundedMapping: _unboundedBinary,
+                    keyMapping: _keyBinary,
+                    rowVersionMapping: _rowversion,
+                    createBoundedMapping: size => new SqlServerByteArrayTypeMapping(
                         "varbinary(" + size + ")",
                         DbType.Binary,
-                        size: size,
-                        hasNonDefaultSize: true));
+                        size));
 
             StringMapper
                 = new StringRelationalTypeMapper(
-                    8000,
-                    _unboundedAnsiString,
-                    _unboundedAnsiString,
-                    _keyAnsiString,
-                    size => new SqlServerStringTypeMapping(
+                    maxBoundedAnsiLength: 8000,
+                    defaultAnsiMapping: _unboundedAnsiString,
+                    unboundedAnsiMapping: _unboundedAnsiString,
+                    keyAnsiMapping: _keyAnsiString,
+                    createBoundedAnsiMapping: size => new SqlServerStringTypeMapping(
                         "varchar(" + size + ")",
-                        dbType: DbType.AnsiString,
+                        DbType.AnsiString,
                         unicode: false,
-                        size: size,
-                        hasNonDefaultUnicode: true,
-                        hasNonDefaultSize: true),
-                    4000,
-                    _unboundedUnicodeString,
-                    _unboundedUnicodeString,
-                    _keyUnicodeString,
-                    size => new SqlServerStringTypeMapping(
+                        size: size),
+                    maxBoundedUnicodeLength: 4000,
+                    defaultUnicodeMapping: _unboundedUnicodeString,
+                    unboundedUnicodeMapping: _unboundedUnicodeString,
+                    keyUnicodeMapping: _keyUnicodeString,
+                    createBoundedUnicodeMapping: size => new SqlServerStringTypeMapping(
                         "nvarchar(" + size + ")",
                         dbType: null,
                         unicode: true,
-                        size: size,
-                        hasNonDefaultUnicode: false,
-                        hasNonDefaultSize: true));
+                        size: size));
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 valueBufferFactoryFactory)
         {
             if (maxBatchSize.HasValue
-                && (maxBatchSize.Value <= 0))
+                && maxBatchSize.Value <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxBatchSize), RelationalStrings.InvalidMaxBatchSize);
             }
@@ -177,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             if (newModificationCommand.EntityState == EntityState.Added)
             {
-                if ((_bulkInsertCommands.Count > 0)
+                if (_bulkInsertCommands.Count > 0
                     && !CanBeInsertedInSameStatement(_bulkInsertCommands[0], newModificationCommand))
                 {
                     CachedCommandText.Append(GetBulkInsertCommandText(commandPosition));

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
             if (!ReferenceEquals(value, null)
-                && (value.Length == 0))
+                && value.Length == 0)
             {
                 NotEmpty(parameterName, nameof(parameterName));
 

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -51,12 +51,12 @@ namespace System.Reflection
             Check.NotNull(otherPropertyInfo, nameof(otherPropertyInfo));
 
             return Equals(propertyInfo, otherPropertyInfo)
-                   || (propertyInfo.Name == otherPropertyInfo.Name
-                       && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
-                           || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
-                           || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
-                           || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
-                           || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType)));
+                   || propertyInfo.Name == otherPropertyInfo.Name
+                   && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
+                       || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
+                       || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
+                       || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
+                       || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType));
         }
 
         public static PropertyInfo FindGetterProperty([NotNull] this PropertyInfo propertyInfo)

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
                 = new Dictionary<string, RelationalTypeMapping>
                 {
-                    { "varchar", new StringTypeMapping("varchar", dbType: null, unicode: false, size: null, hasNonDefaultUnicode: true) },
+                    { "varchar", new StringTypeMapping("varchar", dbType: null, unicode: false, size: null) },
                     { "bigint", new LongTypeMapping("bigint") }
                 };
 

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
@@ -104,8 +104,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 _rowversion, size => new ByteArrayTypeMapping(
                     "just_binary(" + size + ")",
                     DbType.Binary,
-                    size: size,
-                    hasNonDefaultSize: true));
+                    size: size));
 
         public override IStringRelationalTypeMapper StringMapper { get; }
             = new StringRelationalTypeMapper(
@@ -117,9 +116,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     "just_string(" + size + ")",
                     dbType: DbType.AnsiString,
                     unicode: false,
-                    size: size,
-                    hasNonDefaultUnicode: true,
-                    hasNonDefaultSize: true),
+                    size: size),
                 2000,
                 _string,
                 _unboundedString,
@@ -128,9 +125,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     "just_string(" + size + ")",
                     dbType: null,
                     unicode: true,
-                    size: size,
-                    hasNonDefaultUnicode: false,
-                    hasNonDefaultSize: true));
+                    size: size));
 
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _simpleMappings;

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
-            Assert.Equal(4000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.True(typeMapping.IsUnicode);
             Assert.Equal(4000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
-            Assert.Equal(4000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.True(typeMapping.IsUnicode);
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 4001)).Size);
         }
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(max)", typeMapping.StoreType);
-            Assert.Equal(4000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.True(typeMapping.IsUnicode);
             Assert.Equal(4000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
@@ -300,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.False(typeMapping.IsUnicode);
             Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.False(typeMapping.IsUnicode);
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new string('X', 8001)).Size);
         }
@@ -348,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.False(typeMapping.IsUnicode);
             Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
         }
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", new byte[3]).Size);
         }
 
@@ -455,7 +455,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.Equal(-1, typeMapping.CreateParameter(new TestCommand(), "Name", new byte[8001]).Size);
         }
 
@@ -477,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
-            Assert.Equal(8000, typeMapping.Size);
+            Assert.Null(typeMapping.Size);
             Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", new byte[3]).Size);
         }
 
@@ -672,21 +672,21 @@ namespace Microsoft.EntityFrameworkCore
 
         [Theory]
         [InlineData("bigint", typeof(long), null, false)]
-        [InlineData("binary varying", typeof(byte[]), 8000, false)]
+        [InlineData("binary varying", typeof(byte[]), null, false)]
         [InlineData("binary varying(333)", typeof(byte[]), 333, false)]
-        [InlineData("binary varying(max)", typeof(byte[]), 8000, false)]
-        [InlineData("binary", typeof(byte[]), 8000, false)]
+        [InlineData("binary varying(max)", typeof(byte[]), null, false)]
+        [InlineData("binary", typeof(byte[]), null, false)]
         [InlineData("binary(333)", typeof(byte[]), 333, false)]
         [InlineData("bit", typeof(bool), null, false)]
-        [InlineData("char varying", typeof(string), 8000, false)]
+        [InlineData("char varying", typeof(string), null, false)]
         [InlineData("char varying(333)", typeof(string), 333, false)]
-        [InlineData("char varying(max)", typeof(string), 8000, false)]
-        [InlineData("char", typeof(string), 8000, false)]
+        [InlineData("char varying(max)", typeof(string), null, false)]
+        [InlineData("char", typeof(string), null, false)]
         [InlineData("char(333)", typeof(string), 333, false)]
-        [InlineData("character varying", typeof(string), 8000, false)]
+        [InlineData("character varying", typeof(string), null, false)]
         [InlineData("character varying(333)", typeof(string), 333, false)]
-        [InlineData("character varying(max)", typeof(string), 8000, false)]
-        [InlineData("character", typeof(string), 8000, false)]
+        [InlineData("character varying(max)", typeof(string), null, false)]
+        [InlineData("character", typeof(string), null, false)]
         [InlineData("character(333)", typeof(string), 333, false)]
         [InlineData("date", typeof(DateTime), null, false)]
         [InlineData("datetime", typeof(DateTime), null, false)]
@@ -696,43 +696,43 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("decimal", typeof(decimal), null, false)]
         [InlineData("float", typeof(double), null, false)] // This is correct. SQL Server 'float' type maps to C# double
         [InlineData("float(10, 8)", typeof(double), null, false)]
-        [InlineData("image", typeof(byte[]), 8000, false)]
+        [InlineData("image", typeof(byte[]), null, false)]
         [InlineData("int", typeof(int), null, false)]
         [InlineData("money", typeof(decimal), null, false)]
-        [InlineData("national char varying", typeof(string), 4000, true)]
+        [InlineData("national char varying", typeof(string), null, true)]
         [InlineData("national char varying(333)", typeof(string), 333, true)]
-        [InlineData("national char varying(max)", typeof(string), 4000, true)]
-        [InlineData("national character varying", typeof(string), 4000, true)]
+        [InlineData("national char varying(max)", typeof(string), null, true)]
+        [InlineData("national character varying", typeof(string), null, true)]
         [InlineData("national character varying(333)", typeof(string), 333, true)]
-        [InlineData("national character varying(max)", typeof(string), 4000, true)]
-        [InlineData("national character", typeof(string), 4000, true)]
+        [InlineData("national character varying(max)", typeof(string), null, true)]
+        [InlineData("national character", typeof(string), null, true)]
         [InlineData("national character(333)", typeof(string), 333, true)]
-        [InlineData("nchar", typeof(string), 4000, true)]
+        [InlineData("nchar", typeof(string), null, true)]
         [InlineData("nchar(333)", typeof(string), 333, true)]
-        [InlineData("ntext", typeof(string), 4000, true)]
+        [InlineData("ntext", typeof(string), null, true)]
         [InlineData("numeric", typeof(decimal), null, false)]
-        [InlineData("nvarchar", typeof(string), 4000, true)]
+        [InlineData("nvarchar", typeof(string), null, true)]
         [InlineData("nvarchar(333)", typeof(string), 333, true)]
-        [InlineData("nvarchar(max)", typeof(string), 4000, true)]
+        [InlineData("nvarchar(max)", typeof(string), null, true)]
         [InlineData("real", typeof(float), null, false)]
         [InlineData("rowversion", typeof(byte[]), 8, false)]
         [InlineData("smalldatetime", typeof(DateTime), null, false)]
         [InlineData("smallint", typeof(short), null, false)]
         [InlineData("smallmoney", typeof(decimal), null, false)]
-        [InlineData("text", typeof(string), 8000, false)]
+        [InlineData("text", typeof(string), null, false)]
         [InlineData("time", typeof(TimeSpan), null, false)]
         [InlineData("timestamp", typeof(byte[]), 8, false)] // note: rowversion is a synonym but SQL Server stores the data type as 'timestamp'
         [InlineData("tinyint", typeof(byte), null, false)]
         [InlineData("uniqueidentifier", typeof(Guid), null, false)]
-        [InlineData("varbinary", typeof(byte[]), 8000, false)]
+        [InlineData("varbinary", typeof(byte[]), null, false)]
         [InlineData("varbinary(333)", typeof(byte[]), 333, false)]
-        [InlineData("varbinary(max)", typeof(byte[]), 8000, false)]
-        [InlineData("varchar", typeof(string), 8000, false)]
-        [InlineData("VarCHaR", typeof(string), 8000, false)] // case-insensitive
+        [InlineData("varbinary(max)", typeof(byte[]), null, false)]
+        [InlineData("varchar", typeof(string), null, false)]
+        [InlineData("VarCHaR", typeof(string), null, false)] // case-insensitive
         [InlineData("varchar(333)", typeof(string), 333, false)]
-        [InlineData("varchar(max)", typeof(string), 8000, false)]
-        [InlineData("xml", typeof(string), 4000, true)]
-        [InlineData("VARCHAR", typeof(string), 8000, false)]
+        [InlineData("varchar(max)", typeof(string), null, false)]
+        [InlineData("xml", typeof(string), null, true)]
+        [InlineData("VARCHAR", typeof(string), null, false)]
         public void Can_map_by_type_name(string typeName, Type clrType, int? size, bool unicode)
         {
             var mapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeName);


### PR DESCRIPTION
Resolves #8668 

Bring backs `_maxSpecificSize`
`ScaffoldingTypeMapper` gets default mapping and do comparison with that to generate facets.

R# ran redundant parenthesis over whole project.