### PR TITLE
Non-nullable bool column with default constraint

### DIFF
--- a/src/EFCore.Design/Diagnostics/DesignEventId.cs
+++ b/src/EFCore.Design/Diagnostics/DesignEventId.cs
@@ -32,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             PrimaryKeyColumnsNotMappedWarning,
             ForeignKeyReferencesNotMappedTableWarning,
             ForeignKeyReferencesMissingPrincipalKeyWarning,
-            ForeignKeyPrincipalEndContainsNullableColumnsWarning
+            ForeignKeyPrincipalEndContainsNullableColumnsWarning,
+            NonNullableBoooleanColumnHasDefaultConstraintWarning
         }
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
@@ -91,5 +92,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalEndContainsNullableColumnsWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalEndContainsNullableColumnsWarning);
+
+        /// <summary>
+        ///     A column would be mapped to a bool type, is non-nullable and has a default constraint.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId NonNullableBoooleanColumnHasDefaultConstraintWarning = MakeScaffoldingId(Id.NonNullableBoooleanColumnHasDefaultConstraintWarning);
     }
 }

--- a/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
+++ b/src/EFCore.Design/Internal/DesignLoggerExtensions.cs
@@ -123,5 +123,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 foreignKeyName,
                 indexName,
                 nullablePropertyNames.Aggregate((a, b) => a + "," + b));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void NonNullableBoooleanColumnHasDefaultConstraintWarning(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [CanBeNull] string columnName)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => DesignStrings.LogNonNullableBoooleanColumnHasDefaultConstraint.Log(
+                diagnostics,
+                columnName);
     }
 }

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -584,6 +584,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     DesignEventId.ForeignKeyPrincipalEndContainsNullableColumnsWarning,
                     _resourceManager.GetString("LogForeignKeyPrincipalEndContainsNullableColumns")));
 
+        /// <summary>
+        ///     The column '{columnName}' would normally be mapped to a non-nullable bool property, but it has a default constraint. Such a column is mapped to a nullable bool property to allow a difference between setting the property to false and invoking the default constraint.
+        /// </summary>
+        public static readonly EventDefinition<string> LogNonNullableBoooleanColumnHasDefaultConstraint
+            = new EventDefinition<string>(
+                DesignEventId.NonNullableBoooleanColumnHasDefaultConstraintWarning,
+                LogLevel.Warning,
+                LoggerMessage.Define<string>(
+                    LogLevel.Warning,
+                    DesignEventId.NonNullableBoooleanColumnHasDefaultConstraintWarning,
+                    _resourceManager.GetString("LogNonNullableBoooleanColumnHasDefaultConstraint")));
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -339,4 +339,8 @@ Change your target project to the migrations project by using the Package Manage
     <value>The principal end of the foreign key '{foreignKeyName}' is supported by the unique index '{indexName}' and contains the following nullable columns '{columnNames}'. Entity Framework requires the properties representing those columns to be non-nullable.</value>
     <comment>Warning DesignEventId.ForeignKeyPrincipalEndContainsNullableColumnsWarning string string string</comment>
   </data>
+  <data name="LogNonNullableBoooleanColumnHasDefaultConstraint" xml:space="preserve">
+    <value>The column '{columnName}' would normally be mapped to a non-nullable bool property, but it has a default constraint. Such a column is mapped to a nullable bool property to allow a difference between setting the property to false and invoking the default constraint.</value>
+    <comment>Warning DesignEventId.NonNullableBoooleanColumnHasDefaultConstraintWarning string</comment>
+  </data>
 </root>

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -311,13 +311,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var clrType = typeScaffoldingInfo.ClrType;
             var forceNullable = typeof(bool) == clrType && column.DefaultValue != null;
+            if (forceNullable)
+            {
+                Logger.NonNullableBoooleanColumnHasDefaultConstraintWarning(
+                    column.DisplayName);
+            }
             if (column.IsNullable || forceNullable)
             {
-                if (forceNullable)
-                {
-                    Logger.NonNullableBoooleanColumnHasDefaultConstraintWarning(
-                        column.DisplayName);
-                }
                 clrType = clrType.MakeNullable();
             }
 

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -310,8 +310,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var clrType = typeScaffoldingInfo.ClrType;
-            if (column.IsNullable)
+            var forceNullable = typeof(bool) == clrType && column.DefaultValue != null;
+            if (column.IsNullable || forceNullable)
             {
+                if (forceNullable)
+                {
+                    Logger.NonNullableBoooleanColumnHasDefaultConstraintWarning(
+                        column.DisplayName);
+                }
                 clrType = clrType.MakeNullable();
             }
 
@@ -361,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (!column.PrimaryKeyOrdinal.HasValue)
             {
-                property.IsRequired(!column.IsNullable);
+                property.IsRequired(!column.IsNullable && !forceNullable);
             }
 
             property.Metadata.Scaffolding().ColumnOrdinal = column.Ordinal;

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefault.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefault.cs
@@ -6,7 +6,7 @@ namespace E2ETest.Namespace
     public partial class NonNullBoolWithDefault
     {
         public int Id { get; set; }
-        public bool? TestWithDefault { get; set; }
-        public bool TestWithoutDefault { get; set; }
+        public bool? BoolWithDefaultValueSql { get; set; }
+        public bool BoolWithoutDefaultValueSql { get; set; }
     }
 }

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefault.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefault.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace E2ETest.Namespace
+{
+    public partial class NonNullBoolWithDefault
+    {
+        public int Id { get; set; }
+        public bool? TestWithDefault { get; set; }
+        public bool TestWithoutDefault { get; set; }
+    }
+}

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefaultContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefaultContext.cs
@@ -23,7 +23,7 @@ namespace E2ETest.Namespace
             {
                 entity.Property(e => e.Id).ValueGeneratedNever();
 
-                entity.Property(e => e.TestWithDefault).HasDefaultValueSql("(CONVERT([bit],getdate()))");
+                entity.Property(e => e.BoolWithDefaultValueSql).HasDefaultValueSql("(CONVERT([bit],getdate()))");
             });
         }
     }

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefaultContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/NonNullBoolWithDefaultContext.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace E2ETest.Namespace
+{
+    public partial class NonNullBoolWithDefaultContext : DbContext
+    {
+        public virtual DbSet<NonNullBoolWithDefault> NonNullBoolWithDefault { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                #warning To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.
+                optionsBuilder.UseSqlServer(@"{{connectionString}}");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<NonNullBoolWithDefault>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.TestWithDefault).HasDefaultValueSql("(CONVERT([bit],getdate()))");
+            });
+        }
+    }
+}

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -183,6 +183,61 @@ namespace Microsoft.EntityFrameworkCore.ReverseEngineering
             AssertCompile(actualFileSet);
         }
 
+        [Fact]
+        public void Non_null_boolean_columns_with_default_constraint_become_nullable_properties()
+        {
+            using (var scratch = SqlServerTestStore.Create("NonNullBooleanWithDefaultConstraint"))
+            {
+                scratch.ExecuteNonQuery(@"
+CREATE TABLE NonNullBoolWithDefault
+(
+     Id int NOT NULL PRIMARY KEY CLUSTERED,
+     TestWithDefault bit NOT NULL DEFAULT (CONVERT(""bit"", GETDATE())),
+     TestWithoutDefault bit NOT NULL
+)");
+
+                var expectedFileSet = new FileSet(new FileSystemFileService(),
+                    Path.Combine("ReverseEngineering", "Expected"),
+                    contents => contents.Replace("{{connectionString}}", scratch.ConnectionString))
+                {
+                    Files = new List<string>
+                    {
+                        "NonNullBoolWithDefaultContext.cs",
+                        "NonNullBoolWithDefault.cs",
+                    }
+                };
+
+                var filePaths = Generator.GenerateAsync(
+                        scratch.ConnectionString,
+                        TableSelectionSet.All,
+                        TestProjectDir + Path.DirectorySeparatorChar,
+                        outputPath: null, // not used for this test
+                        rootNamespace: TestNamespace,
+                        contextName: "NonNullBoolWithDefaultContext",
+                        useDataAnnotations: false,
+                        overwriteFiles: false)
+                    .GetAwaiter()
+                    .GetResult();
+
+
+                var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
+                {
+                    Files = new[] { filePaths.ContextFile }.Concat(filePaths.EntityTypeFiles).Select(Path.GetFileName).ToList()
+                };
+
+                AssertLog(new LoggerMessages
+                {
+                    Warn =
+                    {
+                        DesignStrings.LogNonNullableBoooleanColumnHasDefaultConstraint.GenerateMessage("dbo.NonNullBoolWithDefault.TestWithDefault")
+                    }
+                });
+
+                AssertEqualFileContents(expectedFileSet, actualFileSet);
+                AssertCompile(actualFileSet);
+            }
+        }
+
         [ConditionalFact]
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public void Sequences()

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -192,8 +192,8 @@ namespace Microsoft.EntityFrameworkCore.ReverseEngineering
 CREATE TABLE NonNullBoolWithDefault
 (
      Id int NOT NULL PRIMARY KEY CLUSTERED,
-     TestWithDefault bit NOT NULL DEFAULT (CONVERT(""bit"", GETDATE())),
-     TestWithoutDefault bit NOT NULL
+     BoolWithDefaultValueSql bit NOT NULL DEFAULT (CONVERT(""bit"", GETDATE())),
+     BoolWithoutDefaultValueSql bit NOT NULL
 )");
 
                 var expectedFileSet = new FileSet(new FileSystemFileService(),
@@ -229,7 +229,7 @@ CREATE TABLE NonNullBoolWithDefault
                 {
                     Warn =
                     {
-                        DesignStrings.LogNonNullableBoooleanColumnHasDefaultConstraint.GenerateMessage("dbo.NonNullBoolWithDefault.TestWithDefault")
+                        DesignStrings.LogNonNullableBoooleanColumnHasDefaultConstraint.GenerateMessage("dbo.NonNullBoolWithDefault.BoolWithDefaultValueSql")
                     }
                 });
 


### PR DESCRIPTION
Fix for #8400. 

If Reverse Engineering would map a non-nullable column to a non-nullable bool property but the column has a default constraint then a) map it to a nullable bool property instead and b) issue a warning message.

This is to allow the user of the generated classes to distinguish between actively setting the property to 'false' and not setting the property and allowing the default constraint to generate the value in the database.
