### PR TITLE
Remove TreatWarningsAsErrors from common.props

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -9,8 +9,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/aspnet/EntityFramework.git</RepositoryUrl>
     <SignAssembly>True</SignAssembly>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <NoWarn>NU1603;NU1605;$(NoWarn)</NoWarn>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <DebugType Condition="'$(Configuration)' == 'Debug' AND '$(OS)' == 'Windows_NT'">full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
- Property is automatically set by Internal.AspNetCore.Sdk