### PR TITLE
[SMALL] Fix to #8186 - Navs: nav expansion on GJ QSRE in projection doesn't introduce parameter

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -292,17 +292,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     Determines whether or not this SelectExpression handles the given query source.
         /// </summary>
         /// <param name="querySource"> The query source. </param>
+        /// <param name="queryForOuterParameterBinding"> True if trying to bind to the query using outer paramter, otherwise false. </param>
         /// <returns>
         ///     true if the supplied query source is handled by this SelectExpression; otherwise false.
         /// </returns>
-        public override bool HandlesQuerySource(IQuerySource querySource)
+        public override bool HandlesQuerySource(IQuerySource querySource, bool queryForOuterParameterBinding = false)
         {
             Check.NotNull(querySource, nameof(querySource));
 
-            var processedQuerySource = PreProcessQuerySource(querySource);
+            var processedQuerySource = PreProcessQuerySource(querySource, queryForOuterParameterBinding);
 
-            return _tables.Any(te => te.QuerySource == processedQuerySource || te.HandlesQuerySource(processedQuerySource))
-                   || base.HandlesQuerySource(querySource);
+            return _tables.Any(te => te.QuerySource == processedQuerySource || te.HandlesQuerySource(processedQuerySource, queryForOuterParameterBinding))
+                   || base.HandlesQuerySource(querySource, queryForOuterParameterBinding);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -244,16 +244,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     Try and get the active SelectExpression for a given query source.
         /// </summary>
         /// <param name="querySource"> The query source. </param>
+        /// <param name="queryForOuterParameterBinding"> True if trying to bind to the query using outer paramter, otherwise false. </param>
         /// <returns>
         ///     A SelectExpression, or null.
         /// </returns>
-        public virtual SelectExpression TryGetQuery([NotNull] IQuerySource querySource)
+        public virtual SelectExpression TryGetQuery([NotNull] IQuerySource querySource, bool queryForOuterParameterBinding = false)
         {
             Check.NotNull(querySource, nameof(querySource));
 
             return QueriesBySource.TryGetValue(querySource, out SelectExpression selectExpression)
                 ? selectExpression
-                : QueriesBySource.Values.LastOrDefault(se => se.HandlesQuerySource(querySource));
+                : QueriesBySource.Values.LastOrDefault(se => se.HandlesQuerySource(querySource, queryForOuterParameterBinding));
         }
 
         /// <summary>
@@ -1972,13 +1973,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (querySource != null && _canBindPropertyToOuterParameter)
             {
                 var outerQueryModelVisitor = ParentQueryModelVisitor;
-                var outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource);
+                var outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource, queryForOuterParameterBinding: true);
 
                 while (outerSelectExpression == null
                        && outerQueryModelVisitor != null)
                 {
                     outerQueryModelVisitor = outerQueryModelVisitor.ParentQueryModelVisitor;
-                    outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource);
+                    outerSelectExpression = outerQueryModelVisitor?.TryGetQuery(querySource, queryForOuterParameterBinding: true);
                 }
 
                 if (outerSelectExpression != null)

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -3164,5 +3164,15 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
     "MemberId": "public static System.String GetDefaultIndexName(System.String tableName, System.Collections.Generic.IEnumerable<System.String> propertyNames)",
     "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.RelationalQueryModelVisitor : Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor",
+    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression TryGetQuery(Remotion.Linq.Clauses.IQuerySource querySource)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpression : Microsoft.EntityFrameworkCore.Query.Expressions.TableExpressionBase",
+    "MemberId": "public virtual System.Boolean HandlesQuerySource(Remotion.Linq.Clauses.IQuerySource querySource)",
+    "Kind": "Removal"
   }
 ]

--- a/src/EFCore/Query/Internal/QueryBuffer.cs
+++ b/src/EFCore/Query/Internal/QueryBuffer.cs
@@ -245,7 +245,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         enumerator.Dispose();
 
-                        _includedCollections[includeId] = null;
+                        if (includeId != -1)
+                        {
+                            _includedCollections[includeId] = null;
+                        }
 
                         break;
                     }

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1210,6 +1210,288 @@ WHERE (
 ) > 30");
         }
 
+        public override void Client_groupjoin_with_orderby_key_descending()
+        {
+            base.Client_groupjoin_with_orderby_key_descending();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Navigation_projection_on_groupjoin_qsre()
+        {
+            base.Navigation_projection_on_groupjoin_qsre();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_OrderID='10643'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10692'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10702'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10835'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10952'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='11011'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]");
+        }
+
+        public override void Navigation_projection_on_groupjoin_qsre_no_outer_in_final_result()
+        {
+            base.Navigation_projection_on_groupjoin_qsre_no_outer_in_final_result();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_OrderID='10643'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10692'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10702'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10835'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10952'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='11011'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]");
+        }
+
+        public override void Navigation_projection_on_groupjoin_qsre_with_empty_grouping()
+        {
+            base.Navigation_projection_on_groupjoin_qsre_with_empty_grouping();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [oo].[OrderID], [oo].[CustomerID], [oo].[EmployeeID], [oo].[OrderDate]
+    FROM [Orders] AS [oo]
+    WHERE [oo].[OrderID] NOT IN (10308, 10625, 10759, 10926)
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_OrderID='10643'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10692'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10702'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10835'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10952'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='11011'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10365'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]",
+                //
+                @"@_outer_OrderID='10507'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE @_outer_OrderID = [o].[OrderID]");
+        }
+
+        public override void Include_on_inner_projecting_groupjoin()
+        {
+            base.Include_on_inner_projecting_groupjoin();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_OrderID='10643'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10692'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10702'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10835'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10952'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='11011'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+WHERE @_outer_OrderID = [o0].[OrderID]");
+        }
+
+        public override void Include_on_inner_projecting_groupjoin_complex()
+        {
+            base.Include_on_inner_projecting_groupjoin_complex();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                //
+                @"@_outer_OrderID='10643'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10692'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10702'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10835'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='10952'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]",
+                //
+                @"@_outer_OrderID='11011'
+
+SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [o.Product].[ProductID], [o.Product].[Discontinued], [o.Product].[ProductName], [o.Product].[UnitPrice], [o.Product].[UnitsInStock]
+FROM [Order Details] AS [o0]
+INNER JOIN [Products] AS [o.Product] ON [o0].[ProductID] = [o.Product].[ProductID]
+WHERE @_outer_OrderID = [o0].[OrderID]");
+        }
+
+        public override void Group_join_doesnt_get_bound_directly_to_group_join_qsre()
+        {
+            base.Group_join_doesnt_get_bound_directly_to_group_join_qsre();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY [c].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that when trying to find query to bind with via outer parameter we were too strict and would not find the appropriate query. We used to share the logic for regular binding and outer parameter binding, however the latter can be more loose and therefore bind to bigger range of queries (e.g. client-side groupjoin).

This also enables additional include scenarios when GJ qsre is projected - fixed a small bug in this area that was exposed by the main fix.