### PR TITLE
Enable configuring a non-key column as identity.

### DIFF
--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -89,8 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         /// </summary>
         public override IEnumerable<IAnnotation> For(IProperty property)
         {
-            if (property.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.IdentityColumn
-                && property.IsKey())
+            if (property.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.IdentityColumn)
             {
                 yield return new Annotation(
                     SqlServerAnnotationNames.ValueGenerationStrategy,

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -91,12 +91,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogByteIdentityColumn")));
 
         /// <summary>
-        ///     The property '{property}' on entity type '{entityType}' is configured to use 'Identity' or 'SequenceHiLo' value generator, which are only intended for keys. If this was intentional configure an alternate key on the property, otherwise call `ValueGeneratedNever` or configure store generation for this property.
+        ///     The property '{property}' on entity type '{entityType}' is configured to use 'SequenceHiLo' value generator, which is only intended for keys. If this was intentional configure an alternate key on the property, otherwise call 'ValueGeneratedNever' or configure store generation for this property.
         /// </summary>
         public static string NonKeyValueGeneration([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
                 GetString("NonKeyValueGeneration", nameof(property), nameof(entityType)),
                 property, entityType);
+
+        /// <summary>
+        ///     The properties {properties} are configured to use 'Identity' value generator and are mapped to the same table '{table}'. Only one column per table can be configured as 'Identity'. Call 'ValueGeneratedNever' for properties that should not use 'Identity'.
+        /// </summary>
+        public static string MultipleIdentityColumns([CanBeNull] object properties, [CanBeNull] object table)
+            => string.Format(
+                GetString("MultipleIdentityColumns", nameof(properties), nameof(table)),
+                properties, table);
 
         /// <summary>
         ///     Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -147,7 +147,10 @@
     <comment>Warning SqlServerEventId.ByteIdentityColumnWarning string string</comment>
   </data>
   <data name="NonKeyValueGeneration" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' is configured to use 'Identity' or 'SequenceHiLo' value generator, which are only intended for keys. If this was intentional configure an alternate key on the property, otherwise call `ValueGeneratedNever` or configure store generation for this property.</value>
+    <value>The property '{property}' on entity type '{entityType}' is configured to use 'SequenceHiLo' value generator, which is only intended for keys. If this was intentional configure an alternate key on the property, otherwise call 'ValueGeneratedNever' or configure store generation for this property.</value>
+  </data>
+  <data name="MultipleIdentityColumns" xml:space="preserve">
+    <value>The properties {properties} are configured to use 'Identity' value generator and are mapped to the same table '{table}'. Only one column per table can be configured as 'Identity'. Call 'ValueGeneratedNever' for properties that should not use 'Identity'.</value>
   </data>
   <data name="IncompatibleTableMemoryOptimizedMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.</value>

--- a/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -58,8 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             var defaultValuesOnly = writeOperations.Count == 0;
             var nonIdentityOperations = modificationCommands[0].ColumnModifications
-                .Where(o => o.Property.SqlServer().ValueGenerationStrategy != SqlServerValueGenerationStrategy.IdentityColumn
-                            || !o.Property.IsKey())
+                .Where(o => o.Property.SqlServer().ValueGenerationStrategy != SqlServerValueGenerationStrategy.IdentityColumn)
                 .ToList();
 
             if (defaultValuesOnly)

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithIdentitySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesWithIdentitySqlServerTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
-
 namespace Microsoft.EntityFrameworkCore
 {
     public class GraphUpdatesWithIdentitySqlServerTest : GraphUpdatesSqlServerTestBase<GraphUpdatesWithIdentitySqlServerTest.GraphUpdatesWithIdentitySqlServerFixture>

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -295,6 +295,40 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [Fact]
+        public void Alter_column_non_key_identity()
+        {
+            Execute(
+                source => source.Entity(
+                    "Lamb",
+                    x =>
+                        {
+                            x.ToTable("Lamb", "bah");
+                            x.Property<int>("Num").ValueGeneratedNever();
+                            x.Property<int>("Id");
+                            x.HasKey("Id");
+                        }),
+                target => target.Entity(
+                    "Lamb",
+                    x =>
+                        {
+                            x.ToTable("Lamb", "bah");
+                            x.Property<int>("Num").ValueGeneratedOnAdd();
+                            x.Property<int>("Id");
+                            x.HasKey("Id");
+                        }),
+                operations =>
+                    {
+                        Assert.Equal(1, operations.Count);
+
+                        var operation = Assert.IsType<AlterColumnOperation>(operations[0]);
+                        Assert.Equal("bah", operation.Schema);
+                        Assert.Equal("Lamb", operation.Table);
+                        Assert.Equal("Num", operation.Name);
+                        Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, operation["SqlServer:ValueGenerationStrategy"]);
+                    });
+        }
+
+        [Fact]
         public void Alter_column_computation()
         {
             Execute(


### PR DESCRIPTION
Throw for multiple columns configured as identity.

Fixes #8271
