### PR TITLE
Design: Enable instantiating DbContext types at design time

### DIFF
--- a/src/EFCore.Design/Design/DbContextActivator.cs
+++ b/src/EFCore.Design/Design/DbContextActivator.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    /// <summary>
+    ///     Used to instantiate <see cref="DbContext"/> types at design time.
+    /// </summary>
+    public static class DbContextActivator
+    {
+        /// <summary>
+        ///     Creates an instance of the specified <see cref="DbContext"/> type using the standard design-time
+        ///     mechanisms. When available, this will use any <see cref="IDesignTimeDbContextFactory{TContext}"/>
+        ///     implementations or the application's service provider.
+        /// </summary>
+        /// <param name="contextType"> The <see cref="DbContext"/> type to instantiate. </param>
+        /// <param name="startupAssembly"> The application's startup assembly. </param>
+        /// <param name="reportHandler"> The design-time report handler. </param>
+        /// <returns> The newly created object. </returns>
+        public static DbContext CreateInstance(
+            [NotNull] Type contextType,
+            [CanBeNull] Assembly startupAssembly = null,
+            [CanBeNull] IOperationReportHandler reportHandler = null)
+        {
+            Check.NotNull(contextType, nameof(contextType));
+
+            return new DbContextOperations(
+                    new OperationReporter(reportHandler),
+                    contextType.Assembly,
+                    startupAssembly ?? contextType.Assembly)
+                .CreateContext(contextType.FullName);
+        }
+    }
+}

--- a/src/EFCore.Design/Design/IOperationReportHandler.cs
+++ b/src/EFCore.Design/Design/IOperationReportHandler.cs
@@ -5,12 +5,39 @@ using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
+    /// <summary>
+    ///     Used to handle reported design-time activity.
+    /// </summary>
     public interface IOperationReportHandler
     {
+        /// <summary>
+        ///     Gets the contract version of this handler.
+        /// </summary>
+        /// <value> The contract version of this handler. </value>
         int Version { get; }
+
+        /// <summary>
+        ///     Invoked when an error is reported.
+        /// </summary>
+        /// <param name="message"> The message. </param>
         void OnError([NotNull] string message);
+
+        /// <summary>
+        ///     Invoked when a warning is reported.
+        /// </summary>
+        /// <param name="message"> The message. </param>
         void OnWarning([NotNull] string message);
+
+        /// <summary>
+        ///     Invoked when information is reported.
+        /// </summary>
+        /// <param name="message"> The message. </param>
         void OnInformation([NotNull] string message);
+
+        /// <summary>
+        ///     Invoked when verbose information is reported.
+        /// </summary>
+        /// <param name="message"> The message. </param>
         void OnVerbose([NotNull] string message);
     }
 }

--- a/src/EFCore.Design/Design/Internal/OperationReporter.cs
+++ b/src/EFCore.Design/Design/Internal/OperationReporter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public OperationReporter([NotNull] IOperationReportHandler handler)
+        public OperationReporter([CanBeNull] IOperationReportHandler handler)
         {
             _handler = handler;
         }
@@ -27,27 +27,27 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void WriteError(string message)
-            => _handler.OnError(message);
+            => _handler?.OnError(message);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void WriteWarning(string message)
-            => _handler.OnWarning(message);
+            => _handler?.OnWarning(message);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void WriteInformation(string message)
-            => _handler.OnInformation(message);
+            => _handler?.OnInformation(message);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual void WriteVerbose(string message)
-            => _handler.OnVerbose(message);
+            => _handler?.OnVerbose(message);
     }
 }

--- a/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
+++ b/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public class DbContextActivatorTest
+    {
+        [Fact]
+        public void CreateInstance_works()
+        {
+            var result = DbContextActivator.CreateInstance(typeof(TestContext));
+
+            Assert.IsType<TestContext>(result);
+        }
+
+        private class TestContext : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
+                => options.UseInMemoryDatabase(nameof(DbContextActivatorTest));
+        }
+    }
+}


### PR DESCRIPTION
Resolves #7050 

cc @prafullbhosale