### PR TITLE
Issue #8817 - "Given key was not present in the dictionary" after migration to 2.0

### DIFF
--- a/src/EFCore/Query/Internal/QueryBuffer.cs
+++ b/src/EFCore/Query/Internal/QueryBuffer.cs
@@ -456,9 +456,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         void IDisposable.Dispose()
         {
-            for (var i = _includedCollections.Count - 1; i >= 0; i--)
+            foreach (var kv in _includedCollections)
             {
-                _includedCollections[i]?.Dispose();
+                kv.Value?.Dispose();
             }
         }
     }


### PR DESCRIPTION
Unable to repro so far, but it looks like there are some cases where {_includedCollections.Keys} != {0.._includedCollections.Count - 1}

This change just removes that assumption during Dispose.

