### PR TITLE
Query: Check for null constructor in NewExpression while computing ha…

### DIFF
--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -476,6 +477,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         Assert.Equal(l2oObjects, efObjects);
                     });
+        }
+
+        [ConditionalFact]
+        public virtual void New_date_time_in_anonymous_type_works()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs
+                      where c.CustomerID.StartsWith("A")
+                      select new { A = new DateTime() });
         }
     }
 }

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         var newExpression = (NewExpression)obj;
 
-                        hashCode += (hashCode * 397) ^ newExpression.Constructor.GetHashCode();
+                        hashCode += (hashCode * 397) ^ (newExpression.Constructor?.GetHashCode() ?? 0);
 
                         if (newExpression.Members != null)
                         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Select.cs
@@ -428,5 +428,15 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
         }
+
+        public override void New_date_time_in_anonymous_type_works()
+        {
+            base.New_date_time_in_anonymous_type_works();
+
+            AssertSql(
+                @"SELECT 1
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
+        }
     }
 }


### PR DESCRIPTION
…sh code

Resolves #8608 

For some reason,  `new { A = new DateTime() }` the inner NewExpression has constructor= null. (even though it is not possible to create NewExpression with null constructor. 