### PR TITLE
Stop generating DiagnosticSource events for purely design-time messages

### DIFF
--- a/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
+++ b/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
-using Microsoft.EntityFrameworkCore.Migrations.Design;
-using Microsoft.EntityFrameworkCore.Migrations.Internal;
-using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -26,233 +20,108 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingSchemaWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string schemaName)
-        {
-            var definition = DesignStrings.LogMissingSchema;
-
-            definition.Log(diagnostics, schemaName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        SchemaName = schemaName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string schemaName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogMissingSchema.Log(diagnostics, schemaName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void SequenceTypeNotSupportedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string sequenceName,
-            [CanBeNull] string dataTypeName)
-        {
-            var definition = DesignStrings.LogBadSequenceType;
-
-            definition.Log(diagnostics, sequenceName, dataTypeName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        SequenceName = sequenceName,
-                        DataTypeName = dataTypeName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string sequenceName,
+                [CanBeNull] string dataTypeName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogBadSequenceType.Log(diagnostics, sequenceName, dataTypeName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void UnableToGenerateEntityTypeWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string tableName)
-        {
-            var definition = DesignStrings.LogUnableToGenerateEntityType;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string tableName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogUnableToGenerateEntityType.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ColumnTypeNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string columnName,
-            [CanBeNull] string dataTypeName)
-        {
-            var definition = DesignStrings.LogCannotFindTypeMappingForColumn;
-
-            definition.Log(diagnostics, columnName, dataTypeName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ColumnName = columnName,
-                        DataTypeName = dataTypeName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string columnName,
+                [CanBeNull] string dataTypeName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogCannotFindTypeMappingForColumn.Log(diagnostics, columnName, dataTypeName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MissingPrimaryKeyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string tableName)
-        {
-            var definition = DesignStrings.LogMissingPrimaryKey;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string tableName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogMissingPrimaryKey.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void PrimaryKeyColumnsNotMappedWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string tableName,
-            [NotNull] IList<string> unmappedColumnNames)
-        {
-            var definition = DesignStrings.LogPrimaryKeyErrorPropertyNotFound;
-
-            definition.Log(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string tableName,
+                [NotNull] IList<string> unmappedColumnNames)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogPrimaryKeyErrorPropertyNotFound.Log(
                 diagnostics,
                 tableName,
                 string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, unmappedColumnNames));
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        UnmappedColumnNames = unmappedColumnNames
-                    });
-            }
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesNotMappedTableWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string foreignKeyName,
-            [NotNull] string principalTableName)
-        {
-            var definition = DesignStrings.LogForeignKeyScaffoldErrorPrincipalTableScaffoldingError;
-
-            definition.Log(diagnostics, foreignKeyName, principalTableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        PrincipalTableName = principalTableName
-                    });
-            }
-        }
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string foreignKeyName,
+                [NotNull] string principalTableName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogForeignKeyScaffoldErrorPrincipalTableScaffoldingError.Log(diagnostics, foreignKeyName, principalTableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyReferencesMissingPrincipalKeyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string foreignKeyName,
-            [CanBeNull] string principalEntityTypeName,
-            [NotNull] IList<string> principalColumnNames)
-        {
-            var definition = DesignStrings.LogForeignKeyScaffoldErrorPrincipalKeyNotFound;
-
-            definition.Log(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string foreignKeyName,
+                [CanBeNull] string principalEntityTypeName,
+                [NotNull] IList<string> principalColumnNames)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogForeignKeyScaffoldErrorPrincipalKeyNotFound.Log(
                 diagnostics,
                 foreignKeyName,
                 string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, principalColumnNames),
                 principalEntityTypeName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        PrincipalEntityTypeName = principalEntityTypeName,
-                        PrincipalColumnNames = principalColumnNames
-                    });
-            }
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void ForeignKeyPrincipalEndContainsNullableColumnsWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string foreignKeyName,
-            [CanBeNull] string indexName,
-            [CanBeNull] IList<string> nullablePropertyNames)
-        {
-            var definition = DesignStrings.LogForeignKeyPrincipalEndContainsNullableColumns;
-
-            definition.Log(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string foreignKeyName,
+                [CanBeNull] string indexName,
+                [CanBeNull] IList<string> nullablePropertyNames)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogForeignKeyPrincipalEndContainsNullableColumns.Log(
                 diagnostics,
                 foreignKeyName,
                 indexName,
                 nullablePropertyNames.Aggregate((a, b) => a + "," + b));
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        IndexName = indexName,
-                        NullablePropertyNames = nullablePropertyNames
-                    });
-            }
-        }
     }
 }

--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -7,7 +7,6 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -1123,21 +1122,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void MissingTableWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogMissingTable;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogMissingTable.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1145,16 +1131,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void SequenceNotNamedWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
-        {
-            var definition = RelationalStrings.LogSequencesRequireName;
-
-            definition.Log(diagnostics);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, null);
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogSequencesRequireName.Log(diagnostics);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1164,25 +1142,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [NotNull] IList<string> unmappedColumnNames)
-        {
-            var definition = RelationalStrings.LogUnableToScaffoldIndexMissingProperty;
-
-            definition.Log(
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogUnableToScaffoldIndexMissingProperty.Log(
                 diagnostics,
                 indexName,
                 string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, unmappedColumnNames));
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        IndexName = indexName,
-                        UnmappedColumnNames = unmappedColumnNames
-                    });
-            }
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1191,21 +1155,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void ForeignKeyReferencesMissingTableWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName)
-        {
-            var definition = RelationalStrings.LogForeignKeyScaffoldErrorPrincipalTableNotFound;
-
-            definition.Log(diagnostics, foreignKeyName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogForeignKeyScaffoldErrorPrincipalTableNotFound.Log(diagnostics, foreignKeyName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1215,25 +1166,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [NotNull] IList<string> unmappedColumnNames)
-        {
-            var definition = RelationalStrings.LogForeignKeyScaffoldErrorPropertyNotFound;
-
-            definition.Log(
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogForeignKeyScaffoldErrorPropertyNotFound.Log(
                 diagnostics,
                 foreignKeyName,
                 string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, unmappedColumnNames));
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        UnmappedColumnNames = unmappedColumnNames
-                    });
-            }
-        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1249,6 +1186,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             long? min,
             long? max)
         {
+            // No DiagnosticsSource events because these are purely design-time messages
             var definition = RelationalStrings.LogFoundSequence;
 
             Debug.Assert(LogLevel.Debug == definition.Level);
@@ -1269,22 +1207,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         min,
                         max));
             }
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        SequenceName = sequenceName,
-                        SequenceTypeName = sequenceTypeName,
-                        Cyclic = cyclic,
-                        Increment = increment,
-                        Start = start,
-                        Min = min,
-                        Max = max
-                    });
-            }
         }
 
         /// <summary>
@@ -1294,21 +1216,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void TableFound(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogFoundTable;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogFoundTable.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1317,21 +1226,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void TableSkipped(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogTableNotInSelectionSet;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogTableNotInSelectionSet.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1341,22 +1237,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName,
             [CanBeNull] string columnName)
-        {
-            var definition = RelationalStrings.LogColumnNotInSelectionSet;
-
-            definition.Log(diagnostics, columnName, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        ColumnName = columnName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogColumnNotInSelectionSet.Log(diagnostics, columnName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1369,25 +1251,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             bool? unique,
             [CanBeNull] string columnName,
             int? ordinal)
-        {
-            var definition = RelationalStrings.LogFoundIndexColumn;
-
-            definition.Log(diagnostics, indexName, tableName, columnName, ordinal);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        IndexName = indexName,
-                        Unique = unique,
-                        ColumnName = columnName,
-                        Ordinal = ordinal
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogFoundIndexColumn.Log(diagnostics, indexName, tableName, columnName, ordinal);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1396,21 +1261,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void ColumnNotNamedWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogColumnNameEmptyOnTable;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogColumnNameEmptyOnTable.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1421,23 +1273,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string tableName,
             [CanBeNull] string indexName,
             [CanBeNull] string columnName)
-        {
-            var definition = RelationalStrings.LogIndexColumnNotInSelectionSet;
-
-            definition.Log(diagnostics, columnName, indexName, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        IndexName = indexName,
-                        ColumnName = columnName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogIndexColumnNotInSelectionSet.Log(diagnostics, columnName, indexName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1446,21 +1283,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void IndexNotNamedWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogIndexNameEmpty;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogIndexNameEmpty.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1470,22 +1294,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogUnableToFindTableForIndex;
-
-            definition.Log(diagnostics, indexName, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        IndexName = indexName,
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogUnableToFindTableForIndex.Log(diagnostics, indexName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1495,22 +1305,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string indexName,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogColumnNameEmptyOnIndex;
-
-            definition.Log(diagnostics, indexName, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        IndexName = indexName,
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogColumnNameEmptyOnIndex.Log(diagnostics, indexName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1519,21 +1315,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void ForeignKeyNotNamedWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogForeignKeyNameEmpty;
-
-            definition.Log(diagnostics, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogForeignKeyNameEmpty.Log(diagnostics, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1544,23 +1327,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string columnName,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogForeignKeyColumnNotInSelectionSet;
-
-            definition.Log(diagnostics, columnName, foreignKeyName, tableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ColumnName = columnName,
-                        ForeignKeyName = foreignKeyName,
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogForeignKeyColumnNotInSelectionSet.Log(diagnostics, columnName, foreignKeyName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1571,23 +1339,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName,
             [CanBeNull] string principalTableName)
-        {
-            var definition = RelationalStrings.LogPrincipalTableNotInSelectionSet;
-
-            definition.Log(diagnostics, foreignKeyName, tableName, principalTableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        TableName = tableName,
-                        PrincipalTableName = principalTableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogPrincipalTableNotInSelectionSet.Log(diagnostics, foreignKeyName, tableName, principalTableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1597,22 +1350,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string foreignKeyName,
             [CanBeNull] string tableName)
-        {
-            var definition = RelationalStrings.LogColumnNameEmptyOnForeignKey;
-
-            definition.Log(diagnostics, tableName, foreignKeyName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        TableName = tableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogColumnNameEmptyOnForeignKey.Log(diagnostics, tableName, foreignKeyName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1623,23 +1362,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string indexName,
             [CanBeNull] string tableName,
             bool? unique)
-        {
-            var definition = RelationalStrings.LogFoundIndex;
-
-            definition.Log(diagnostics, indexName, tableName, unique);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        IndexName = indexName,
-                        TableName = tableName,
-                        Unique = unique
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogFoundIndex.Log(diagnostics, indexName, tableName, unique);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1651,23 +1375,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string tableName,
             [CanBeNull] string principalColumnName,
             [CanBeNull] string principalTableName)
-        {
-            var definition = RelationalStrings.LogPrincipalColumnNotFound;
-
-            definition.Log(diagnostics, foreignKeyName, tableName, principalColumnName, principalTableName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ForeignKeyName = foreignKeyName,
-                        TableName = tableName,
-                        PrincipalColumnName = principalColumnName,
-                        PrincipalTableName = principalTableName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => RelationalStrings.LogPrincipalColumnNotFound.Log(diagnostics, foreignKeyName, tableName, principalColumnName, principalTableName);
     }
 }

--- a/src/EFCore.Specification.Tests/TestHelpers.cs
+++ b/src/EFCore.Specification.Tests/TestHelpers.cs
@@ -162,7 +162,8 @@ namespace Microsoft.EntityFrameworkCore
                             logged = true;
                         }
 
-                        if (enableFor == eventId.Name)
+                        if (enableFor == eventId.Name
+                            && categoryName != DbLoggerCategory.Scaffolding.Name)
                         {
                             Assert.Equal(eventId.Name, testDiagnostics.LoggedEventName);
                             if (testDiagnostics.LoggedMessage != null)
@@ -228,16 +229,14 @@ namespace Microsoft.EntityFrameworkCore
             {
                 LoggedEventName = name;
 
-                var eventData = value as EventData;
-                if (eventData != null)
-                {
-                    LoggedMessage = eventData.ToString();
+                Assert.IsAssignableFrom<EventData>(value);
 
-                    var exceptionProperty = eventData.GetType().GetTypeInfo().GetDeclaredProperty("Exception");
-                    if (exceptionProperty != null)
-                    {
-                        Assert.IsAssignableFrom<IErrorEventData>(eventData);
-                    }
+                LoggedMessage = value.ToString();
+
+                var exceptionProperty = value.GetType().GetTypeInfo().GetDeclaredProperty("Exception");
+                if (exceptionProperty != null)
+                {
+                    Assert.IsAssignableFrom<IErrorEventData>(value);
                 }
             }
 

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -30,8 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ColumnFound = CoreEventId.ProviderBaseId + 100,
             ForeignKeyColumnFound,
             DefaultSchemaFound,
-            TypeAliasFound,
-            DataTypeDoesNotAllowSqlServerIdentityStrategyWarning
+            TypeAliasFound
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
@@ -89,11 +88,5 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId TypeAliasFound = MakeScaffoldingId(Id.TypeAliasFound);
-
-        /// <summary>
-        ///     The data type does not support the SQL Server identity strategy.
-        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
-        /// </summary>
-        public static readonly EventId DataTypeDoesNotAllowSqlServerIdentityStrategyWarning = MakeScaffoldingId(Id.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning);
     }
 }

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -108,6 +108,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] bool? identity,
             [CanBeNull] bool? computed)
         {
+            // No DiagnosticsSource events because these are purely design-time messages
+
             var definition = SqlServerStrings.LogFoundColumn;
 
             Debug.Assert(LogLevel.Debug == definition.Level);
@@ -134,28 +136,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         identity,
                         computed));
             }
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        ColumnName = columnName,
-                        DataTypeName = dataTypeName,
-                        Ordinal = ordinal,
-                        Nullable = nullable,
-                        PrimaryKeyOrdinal = primaryKeyOrdinal,
-                        DefaultValue = defaultValue,
-                        ComputedValue = computedValue,
-                        Precision = precision,
-                        Scale = scale,
-                        MaxLength = maxLength,
-                        Identity = identity,
-                        Computed = computed
-                    });
-            }
         }
 
         /// <summary>
@@ -173,6 +153,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string deleteAction,
             int? ordinal)
         {
+            // No DiagnosticsSource events because these are purely design-time messages
+
             var definition = SqlServerStrings.LogFoundForeignKeyColumn;
 
             Debug.Assert(LogLevel.Debug == definition.Level);
@@ -194,23 +176,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         deleteAction,
                         ordinal));
             }
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        ForeignKeyName = foreignKeyName,
-                        PrincipalTableName = principalTableName,
-                        ColumnName = columnName,
-                        PrincipalColumnName = principalColumnName,
-                        UpdateAction = updateAction,
-                        DeleteAction = deleteAction,
-                        Ordinal = ordinal
-                    });
-            }
         }
 
         /// <summary>
@@ -220,21 +185,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static void DefaultSchemaFound(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string schemaName)
-        {
-            var definition = SqlServerStrings.LogFoundDefaultSchema;
-
-            definition.Log(diagnostics, schemaName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        SchemaName = schemaName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => SqlServerStrings.LogFoundDefaultSchema.Log(diagnostics, schemaName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -244,46 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [CanBeNull] string typeAliasName,
             [CanBeNull] string systemTypeName)
-        {
-            var definition = SqlServerStrings.LogFoundTypeAlias;
-
-            definition.Log(diagnostics, typeAliasName, systemTypeName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TypeAliasName = typeAliasName,
-                        SystemTypeName = systemTypeName
-                    });
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static void DataTypeDoesNotAllowSqlServerIdentityStrategyWarning(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string columnName,
-            [CanBeNull] string typeName)
-        {
-            var definition = SqlServerStrings.LogDataTypeDoesNotAllowSqlServerIdentityStrategy;
-
-            definition.Log(diagnostics, columnName, typeName);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        ColumnName = columnName,
-                        TypeName = typeName
-                    });
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => SqlServerStrings.LogFoundTypeAlias.Log(diagnostics, typeAliasName, systemTypeName);
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -107,18 +107,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 table, entityType, otherEntityType, memoryOptimizedEntityType, nonMemoryOptimizedEntityType);
 
         /// <summary>
-        ///     For column {columnId}. This column is set up as an Identity column, but the SQL Server data type is {sqlServerDataType}. This will be mapped to CLR type byte which does not allow the SqlServerValueGenerationStrategy.IdentityColumn setting. Generating a matching Property but ignoring the Identity setting.
-        /// </summary>
-        public static readonly EventDefinition<string, string> LogDataTypeDoesNotAllowSqlServerIdentityStrategy
-            = new EventDefinition<string, string>(
-                SqlServerEventId.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning,
-                LogLevel.Warning,
-                LoggerMessage.Define<string, string>(
-                    LogLevel.Warning,
-                    SqlServerEventId.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning,
-                    _resourceManager.GetString("LogDataTypeDoesNotAllowSqlServerIdentityStrategy")));
-
-        /// <summary>
         ///     Found default schema {defaultSchema}.
         /// </summary>
         public static readonly EventDefinition<string> LogFoundDefaultSchema

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -152,10 +152,6 @@
   <data name="IncompatibleTableMemoryOptimizedMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.</value>
   </data>
-  <data name="LogDataTypeDoesNotAllowSqlServerIdentityStrategy" xml:space="preserve">
-    <value>For column {columnId}. This column is set up as an Identity column, but the SQL Server data type is {sqlServerDataType}. This will be mapped to CLR type byte which does not allow the SqlServerValueGenerationStrategy.IdentityColumn setting. Generating a matching Property but ignoring the Identity setting.</value>
-    <comment>Warning SqlServerEventId.DataTypeDoesNotAllowSqlServerIdentityStrategyWarning string string</comment>
-  </data>
   <data name="LogFoundDefaultSchema" xml:space="preserve">
     <value>Found default schema {defaultSchema}.</value>
     <comment>Debug SqlServerEventId.DefaultSchemaFound string</comment>

--- a/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
@@ -94,6 +94,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             int? primaryKeyOrdinal,
             [CanBeNull] string defaultValue)
         {
+            // No DiagnosticsSource events because these are purely design-time messages
+
             var definition = SqliteStrings.LogFoundColumn;
 
             Debug.Assert(LogLevel.Debug == definition.Level);
@@ -114,22 +116,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         primaryKeyOrdinal,
                         defaultValue));
             }
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        ColumnName = columnName,
-                        DataTypeName = dataTypeName,
-                        Ordinal = ordinal,
-                        NotNull = notNull,
-                        PrimaryKeyOrdinal = primaryKeyOrdinal,
-                        DefaultValue = defaultValue
-                    });
-            }
         }
 
         /// <summary>
@@ -146,6 +132,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [CanBeNull] string deleteAction,
             int? ordinal)
         {
+            // No DiagnosticsSource events because these are purely design-time messages
+
             var definition = SqliteStrings.LogFoundForeignKeyColumn;
 
             Debug.Assert(LogLevel.Debug == definition.Level);
@@ -166,22 +154,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         deleteAction,
                         ordinal));
             }
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(
-                    definition.EventId.Name,
-                    new
-                    {
-                        TableName = tableName,
-                        Id = id,
-                        PrincipalTableName = principalTableName,
-                        ColumnName = columnName,
-                        PrincipalColumnName = principalColumnName,
-                        DeleteAction = deleteAction,
-                        Ordinal = ordinal
-                    });
-            }
         }
 
         /// <summary>
@@ -190,15 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void SchemasNotSupportedWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics)
-        {
-            var definition = SqliteStrings.LogUsingSchemaSelectionsWarning;
-
-            definition.Log(diagnostics);
-
-            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-            {
-                diagnostics.DiagnosticSource.Write(definition.EventId.Name, null);
-            }
-        }
+            // No DiagnosticsSource events because these are purely design-time messages
+            => SqliteStrings.LogUsingSchemaSelectionsWarning.Log(diagnostics);
     }
 }


### PR DESCRIPTION
This means if the message is in "Scaffolding", then it is tested to not generate DiagnosticSource events.

All other events are tested to be doing DiagnosticSource messages using nominal types.

Issue #7939
