### PR TITLE
Cache DbSet objects to prevent memory leaks when DbSets cache local views

### DIFF
--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public DbContextDependencies(
             [NotNull] IChangeDetector changeDetector,
-            [NotNull] IDbSetInitializer dbSetInitializer,
+            [NotNull] IDbSetSource setSource,
             [NotNull] IEntityFinderSource entityFinderSource,
             [NotNull] IEntityGraphAttacher entityGraphAttacher,
             [NotNull] IModel model,
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] IStateManager stateManager)
         {
             Check.NotNull(changeDetector, nameof(changeDetector));
-            Check.NotNull(dbSetInitializer, nameof(dbSetInitializer));
+            Check.NotNull(setSource, nameof(setSource));
             Check.NotNull(entityFinderSource, nameof(entityFinderSource));
             Check.NotNull(entityGraphAttacher, nameof(entityGraphAttacher));
             Check.NotNull(model, nameof(model));
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             Check.NotNull(stateManager, nameof(stateManager));
 
             ChangeDetector = changeDetector;
-            DbSetInitializer = dbSetInitializer;
+            SetSource = setSource;
             EntityFinderSource = entityFinderSource;
             EntityGraphAttacher = entityGraphAttacher;
             Model = model;
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public IDbSetInitializer DbSetInitializer { get; }
+        public IDbSetSource SetSource { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/DbSetInitializer.cs
+++ b/src/EFCore/Internal/DbSetInitializer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using JetBrains.Annotations;
 
@@ -36,22 +35,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             foreach (var setInfo in _setFinder.FindSets(context).Where(p => p.Setter != null))
             {
-                setInfo.Setter.SetClrValue(context, _setSource.Create(context, setInfo.ClrType));
+                setInfo.Setter.SetClrValue(context, ((IDbSetCache)context).GetOrAddSet(_setSource, setInfo.ClrType));
             }
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual DbSet<TEntity> CreateSet<TEntity>(DbContext context) where TEntity : class
-            => (DbSet<TEntity>)CreateSet(context, typeof(TEntity));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual object CreateSet(DbContext context, Type type)
-            => _setSource.Create(context, type);
     }
 }

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var definingEntityType = entityType.DefiningEntityType;
             if (definingEntityType == null)
             {
-                return (IQueryable)context.GetService<IDbSetInitializer>().CreateSet(context, entityType.ClrType);
+                return (IQueryable)((IDbSetCache)context).GetOrAddSet(context.GetDependencies().SetSource, entityType.ClrType);
             }
 
             return BuildQueryRoot(context, definingEntityType)

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        IDbSetInitializer DbSetInitializer { get; }
+        IDbSetSource SetSource { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Internal/IDbSetCache.cs
+++ b/src/EFCore/Internal/IDbSetCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -9,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IDbSetInitializer
+    public interface IDbSetCache
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void InitializeSets([NotNull] DbContext context);
+        object GetOrAddSet([NotNull] IDbSetSource source, [NotNull] Type type);
     }
 }

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -16,6 +16,42 @@ namespace Microsoft.EntityFrameworkCore
     public class DbSetTest
     {
         [Fact]
+        public void DbSets_are_cached()
+        {
+            DbSet<Category> set;
+
+            using (var context = new EarlyLearningCenter())
+            {
+                set = context.Categories;
+                Assert.Same(set, context.Set<Category>());
+            }
+
+            using (var context = new EarlyLearningCenter())
+            {
+                Assert.NotSame(set, context.Categories);
+                Assert.NotSame(set, context.Set<Category>());
+            }
+        }
+
+        [Fact]
+        public void Use_of_LocalView_throws_if_context_is_disposed()
+        {
+            LocalView<Category> view;
+
+            using (var context = new EarlyLearningCenter())
+            {
+                view = context.Categories.Local;
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => view.Add(new Category()));
+            Assert.Throws<ObjectDisposedException>(() => view.Remove(new Category()));
+            Assert.Throws<ObjectDisposedException>(() => view.Contains(new Category()));
+            Assert.Throws<ObjectDisposedException>(() => view.CopyTo(new Category[0], 0));
+            Assert.Throws<ObjectDisposedException>(() => view.Clear());
+            Assert.Throws<ObjectDisposedException>(() => view.GetEnumerator());
+        }
+
+        [Fact]
         public void Using_ignored_entity_that_has_DbSet_on_context_throws_appropriately()
         {
             using (var context = new IgnoredCntext())

--- a/test/EFCore.Tests/Infrastructure/EntityFrameworkServicesBuilderTest.cs
+++ b/test/EFCore.Tests/Infrastructure/EntityFrameworkServicesBuilderTest.cs
@@ -329,15 +329,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             {
             }
 
-            public DbSet<TEntity> CreateSet<TEntity>(DbContext context) where TEntity : class
-            {
-                throw new NotImplementedException();
-            }
+            public DbSet<TEntity> CreateSet<TEntity>(DbContext context) where TEntity : class => throw new NotImplementedException();
 
-            public object CreateSet(DbContext context, Type type)
-            {
-                throw new NotImplementedException();
-            }
+            public object CreateSet(DbContext context, Type type) => throw new NotImplementedException();
         }
 
         private class FakeEntityStateListener : IEntityStateListener


### PR DESCRIPTION
Issue #8144

I don't think that there is any issue not un-registering the listeners, since LocalView objects always have the same lifetime as the underlying context. I added checks so that the LocalView will throw if it is being used with a disposed context.
