### PR TITLE
Add a hybrid OnDelete behavior that does SetNull in the StateManager and Restrict in the database

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -563,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     }
                 }
 
-                if (foreignKey.DeleteBehavior != DeleteBehavior.Restrict)
+                if (foreignKey.DeleteBehavior != DeleteBehavior.ClientSetNull)
                 {
                     stringBuilder
                         .AppendLine()

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -621,7 +621,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var defaultOnDeleteAction = foreignKey.IsRequired
                 ? DeleteBehavior.Cascade
-                : DeleteBehavior.Restrict;
+                : DeleteBehavior.ClientSetNull;
 
             if (foreignKey.DeleteBehavior != defaultOnDeleteAction)
             {

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -704,7 +704,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     break;
 
                 default:
-                    foreignKey.DeleteBehavior = DeleteBehavior.Restrict;
+                    foreignKey.DeleteBehavior = DeleteBehavior.ClientSetNull;
                     break;
             }
         }

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -324,7 +325,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             }
                         }
 
-                        if (newPrincipalEntry != null)
+                        if (newPrincipalEntry != null
+                            && !entry.IsConceptualNull(property))
                         {
                             // Add this entity to the collection of the new principal, or set the navigation for a 1:1
                             SetReferenceOrAddToCollection(newPrincipalEntry, principalToDependent, collectionAccessor, entry.Entity);
@@ -358,7 +360,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 }
                             }
 
-                            SetNavigation(entry, dependentToPrincipal, newPrincipalEntry.Entity);
+                            if (!entry.IsConceptualNull(property))
+                            {
+                                SetNavigation(entry, dependentToPrincipal, newPrincipalEntry.Entity);
+                            }
                         }
                         else if (oldPrincipalEntry != null
                                  && ReferenceEquals(entry[dependentToPrincipal], oldPrincipalEntry.Entity))

--- a/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -44,6 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual DeleteBehavior TargetDeleteBehavior([NotNull] ForeignKey foreignKey)
-            => foreignKey.IsRequired ? DeleteBehavior.Cascade : DeleteBehavior.Restrict;
+            => foreignKey.IsRequired ? DeleteBehavior.Cascade : DeleteBehavior.ClientSetNull;
     }
 }

--- a/src/EFCore/Metadata/DeleteBehavior.cs
+++ b/src/EFCore/Metadata/DeleteBehavior.cs
@@ -1,32 +1,98 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Metadata
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     Indicates how a delete operation is applied to dependent entities in a relationship when the principal is deleted
-    ///     or the relationship is severed.
+    ///     <para>
+    ///         Indicates how a delete operation is applied to dependent entities in a relationship when the
+    ///         principal is deleted or the relationship is severed.
+    ///     </para>
+    ///     <para>
+    ///         Behaviors in the database are dependent on the database schema being created
+    ///         appropriately. Using Entity Framework Migrations or <see cref="DatabaseFacade.EnsureCreated" />
+    ///         will create the appropriate schema.
+    ///     </para>
+    ///     <para>
+    ///         Note that the in-memory behavior for entities that are currently tracked by
+    ///         the <see cref="DbContext" /> can be different from the behavior that happens in the database.
+    ///         See the <see cref="ClientSetNull" /> behavior for more details.
+    ///     </para>
     /// </summary>
     public enum DeleteBehavior
     {
         /// <summary>
-        ///     The delete operation is not applied to dependent entities. The dependent entities remain unchanged.
+        ///     <para>
+        ///         For entities being tracked by the <see cref="DbContext" />, the values of foreign key properties in
+        ///         dependent entities are set to null. This helps keep the graph of entities in a consistent
+        ///         state while they are being tracked, such that a fully consistent graph can then be written to
+        ///         the database. If a property cannot be set to null because it is not a nullable type,
+        ///         then an exception will be thrown when <see cref="DbContext.SaveChanges()" /> is called.
+        ///         This is the same as the <see cref="SetNull" /> behavior.
+        ///     </para>
+        ///     <para>
+        ///         If the database has been created from the model using Entity Framework Migrations or the
+        ///         <see cref="DatabaseFacade.EnsureCreated" /> method, then the behavior in the database
+        ///         is to generate an error if a foreign key constraint is violated.
+        ///         This is the same as the <see cref="Restrict" /> behavior.
+        ///     </para>
+        ///     <para>
+        ///         This is the default for optional relationships. That is, for relationships that have
+        ///         nullable foreign keys.
+        ///     </para>
+        /// </summary>
+        ClientSetNull,
+
+        /// <summary>
+        ///     <para>
+        ///         For entities being tracked by the <see cref="DbContext" />, the values of foreign key properties in
+        ///         dependent entities are not changed. This can result in an inconsistent graph of entities
+        ///         where the values of foreign key properties do not match the relationships in the
+        ///         graph. If a property remains in this state when <see cref="DbContext.SaveChanges()" />
+        ///         is called, then an exception will be thrown.
+        ///     </para>
+        ///     <para>
+        ///         If the database has been created from the model using Entity Framework Migrations or the
+        ///         <see cref="DatabaseFacade.EnsureCreated" /> method, then the behavior in the database
+        ///         is to generate an error if a foreign key constraint is violated.
+        ///     </para>
         /// </summary>
         Restrict,
 
         /// <summary>
-        ///     The foreign key properties in dependent entities are set to null. This cascading behavior is only applied
-        ///     to entities that are being tracked by the context. A corresponding cascade behavior should be setup in the
-        ///     database to ensure data that is not being tracked by the context has the same action applied. If you use
-        ///     EF to create the database, this cascade behavior will be setup for you.
+        ///     <para>
+        ///         For entities being tracked by the <see cref="DbContext" />, the values of foreign key properties in
+        ///         dependent entities are set to null. This helps keep the graph of entities in a consistent
+        ///         state while they are being tracked, such that a fully consistent graph can then be written to
+        ///         the database. If a property cannot be set to null because it is not a nullable type,
+        ///         then an exception will be thrown when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         If the database has been created from the model using Entity Framework Migrations or the
+        ///         <see cref="DatabaseFacade.EnsureCreated" /> method, then the behavior in the database is
+        ///         the same as is described above for tracked entities. Keep in mind that some databases cannot easily
+        ///         support this behavior, especially if there are cycles in relationships.
+        ///     </para>
         /// </summary>
         SetNull,
 
         /// <summary>
-        ///     Dependent entities are also deleted. This cascading behavior is only applied
-        ///     to entities that are being tracked by the context. A corresponding cascade behavior should be setup in the
-        ///     database to ensure data that is not being tracked by the context has the same action applied. If you use
-        ///     EF to create the database, this cascade behavior will be setup for you.
+        ///     <para>
+        ///         For entities being tracked by the <see cref="DbContext" />, the dependent entities
+        ///         will also be deleted when <see cref="DbContext.SaveChanges()" /> is called.
+        ///     </para>
+        ///     <para>
+        ///         If the database has been created from the model using Entity Framework Migrations or the
+        ///         <see cref="DatabaseFacade.EnsureCreated" /> method, then the behavior in the database is
+        ///         the same as is described above for tracked entities. Keep in mind that some databases cannot easily
+        ///         support this behavior, especially if there are cycles in relationships.
+        ///     </para>
+        ///     <para>
+        ///         This is the default for required relationships. That is, for relationships that have
+        ///         non-nullable foreign keys.
+        ///     </para>
         /// </summary>
         Cascade
     }

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -468,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             UpdateDeleteBehaviorConfigurationSource(configurationSource);
         }
 
-        private static DeleteBehavior DefaultDeleteBehavior => DeleteBehavior.Restrict;
+        private static DeleteBehavior DefaultDeleteBehavior => DeleteBehavior.ClientSetNull;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,5 +1,59 @@
   [
     {
+      "TypeId": "public enum Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IForeignKey : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior get_DeleteBehavior()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior get_DeleteBehavior()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "System.Void set_DeleteBehavior(Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceCollectionBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceCollectionBuilder OnDelete(Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior deleteBehavior)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceCollectionBuilder<T0, T1> : Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceCollectionBuilder where T0 : class where T1 : class",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceCollectionBuilder<T0, T1> OnDelete(Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior deleteBehavior)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.IMutableModel>, Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.Metadata.Internal.InternalRelationshipBuilder>",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder OnDelete(Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior deleteBehavior)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder<T0, T1> : Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder where T0 : class where T1 : class",
+      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Metadata.Builders.ReferenceReferenceBuilder<T0, T1> OnDelete(Microsoft.EntityFrameworkCore.Metadata.DeleteBehavior deleteBehavior)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IForeignKey : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.DeleteBehavior get_DeleteBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.DeleteBehavior get_DeleteBehavior()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableForeignKey : Microsoft.EntityFrameworkCore.Metadata.IForeignKey, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "System.Void set_DeleteBehavior(Microsoft.EntityFrameworkCore.DeleteBehavior value)",
+      "Kind": "Addition"
+    },
+    {
       "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Storage.DatabaseProviderServices : Microsoft.EntityFrameworkCore.Storage.IDatabaseProviderServices",
       "Kind": "Removal"
     },

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -463,7 +463,7 @@ namespace Microsoft.EntityFrameworkCore
 
             var fk = Assert.Single(children.GetForeignKeys());
             Assert.True(fk.IsUnique);
-            Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.ClientSetNull, fk.DeleteBehavior);
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
@@ -294,7 +294,7 @@ namespace E2ETest.Namespace
                 entity.HasOne(d => d.RelationA)
                     .WithMany(p => p.MultipleFksDependentRelationA)
                     .HasForeignKey(d => d.RelationAid)
-                    .OnDelete(DeleteBehavior.Restrict)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_RelationA");
 
                 entity.HasOne(d => d.RelationB)
@@ -371,7 +371,7 @@ namespace E2ETest.Namespace
                 entity.HasOne(d => d.OneToOneDependentNavigation)
                     .WithOne(p => p.OneToOneDependent)
                     .HasForeignKey<OneToOneDependent>(d => new { d.OneToOneDependentId1, d.OneToOneDependentId2 })
-                    .OnDelete(DeleteBehavior.Restrict)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_OneToOneDependent");
             });
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.cs
@@ -65,7 +65,7 @@ namespace E2ETest.Namespace.SubDir
                 entity.HasOne(d => d.RelationA)
                     .WithMany(p => p.MultipleFksDependentRelationA)
                     .HasForeignKey(d => d.RelationAid)
-                    .OnDelete(DeleteBehavior.Restrict)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_RelationA");
 
                 entity.HasOne(d => d.RelationB)
@@ -106,7 +106,7 @@ namespace E2ETest.Namespace.SubDir
                 entity.HasOne(d => d.OneToOneDependentNavigation)
                     .WithOne(p => p.OneToOneDependent)
                     .HasForeignKey<OneToOneDependent>(d => new { d.OneToOneDependentId1, d.OneToOneDependentId2 })
-                    .OnDelete(DeleteBehavior.Restrict)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_OneToOneDependent");
             });
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithIdentitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithIdentitySqlServerTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+
 namespace Microsoft.EntityFrameworkCore
 {
     public class GraphUpdatesWithIdentitySqlServerTest : GraphUpdatesSqlServerTestBase<GraphUpdatesWithIdentitySqlServerTest.GraphUpdatesWithIdentitySqlServerFixture>

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithRestrictSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithRestrictSqlServerTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class GraphUpdatesWithRestrictSqlServerTest : GraphUpdatesSqlServerTestBase<GraphUpdatesWithRestrictSqlServerTest.GraphUpdatesWithRestrictSqlServerFixture>
+    {
+        public GraphUpdatesWithRestrictSqlServerTest(GraphUpdatesWithRestrictSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class GraphUpdatesWithRestrictSqlServerFixture : GraphUpdatesSqlServerFixtureBase
+        {
+            protected override string DatabaseName => "GraphRestrictUpdatesTest";
+
+            public override bool ForceRestrict => true;
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                foreach (var foreignKey in modelBuilder.Model
+                    .GetEntityTypes()
+                    .SelectMany(e => e.GetDeclaredForeignKeys()))
+                {
+                    foreignKey.DeleteBehavior = DeleteBehavior.Restrict;
+                }
+            }
+        }
+    }
+}

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.cs
@@ -28,7 +28,7 @@ namespace E2E.Sqlite
                     .WithMany(p => p.Comment)
                     .HasPrincipalKey(p => p.AltId)
                     .HasForeignKey(d => d.UserAltId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .OnDelete(DeleteBehavior.ClientSetNull);
             });
 
             modelBuilder.Entity<User>(entity =>

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.cs
@@ -35,7 +35,7 @@ namespace E2E.Sqlite
                 entity.HasOne(d => d.Principal)
                     .WithOne(p => p.Dependent)
                     .HasForeignKey<Dependent>(d => d.PrincipalId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .OnDelete(DeleteBehavior.ClientSetNull);
             });
 
             modelBuilder.Entity<Principal>(entity =>

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/FkToAltKey/FkToAltKeyContext.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/FkToAltKey/FkToAltKeyContext.cs
@@ -28,7 +28,7 @@ namespace E2E.Sqlite
                     .WithMany(p => p.Comment)
                     .HasPrincipalKey(p => p.AltId)
                     .HasForeignKey(d => d.UserAltId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .OnDelete(DeleteBehavior.ClientSetNull);
             });
 
             modelBuilder.Entity<User>(entity =>

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/OneToOne/OneToOneAttributesContext.cs
@@ -31,7 +31,7 @@ namespace E2E.Sqlite
                 entity.HasOne(d => d.Principal)
                     .WithOne(p => p.Dependent)
                     .HasForeignKey<Dependent>(d => d.PrincipalId)
-                    .OnDelete(DeleteBehavior.Restrict);
+                    .OnDelete(DeleteBehavior.ClientSetNull);
             });
 
             modelBuilder.Entity<Principal>(entity =>

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/CascadeDeleteConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/CascadeDeleteConventionTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 .HasMany(e => e.Posts)
                 .WithOne(e => e.Blog).Metadata;
 
-            Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.ClientSetNull, fk.DeleteBehavior);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 .Property(e => e.BlogId)
                 .IsRequired(false);
 
-            Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.ClientSetNull, fk.DeleteBehavior);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -564,7 +564,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var foreignKey = entityType.AddForeignKey(new[] { dependentProp }, principalKey, entityType);
 
-            Assert.Equal(DeleteBehavior.Restrict, foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.ClientSetNull, foreignKey.DeleteBehavior);
 
             foreignKey.DeleteBehavior = DeleteBehavior.Cascade;
 
@@ -573,6 +573,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreignKey.DeleteBehavior = DeleteBehavior.Restrict;
 
             Assert.Equal(DeleteBehavior.Restrict, foreignKey.DeleteBehavior);
+
+            foreignKey.DeleteBehavior = DeleteBehavior.SetNull;
+
+            Assert.Equal(DeleteBehavior.SetNull, foreignKey.DeleteBehavior);
+
+            foreignKey.DeleteBehavior = DeleteBehavior.ClientSetNull;
+
+            Assert.Equal(DeleteBehavior.ClientSetNull, foreignKey.DeleteBehavior);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Null(relationshipBuilder.IsUnique(true, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.IsRequired(true, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.IsOwnership(true, ConfigurationSource.DataAnnotation));
-            Assert.Null(relationshipBuilder.DeleteBehavior(DeleteBehavior.Restrict, ConfigurationSource.DataAnnotation));
+            Assert.Null(relationshipBuilder.DeleteBehavior(DeleteBehavior.ClientSetNull, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.DependentEntityType(
                 relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.DependentToPrincipal((string)null, ConfigurationSource.DataAnnotation));

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -3307,7 +3307,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .HasForeignKey<Nob>(e => e.HobId1);
 
-                Assert.Equal(DeleteBehavior.Restrict, dependentType.GetNavigations().Single().ForeignKey.DeleteBehavior);
+                Assert.Equal(DeleteBehavior.ClientSetNull, dependentType.GetNavigations().Single().ForeignKey.DeleteBehavior);
 
                 modelBuilder
                     .Entity<Nob>().HasKey(e => e.HobId1);


### PR DESCRIPTION
Issues #8654, #8632, #8633

The new behavior is called 'ClientSetNull'.
'Restrict' now throws on SaveChanges if EF would have set null. This is the same behavior that has always been there for required relationships, so this is only a break for optional relationships explicitly configured with Restrict, which should be relatively rare since this was the default anyway. The default is now 'ClientSetNull', which matches the old behavior of 'Restrict', so apps that were not setting anything explicitly will not get a breaking change.
