### PR TITLE
[Preview2] Fix to #3910 - Query: Support Include/ThenInclude for navigation on derived type

### DIFF
--- a/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/GearsOfWarQueryTestBase.cs
@@ -2806,7 +2806,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateContext())
             {
-                var prm = "Marcus's Tag";
+                var prm = "Marcus' Tag";
                 var query = context.Gears.Where(g => ClientEquals(g.Tag.Note, prm));
 
                 var result = query.ToList();
@@ -3677,7 +3677,7 @@ namespace Microsoft.EntityFrameworkCore
                 var result = query.ToList();
 
                 Assert.Equal(1, result.Count);
-                Assert.Equal("Marcus's Tag", result[0].Note);
+                Assert.Equal("Marcus' Tag", result[0].Note);
             }
         }
 
@@ -3769,6 +3769,157 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(1, result.Count(r => r.Id == 1 && r.Gears.Count == 3));
                 Assert.Equal(1, result.Count(r => r.Id == 2 && r.Gears.Count == 0));
             }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_string()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.LocustLeaders.Include("DefeatedBy");
+                var result = query.ToList();
+
+                var included = result.OfType<LocustCommander>().Where(lc => lc.DefeatedBy != null).ToList();
+
+                Assert.Equal(6, result.Count);
+                Assert.Equal(1, included.Count);
+                Assert.Equal("Marcus", included[0].DefeatedBy.Nickname);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_lambda()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.LocustLeaders.Include((LocustCommander ll) => ll.DefeatedBy);
+                var result = query.ToList();
+
+                var included = result.OfType<LocustCommander>().Where(lc => lc.DefeatedBy != null).ToList();
+
+                Assert.Equal(6, result.Count);
+                Assert.Equal(1, included.Count);
+                Assert.Equal("Queen Myrrah", included[0].Name);
+                Assert.Equal("Marcus", included[0].DefeatedBy.Nickname);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_lambda_with_tracking()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.LocustLeaders.AsTracking().Include((LocustCommander ll) => ll.DefeatedBy);
+                var result = query.ToList();
+
+                var included = result.OfType<LocustCommander>().Where(lc => lc.DefeatedBy != null).ToList();
+
+                Assert.Equal(6, result.Count);
+                Assert.Equal(1, included.Count);
+                Assert.Equal("Queen Myrrah", included[0].Name);
+                Assert.Equal("Marcus", included[0].DefeatedBy.Nickname);
+                Assert.Equal(7, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_on_derived_type_using_string()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Include((Officer g) => g.Reports);
+                var result = query.ToList();
+
+                var included = result.OfType<Officer>().Where(lc => lc.Reports.Any()).OrderBy(g => g.Nickname).ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal(2, included.Count);
+                Assert.Equal("Baird", included[0].Nickname);
+                Assert.Equal(1, included[0].Reports.Count);
+                Assert.Equal("Marcus", included[1].Nickname);
+                Assert.Equal(3, included[1].Reports.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_on_derived_type_using_lambda()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Include((Officer g) => g.Reports);
+                var result = query.ToList();
+
+                var included = result.OfType<Officer>().Where(lc => lc.Reports.Any()).OrderBy(g => g.Nickname).ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal(2, included.Count);
+                Assert.Equal("Baird", included[0].Nickname);
+                Assert.Equal(1, included[0].Reports.Count);
+                Assert.Equal("Marcus", included[1].Nickname);
+                Assert.Equal(3, included[1].Reports.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_base_navigation_on_derived_entity()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Include((Officer g) => g.Tag)
+                    .Include((Officer g) => g.Weapons);
+
+                var result = query.ToList();
+
+                var included = result.OfType<Officer>().OrderBy(o => o.Nickname).ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal(2, included.Count);
+                Assert.Equal("Baird's Tag", included[0].Tag.Note);
+                Assert.Equal(2, included[0].Weapons.Count);
+                Assert.Equal("Marcus' Tag", included[1].Tag.Note);
+                Assert.Equal(2, included[0].Weapons.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_on_derived_multi_level()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Include((Officer g) => g.Reports)
+                    .ThenInclude(g => g.Squad.Missions);
+
+                var result = query.ToList();
+                var included = result.OfType<Officer>().OrderBy(o => o.Nickname).ToList();
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal(2, included.Count);
+                Assert.Equal(1, included[0].Reports.Count);
+                Assert.Equal("Paduk", included[0].Reports.First().Nickname);
+                Assert.Equal("Kilo", included[0].Reports.First().Squad.Name);
+                Assert.Equal(1, included[0].Reports.First().Squad.Missions.Count);
+                Assert.Equal(3, included[1].Reports.Count);
+                Assert.Equal("Delta", included[1].Reports.First().Squad.Name);
+                Assert.Equal(2, included[1].Reports.First().Squad.Missions.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_on_derived_using_as_operator_throws()
+        {
+
+            Assert.Throws<ArgumentException>(
+                () =>
+                    {
+                        using (var context = CreateContext())
+                        {
+                            var query = context.Gears
+                                .Include(g => (g as Officer).Reports)
+                                .ToList();
+                        }
+                    });
         }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);

--- a/src/EFCore.Specification.Tests/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/IncludeTestBase.cs
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore
                 Expression.Parameter(typeof(Order), "o"));
 
             Assert.Equal(
-                CoreStrings.InvalidComplexPropertyExpression(lambdaExpression.ToString()),
+                CoreStrings.InvalidIncludeLambdaExpression(lambdaExpression.ToString()),
                 Assert.Throws<ArgumentException>(
                     () =>
                         {

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             var marcusTag = new CogTag
             {
                 Id = Guid.NewGuid(),
-                Note = "Marcus's Tag"
+                Note = "Marcus' Tag"
             };
 
             var domsTag = new CogTag
@@ -201,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             var bairdsTag = new CogTag
             {
                 Id = Guid.NewGuid(),
-                Note = "Bairds's Tag"
+                Note = "Baird's Tag"
             };
 
             var paduksTag = new CogTag

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -2162,8 +2162,16 @@ namespace Microsoft.EntityFrameworkCore
         internal static readonly MethodInfo IncludeMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(Include))
-                .Single(mi => mi.GetParameters().Any(
-                    pi => pi.Name == "navigationPropertyPath" && pi.ParameterType != typeof(string)));
+                .Single(mi => mi.GetGenericArguments().Count() == 2
+                    && mi.GetParameters().Any(
+                        pi => pi.Name == "navigationPropertyPath" && pi.ParameterType != typeof(string)));
+
+        internal static readonly MethodInfo IncludeOnDerivedMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethods(nameof(Include))
+                .Single(mi => mi.GetGenericArguments().Count() == 3
+                    && mi.GetParameters().Any(
+                        pi => pi.Name == "navigationPropertyPath" && pi.ParameterType != typeof(string)));
 
         /// <summary>
         ///     Specifies related entities to include in the query results. The navigation property to be included is specified starting with the
@@ -2223,13 +2231,94 @@ namespace Microsoft.EntityFrameworkCore
                     : source);
         }
 
+        /// <summary>
+        ///     Specifies related entities to include in the query results. The navigation property to be included is specified starting with the
+        ///     type of entity being queried (<typeparamref name="TEntity" />). If you wish to include additional types based on the navigation
+        ///     properties of the type being included, then chain a call to
+        ///     <see
+        ///         cref="ThenInclude{TEntity, TPreviousProperty, TDerived, TProperty}(IIncludableQueryable{TEntity, IEnumerable{TPreviousProperty}}, Expression{Func{TDerived, TProperty}})" />
+        ///     after this call.
+        /// </summary>
+        /// <example>
+        ///     <para>
+        ///         The following query shows including a single level of related entities.
+        ///         <code>
+        ///             context.Blogs.Include(blog => blog.Posts);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including multiple levels and branches of related data.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags).ThenInclude(tag => tag.TagInfo)
+        ///                 .Include(blog => blog.Contributors);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including a single level of related entities on a derived type.
+        ///         <code>
+        ///             context.Blogs.Include((SpecialBlog specialBlog) => specialBlog.SpecialPosts);
+        ///         </code>
+        ///     </para>
+        /// </example>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
+        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="navigationPropertyPath">
+        ///     A lambda expression representing the navigation property to be included (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns>
+        ///     A new query with the related data included.
+        /// </returns>
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TDerived, TProperty>(
+            [NotNull] this IQueryable<TEntity> source,
+            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
+            where TEntity : class
+            where TDerived : TEntity
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(navigationPropertyPath, nameof(navigationPropertyPath));
+
+            return new IncludableQueryable<TEntity, TProperty>(
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: IncludeOnDerivedMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TDerived), typeof(TProperty)),
+                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
+                    : source);
+        }
+
         internal static readonly MethodInfo ThenIncludeAfterEnumerableMethodInfo
             = GetThenIncludeMethodInfo(typeof(IEnumerable<>));
 
         private static MethodInfo GetThenIncludeMethodInfo(Type navType)
             => typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                .Where(mi => mi.GetGenericArguments().Count() == 3)
                 .Single(mi =>
+                    {
+                        var typeInfo = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].GetTypeInfo();
+                        return typeInfo.IsGenericType
+                               && typeInfo.GetGenericTypeDefinition() == navType;
+                    });
+
+        internal static readonly MethodInfo ThenIncludeOnDerivedAfterEnumerableMethodInfo
+            = GetThenIncludeOnDerivedMethodInfo(typeof(IEnumerable<>));
+
+        private static MethodInfo GetThenIncludeOnDerivedMethodInfo(Type navType)
+            => typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                .Where(mi => mi.GetGenericArguments().Count() == 4)
+                .Single(mi => 
                     {
                         var typeInfo = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].GetTypeInfo();
                         return typeInfo.IsGenericType
@@ -2239,7 +2328,14 @@ namespace Microsoft.EntityFrameworkCore
         internal static readonly MethodInfo ThenIncludeAfterReferenceMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Single(mi => mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
+                .Single(mi => mi.GetGenericArguments().Count() == 3
+                    && mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
+
+        internal static readonly MethodInfo ThenIncludeOnDerivedAfterReferenceMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                .Single(mi => mi.GetGenericArguments().Count() == 4
+                    && mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
 
         /// <summary>
         ///     Specifies additional related data to be further included based on a related type that was just included.
@@ -2315,6 +2411,64 @@ namespace Microsoft.EntityFrameworkCore
         ///                 .Include(blog => blog.Contributors);
         ///         </code>
         ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude((SpecialPost specialPost) => specialPost.SpecialTags);
+        ///         </code>
+        ///     </para>
+        /// </example>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
+        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
+        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="navigationPropertyPath">
+        ///     A lambda expression representing the navigation property to be included (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns>
+        ///     A new query with the related data included.
+        /// </returns>
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TDerived, TProperty>(
+            [NotNull] this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
+            where TEntity : class 
+            where TDerived : TPreviousProperty
+            => new IncludableQueryable<TEntity, TProperty>(
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: ThenIncludeOnDerivedAfterEnumerableMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TDerived), typeof(TProperty)),
+                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
+                    : source);
+
+        /// <summary>
+        ///     Specifies additional related data to be further included based on a related type that was just included.
+        /// </summary>
+        /// <example>
+        ///     <para>
+        ///         The following query shows including a single level of related entities.
+        ///         <code>
+        ///             context.Blogs.Include(blog => blog.Posts);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including multiple levels and branches of related data.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags).ThenInclude(tag => tag.TagInfo)
+        ///                 .Include(blog => blog.Contributors);
+        ///         </code>
+        ///     </para>
         /// </example>
         /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
         /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
@@ -2336,6 +2490,64 @@ namespace Microsoft.EntityFrameworkCore
                         Expression.Call(
                             instance: null,
                             method: ThenIncludeAfterReferenceMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty)),
+                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
+                    : source);
+
+        /// <summary>
+        ///     Specifies additional related data to be further included based on a related type that was just included.
+        /// </summary>
+        /// <example>
+        ///     <para>
+        ///         The following query shows including a single level of related entities.
+        ///         <code>
+        ///             context.Blogs.Include(blog => blog.Posts);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including multiple levels and branches of related data.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags).ThenInclude(tag => tag.TagInfo)
+        ///                 .Include(blog => blog.Contributors);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude((SpecialPost specialPost) => specialPost.SpecialTags);
+        ///         </code>
+        ///     </para>
+        /// </example>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
+        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
+        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="navigationPropertyPath">
+        ///     A lambda expression representing the navigation property to be included (<c>t => t.Property1</c>).
+        /// </param>
+        /// <returns>
+        ///     A new query with the related data included.
+        /// </returns>
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TDerived, TProperty>(
+            [NotNull] this IIncludableQueryable<TEntity, TPreviousProperty> source,
+            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
+            where TEntity : class 
+            where TDerived : TPreviousProperty
+            => new IncludableQueryable<TEntity, TProperty>(
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: ThenIncludeOnDerivedAfterReferenceMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TDerived), typeof(TProperty)),
                             arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
                     : source);
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1365,12 +1365,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 firstDependentToPrincipalNavigationSpecification, firstPrincipalToDependentNavigationSpecification, secondDependentToPrincipalNavigationSpecification, secondPrincipalToDependentNavigationSpecification, foreignKeyProperties);
 
         /// <summary>
-        ///     The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.
+        ///     The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'.
         /// </summary>
         public static string InvalidComplexPropertyExpression([CanBeNull] object propertyAccessExpression)
             => string.Format(
                 GetString("InvalidComplexPropertyExpression", nameof(propertyAccessExpression)),
                 propertyAccessExpression);
+
+        /// <summary>
+        ///     Lambda expression '{includeLambdaExpression}' is not valid for Include/ThenInclude result operator. The expression should represent a property access: 't =&gt; t.MyProperty'. Specify lambda parameter explicitly to access navigations on derived types: '(Derived t) =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.
+        /// </summary>
+        public static string InvalidIncludeLambdaExpression([CanBeNull] object includeLambdaExpression)
+            => string.Format(
+                GetString("InvalidIncludeLambdaExpression", nameof(includeLambdaExpression)),
+                includeLambdaExpression);
 
         /// <summary>
         ///     The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -628,7 +628,10 @@
     <value>Both relationships between '{firstDependentToPrincipalNavigationSpecification}' and '{firstPrincipalToDependentNavigationSpecification}' and between '{secondDependentToPrincipalNavigationSpecification}' and '{secondPrincipalToDependentNavigationSpecification}' could use {foreignKeyProperties} as the foreign key. To resolve this configure the foreign key properties explicitly on at least one of the relationships.</value>
   </data>
   <data name="InvalidComplexPropertyExpression" xml:space="preserve">
-    <value>The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.</value>
+    <value>The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'.</value>
+  </data>
+  <data name="InvalidIncludeLambdaExpression" xml:space="preserve">
+    <value>Lambda expression '{includeLambdaExpression}' is not valid for Include/ThenInclude result operator. The expression should represent a property access: 't =&gt; t.MyProperty'. Specify lambda parameter explicitly to access navigations on derived types: '(Derived t) =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.</value>
   </data>
   <data name="AbstractLeafEntityType" xml:space="preserve">
     <value>The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.</value>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
@@ -72,18 +72,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 && properties[properties.Count - 1] is INavigation lastNavigation
                 && lastNavigation.IsCollection())
             {
-                // include doesn't handle navigations on derived class, so we can't leverage include pipeline for those cases
-                var expectedCallerType = querySource.ItemType;
-                foreach (var property in properties)
-                {
-                    if (expectedCallerType != property.DeclaringType.ClrType)
-                    {
-                        return expression;
-                    }
-
-                    expectedCallerType = property.ClrType;
-                }
-
                 var qsre = new QuerySourceReferenceExpression(querySource);
 
                 CollectionNavigationIncludeResultOperators.Add(

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNodeBase.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNodeBase.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class IncludeExpressionNodeBase : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual LambdaExpression NavigationPropertyPathLambda { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected IncludeExpressionNodeBase(
+            MethodCallExpressionParseInfo parseInfo,
+            [NotNull] LambdaExpression navigationPropertyPathLambda)
+            : base(parseInfo, null, null)
+        {
+            NavigationPropertyPathLambda = navigationPropertyPathLambda;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+            => Source.Resolve(
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static IReadOnlyList<PropertyInfo> MatchIncludeLambdaPropertyAccess([NotNull] LambdaExpression includeLambda)
+        {
+            Check.NotNull(includeLambda, nameof(includeLambda));
+
+            var parameterExpression = includeLambda.Parameters.Single();
+            var propertyInfos = new List<PropertyInfo>();
+
+            var expression = includeLambda.Body;
+            while (expression != null)
+            {
+                expression = expression.RemoveConvert();
+                if (expression == parameterExpression)
+                {
+                    break;
+                }
+
+                if (expression is MemberExpression memberExpression)
+                {
+                    propertyInfos.Insert(0, (PropertyInfo)memberExpression.Member);
+                    expression = memberExpression.Expression;
+
+                    continue;
+                }
+
+                propertyInfos.Clear();
+                break;
+            }
+
+            if (propertyInfos.Count == 0)
+            {
+                throw new ArgumentException(
+                    CoreStrings.InvalidIncludeLambdaExpression(includeLambda));
+            }
+
+            return propertyInfos;
+        }
+    }
+}

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
 
                 for (var i = 0; i < NavigationPropertyPaths.Count; i++)
                 {
-                    _navigationPath[i] = entityType.FindNavigation(NavigationPropertyPaths[i]);
+                    _navigationPath[i] = FindNavigation(entityType, NavigationPropertyPaths[i]);
 
                     if (_navigationPath[i] == null)
                     {
@@ -153,6 +153,26 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
             }
 
             return _navigationPath;
+        }
+
+        private INavigation FindNavigation(IEntityType entityType, string name)
+        {
+            var navigationPath = entityType.FindNavigation(name);
+            if (navigationPath != null)
+            {
+                return navigationPath;
+            }
+
+            foreach (var derived in entityType.GetDirectlyDerivedTypes())
+            {
+                navigationPath = FindNavigation(derived, name);
+                if (navigationPath != null)
+                {
+                    return navigationPath;
+                }
+            }
+
+            return navigationPath;
         }
 
         /// <summary>

--- a/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;
@@ -16,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ThenIncludeExpressionNode : ResultOperatorExpressionNodeBase
+    public class ThenIncludeExpressionNode : IncludeExpressionNodeBase
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,10 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
             EntityFrameworkQueryableExtensions.ThenIncludeAfterEnumerableMethodInfo,
-            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo
+            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo,
+            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterEnumerableMethodInfo,
+            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterReferenceMethodInfo,
         };
-
-        private readonly LambdaExpression _navigationPropertyPathLambda;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -37,9 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         public ThenIncludeExpressionNode(
             MethodCallExpressionParseInfo parseInfo,
             [NotNull] LambdaExpression navigationPropertyPathLambda)
-            : base(parseInfo, null, null)
+            : base(parseInfo, navigationPropertyPathLambda)
         {
-            _navigationPropertyPathLambda = navigationPropertyPathLambda;
         }
 
         /// <summary>
@@ -53,7 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
                 = (IncludeResultOperator)clauseGenerationContext.GetContextInfo(Source);
 
             includeResultOperator
-                .AppendToNavigationPath(_navigationPropertyPathLambda.GetComplexPropertyAccess());
+                .AppendToNavigationPath(
+                    MatchIncludeLambdaPropertyAccess(
+                        NavigationPropertyPathLambda));
 
             clauseGenerationContext.AddContextInfo(this, includeResultOperator);
         }
@@ -64,18 +64,5 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
             => null;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Expression Resolve(
-            ParameterExpression inputParameter,
-            Expression expressionToBeResolved,
-            ClauseGenerationContext clauseGenerationContext)
-            => Source.Resolve(
-                inputParameter,
-                expressionToBeResolved,
-                clauseGenerationContext);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GearsOfWarQueryInMemoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
@@ -11,6 +12,24 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalFact(Skip = "issue #8804")]
+        public override void Include_reference_on_derived_type_using_lambda()
+        {
+            base.Include_reference_on_derived_type_using_lambda();
+        }
+
+        [ConditionalFact(Skip = "issue #8804")]
+        public override void Include_reference_on_derived_type_using_lambda_with_tracking()
+        {
+            base.Include_reference_on_derived_type_using_lambda_with_tracking();
+        }
+
+        [ConditionalFact(Skip = "issue #8804")]
+        public override void Include_reference_on_derived_type_using_string()
+        {
+            base.Include_reference_on_derived_type_using_string();
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -3544,7 +3544,7 @@ ORDER BY [t3].[Id]");
             base.Project_collection_navigation_with_inheritance2();
 
             AssertSql(
-                @"SELECT [h].[Id], [t0].[Nickname], [t0].[SquadId]
+                @"SELECT [h].[Id], [h].[CapitalName], [h].[Discriminator], [h].[Name], [h].[CommanderName], [h].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Faction] AS [h]
 LEFT JOIN (
     SELECT [h.Commander].*
@@ -3556,21 +3556,28 @@ LEFT JOIN (
     FROM [Gear] AS [h.Commander.DefeatedBy]
     WHERE [h.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
-WHERE [h].[Discriminator] = N'LocustHorde'",
+WHERE [h].[Discriminator] = N'LocustHorde'
+ORDER BY [t0].[Nickname], [t0].[SquadId]",
                 //
-                @"@_outer_Nickname='Marcus' (Size = 4000)
-@_outer_SquadId='1'
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
-                //
-                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
-@_outer_SquadId='' (Nullable = false) (DbType = Int32)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+                @"SELECT [h.Commander.DefeatedBy.Reports].[Nickname], [h.Commander.DefeatedBy.Reports].[SquadId], [h.Commander.DefeatedBy.Reports].[AssignedCityName], [h.Commander.DefeatedBy.Reports].[CityOrBirthName], [h.Commander.DefeatedBy.Reports].[Discriminator], [h.Commander.DefeatedBy.Reports].[FullName], [h.Commander.DefeatedBy.Reports].[HasSoulPatch], [h.Commander.DefeatedBy.Reports].[LeaderNickname], [h.Commander.DefeatedBy.Reports].[LeaderSquadId], [h.Commander.DefeatedBy.Reports].[Rank]
+FROM [Gear] AS [h.Commander.DefeatedBy.Reports]
+INNER JOIN (
+    SELECT DISTINCT [t2].[Nickname], [t2].[SquadId]
+    FROM [Faction] AS [h0]
+    LEFT JOIN (
+        SELECT [h.Commander0].*
+        FROM [LocustLeader] AS [h.Commander0]
+        WHERE [h.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t1] ON [h0].[CommanderName] = [t1].[Name]
+    LEFT JOIN (
+        SELECT [h.Commander.DefeatedBy0].*
+        FROM [Gear] AS [h.Commander.DefeatedBy0]
+        WHERE [h.Commander.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t2] ON ([t1].[DefeatedByNickname] = [t2].[Nickname]) AND ([t1].[DefeatedBySquadId] = [t2].[SquadId])
+    WHERE [h0].[Discriminator] = N'LocustHorde'
+) AS [t3] ON ([h.Commander.DefeatedBy.Reports].[LeaderNickname] = [t3].[Nickname]) AND ([h.Commander.DefeatedBy.Reports].[LeaderSquadId] = [t3].[SquadId])
+WHERE [h.Commander.DefeatedBy.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t3].[Nickname], [t3].[SquadId]");
         }
 
         public override void Project_collection_navigation_with_inheritance3()
@@ -3578,7 +3585,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].
             base.Project_collection_navigation_with_inheritance3();
 
             AssertSql(
-                @"SELECT [f].[Id], [t0].[Nickname], [t0].[SquadId]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Faction] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -3590,21 +3597,174 @@ LEFT JOIN (
     FROM [Gear] AS [f.Commander.DefeatedBy]
     WHERE [f.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
-WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')",
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [t0].[Nickname], [t0].[SquadId]",
                 //
-                @"@_outer_Nickname='Marcus' (Size = 4000)
-@_outer_SquadId='1'
+                @"SELECT [f.Commander.DefeatedBy.Reports].[Nickname], [f.Commander.DefeatedBy.Reports].[SquadId], [f.Commander.DefeatedBy.Reports].[AssignedCityName], [f.Commander.DefeatedBy.Reports].[CityOrBirthName], [f.Commander.DefeatedBy.Reports].[Discriminator], [f.Commander.DefeatedBy.Reports].[FullName], [f.Commander.DefeatedBy.Reports].[HasSoulPatch], [f.Commander.DefeatedBy.Reports].[LeaderNickname], [f.Commander.DefeatedBy.Reports].[LeaderSquadId], [f.Commander.DefeatedBy.Reports].[Rank]
+FROM [Gear] AS [f.Commander.DefeatedBy.Reports]
+INNER JOIN (
+    SELECT DISTINCT [t2].[Nickname], [t2].[SquadId]
+    FROM [Faction] AS [f0]
+    LEFT JOIN (
+        SELECT [f.Commander0].*
+        FROM [LocustLeader] AS [f.Commander0]
+        WHERE [f.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t1] ON [f0].[CommanderName] = [t1].[Name]
+    LEFT JOIN (
+        SELECT [f.Commander.DefeatedBy0].*
+        FROM [Gear] AS [f.Commander.DefeatedBy0]
+        WHERE [f.Commander.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t2] ON ([t1].[DefeatedByNickname] = [t2].[Nickname]) AND ([t1].[DefeatedBySquadId] = [t2].[SquadId])
+    WHERE ([f0].[Discriminator] = N'LocustHorde') AND ([f0].[Discriminator] = N'LocustHorde')
+) AS [t3] ON ([f.Commander.DefeatedBy.Reports].[LeaderNickname] = [t3].[Nickname]) AND ([f.Commander.DefeatedBy.Reports].[LeaderSquadId] = [t3].[SquadId])
+WHERE [f.Commander.DefeatedBy.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t3].[Nickname], [t3].[SquadId]");
+        }
 
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        public override void Include_reference_on_derived_type_using_string()
+        {
+            base.Include_reference_on_derived_type_using_string();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeader] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gear] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_reference_on_derived_type_using_lambda()
+        {
+            base.Include_reference_on_derived_type_using_lambda();
+
+            AssertSql(
+                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeader] AS [ll]
+LEFT JOIN (
+    SELECT [ll.DefeatedBy].*
+    FROM [Gear] AS [ll.DefeatedBy]
+    WHERE [ll.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([ll].[DefeatedByNickname] = [t].[Nickname]) AND ([ll].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_reference_on_derived_type_using_lambda_with_tracking()
+        {
+            base.Include_reference_on_derived_type_using_lambda_with_tracking();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeader] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gear] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_collection_on_derived_type_using_string()
+        {
+            base.Include_collection_on_derived_type_using_string();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
                 //
-                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
-@_outer_SquadId='' (Nullable = false) (DbType = Int32)
+                @"SELECT [g.Reports].[Nickname], [g.Reports].[SquadId], [g.Reports].[AssignedCityName], [g.Reports].[CityOrBirthName], [g.Reports].[Discriminator], [g.Reports].[FullName], [g.Reports].[HasSoulPatch], [g.Reports].[LeaderNickname], [g.Reports].[LeaderSquadId], [g.Reports].[Rank]
+FROM [Gear] AS [g.Reports]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([g.Reports].[LeaderNickname] = [t].[Nickname]) AND ([g.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [g.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId]");
+        }
 
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        public override void Include_collection_on_derived_type_using_lambda()
+        {
+            base.Include_collection_on_derived_type_using_lambda();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gear] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                //
+                @"SELECT [g.Reports].[Nickname], [g.Reports].[SquadId], [g.Reports].[AssignedCityName], [g.Reports].[CityOrBirthName], [g.Reports].[Discriminator], [g.Reports].[FullName], [g.Reports].[HasSoulPatch], [g.Reports].[LeaderNickname], [g.Reports].[LeaderSquadId], [g.Reports].[Rank]
+FROM [Gear] AS [g.Reports]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([g.Reports].[LeaderNickname] = [t].[Nickname]) AND ([g.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [g.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override void Include_base_navigation_on_derived_entity()
+        {
+            base.Include_base_navigation_on_derived_entity();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
+FROM [Gear] AS [g]
+LEFT JOIN [CogTag] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[FullName]",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
+FROM [Weapon] AS [g.Weapons]
+INNER JOIN (
+    SELECT DISTINCT [g0].[FullName]
+    FROM [Gear] AS [g0]
+    LEFT JOIN [CogTag] AS [g.Tag0] ON ([g0].[Nickname] = [g.Tag0].[GearNickName]) AND ([g0].[SquadId] = [g.Tag0].[GearSquadId])
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[FullName]");
+        }
+
+        public override void Include_on_derived_multi_level()
+        {
+            base.Include_on_derived_multi_level();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                //
+                @"SELECT [g.Reports].[Nickname], [g.Reports].[SquadId], [g.Reports].[AssignedCityName], [g.Reports].[CityOrBirthName], [g.Reports].[Discriminator], [g.Reports].[FullName], [g.Reports].[HasSoulPatch], [g.Reports].[LeaderNickname], [g.Reports].[LeaderSquadId], [g.Reports].[Rank], [g.Squad].[Id], [g.Squad].[InternalNumber], [g.Squad].[Name]
+FROM [Gear] AS [g.Reports]
+INNER JOIN [Squad] AS [g.Squad] ON [g.Reports].[SquadId] = [g.Squad].[Id]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gear] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([g.Reports].[LeaderNickname] = [t].[Nickname]) AND ([g.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [g.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId], [g.Squad].[Id]",
+                //
+                @"SELECT [g.Squad.Missions].[SquadId], [g.Squad.Missions].[MissionId]
+FROM [SquadMission] AS [g.Squad.Missions]
+INNER JOIN (
+    SELECT DISTINCT [g.Squad0].[Id], [t0].[Nickname], [t0].[SquadId]
+    FROM [Gear] AS [g.Reports0]
+    INNER JOIN [Squad] AS [g.Squad0] ON [g.Reports0].[SquadId] = [g.Squad0].[Id]
+    INNER JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId]
+        FROM [Gear] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t0] ON ([g.Reports0].[LeaderNickname] = [t0].[Nickname]) AND ([g.Reports0].[LeaderSquadId] = [t0].[SquadId])
+    WHERE [g.Reports0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t1] ON [g.Squad.Missions].[SquadId] = [t1].[Id]
+ORDER BY [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
It was not possible to specify include on a derived type. Include was very strict when computing navigation paths from Include method and generated code wasn't accounting for type discrepancies between caller and navigation.

Fix is to allow specifying include on derived types using string overload:
entities.Include("DerivedProperty")

or using lambda with "as" operator:
entities.Include(e => (e as Derived).DerivedProperty)

Made tweaks to the logic that computes navigation paths - now it looks for navigation on derived types also.
Added additional checks to the generated code (_Include method fixup)

old:

    fixup: (QueryContext queryContext | SomeEntity entity | Object[] included) =>
    {
        return !(bool ReferenceEquals(included[0], null))
        {
            return entity.Navigation = (OtherEntity)included[0]
        }
         : default(OtherEntity)
    }

new:

    fixup: (QueryContext queryContext | SomeEntity entity | Object[] included) =>
    {
        return !(bool ReferenceEquals(included[0], null)) && (entity is DerivedEntity) ?
        {
            return ((DerivedEntity)entity).DerivedNavigation = (OtherEntity)included[0]
        }
         : default(OtherEntity)
    }

This also allows to reuse include pipeline to project collection navigations on derived types (before it was producing N+1 queries)