### PR TITLE
fix #8590 - Add DateAdd support for DatetimeOffset

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -2625,6 +2625,133 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddYears()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddYears(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(3, 1, 2, 10, 0, 0, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(3, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(11, 5, 3, 12, 0, 0, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddMonths()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddMonths(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 2, 2, 10, 0, 0, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 4, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 6, 3, 12, 0, 0, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddDays()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddDays(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 1, 3, 10, 0, 0, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 3, 2, 8, 0, 0, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 5, 4, 12, 0, 0, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddHours()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddHours(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 1, 2, 11, 0, 0, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 3, 1, 9, 0, 0, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 5, 3, 13, 0, 0, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddMinutes()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddMinutes(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 1, 2, 10, 1, 0, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 3, 1, 8, 1, 0, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 5, 3, 12, 1, 0, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddSeconds()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddSeconds(1);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 1, 2, 10, 0, 1, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 3, 1, 8, 0, 1, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 5, 3, 12, 0, 1, new TimeSpan()), result[2]);
+            }
+        }
+
+
+        [ConditionalFact]
+        public virtual void DateTimeOffset_DateAdd_AddMilliseconds()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from m in context.Missions
+                            orderby m.Timeline
+                            select m.Timeline.AddMilliseconds(300);
+
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal(new DateTimeOffset(2, 1, 2, 10, 0, 0, 300, new TimeSpan(1, 30, 0)), result[0]);
+                Assert.Equal(new DateTimeOffset(2, 3, 1, 8, 0, 0, 300, new TimeSpan(-5, 0, 0)), result[1]);
+                Assert.Equal(new DateTimeOffset(10, 5, 3, 12, 0, 0, 300, new TimeSpan()), result[2]);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Orderby_added_for_client_side_GroupJoin_composite_dependent_to_principal_LOJ_when_incomplete_key_is_used()
         {
             using (var ctx = CreateContext())

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -29,13 +29,13 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             var lightmassOffensive = new Mission
             {
                 CodeName = "Lightmass Offensive",
-                Timeline = new DateTimeOffset(2, 1, 2, 10, 0, 0, new TimeSpan())
+                Timeline = new DateTimeOffset(2, 1, 2, 10, 0, 0, new TimeSpan(1, 30, 0))
             };
 
             var hollowStorm = new Mission
             {
                 CodeName = "Lightmass Offensive",
-                Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan())
+                Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0))
             };
 
             var halvoBay = new Mission

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateAddTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateAddTranslator.cs
@@ -24,7 +24,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             {  typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddHours), new[] { typeof(double) }), "hour" },
             {  typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMinutes), new[] { typeof(double) }), "minute" },
             {  typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddSeconds), new[] { typeof(double) }), "second" },
-            {  typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMilliseconds), new[] { typeof(double) }), "millisecond" }
+            {  typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMilliseconds), new[] { typeof(double) }), "millisecond" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddYears), new[] { typeof(int) }), "year" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMonths), new[] { typeof(int) }), "month" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddDays), new[] { typeof(double) }), "day" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddHours), new[] { typeof(double) }), "hour" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMinutes), new[] { typeof(double) }), "minute" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddSeconds), new[] { typeof(double) }), "second" },
+            {  typeof(DateTimeOffset).GetRuntimeMethod(nameof(DateTimeOffset.AddMilliseconds), new[] { typeof(double) }), "millisecond" }
         };
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2599,6 +2599,76 @@ FROM [Mission] AS [m]
 WHERE DATEPART(month, [m].[Timeline]) = 5");
         }
 
+        public override void DateTimeOffset_DateAdd_AddYears()
+        {
+            base.DateTimeOffset_DateAdd_AddYears();
+
+            AssertSql(
+                @"SELECT DATEADD(year, 1, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddMonths()
+        {
+            base.DateTimeOffset_DateAdd_AddMonths();
+
+            AssertSql(
+                @"SELECT DATEADD(month, 1, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddDays()
+        {
+            base.DateTimeOffset_DateAdd_AddDays();
+
+            AssertSql(
+                @"SELECT DATEADD(day, 1E0, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddHours()
+        {
+            base.DateTimeOffset_DateAdd_AddHours();
+
+            AssertSql(
+                @"SELECT DATEADD(hour, 1E0, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddMinutes()
+        {
+            base.DateTimeOffset_DateAdd_AddMinutes();
+
+            AssertSql(
+                @"SELECT DATEADD(minute, 1E0, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddSeconds()
+        {
+            base.DateTimeOffset_DateAdd_AddSeconds();
+
+            AssertSql(
+                @"SELECT DATEADD(second, 1E0, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
+        public override void DateTimeOffset_DateAdd_AddMilliseconds()
+        {
+            base.DateTimeOffset_DateAdd_AddMilliseconds();
+
+            AssertSql(
+                @"SELECT DATEADD(millisecond, 300E0, [m].[Timeline])
+FROM [Mission] AS [m]
+ORDER BY [m].[Timeline]");
+        }
+
         public override void Orderby_added_for_client_side_GroupJoin_composite_dependent_to_principal_LOJ_when_incomplete_key_is_used()
         {
             base.Orderby_added_for_client_side_GroupJoin_composite_dependent_to_principal_LOJ_when_incomplete_key_is_used();


### PR DESCRIPTION
Adds DateAdd support for DatetimeOffset datatype in Sql Server.  Fixes issue #8590 
