### PR TITLE
Test: Print debug output when AssertSql fails

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -23,8 +23,9 @@ namespace Microsoft.EntityFrameworkCore
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override async Task ToList_on_nav_in_projection_is_async()

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
         public BuiltInDataTypesSqlServerTest(BuiltInDataTypesSqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CompiledQuerySqlServerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public CompiledQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void DbSet_query()

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -16,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         // TODO: Assert SQL

--- a/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -15,7 +15,9 @@ namespace Microsoft.EntityFrameworkCore
             ComplexNavigationsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         private bool SupportsOffset => TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore
         public DataAnnotationSqlServerTest(DataAnnotationSqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)

--- a/test/EFCore.SqlServer.FunctionalTests/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbFunctionsSqlServerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public DbFunctionsSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void String_Like_Literal()

--- a/test/EFCore.SqlServer.FunctionalTests/FiltersInheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FiltersInheritanceSqlServerTest.cs
@@ -11,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Can_use_of_type_animal()

--- a/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FiltersSqlServerTest.cs
@@ -14,8 +14,9 @@ namespace Microsoft.EntityFrameworkCore
         public FiltersSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Count_query()

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
         protected FindSqlServerTest(FindSqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public class FindSqlServerTestSet : FindSqlServerTest

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -12,8 +12,9 @@ namespace Microsoft.EntityFrameworkCore
         public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void From_sql_queryable_simple()

--- a/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FromSqlSprocQuerySqlServerTest.cs
@@ -137,7 +137,7 @@ FROM (
             NorthwindSprocQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         protected override string TenMostExpensiveProductsSproc => "[dbo].[Ten Most Expensive Products]";

--- a/test/EFCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FunkyDataQuerySqlServerTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore
         public FunkyDataQuerySqlServerTest(FunkyDataQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void String_ends_with_equals_nullable_column()

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarFromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarFromSqlQuerySqlServerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public GearsOfWarFromSqlQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void From_sql_queryable_simple_columns_out_of_order()

--- a/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -15,7 +15,8 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Entity_equality_empty()

--- a/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -14,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore
         public IncludeSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Include_list(bool useString)

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -14,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore
             InheritanceRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Include_reference_with_inheritance1()

--- a/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore
         public LoadSqlServerTest(LoadSqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override async Task Load_collection(EntityState state, bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore
         public NullSemanticsQuerySqlServerTest(NullSemanticsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Compare_bool_with_bool_equal()

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public PropertyEntrySqlServerTest(F1SqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void Property_entry_original_value_is_set()

--- a/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore
             NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Join_with_nav_projected_in_subquery_when_client_eval()

--- a/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -18,7 +18,8 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Lifting_when_subquery_nested_order_by_anonymous()

--- a/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -15,7 +15,9 @@ namespace Microsoft.EntityFrameworkCore
         public RowNumberPagingTest(NorthwindRowNumberPagingQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public void Dispose()

--- a/test/EFCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlExecutorSqlServerTest.cs
@@ -13,8 +13,9 @@ namespace Microsoft.EntityFrameworkCore
         public SqlExecutorSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         public override void Executes_stored_procedure()

--- a/test/EFCore.SqlServer.FunctionalTests/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UdfDbFunctionSqlServerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -17,11 +18,13 @@ namespace Microsoft.EntityFrameworkCore
 
     public class UdfDbFunctionSqlServerTests : IClassFixture<NorthwindDbFunctionSqlServerFixture>
     {
-        public UdfDbFunctionSqlServerTests(NorthwindDbFunctionSqlServerFixture fixture)
+        public UdfDbFunctionSqlServerTests(NorthwindDbFunctionSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
         {
             Fixture = fixture;
 
             Fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.EnableLog();
         }
 
         protected NorthwindDbFunctionSqlServerFixture Fixture { get; }

--- a/test/EFCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/WarningsSqlServerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public WarningsSqlServerTest(WarningsSqlServerFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void Does_not_throw_for_top_level_single()

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore
         public DataAnnotationSqliteTest(DataAnnotationSqliteFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore
         public PropertyEntrySqliteTest(F1SqliteFixture fixture)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void Property_entry_original_value_is_set()

--- a/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore
         public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void Take_Skip()


### PR DESCRIPTION
Resolves #8759 

This works only for "AssertSql" functions. We cannot output anything unless our logger captures it. And I am not able to find a hook where I can capture failed test and print out the output to ITestOutputHelper.
This will print out whole query plan whenever AssertSql fails.
