### PR TITLE
Add `TestFilter` property on build.cmd to allow selective test runs

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,13 +1,9 @@
 <Project>
-  <ItemGroup>
-    <!-- SQL Server functional tests which needs SQL connection but no exsting database. -->
-    <SqlServerTests Include="$(RepositoryRoot)test\EFCore.SqlServer*FunctionalTests\*.csproj" />
-  </ItemGroup>
 
   <Target Name="_FilterTestProjects" BeforeTargets="TestProjects">
-    <ItemGroup Condition="'$(TestGroup)' != ''">
-      <ProjectsToTest Remove="@(ProjectsToTest)" Condition="'$(TestGroup)' != 'All'" />
-      <ProjectsToTest Include="@(SqlServerTests)" Condition="'$(TestGroup)' == 'SqlServer'" />
+    <ItemGroup Condition="'$(TestFilter)' != ''">
+      <ProjectsToTest Remove="@(ProjectsToTest)"/>
+      <ProjectsToTest Include="$(RepositoryRoot)test\*$(TestFilter)*\*.csproj" Exclude="@(ExcludeFromTest)" />
     </ItemGroup>
 
     <Error Text="Could not find test projects to run" Condition="@(ProjectsToTest->Count()) == 0" />


### PR DESCRIPTION
Usage: build.cmd /p:TestFilter=InMemory would run only tests whose folder names contain InMemory

Resolves #8679 
`build.cmd /p:TestFilter=Functional`
