### PR TITLE
Fix to #8652 - InvalidCastException when casting from one value type to another in a simple select statement

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -233,6 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         outputType = inputType.IsNullableType() ? typeof(double?) : typeof(double);
                     }
 
+                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     expression = new ExplicitCastExpression(expression, outputType);
                     Expression averageExpression = new SqlFunctionExpression("AVG", outputType, new [] { expression });
 
@@ -621,6 +622,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
+                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     var minExpression = new SqlFunctionExpression("MIN", handlerContext.QueryModel.SelectClause.Selector.Type, new [] { expression });
 
                     handlerContext.SelectExpression.SetProjectionExpression(minExpression);
@@ -644,6 +646,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
+                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     var maxExpression = new SqlFunctionExpression("MAX", handlerContext.QueryModel.SelectClause.Selector.Type, new [] { expression });
 
                     handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
@@ -702,6 +705,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
 
+                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     Expression sumExpression = new SqlFunctionExpression("SUM", inputType, new [] { expression });
                     if (inputType.UnwrapNullableType() == typeof(float))
                     {

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.ResultOperators.cs
@@ -1064,5 +1064,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(19, query.Count);
             }
         }
+
+        [ConditionalFact]
+        public virtual void Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID.StartsWith("A"))
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)o.OrderID).Average());
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
@@ -487,5 +487,127 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where c.CustomerID.StartsWith("A")
                       select new { A = new DateTime() });
         }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_int_to_long_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)o.OrderID),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)o.EmployeeID),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (int)o.EmployeeID),
+            assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (int?)o.OrderID), 
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)(o.OrderID + o.OrderID)),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (short)((long)o.OrderID + (long)o.OrderID)),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)-o.OrderID),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => -((long)o.OrderID)),
+                assertOrder: true);
+        }
+
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_length_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)o.CustomerID.Length),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_method_call_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)Math.Abs(o.OrderID)),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast()
+        {
+            AssertQuery<Order>(
+                os => os
+                    .Where(o => o.CustomerID == "ALFKI")
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => new { LongOrder = (long)o.OrderID, ShortOrder = (short)o.OrderID, Order = o.OrderID }),
+                assertOrder: true);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.ResultOperators.cs
@@ -914,5 +914,15 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 ORDER BY [o].[OrderID]");
         }
+
+        public override void Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast()
+        {
+            base.Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast();
+
+            AssertSql(
+                @"SELECT AVG(CAST([o].[OrderID] AS float))
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Select.cs
@@ -438,5 +438,126 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
         }
+
+        public override void Select_non_matching_value_types_int_to_long_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_int_to_long_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST([o].[EmployeeID] AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT [o].[EmployeeID]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast()
+        {
+            base.Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast();
+
+            AssertSql(
+                @"SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] + [o].[OrderID] AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast()
+        {
+            base.Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] + [o].[OrderID] AS smallint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1()
+        {
+            base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1();
+
+            AssertSql(
+                @"SELECT CAST(-[o].[OrderID] AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2()
+        {
+            base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2();
+
+            AssertSql(
+                @"SELECT -CAST([o].[OrderID] AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_length_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_from_length_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST(CAST(LEN([o].[CustomerID]) AS int) AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_method_call_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_from_method_call_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST(ABS([o].[OrderID]) AS bigint)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [o].[OrderID]");
+        }
+
+        public override void Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast()
+        {
+            base.Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] AS bigint) AS [LongOrder], CAST([o].[OrderID] AS smallint) AS [ShortOrder], [o].[OrderID] AS [Order]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'
+ORDER BY [Order]");
+        }
     }
 }


### PR DESCRIPTION
Problem was for queries with value types being projected in a select expression when also using convert. The problem was that getValue is typed as object which then was converted to an expected type. However if the value returned by SQL was not exactly the same type, exception would get thrown due to boxing/unboxing.

Fix is to detect when we apply convert on a top level projection, and in this case use explicit cast, so that type returned by SQL was exactly the same as the type that was expected after unboxing.

Also added support for translating Negate expression, which was previously evaluated on the client.