### PR TITLE
Uniquify column names for types sharing a table

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -62,6 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(sharedTableConvention);
 
             conventionSet.ModelBuiltConventions.Add(new RelationalTypeMappingConvention(Dependencies.TypeMapper));
+            conventionSet.ModelBuiltConventions.Add(sharedTableConvention);
 
             conventionSet.ModelAnnotationChangedConventions.Add(new RelationalDbFunctionConvention());
 

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/SharedTableConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -15,9 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IEntityTypeAddedConvention,
         IEntityTypeAnnotationChangedConvention,
         IForeignKeyOwnershipChangedConvention,
-        IForeignKeyUniquenessChangedConvention
+        IForeignKeyUniquenessChangedConvention,
+        IModelBuiltConvention
     {
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -79,5 +80,79 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             foreignKey.DeclaringEntityType.Builder.Relational(ConfigurationSource.Convention)
                 .ToTable(ownerType.Relational().TableName, ownerType.Relational().Schema);
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            var tables = new Dictionary<string, (List<EntityType> MappedEntityTypes, Dictionary<string, Property> Columns)>();
+            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            {
+                var annotations = entityType.Relational();
+                var tableName = Format(annotations.Schema, annotations.TableName);
+
+                if (tables.TryGetValue(tableName, out var tableMapping))
+                {
+                    if (tableMapping.MappedEntityTypes.Count == 1)
+                    {
+                        TryUniquifyColumnNames(tableMapping.MappedEntityTypes[0], tableMapping.Columns);
+                    }
+                    tableMapping.MappedEntityTypes.Add(entityType);
+                    TryUniquifyColumnNames(entityType, tableMapping.Columns);
+                }
+                else
+                {
+                    var mappedEntityTypes = new List<EntityType>();
+                    tables[tableName] = (mappedEntityTypes, new Dictionary<string, Property>());
+                    mappedEntityTypes.Add(entityType);
+                }
+            }
+
+            return modelBuilder;
+        }
+
+        private static void TryUniquifyColumnNames(EntityType entityType, Dictionary<string, Property> properties)
+        {
+            foreach (var property in entityType.GetDeclaredProperties())
+            {
+                var columnName = property.Relational().ColumnName;
+                if (properties.TryGetValue(columnName, out var otherProperty)
+                    && !property.IsPrimaryKey())
+                {
+                    var relationalPropertyBuilder = property.Builder.Relational(ConfigurationSource.Convention);
+                    if (relationalPropertyBuilder.CanSetColumnName(null))
+                    {
+                        relationalPropertyBuilder.ColumnName = Uniquify(columnName, properties);
+                        continue;
+                    }
+
+                    var otherRelationalPropertyBuilder = otherProperty.Builder.Relational(ConfigurationSource.Convention);
+                    if (!otherRelationalPropertyBuilder.CanSetColumnName(null))
+                    {
+                        continue;
+                    }
+                    otherRelationalPropertyBuilder.ColumnName = Uniquify(columnName, properties);
+                }
+                properties[columnName] = property;
+            }
+        }
+
+        private static string Uniquify<T>(string baseIdentifier, Dictionary<string, T> existingIdentifiers)
+        {
+            var finalIdentifier = baseIdentifier;
+            var suffix = 1;
+            while (existingIdentifiers.ContainsKey(finalIdentifier))
+            {
+                finalIdentifier = baseIdentifier + suffix;
+                suffix++;
+            }
+
+            return finalIdentifier;
+        }
+
+        private static string Format(string schema, string name)
+            => (string.IsNullOrEmpty(schema) ? "" : schema + ".") + name;
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
@@ -50,6 +50,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool CanSetColumnName([CanBeNull] string value)
+            => Annotations.CanSetAnnotation(RelationalAnnotationNames.ColumnName, value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool HasColumnType([CanBeNull] string value) => SetColumnType(value);
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/TestHelpers.cs
+++ b/src/EFCore.Specification.Tests/TestHelpers.cs
@@ -360,6 +360,9 @@ namespace Microsoft.EntityFrameworkCore
             return new ModelBuilder(conventionSet);
         }
 
+        public IModelValidator CreateModelValidator()
+            => CreateContextServices().GetRequiredService<IModelValidator>();
+
         public InternalEntityEntry CreateInternalEntry<TEntity>(
             IModel model, EntityState entityState = EntityState.Detached, TEntity entity = null)
             where TEntity : class, new()

--- a/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
@@ -68,23 +68,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         protected override void ValidateSharedTableCompatibility(
-            IEntityType newEntityType, List<IEntityType> otherMappedTypes, string tableName)
+            IReadOnlyList<IEntityType> mappedTypes, string tableName)
         {
-            var isMemoryOptimized = newEntityType.SqlServer().IsMemoryOptimized;
+            var firstMappedType = mappedTypes[0];
+            var isMemoryOptimized = firstMappedType.SqlServer().IsMemoryOptimized;
 
-            foreach (var otherMappedType in otherMappedTypes)
+            foreach (var otherMappedType in mappedTypes.Skip(1))
             {
                 if (isMemoryOptimized != otherMappedType.SqlServer().IsMemoryOptimized)
                 {
                     throw new InvalidOperationException(
                         SqlServerStrings.IncompatibleTableMemoryOptimizedMismatch(
-                            tableName, newEntityType.DisplayName(), otherMappedType.DisplayName(),
-                            isMemoryOptimized ? newEntityType.DisplayName() : otherMappedType.DisplayName(),
-                            !isMemoryOptimized ? newEntityType.DisplayName() : otherMappedType.DisplayName()));
+                            tableName, firstMappedType.DisplayName(), otherMappedType.DisplayName(),
+                            isMemoryOptimized ? firstMappedType.DisplayName() : otherMappedType.DisplayName(),
+                            !isMemoryOptimized ? firstMappedType.DisplayName() : otherMappedType.DisplayName()));
                 }
             }
 
-            base.ValidateSharedTableCompatibility(newEntityType, otherMappedTypes, tableName);
+            base.ValidateSharedTableCompatibility(mappedTypes, tableName);
         }
 
         protected override void ValidateSharedColumnsCompatibility(IReadOnlyList<IEntityType> mappedTypes, string tableName)

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<A>().ToTable("Table").ForSqlServerIsMemoryOptimized();
             modelBuilder.Entity<B>().ToTable("Table");
 
-            VerifyError(SqlServerStrings.IncompatibleTableMemoryOptimizedMismatch("Table", nameof(B), nameof(A), nameof(A), nameof(B)),
+            VerifyError(SqlServerStrings.IncompatibleTableMemoryOptimizedMismatch("Table", nameof(A), nameof(B), nameof(A), nameof(B)),
                 modelBuilder.Model);
         }
 

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -712,6 +712,45 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(baseEntity2, derivedEntity2.BaseType);
                 Assert.NotNull(baseEntity2.FindPrimaryKey());
             }
+
+            [Fact] // #7049
+            public void Base_type_can_be_discovered_after_creating_foreign_keys_on_derived()
+            {
+                var mb = CreateModelBuilder();
+                mb.Entity<AL>();
+                mb.Entity<L>();
+
+                Assert.Equal(ValueGenerated.OnAdd, mb.Model.FindEntityType(typeof(Q)).FindProperty(nameof(Q.ID)).ValueGenerated);
+            }
+
+            public class L
+            {
+                public int Id { get; set; }
+                public IList<T> Ts { get; set; }
+            }
+
+            public class T : P
+            {
+                public Q D { get; set; }
+                public P P { get; set; }
+                public Q F { get; set; }
+            }
+
+            public class P : PBase { }
+
+            public class Q : PBase { }
+
+            public abstract class PBase
+            {
+                public int ID { get; set; }
+                public string Stuff { get; set; }
+            }
+
+            public class AL
+            {
+                public int Id { get; set; }
+                public PBase L { get; set; }
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
@@ -14,23 +14,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         public class GenericOneToManyString : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericStringTestModelBuilder(testHelpers);
         }
 
         public class GenericManyToOneString : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericStringTestModelBuilder(testHelpers);
         }
 
         public class GenericOneToOneString : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericStringTestModelBuilder(testHelpers);
         }
 
         private class GenericStringTestModelBuilder : TestModelBuilder
         {
-            public GenericStringTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public GenericStringTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -38,11 +41,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new GenericStringTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity<TEntity>());
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new GenericStringTestModelBuilder(ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
-                    buildAction(new GenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
+                    buildAction(new GenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new GenericStringTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+            {
+                ModelBuilder.Ignore<TEntity>();
+                return this;
+            }
 
             public override string GetDisplayName(Type entityType) => entityType.FullName;
         }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeStringTest.cs
@@ -12,14 +12,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         public class GenericOneToOneTypeString : GenericOneToOneType
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTypeTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTypeTestModelBuilder(testHelpers);
         }
 
         private class GenericTypeTestModelBuilder : TestModelBuilder
         {
-            public GenericTypeTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public GenericTypeTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -27,11 +27,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new GenericTypeTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity<TEntity>());
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new GenericTypeTestModelBuilder(ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
-                    buildAction(new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
+                    buildAction(new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new GenericTypeTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+            {
+                ModelBuilder.Ignore<TEntity>();
+                return this;
+            }
         }
 
         private class GenericTypeTestEntityTypeBuilder<TEntity> : GenericTestEntityTypeBuilder<TEntity>

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
@@ -13,13 +13,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         public class GenericOneToOneType : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericTypeTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTypeTestModelBuilder(testHelpers);
         }
 
         private class GenericTypeTestModelBuilder : TestModelBuilder
         {
-            public GenericTypeTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public GenericTypeTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -27,11 +28,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new GenericTypeTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity<TEntity>());
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new GenericTypeTestModelBuilder(ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
-                    buildAction(new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
+                    buildAction(new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new GenericTypeTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+            {
+                ModelBuilder.Ignore<TEntity>();
+                return this;
+            }
         }
 
         private class GenericTypeTestEntityTypeBuilder<TEntity> : GenericTestEntityTypeBuilder<TEntity>

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -70,44 +70,44 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(1, modelBuilder.Model.FindEntityType(typeof(EntityBase)).GetProperties().Count());
             }
 
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         public class GenericInheritance : InheritanceTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         public class GenericOwnedTypes : OwnedTypesTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         public class GenericOneToMany : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         public class GenericManyToOne : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         public class GenericOneToOne : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new GenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new GenericTestModelBuilder(testHelpers);
         }
 
         protected class GenericTestModelBuilder : TestModelBuilder
         {
-            public GenericTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public GenericTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -115,11 +115,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new GenericTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity<TEntity>());
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new GenericTestModelBuilder(ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
-                    buildAction(new GenericTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity<TEntity>(entityTypeBuilder =>
+                    buildAction(new GenericTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new GenericTestModelBuilder(ModelBuilder.Ignore<TEntity>());
+            {
+                ModelBuilder.Ignore<TEntity>();
+                return this;
+            }
         }
 
         protected class GenericTestEntityTypeBuilder<TEntity> : TestEntityTypeBuilder<TEntity>

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -56,7 +56,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(typeof(Customer), "CustomerNavigation")).Message);
             }
 
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         public class NonGenericStringManyToOneType : ManyToOneTestBase
@@ -101,7 +102,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     Assert.Throws<InvalidOperationException>(() => customerEntityType.HasMany(typeof(Order), "OrdersNavigation")).Message);
             }
 
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         public class NonGenericStringOneToOneType : OneToOneTestBase
@@ -147,13 +149,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     Assert.Throws<InvalidOperationException>(() => orderEntityType.HasOne(typeof(OrderDetails), "OrderDetailsNavigation")).Message);
             }
 
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         private class NonGenericStringTestModelBuilder : TestModelBuilder
         {
-            public NonGenericStringTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public NonGenericStringTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -161,8 +164,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericStringTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity(typeof(TEntity)));
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new NonGenericStringTestModelBuilder(ModelBuilder.Entity(typeof(TEntity),
-                    e => buildAction(new NonGenericStringTestEntityTypeBuilder<TEntity>(e))));
+            {
+                ModelBuilder.Entity(typeof(TEntity),
+                    e => buildAction(new NonGenericStringTestEntityTypeBuilder<TEntity>(e)));
+                return this;
+            }
 
             public NonGenericStringTestEntityTypeBuilder Entity(Type type)
                 => new NonGenericStringTestEntityTypeBuilder(ModelBuilder.Entity(type));
@@ -171,7 +177,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericStringTestEntityTypeBuilder(ModelBuilder.Entity(name));
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new NonGenericStringTestModelBuilder(ModelBuilder.Ignore(typeof(TEntity)));
+            {
+                ModelBuilder.Ignore(typeof(TEntity));
+                return this;
+            }
 
             public override string GetDisplayName(Type entityType) => entityType.FullName;
         }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -18,70 +18,62 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         public class NonGenericNonRelationship : NonRelationshipTestBase
         {
-            [Fact]
-            public void Can_set_model_annotation()
-            {
-                var modelBuilder = (NonGenericTestModelBuilder)CreateModelBuilder();
-                var model = modelBuilder.Model;
-
-                modelBuilder = modelBuilder.HasAnnotation("Fus", "Ro");
-
-                Assert.NotNull(modelBuilder);
-                Assert.Equal("Ro", model.GetAnnotation("Fus").Value);
-            }
-
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         public class NonGenericInheritance : InheritanceTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         public class NonGenericOwnedTypes : OwnedTypesTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         public class NonGenericOneToMany : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         public class NonGenericManyToOne : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         public class NonGenericOneToOne : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-                => new NonGenericTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericTestModelBuilder(testHelpers);
         }
 
         private class NonGenericTestModelBuilder : TestModelBuilder
         {
-            public NonGenericTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public NonGenericTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
-
-            public NonGenericTestModelBuilder HasAnnotation(string annotation, object value)
-                => new NonGenericTestModelBuilder(ModelBuilder.HasAnnotation(annotation, value));
 
             public override TestEntityTypeBuilder<TEntity> Entity<TEntity>()
                 => new NonGenericTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity(typeof(TEntity)));
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new NonGenericTestModelBuilder(ModelBuilder.Entity(typeof(TEntity), entityTypeBuilder =>
-                    buildAction(new NonGenericTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity(typeof(TEntity), entityTypeBuilder =>
+                    buildAction(new NonGenericTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new NonGenericTestModelBuilder(ModelBuilder.Ignore(typeof(TEntity)));
+            {
+                ModelBuilder.Ignore(typeof(TEntity));
+                return this;
+            }
         }
 
         protected class NonGenericTestEntityTypeBuilder<TEntity> : TestEntityTypeBuilder<TEntity>

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -14,23 +14,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
     {
         public class NonGenericStringOneToManyType : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         public class NonGenericStringManyToOneType : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         public class NonGenericStringOneToOneType : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
         }
 
         private class NonGenericStringTestModelBuilder : TestModelBuilder
         {
-            public NonGenericStringTestModelBuilder(ModelBuilder modelBuilder)
-                : base(modelBuilder)
+            public NonGenericStringTestModelBuilder(TestHelpers testHelpers)
+                : base(testHelpers)
             {
             }
 
@@ -38,11 +41,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericStringTestEntityTypeBuilder<TEntity>(ModelBuilder.Entity(typeof(TEntity)));
 
             public override TestModelBuilder Entity<TEntity>(Action<TestEntityTypeBuilder<TEntity>> buildAction)
-                => new NonGenericStringTestModelBuilder(ModelBuilder.Entity(typeof(TEntity), entityTypeBuilder =>
-                    buildAction(new NonGenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder))));
+            {
+                ModelBuilder.Entity(typeof(TEntity), entityTypeBuilder =>
+                    buildAction(new NonGenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder)));
+                return this;
+            }
 
             public override TestModelBuilder Ignore<TEntity>()
-                => new NonGenericStringTestModelBuilder(ModelBuilder.Ignore(typeof(TEntity)));
+            {
+                ModelBuilder.Ignore(typeof(TEntity));
+                return this;
+            }
         }
 
         private class NonGenericStringTestEntityTypeBuilder<TEntity> : NonGenericTestEntityTypeBuilder<TEntity>

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -17,6 +17,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public abstract class NonRelationshipTestBase : ModelBuilderTestBase
         {
             [Fact]
+            public void Can_set_model_annotation()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder = modelBuilder.HasAnnotation("Fus", "Ro");
+
+                Assert.NotNull(modelBuilder);
+                Assert.Equal("Ro", model.FindAnnotation("Fus").Value);
+            }
+
+            [Fact]
             public virtual void Can_get_entity_builder_for_clr_type()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Use the provider model validator in the ModelBuilding tests
Fix and refactor RelationalModelValidator.ValidateSharedTableCompatibility

Fixes #7240