### PR TITLE
Fix to #8584 - Query: reuse include pipeline for queries projecting uncomposed collection navigations

### DIFF
--- a/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsOwnedQueryTestBase.cs
@@ -308,6 +308,42 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override void Project_collection_navigation()
+        {
+        }
+
+        public override void Project_collection_navigation_nested()
+        {
+        }
+
+        public override void Project_collection_navigation_using_ef_property()
+        {
+        }
+
+        public override void Project_collection_navigation_nested_anonymous()
+        {
+        }
+
+        public override void Project_collection_navigation_count()
+        {
+        }
+
+        public override void Project_collection_navigation_composed()
+        {
+        }
+
+        public override void Project_collection_and_root_entity()
+        {
+        }
+
+        public override void Project_collection_and_include()
+        {
+        }
+
+        public override void Project_navigation_and_collection()
+        {
+        }
+
         protected override IQueryable<Level1> GetExpectedLevelOne()
             => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 

--- a/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/ComplexNavigationsQueryTestBase.cs
@@ -3292,6 +3292,219 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalFact]
+        public virtual void Project_collection_navigation()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select l1.OneToMany_Optional,
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_nested()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select l1.OneToOne_Optional_FK.OneToMany_Optional,
+                l1s => from l1 in l1s
+                       select Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional),
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_using_ef_property()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select EF.Property<ICollection<Level3>>(
+                           EF.Property<Level2>(
+                               l1,
+                               "OneToOne_Optional_FK"),
+                           "OneToMany_Optional"),
+                l1s => from l1 in l1s
+                       select Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional),
+                elementSorter: e => e != null ? e.Count : 0,
+                elementAsserter: (e, a) =>
+                    {
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_nested_anonymous()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1.Id, l1.OneToOne_Optional_FK.OneToMany_Optional },
+                l1s => from l1 in l1s
+                       select new
+                       {
+                           l1.Id,
+                           OneToMany_Optional = Maybe(
+                               l1.OneToOne_Optional_FK,
+                               () => l1.OneToOne_Optional_FK.OneToMany_Optional)
+                       },
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.Id, a.Id);
+
+                        var actualCollection = new List<Level3>();
+                        foreach (var actualElement in a.OneToMany_Optional)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level3>)e.OneToMany_Optional)?.Count() ?? 0, actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_count()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1.Id, l1.OneToOne_Optional_FK.OneToMany_Optional.Count },
+                l1s => from l1 in l1s
+                       select new
+                       {
+                           l1.Id,
+                           Count = MaybeScalar(
+                                       l1.OneToOne_Optional_FK,
+                                       () => MaybeScalar<int>(
+                                           l1.OneToOne_Optional_FK.OneToMany_Optional,
+                                           () => l1.OneToOne_Optional_FK.OneToMany_Optional.Count)) ?? 0
+                       },
+                elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_composed()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       where l1.Id < 3
+                       select new { l1.Id, collection = l1.OneToMany_Optional.Where(l2 => l2.Name != "Foo") },
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.Id, a.Id);
+
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a.collection)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e.collection).Count(), actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_and_root_entity()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1, l1.OneToMany_Optional },
+                elementSorter: e => e.l1.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.l1.Id, a.l1.Id);
+
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a.OneToMany_Optional)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional).Count(), actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_and_include()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s.Include(l => l.OneToMany_Optional)
+                       select new { l1, l1.OneToMany_Optional },
+                elementSorter: e => e.l1.Id,
+                elementAsserter: (e, a) =>
+                    {
+                        Assert.Equal(e.l1.Id, a.l1.Id);
+
+                        var actualCollection = new List<Level2>();
+                        foreach (var actualElement in a.OneToMany_Optional)
+                        {
+                            actualCollection.Add(actualElement);
+                        }
+
+                        Assert.Equal(((IEnumerable<Level2>)e.OneToMany_Optional).Count(), actualCollection.Count);
+                    });
+        }
+
+        [ConditionalFact]
+        public virtual void Project_navigation_and_collection()
+        {
+            AssertQuery<Level1>(
+                l1s => from l1 in l1s
+                       select new { l1.OneToOne_Optional_FK, l1.OneToOne_Optional_FK.OneToMany_Optional },
+                l1s => from l1 in l1s
+                       select new { l1.OneToOne_Optional_FK, OneToMany_Optional = Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.OneToMany_Optional) },
+                elementSorter: e => e.OneToOne_Optional_FK?.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.OneToOne_Optional_FK?.Id, a.OneToOne_Optional_FK?.Id);
+
+                    var actualCollection = new List<Level3>();
+                    foreach (var actualElement in a.OneToMany_Optional)
+                    {
+                        actualCollection.Add(actualElement);
+                    }
+
+                    Assert.Equal(((IEnumerable<Level3>)e.OneToMany_Optional)?.Count() ?? 0, actualCollection.Count);
+                });
+        }
+
+        [ConditionalFact(Skip = "issue #8722")]
+        public virtual void Include_inside_subquery()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = ctx.LevelOne
+                    .Where(l1 => l1.Id < 3)
+                    .Select(l1 => new { subquery = ctx.LevelTwo.Include(l => l.OneToMany_Optional).Where(l => l.Id > 0) });
+
+                var result = query.ToList();
+            }
+        }
+
         private static TResult Maybe<TResult>(object caller, Func<TResult> expression) where TResult : class
         {
             if (caller == null)

--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -3713,6 +3713,64 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_with_inheritance1()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Factions.OfType<LocustHorde>()
+                    .Select(h => new
+                    {
+                        h.Id,
+                        Leaders = EF.Property<ICollection<LocustLeader>>(h.Commander.CommandingFaction, "Leaders")
+                    });
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+                Assert.Equal(1, result.Count(r => r.Id == 1 && r.Leaders.Count == 4));
+                Assert.Equal(1, result.Count(r => r.Id == 2 && r.Leaders.Count == 1));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_with_inheritance2()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Factions.OfType<LocustHorde>()
+                    .Select(h => new
+                    {
+                        h.Id,
+                        Gears = EF.Property<ICollection<Gear>>((Officer)h.Commander.DefeatedBy, "Reports")
+                    });
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+                Assert.Equal(1, result.Count(r => r.Id == 1 && r.Gears.Count == 3));
+                Assert.Equal(1, result.Count(r => r.Id == 2 && r.Gears.Count == 0));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Project_collection_navigation_with_inheritance3()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Factions
+                    .Where(f => f is LocustHorde)
+                    .Select(f => new
+                    {
+                        f.Id,
+                        Gears = EF.Property<ICollection<Gear>>((Officer)((LocustHorde)f).Commander.DefeatedBy, "Reports")
+                    });
+
+                var result = query.ToList();
+                Assert.Equal(2, result.Count);
+                Assert.Equal(1, result.Count(r => r.Id == 1 && r.Gears.Count == 3));
+                Assert.Equal(1, result.Count(r => r.Id == 2 && r.Gears.Count == 0));
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/QueryNavigationsTestBase.cs
@@ -429,7 +429,8 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
                         }
-                    });
+                    },
+                entryCount: 34);
         }
 
         [ConditionalFact]
@@ -448,7 +449,8 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
                         }
-                    });
+                    },
+                entryCount: 7);
         }
 
         [ConditionalFact]

--- a/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/EFCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual object Create(IEnumerable<object> values)
+        public virtual object Create()
         {
             if (_createCollection == null)
             {
@@ -92,7 +92,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     _propertyName, typeof(TEntity).ShortDisplayName(), typeof(TCollection).ShortDisplayName()));
             }
 
-            var collection = (ICollection<TElement>)_createCollection();
+            return _createCollection();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual object Create(IEnumerable<object> values)
+        {
+            var collection = (ICollection<TElement>)Create();
             foreach (TElement value in values)
             {
                 collection.Add(value);

--- a/src/EFCore/Metadata/Internal/IClrCollectionAccessor.cs
+++ b/src/EFCore/Metadata/Internal/IClrCollectionAccessor.cs
@@ -41,6 +41,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        object Create();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         object Create([NotNull] IEnumerable<object> values);
 
         /// <summary>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class CollectionNavigationIncludeExpressionRewriter : ExpressionVisitorBase
+    {
+        private readonly EntityQueryModelVisitor _queryModelVisitor;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public CollectionNavigationIncludeExpressionRewriter(
+            [NotNull] EntityQueryModelVisitor queryModelVisitor)
+        {
+            _queryModelVisitor = queryModelVisitor;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual List<IQueryAnnotation> CollectionNavigationIncludeResultOperators { get; }
+            = new List<IQueryAnnotation>();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMember(MemberExpression node)
+            => _queryModelVisitor.BindNavigationPathPropertyExpression(
+                node,
+                (ps, qs) => RewritePropertyAccess(node, ps, qs)) ?? base.VisitMember(node);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+            => _queryModelVisitor.BindNavigationPathPropertyExpression(
+                node,
+                (ps, qs) => RewritePropertyAccess(node, ps, qs)) ?? base.VisitMethodCall(node);
+
+        private Expression RewritePropertyAccess(
+            Expression expression,
+            IReadOnlyList<IPropertyBase> properties,
+            IQuerySource querySource)
+        {
+            if (querySource != null
+                && properties.Count > 0
+                && properties.All(p => p is INavigation)
+                && properties[properties.Count - 1] is INavigation lastNavigation
+                && lastNavigation.IsCollection())
+            {
+                // include doesn't handle navigations on derived class, so we can't leverage include pipeline for those cases
+                var expectedCallerType = querySource.ItemType;
+                foreach (var property in properties)
+                {
+                    if (expectedCallerType != property.DeclaringType.ClrType)
+                    {
+                        return expression;
+                    }
+
+                    expectedCallerType = property.ClrType;
+                }
+
+                var qsre = new QuerySourceReferenceExpression(querySource);
+
+                CollectionNavigationIncludeResultOperators.Add(
+                    new IncludeResultOperator(properties.Cast<INavigation>().ToArray(), qsre));
+
+                var parameter = Expression.Parameter(querySource.ItemType, querySource.ItemName);
+                var accessorBody = BuildCollectionAccessorExpression(parameter, properties);
+                var emptyCollection = lastNavigation.GetCollectionAccessor().Create();
+
+                return Expression.Call(
+                    ProjectCollectionNavigationMethodInfo
+                        .MakeGenericMethod(querySource.ItemType, expression.Type),
+                    qsre,
+                    Expression.Lambda(
+                        Expression.Coalesce(
+                            accessorBody,
+                            Expression.Constant(emptyCollection, accessorBody.Type)),
+                        parameter));
+            }
+
+            return expression;
+        }
+
+        private Expression BuildCollectionAccessorExpression(
+            ParameterExpression parameter, 
+            IEnumerable<IPropertyBase> navigations)
+        {
+            Expression result = parameter;
+            Expression memberExpression = parameter;
+            foreach (var navigation in navigations)
+            {
+                memberExpression = memberExpression.MakeMemberAccess(navigation.PropertyInfo);
+                result = new NullConditionalExpression(result, memberExpression);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+            => subQueryExpression;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static readonly MethodInfo ProjectCollectionNavigationMethodInfo
+            = typeof(CollectionNavigationIncludeExpressionRewriter).GetTypeInfo()
+                .GetDeclaredMethod(nameof(_ProjectCollectionNavigation));
+
+        // ReSharper disable once InconsistentNaming
+        private static TResult _ProjectCollectionNavigation<TEntity, TResult>(TEntity entity, Func<TEntity, TResult> accessor)
+            => accessor(entity);
+    }
+}

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -568,6 +568,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Check.NotNull(node, nameof(node));
 
+            if (node.Method.MethodIsClosedFormOf(
+                CollectionNavigationIncludeExpressionRewriter.ProjectCollectionNavigationMethodInfo))
+            {
+                var newArgument = Visit(node.Arguments[0]);
+
+                return newArgument != node.Arguments[0]
+                    ? node.Update(node.Object, new[] { newArgument, node.Arguments[1] })
+                    : node;
+            }
+
             if (node.Method.IsEFPropertyMethod())
             {
                 var result = _queryModelVisitor.BindNavigationPathPropertyExpression(

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -186,6 +186,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 _queryAnnotations = value;
             }
+        }
+
+        /// <summary>
+        ///     Adds query annotations to the exisiting list.
+        /// </summary>
+        /// <param name="annotations">The query annotations.</param>
+        public virtual void AddAnnotations([NotNull] IEnumerable<IQueryAnnotation> annotations)
+        {
+            Check.NotNull(annotations, nameof(annotations));
+
+            _queryAnnotations = new ReadOnlyCollection<IQueryAnnotation>(_queryAnnotations.ToList().Concat(annotations).ToList());
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -2958,6 +2958,184 @@ WHERE [l1].[Id] < 3");
                 @"");
         }
 
+        public override void Project_collection_navigation()
+        {
+            base.Project_collection_navigation();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l1.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [Level1] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_nested()
+        {
+            base.Project_collection_navigation_nested();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_using_ef_property()
+        {
+            base.Project_collection_navigation_using_ef_property();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_nested_anonymous()
+        {
+            base.Project_collection_navigation_nested_anonymous();
+
+            AssertSql(
+                @"SELECT [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_navigation_count()
+        {
+            base.Project_collection_navigation_count();
+
+            AssertSql(
+                @"SELECT [l1].[Id], (
+    SELECT COUNT(*)
+    FROM [Level3] AS [l]
+    WHERE [l1.OneToOne_Optional_FK].[Id] = [l].[OneToMany_Optional_InverseId]
+) AS [Count]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]");
+        }
+
+        public override void Project_collection_navigation_composed()
+        {
+            base.Project_collection_navigation_composed();
+
+            AssertSql(
+                @"SELECT [l1].[Id]
+FROM [Level1] AS [l1]
+WHERE [l1].[Id] < 3",
+                //
+                @"@_outer_Id='1'
+
+SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+WHERE (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL) AND (@_outer_Id = [l2].[OneToMany_Optional_InverseId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l2]
+WHERE (([l2].[Name] <> N'Foo') OR [l2].[Name] IS NULL) AND (@_outer_Id = [l2].[OneToMany_Optional_InverseId])");
+        }
+
+        public override void Project_collection_and_root_entity()
+        {
+            base.Project_collection_and_root_entity();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l1.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [Level1] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_collection_and_include()
+        {
+            base.Project_collection_and_include();
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+ORDER BY [l].[Id]",
+                //
+                @"SELECT [l.OneToMany_Optional].[Id], [l.OneToMany_Optional].[Date], [l.OneToMany_Optional].[Level1_Optional_Id], [l.OneToMany_Optional].[Level1_Required_Id], [l.OneToMany_Optional].[Name], [l.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l0].[Id]
+    FROM [Level1] AS [l0]
+) AS [t] ON [l.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Project_navigation_and_collection()
+        {
+            base.Project_navigation_and_collection();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Include_inside_subquery()
+        {
+            base.Include_inside_subquery();
+
+            AssertSql(
+                @"");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -3499,6 +3499,114 @@ FROM [Faction] AS [f]
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')");
         }
 
+        public override void Project_collection_navigation_with_inheritance1()
+        {
+            base.Project_collection_navigation_with_inheritance1();
+
+            AssertSql(
+                @"SELECT [h].[Id] AS [Id0], [h].[CapitalName], [h].[Discriminator], [h].[Name], [h].[CommanderName], [h].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Id], [t0].[CapitalName], [t0].[Discriminator], [t0].[Name], [t0].[CommanderName], [t0].[Eradicated]
+FROM [Faction] AS [h]
+LEFT JOIN (
+    SELECT [h.Commander].*
+    FROM [LocustLeader] AS [h.Commander]
+    WHERE [h.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [h].[CommanderName] = [t].[Name]
+LEFT JOIN (
+    SELECT [h.Commander.CommandingFaction].*
+    FROM [Faction] AS [h.Commander.CommandingFaction]
+    WHERE [h.Commander.CommandingFaction].[Discriminator] = N'LocustHorde'
+) AS [t0] ON [t].[Name] = [t0].[CommanderName]
+WHERE [h].[Discriminator] = N'LocustHorde'
+ORDER BY [t0].[Id]",
+                //
+                @"SELECT [h.Commander.CommandingFaction.Leaders].[Name], [h.Commander.CommandingFaction.Leaders].[Discriminator], [h.Commander.CommandingFaction.Leaders].[LocustHordeId], [h.Commander.CommandingFaction.Leaders].[ThreatLevel], [h.Commander.CommandingFaction.Leaders].[DefeatedByNickname], [h.Commander.CommandingFaction.Leaders].[DefeatedBySquadId]
+FROM [LocustLeader] AS [h.Commander.CommandingFaction.Leaders]
+INNER JOIN (
+    SELECT DISTINCT [t2].[Id]
+    FROM [Faction] AS [h0]
+    LEFT JOIN (
+        SELECT [h.Commander0].*
+        FROM [LocustLeader] AS [h.Commander0]
+        WHERE [h.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t1] ON [h0].[CommanderName] = [t1].[Name]
+    LEFT JOIN (
+        SELECT [h.Commander.CommandingFaction0].*
+        FROM [Faction] AS [h.Commander.CommandingFaction0]
+        WHERE [h.Commander.CommandingFaction0].[Discriminator] = N'LocustHorde'
+    ) AS [t2] ON [t1].[Name] = [t2].[CommanderName]
+    WHERE [h0].[Discriminator] = N'LocustHorde'
+) AS [t3] ON [h.Commander.CommandingFaction.Leaders].[LocustHordeId] = [t3].[Id]
+WHERE [h.Commander.CommandingFaction.Leaders].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t3].[Id]");
+        }
+        public override void Project_collection_navigation_with_inheritance2()
+        {
+            base.Project_collection_navigation_with_inheritance2();
+
+            AssertSql(
+                @"SELECT [h].[Id], [t0].[Nickname], [t0].[SquadId]
+FROM [Faction] AS [h]
+LEFT JOIN (
+    SELECT [h.Commander].*
+    FROM [LocustLeader] AS [h.Commander]
+    WHERE [h.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [h].[CommanderName] = [t].[Name]
+LEFT JOIN (
+    SELECT [h.Commander.DefeatedBy].*
+    FROM [Gear] AS [h.Commander.DefeatedBy]
+    WHERE [h.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
+WHERE [h].[Discriminator] = N'LocustHorde'",
+                //
+                @"@_outer_Nickname='Marcus' (Size = 4000)
+@_outer_SquadId='1'
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
+                //
+                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
+@_outer_SquadId='' (Nullable = false) (DbType = Int32)
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+        }
+
+        public override void Project_collection_navigation_with_inheritance3()
+        {
+            base.Project_collection_navigation_with_inheritance3();
+
+            AssertSql(
+                @"SELECT [f].[Id], [t0].[Nickname], [t0].[SquadId]
+FROM [Faction] AS [f]
+LEFT JOIN (
+    SELECT [f.Commander].*
+    FROM [LocustLeader] AS [f.Commander]
+    WHERE [f.Commander].[Discriminator] = N'LocustCommander'
+) AS [t] ON [f].[CommanderName] = [t].[Name]
+LEFT JOIN (
+    SELECT [f.Commander.DefeatedBy].*
+    FROM [Gear] AS [f.Commander.DefeatedBy]
+    WHERE [f.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')",
+                //
+                @"@_outer_Nickname='Marcus' (Size = 4000)
+@_outer_SquadId='1'
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
+                //
+                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
+@_outer_SquadId='' (Nullable = false) (DbType = Int32)
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -477,34 +477,19 @@ WHERE [e].[ReportsTo] IS NULL");
             base.Select_collection_navigation_simple();
 
             AssertSql(
-                @"SELECT [c].[CustomerID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
 ORDER BY [c].[CustomerID]",
                 //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ANATR' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ANTON' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
-                //
-                @"@_outer_CustomerID='AROUT' (Size = 450)
-
-SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]");
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override void Select_collection_navigation_multi_part()
@@ -512,46 +497,21 @@ WHERE @_outer_CustomerID = [o].[CustomerID]");
             base.Select_collection_navigation_multi_part();
 
             AssertSql(
-                @"SELECT [o].[OrderID], [o.Customer].[CustomerID]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o].[CustomerID] = N'ALFKI'",
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o.Customer].[CustomerID]",
                 //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]",
-                //
-                @"@_outer_CustomerID='ALFKI' (Size = 450)
-
-SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
-FROM [Orders] AS [o0]
-WHERE @_outer_CustomerID = [o0].[CustomerID]");
+                @"SELECT [o.Customer.Orders].[OrderID], [o.Customer.Orders].[CustomerID], [o.Customer.Orders].[EmployeeID], [o.Customer.Orders].[OrderDate]
+FROM [Orders] AS [o.Customer.Orders]
+INNER JOIN (
+    SELECT DISTINCT [o.Customer0].[CustomerID]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Customers] AS [o.Customer0] ON [o0].[CustomerID] = [o.Customer0].[CustomerID]
+    WHERE [o0].[CustomerID] = N'ALFKI'
+) AS [t] ON [o.Customer.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override void Collection_select_nav_prop_any()


### PR DESCRIPTION
Currently when projecting collection navigation we produce N+1 queries. This change leverages include pipeline which produces 2 queries instead and joins the result on the client.

We only do this for collection navigation that are not composed on - otherwise, the query that happens after collection navigation would be performed on the client, so it's not clear that would be preferable to N+1.
Also as a side effect, we always materialize root entity (or all intermediate entities in case of multi-level navigation). This is a side effect of reusing Include pipeline, which always expects (and depends on) root element being materialized.

We leverage the include pipeline by performing a simple QM rewrite:

```
from [e] in entities
select new { [e].Id, [e].Reference.Collection }
```

will be translated to:

```
from [e] in entities
select new { [e].Id, _ProjectCollectionNavigation([e], prm => prm?.Reference?.Collection ?? new ICollection<Entity>()) }
```
additionally, we generate include result operator for [e].Reference.Collection.

When include pipeline processes the updated QM, it will apply the include on first argument to _ProjectCollectionNavigation.
Implementation of _ProjectCollectionNavigation simply invokes the Func specified as it's second argument (which accesses requested collection navigation), given the root entity (which now has include applied)