### PR TITLE
Query: Explicit cast to long when Enum.HasFlag is used with long type…

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/EnumHasFlagTranslator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
@@ -56,10 +57,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
                 var convertedObjectExpression = Expression.Convert(methodCallExpression.Object, objectType);
                 var convertedArgumentExpression = Expression.Convert(argument, objectType);
 
+                var bitwiseArgumentExpression
+                    = objectType == typeof(long) && argument is ConstantExpression
+                        ? (Expression)new ExplicitCastExpression(argument, objectType)
+                        : convertedArgumentExpression;
+
                 return Expression.Equal(
                     Expression.And(
                         convertedObjectExpression,
-                        convertedArgumentExpression),
+                        bitwiseArgumentExpression),
                     convertedArgumentExpression);
             }
 


### PR DESCRIPTION
… Enum

Constants are assumed numeric in SqlServer
bitwise & is not defined for bigint & numeric

Resolves #8538 
