### PR TITLE
Fix #8197 - Diagnostics: Report number of rows returned by server on reader dispose

### DIFF
--- a/src/EFCore.Relational/Diagnostics/DataReaderDisposingEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/DataReaderDisposingEventData.cs
@@ -33,6 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="recordsAffected">
         ///     Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.
         /// </param>
+        /// <param name="readCount">
+        ///     Gets the number of read operations performed by this reader.
+        /// </param>
         /// <param name="startTime">
         ///     The start time of this event.
         /// </param>
@@ -47,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid commandId,
             Guid connectionId,
             int recordsAffected,
+            int readCount,
             DateTimeOffset startTime,
             TimeSpan duration)
             : base(eventDefinition, messageGenerator)
@@ -56,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             CommandId = commandId;
             ConnectionId = connectionId;
             RecordsAffected = recordsAffected;
+            ReadCount = readCount;
             StartTime = startTime;
             Duration = duration;
         }
@@ -84,6 +89,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     Gets the number of rows changed, inserted, or deleted by execution of the SQL statement.
         /// </summary>
         public virtual int RecordsAffected { get; }
+
+        /// <summary>
+        ///     Gets the number of read operations performed by this reader.
+        /// </summary>
+        public virtual int ReadCount { get; }
 
         /// <summary>
         ///     The start time of this event.

--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -684,6 +684,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] DbDataReader dataReader,
             Guid commandId,
             int recordsAffected,
+            int readCount,
             DateTimeOffset startTime,
             TimeSpan duration)
         {
@@ -703,6 +704,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         commandId,
                         connection.ConnectionId,
                         recordsAffected,
+                        readCount,
                         startTime,
                         duration));
             }

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 using (var reader = command.ExecuteReader(Dependencies.Connection))
                 {
-                    while (reader.DbDataReader.Read())
+                    while (reader.Read())
                     {
                         rows.Add(new HistoryRow(reader.DbDataReader.GetString(0), reader.DbDataReader.GetString(1)));
                     }
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 using (var reader = await command.ExecuteReaderAsync(Dependencies.Connection, cancellationToken: cancellationToken))
                 {
-                    while (await reader.DbDataReader.ReadAsync(cancellationToken))
+                    while (await reader.ReadAsync(cancellationToken))
                     {
                         rows.Add(new HistoryRow(reader.DbDataReader.GetString(0), reader.DbDataReader.GetString(1)));
                     }

--- a/src/EFCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _valueBufferFactory = _shaperCommandContext.ValueBufferFactory;
                     }
 
-                    var hasNext = await _dbDataReader.ReadAsync(cancellationToken);
+                    var hasNext = await _dataReader.ReadAsync(cancellationToken);
 
                     Current
                         = hasNext
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     using (_dataReader)
                     {
-                        while (await _dbDataReader.ReadAsync(cancellationToken))
+                        while (await _dataReader.ReadAsync(cancellationToken))
                         {
                             _buffer.Enqueue(_valueBufferFactory.Create(_dbDataReader));
                         }
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     using (_dataReader)
                     {
-                        while (_dbDataReader.Read())
+                        while (_dataReader.Read())
                         {
                             _buffer.Enqueue(_valueBufferFactory.Create(_dbDataReader));
                         }

--- a/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _valueBufferFactory = _shaperCommandContext.ValueBufferFactory;
                     }
 
-                    var hasNext = _dbDataReader.Read();
+                    var hasNext = _dataReader.Read();
 
                     Current
                         = hasNext
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     using (_dataReader)
                     {
-                        while (_dbDataReader.Read())
+                        while (_dataReader.Read())
                         {
                             _buffer.Enqueue(_valueBufferFactory.Create(_dbDataReader));
                         }
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     using (_dataReader)
                     {
-                        while (await _dbDataReader.ReadAsync(cancellationToken))
+                        while (await _dataReader.ReadAsync(cancellationToken))
                         {
                             _buffer.Enqueue(_valueBufferFactory.Create(_dbDataReader));
                         }

--- a/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         {
         }
 
-        protected override void Consume(DbDataReader reader)
+        protected override void Consume(RelationalDataReader reader)
         {
             Debug.Assert(CommandResultSet.Count == ModificationCommands.Count);
             var commandIndex = 0;
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     }
                 }
                 while (commandIndex < CommandResultSet.Count
-                       && reader.NextResult());
+                       && reader.DbDataReader.NextResult());
 
 #if DEBUG
                 while (commandIndex < CommandResultSet.Count
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         }
 
         protected override async Task ConsumeAsync(
-            DbDataReader reader,
+            RelationalDataReader reader,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Debug.Assert(CommandResultSet.Count == ModificationCommands.Count);
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     }
                 }
                 while (commandIndex < CommandResultSet.Count
-                       && await reader.NextResultAsync(cancellationToken));
+                       && await reader.DbDataReader.NextResultAsync(cancellationToken));
 
 #if DEBUG
                 while (commandIndex < CommandResultSet.Count
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
         }
 
-        protected virtual int ConsumeResultSetWithPropagation(int commandIndex, [NotNull] DbDataReader reader)
+        protected virtual int ConsumeResultSetWithPropagation(int commandIndex, [NotNull] RelationalDataReader reader)
         {
             var rowsAffected = 0;
             do
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
                 var valueBufferFactory = CreateValueBufferFactory(tableModification.ColumnModifications);
 
-                tableModification.PropagateResults(valueBufferFactory.Create(reader));
+                tableModification.PropagateResults(valueBufferFactory.Create(reader.DbDataReader));
                 rowsAffected++;
             }
             while (++commandIndex < CommandResultSet.Count
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         }
 
         protected virtual async Task<int> ConsumeResultSetWithPropagationAsync(
-            int commandIndex, [NotNull] DbDataReader reader, CancellationToken cancellationToken)
+            int commandIndex, [NotNull] RelationalDataReader reader, CancellationToken cancellationToken)
         {
             var rowsAffected = 0;
             do
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
                 var valueBufferFactory = CreateValueBufferFactory(tableModification.ColumnModifications);
 
-                tableModification.PropagateResults(valueBufferFactory.Create(reader));
+                tableModification.PropagateResults(valueBufferFactory.Create(reader.DbDataReader));
                 rowsAffected++;
             }
             while (++commandIndex < CommandResultSet.Count
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             return commandIndex;
         }
 
-        protected virtual int ConsumeResultSetWithoutPropagation(int commandIndex, [NotNull] DbDataReader reader)
+        protected virtual int ConsumeResultSetWithoutPropagation(int commandIndex, [NotNull] RelationalDataReader reader)
         {
             var expectedRowsAffected = 1;
             while (++commandIndex < CommandResultSet.Count
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             if (reader.Read())
             {
-                var rowsAffected = reader.GetInt32(0);
+                var rowsAffected = reader.DbDataReader.GetInt32(0);
                 if (rowsAffected != expectedRowsAffected)
                 {
                     ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         }
 
         protected virtual async Task<int> ConsumeResultSetWithoutPropagationAsync(
-            int commandIndex, [NotNull] DbDataReader reader, CancellationToken cancellationToken)
+            int commandIndex, [NotNull] RelationalDataReader reader, CancellationToken cancellationToken)
         {
             var expectedRowsAffected = 1;
             while (++commandIndex < CommandResultSet.Count
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             if (await reader.ReadAsync(cancellationToken))
             {
-                var rowsAffected = reader.GetInt32(0);
+                var rowsAffected = reader.DbDataReader.GetInt32(0);
                 if (rowsAffected != expectedRowsAffected)
                 {
                     ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     connection,
                     parameterValues: storeCommand.ParameterValues))
                 {
-                    Consume(dataReader.DbDataReader);
+                    Consume(dataReader);
                 }
             }
             catch (DbUpdateException)
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     parameterValues: storeCommand.ParameterValues,
                     cancellationToken: cancellationToken))
                 {
-                    await ConsumeAsync(dataReader.DbDataReader, cancellationToken);
+                    await ConsumeAsync(dataReader, cancellationToken);
                 }
             }
             catch (DbUpdateException)
@@ -213,10 +213,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
         }
 
-        protected abstract void Consume([NotNull] DbDataReader reader);
+        protected abstract void Consume([NotNull] RelationalDataReader reader);
 
         protected abstract Task ConsumeAsync(
-            [NotNull] DbDataReader reader,
+            [NotNull] RelationalDataReader reader,
             CancellationToken cancellationToken = default(CancellationToken));
 
         protected virtual IRelationalValueBufferFactory CreateValueBufferFactory([NotNull] IReadOnlyList<ColumnModification> columnModifications)

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -3164,5 +3164,55 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Metadata.RelationalIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
     "MemberId": "public static System.String GetDefaultIndexName(System.String tableName, System.Collections.Generic.IEnumerable<System.String> propertyNames)",
     "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ModificationCommandBatch",
+    "MemberId": "protected abstract System.Threading.Tasks.Task ConsumeAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ModificationCommandBatch",
+    "MemberId": "protected abstract System.Void Consume(System.Data.Common.DbDataReader reader)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected override System.Threading.Tasks.Task ConsumeAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected override System.Void Consume(System.Data.Common.DbDataReader reader)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected virtual System.Int32 ConsumeResultSetWithoutPropagation(System.Int32 commandIndex, System.Data.Common.DbDataReader reader)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected virtual System.Int32 ConsumeResultSetWithPropagation(System.Int32 commandIndex, System.Data.Common.DbDataReader reader)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected virtual System.Threading.Tasks.Task<System.Int32> ConsumeResultSetWithoutPropagationAsync(System.Int32 commandIndex, System.Data.Common.DbDataReader reader, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.AffectedCountModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch",
+    "MemberId": "protected virtual System.Threading.Tasks.Task<System.Int32> ConsumeResultSetWithPropagationAsync(System.Int32 commandIndex, System.Data.Common.DbDataReader reader, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ModificationCommandBatch",
+    "MemberId": "protected abstract System.Threading.Tasks.Task ConsumeAsync(Microsoft.EntityFrameworkCore.Storage.RelationalDataReader reader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Update.ReaderModificationCommandBatch : Microsoft.EntityFrameworkCore.Update.ModificationCommandBatch",
+    "MemberId": "protected abstract System.Void Consume(Microsoft.EntityFrameworkCore.Storage.RelationalDataReader reader)",
+    "Kind": "Addition"
   }
 ]

--- a/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BadDataSqliteTest.cs
@@ -183,17 +183,13 @@ namespace Microsoft.EntityFrameworkCore
 
                     public override RelationalDataReader ExecuteReader(
                             IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
-                        => new BadDataRelationalDataReader(base.ExecuteReader(connection, parameterValues), _values);
+                        => new BadDataRelationalDataReader(_values);
 
                     private class BadDataRelationalDataReader : RelationalDataReader
                     {
-                        private readonly RelationalDataReader _relationalDataReader;
-                        private readonly BadDataDataReader _dataReader;
-
-                        public BadDataRelationalDataReader(RelationalDataReader relationalDataReader, object[] values)
+                        public BadDataRelationalDataReader(object[] values)
+                            : base(new BadDataDataReader(values))
                         {
-                            _relationalDataReader = relationalDataReader;
-                            _dataReader = new BadDataDataReader(values);
                         }
 
                         private class BadDataDataReader : DbDataReader
@@ -232,45 +228,24 @@ namespace Microsoft.EntityFrameworkCore
                                 throw new NotImplementedException();
                             }
 
-                            public override int FieldCount
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override int FieldCount => throw new NotImplementedException();
 
-                            public override object this[int ordinal]
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override object this[int ordinal] => throw new NotImplementedException();
 
-                            public override object this[string name]
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override object this[string name] => throw new NotImplementedException();
 
-                            public override bool HasRows
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override bool HasRows => throw new NotImplementedException();
 
-                            public override bool IsClosed
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override bool IsClosed => throw new NotImplementedException();
 
-                            public override int RecordsAffected
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override int RecordsAffected => throw new NotImplementedException();
 
                             public override bool NextResult()
                             {
                                 throw new NotImplementedException();
                             }
 
-                            public override int Depth
-                            {
-                                get { throw new NotImplementedException(); }
-                            }
+                            public override int Depth => throw new NotImplementedException();
 
                             public override int GetOrdinal(string name)
                             {
@@ -344,10 +319,6 @@ namespace Microsoft.EntityFrameworkCore
 
                             #endregion
                         }
-
-                        public override DbDataReader DbDataReader => _dataReader;
-
-                        public override void Dispose() => _relationalDataReader.Dispose();
                     }
                 }
             }


### PR DESCRIPTION
- Track DbDataReader.Read/Async invocation count via new delegating methods on RelationalDataReader.