### PR TITLE
Generate temp values for string, Guid, and binary key properties if column has default SQL

### DIFF
--- a/src/EFCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/EFCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -45,6 +45,24 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
                 {
                     return new TemporaryDateTimeOffsetValueGenerator();
                 }
+
+                if (property.Relational().DefaultValueSql != null)
+                {
+                    if (propertyType == typeof(Guid))
+                    {
+                        return new TemporaryGuidValueGenerator();
+                    }
+
+                    if (propertyType == typeof(string))
+                    {
+                        return new StringValueGenerator(generateTemporaryValues: true);
+                    }
+
+                    if (propertyType == typeof(byte[]))
+                    {
+                        return new BinaryValueGenerator(generateTemporaryValues: true);
+                    }
+                }
             }
 
             return base.Create(property, entityType);

--- a/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -53,6 +53,36 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public void Returns_temp_string_generator_when_default_sql_set()
+        {
+            var model = BuildModel();
+            var entityType = model.FindEntityType(typeof(AnEntity));
+
+            entityType.FindProperty("String").SqlServer().DefaultValueSql = "Foo";
+
+            var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
+
+            var generator = selector.Select(entityType.FindProperty("String"), entityType);
+            Assert.IsType<StringValueGenerator>(generator);
+            Assert.True(generator.GeneratesTemporaryValues);
+        }
+
+        [Fact]
+        public void Returns_temp_binary_generator_when_default_sql_set()
+        {
+            var model = BuildModel();
+            var entityType = model.FindEntityType(typeof(AnEntity));
+
+            entityType.FindProperty("Binary").SqlServer().DefaultValueSql = "Foo";
+
+            var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
+
+            var generator = selector.Select(entityType.FindProperty("Binary"), entityType);
+            Assert.IsType<BinaryValueGenerator>(generator);
+            Assert.True(generator.GeneratesTemporaryValues);
+        }
+
+        [Fact]
         public void Returns_sequence_value_generators_when_configured_for_model()
         {
             var model = BuildModel();


### PR DESCRIPTION
Otherwise we just send the generated key to the database.

Issue #8239
