### PR TITLE
Fix #8843 - Automatic eager loading of owned types.

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -347,6 +347,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Simple_owned_level1_convention()
+        {
+            AssertQuery<Level1>(l1s => l1s, elementSorter: e => e.Id);
+        }
+
+        [ConditionalFact]
         public virtual void Simple_owned_level1_level2()
         {
             AssertQuery<Level1>(l1s => l1s.Include(l1 => l1.OneToOne_Required_PK.OneToOne_Required_PK), elementSorter: e => e.Id);

--- a/src/EFCore.Specification.Tests/Query/OneToOneQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OneToOneQueryFixtureBase.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore
+namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class OneToOneQueryFixtureBase
     {

--- a/src/EFCore.Specification.Tests/Query/OwnedQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryFixtureBase.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class OwnedQueryFixtureBase
+    {
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OwnedPerson>().OwnsOne(p => p.PersonAddress).OwnsOne(a => a.Country);
+            modelBuilder.Entity<Branch>().OwnsOne(p => p.BranchAddress).OwnsOne(a => a.Country);
+            modelBuilder.Entity<LeafA>().OwnsOne(p => p.LeafAAddress).OwnsOne(a => a.Country);
+            modelBuilder.Entity<LeafB>().OwnsOne(p => p.LeafBAddress).OwnsOne(a => a.Country);
+        }
+
+        protected static void AddTestData(DbContext context)
+        {
+            context.Set<OwnedPerson>().AddRange(
+                new OwnedPerson
+                {
+                    PersonAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "USA" }
+                    }
+                },
+                new Branch
+                {
+                    PersonAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "USA" }
+                    },
+                    BranchAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "Canada" }
+                    }
+                },
+                new LeafA
+                {
+                    PersonAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "USA" }
+                    },
+                    BranchAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "Canada" }
+                    },
+                    LeafAAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "Mexico" }
+                    }
+                },
+                new LeafB
+                {
+                    PersonAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "USA" }
+                    },
+                    LeafBAddress = new OwnedAddress
+                    {
+                        Country = new OwnedCountry { Name = "Panama" }
+                    }
+                });
+
+            context.SaveChanges();
+        }
+    }
+
+    public class OwnedAddress
+    {
+        public OwnedCountry Country { get; set; }
+    }
+
+    public class OwnedCountry
+    {
+        public string Name { get; set; }
+    }
+
+    public class OwnedPerson
+    {
+        public int Id { get; set; }
+        public OwnedAddress PersonAddress { get; set; }
+    }
+
+    public class Branch : OwnedPerson
+    {
+        public OwnedAddress BranchAddress { get; set; }
+    }
+
+    public class LeafA : Branch
+    {
+        public OwnedAddress LeafAAddress { get; set; }
+    }
+
+    public class LeafB : OwnedPerson
+    {
+        public OwnedAddress LeafBAddress { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Xunit;
+// ReSharper disable InconsistentNaming
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class OwnedQueryTestBase
+    {
+        [Fact]
+        public virtual void Query_for_base_type_loads_all_owned_navs()
+        {
+            using (var context = CreateContext())
+            {
+                var people = context.Set<OwnedPerson>().ToList();
+                
+                Assert.Equal(4, people.Count);
+                Assert.True(people.All(p => p.PersonAddress != null));
+                Assert.True(people.OfType<Branch>().All(b => b.BranchAddress != null));
+                Assert.True(people.OfType<LeafA>().All(a => a.LeafAAddress != null));
+                Assert.True(people.OfType<LeafB>().All(b => b.LeafBAddress != null));
+            }
+        }
+        
+        [Fact]
+        public virtual void Query_for_branch_type_loads_all_owned_navs()
+        {
+            using (var context = CreateContext())
+            {
+                var people = context.Set<Branch>().ToList();
+
+                Assert.Equal(2, people.Count);
+                Assert.True(people.All(p => p.PersonAddress != null));
+                Assert.True(people.All(b => b.BranchAddress != null));
+                Assert.True(people.OfType<LeafA>().All(a => a.LeafAAddress != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Query_for_leaf_type_loads_all_owned_navs()
+        {
+            using (var context = CreateContext())
+            {
+                var people = context.Set<LeafA>().ToList();
+
+                Assert.Equal(1, people.Count);
+                Assert.True(people.All(p => p.PersonAddress != null));
+                Assert.True(people.All(b => b.BranchAddress != null));
+                Assert.True(people.All(a => a.LeafAAddress != null));
+            }
+        }
+
+        protected abstract DbContext CreateContext();
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -110,6 +110,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyIndexConvention);
 
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention());
+
             conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
             conventionSet.ModelBuiltConventions.Add(new IgnoredMembersValidationConvention());
@@ -144,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyFieldChangedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(timestampAttributeConvention);
-
+            
             return conventionSet;
         }
     }

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class NavigationEagerLoadingConvention : IForeignKeyOwnershipChangedConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
+        {
+            relationshipBuilder.Metadata.PrincipalToDependent.IsEager = relationshipBuilder.Metadata.IsOwnership;
+
+            return relationshipBuilder;
+        }
+    }
+}

--- a/src/EFCore/Metadata/IMutableNavigation.cs
+++ b/src/EFCore/Metadata/IMutableNavigation.cs
@@ -23,5 +23,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.
         /// </summary>
         new IMutableForeignKey ForeignKey { get; }
+        
+        /// <summary>
+        ///     Determines whether this navigation should be eager loaded by default.
+        /// </summary>
+        new bool IsEager { get; set; }
     }
 }

--- a/src/EFCore/Metadata/INavigation.cs
+++ b/src/EFCore/Metadata/INavigation.cs
@@ -17,5 +17,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.
         /// </summary>
         IForeignKey ForeignKey { get; }
+
+        /// <summary>
+        ///     Determines whether this navigation should be eager loaded by default.
+        /// </summary>
+        bool IsEager { get; }
     }
 }

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -364,12 +364,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _isUnique = unique;
             UpdateIsUniqueConfigurationSource(configurationSource);
 
-            if (isChanging)
-            {
-                return DeclaringEntityType.Model.ConventionDispatcher.OnForeignKeyUniquenessChanged(Builder)?.Metadata;
-            }
-
-            return this;
+            return isChanging 
+                ? DeclaringEntityType.Model.ConventionDispatcher.OnForeignKeyUniquenessChanged(Builder)?.Metadata 
+                : this;
         }
 
         private static bool DefaultIsUnique => false;
@@ -394,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool IsRequired
         {
             get { return !Properties.Any(p => p.IsNullable); }
-            set { SetIsRequired(value, ConfigurationSource.Explicit); }
+            set => SetIsRequired(value, ConfigurationSource.Explicit);
         }
 
         /// <summary>
@@ -454,8 +451,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual DeleteBehavior DeleteBehavior
         {
-            get { return _deleteBehavior ?? DefaultDeleteBehavior; }
-            set { SetDeleteBehavior(value, ConfigurationSource.Explicit); }
+            get => _deleteBehavior ?? DefaultDeleteBehavior;
+            set => SetDeleteBehavior(value, ConfigurationSource.Explicit);
         }
 
         /// <summary>
@@ -489,8 +486,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual bool IsOwnership
         {
-            get { return _isOwnership ?? DefaultIsOwnership; }
-            set { SetIsOwnership(value, ConfigurationSource.Explicit); }
+            get => _isOwnership ?? DefaultIsOwnership;
+            set => SetIsOwnership(value, ConfigurationSource.Explicit);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1729,12 +1729,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var existingNavigation = Metadata
                     .FindNavigationsInHierarchy(navigation.Name)
                     .SingleOrDefault(n => n.GetTargetType().Name == targetEntityType.Name && n.GetTargetType().HasDefiningNavigation());
+                
                 var builder = existingNavigation?.ForeignKey.Builder;
+                
                 if (builder != null)
                 {
                     builder = builder.RelatedEntityTypes(Metadata, existingNavigation.GetTargetType(), configurationSource);
                     builder = builder?.IsOwnership(true, configurationSource);
                     builder = builder?.Navigations(inverse, navigation, configurationSource);
+                    
                     return builder == null ? null : batch.Run(builder);
                 }
 

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -47,6 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ForeignKey ForeignKey { get; }
+        
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsEager { get; set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -74,8 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return;
             }
 
-            foreach (var includeLoadTree
-                in CreateIncludeLoadTrees(queryModel.SelectClause.Selector))
+            foreach (var includeLoadTree in CreateIncludeLoadTrees(queryModel.SelectClause.Selector))
             {
                 includeLoadTree.Compile(
                     _queryCompilationContext,

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -798,5 +798,20 @@
       "TypeId": "public abstract class Microsoft.EntityFrameworkCore.Infrastructure.ModelSource : Microsoft.EntityFrameworkCore.Infrastructure.IModelSource",
       "MemberId": "protected virtual System.Void FindSets(Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder, Microsoft.EntityFrameworkCore.DbContext context)",
       "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableNavigation : Microsoft.EntityFrameworkCore.Metadata.INavigation, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Boolean get_IsEager()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableNavigation : Microsoft.EntityFrameworkCore.Metadata.INavigation, Microsoft.EntityFrameworkCore.Metadata.IMutablePropertyBase",
+      "MemberId": "System.Void set_IsEager(System.Boolean value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.INavigation : Microsoft.EntityFrameworkCore.Metadata.IPropertyBase",
+      "MemberId": "System.Boolean get_IsEager()",
+      "Kind": "Addition"
     }
   ]

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryFixture.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQueryInMemoryFixture : OwnedQueryFixtureBase
+    {
+        private readonly DbContextOptions _options;
+
+        public OwnedQueryInMemoryFixture()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
+                .BuildServiceProvider();
+
+            _options = new DbContextOptionsBuilder()
+                .UseInMemoryDatabase(nameof(OwnedQueryInMemoryFixture))
+                .UseInternalServiceProvider(serviceProvider).Options;
+
+            using (var context = new DbContext(_options))
+            {
+                AddTestData(context);
+            }
+        }
+
+        public DbContext CreateContext() => new DbContext(_options);
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQueryInMemoryTest : OwnedQueryTestBase, IClassFixture<OwnedQueryInMemoryFixture>
+    {
+        private readonly OwnedQueryInMemoryFixture _fixture;
+
+        public OwnedQueryInMemoryTest(OwnedQueryInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
+        {
+            _fixture = fixture;
+            //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        protected override DbContext CreateContext() => _fixture.CreateContext();
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Property_entry_original_value_is_set();
 
             Assert.Contains(
-                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name]
+                @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [e].[Id], [e].[StorageLocation_Latitude], [e].[StorageLocation_Longitude]
 FROM [Engines] AS [e]",
                 Sql);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -27,8 +27,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Simple_owned_level1();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
 FROM [Level1] AS [l1]");
+        }
+        
+        [Fact]
+        public override void Simple_owned_level1_convention()
+        {
+            base.Simple_owned_level1_convention();
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[Id], [l].[OneToOne_Required_PK_Date], [l].[OneToOne_Required_PK_Level1_Optional_Id], [l].[OneToOne_Required_PK_Level1_Required_Id], [l].[OneToOne_Required_PK_Name], [l].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l].[Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l].[Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Optional_Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Required_Id], [l].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Name], [l].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+FROM [Level1] AS [l]");
         }
 
         [Fact]
@@ -37,7 +47,7 @@ FROM [Level1] AS [l1]");
             base.Simple_owned_level1_level2();
 
             AssertSql(
-                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[OneToOne_Required_PK_Level1_Optional_Id], [l1].[OneToOne_Required_PK_Level1_Required_Id], [l1].[OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Level2_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Optional_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Level3_Required_Id], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_Name], [l1].[OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Required_PK_OneToOne_Optional_PK_InverseId]
 FROM [Level1] AS [l1]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerFixture.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQuerySqlServerFixture : OwnedQueryFixtureBase, IDisposable
+    {
+        private readonly DbContextOptions _options;
+        private readonly SqlServerTestStore _testStore;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
+
+        public OwnedQuerySqlServerFixture()
+        {
+            _testStore = SqlServerTestStore.Create("OwnedQueryTest");
+
+            _options = new DbContextOptionsBuilder()
+                .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration())
+                .UseInternalServiceProvider(
+                    new ServiceCollection()
+                        .AddEntityFrameworkSqlServer()
+                        .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                        .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                        .BuildServiceProvider())
+                .Options;
+
+            using (var context = new DbContext(_options))
+            {
+                context.Database.EnsureCreated();
+
+                AddTestData(context);
+            }
+        }
+
+        public DbContext CreateContext() => new DbContext(_options);
+
+        public void Dispose() => _testStore.Dispose();
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQuerySqlServerTest : OwnedQueryTestBase, IClassFixture<OwnedQuerySqlServerFixture>
+    {
+        private readonly OwnedQuerySqlServerFixture _fixture;
+
+        public OwnedQuerySqlServerTest(OwnedQuerySqlServerFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_base_type_loads_all_owned_navs()
+        {
+            base.Query_for_base_type_loads_all_owned_navs();
+
+            AssertSql("");
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_branch_type_loads_all_owned_navs()
+        {
+            base.Query_for_branch_type_loads_all_owned_navs();
+
+            AssertSql("");
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_leaf_type_loads_all_owned_navs()
+        {
+            base.Query_for_leaf_type_loads_all_owned_navs();
+
+            AssertSql("");
+        }
+
+        protected override DbContext CreateContext() => _fixture.CreateContext();
+
+        private void AssertSql(params string[] expected)
+            => _fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/AutoincrementTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/AutoincrementTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
             base.Property_entry_original_value_is_set();
 
             Assert.Contains(
-                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name""
+                @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""e"".""Id"", ""e"".""StorageLocation_Latitude"", ""e"".""StorageLocation_Longitude""
 FROM ""Engines"" AS ""e""
 LIMIT 1",
                 Sql);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteFixture.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQuerySqliteFixture : OwnedQueryFixtureBase, IDisposable
+    {
+        private readonly DbContextOptions _options;
+        private readonly SqliteTestStore _testStore;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
+
+        public OwnedQuerySqliteFixture()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlite()
+                .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                .BuildServiceProvider();
+
+            _testStore = SqliteTestStore.CreateScratch();
+
+            _options = new DbContextOptionsBuilder()
+                .UseSqlite(_testStore.ConnectionString)
+                .UseInternalServiceProvider(serviceProvider)
+                .Options;
+
+            using (var context = new DbContext(_options))
+            {
+                context.Database.EnsureClean();
+
+                AddTestData(context);
+            }
+        }
+
+        public DbContext CreateContext() => new DbContext(_options);
+
+        public void Dispose() => _testStore.Dispose();
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class OwnedQuerySqliteTest : OwnedQueryTestBase, IClassFixture<OwnedQuerySqliteFixture>
+    {
+        private readonly OwnedQuerySqliteFixture _fixture;
+
+        public OwnedQuerySqliteTest(OwnedQuerySqliteFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_base_type_loads_all_owned_navs()
+        {
+            base.Query_for_base_type_loads_all_owned_navs();
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_branch_type_loads_all_owned_navs()
+        {
+            base.Query_for_branch_type_loads_all_owned_navs();
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_for_leaf_type_loads_all_owned_navs()
+        {
+            base.Query_for_leaf_type_loads_all_owned_navs();
+        }
+
+        protected override DbContext CreateContext() => _fixture.CreateContext();
+    }
+}


### PR DESCRIPTION
- Adds INavigation.IsEager - navs can now be marked as eager by-default (core metadata only).
- Adds a core convention that sets IsEager=true for principal-to-dependent navs when FK.IsOwnership=true.
- Updates the query compiler to auto-synthesize Include trees for owned navs on result QSREs.
- Adds a new query test suite for testing queries involving ownership.

