### PR TITLE
Fix #8884 - CompileQuery throws if query ends in Include

### DIFF
--- a/src/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
@@ -45,6 +45,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Query_ending_with_include()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context)
+                    => context.Customers.Include(c => c.Orders));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(91, query(context).ToList().Count);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(91, query(context).ToList().Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Untyped_context()
         {
             var query = EF.CompileQuery((DbContext context) => context.Set<Customer>());
@@ -77,7 +95,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal("ANATR", query(context, "ANATR").First().CustomerID);
             }
         }
+        
+        [ConditionalFact]
+        public virtual void Query_with_single_parameter_with_include()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context, string customerID)
+                    => context.Customers.Where(c => c.CustomerID == customerID).Include(c => c.Orders));
 
+            using (var context = CreateContext())
+            {
+                Assert.Equal("ALFKI", query(context, "ALFKI").First().CustomerID);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("ANATR", query(context, "ANATR").First().CustomerID);
+            }
+        }
+        
         [ConditionalFact]
         public virtual void First_query_with_single_parameter()
         {

--- a/src/EFCore/EF.CompileQuery.cs
+++ b/src/EFCore/EF.CompileQuery.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore
@@ -43,6 +44,19 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <typeparam name="TContext">The target DbContext type.</typeparam>
         /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, IEnumerable<TResult>> CompileQuery<TContext, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, IIncludableQueryable<TResult, TProperty>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
         /// <param name="queryExpression">The LINQ query expression.</param>
         /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
         public static Func<TContext, TResult> CompileQuery<TContext, TResult>(
@@ -60,6 +74,20 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
         public static Func<TContext, TParam1, IEnumerable<TResult>> CompileQuery<TContext, TParam1, TResult>(
             [NotNull] Expression<Func<TContext, TParam1, IQueryable<TResult>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, TParam1, IEnumerable<TResult>> CompileQuery<TContext, TParam1, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, TParam1, IIncludableQueryable<TResult, TProperty>>> queryExpression)
             where TContext : DbContext
         => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
 
@@ -98,6 +126,22 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
         /// <typeparam name="TParam2">The type of the second query parameter.</typeparam>
         /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, TParam1, TParam2, IEnumerable<TResult>> CompileQuery<
+            TContext, TParam1, TParam2, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, TParam1, TParam2, IIncludableQueryable<TResult, TProperty>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
+        /// <typeparam name="TParam2">The type of the second query parameter.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
         /// <param name="queryExpression">The LINQ query expression.</param>
         /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
         public static Func<TContext, TParam1, TParam2, TResult> CompileQuery<
@@ -119,6 +163,23 @@ namespace Microsoft.EntityFrameworkCore
         public static Func<TContext, TParam1, TParam2, TParam3, IEnumerable<TResult>> CompileQuery<
             TContext, TParam1, TParam2, TParam3, TResult>(
             [NotNull] Expression<Func<TContext, TParam1, TParam2, TParam3, IQueryable<TResult>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
+        /// <typeparam name="TParam2">The type of the second query parameter.</typeparam>
+        /// <typeparam name="TParam3">The type of the third query parameter.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, TParam1, TParam2, TParam3, IEnumerable<TResult>> CompileQuery<
+            TContext, TParam1, TParam2, TParam3, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, TParam1, TParam2, TParam3, IIncludableQueryable<TResult, TProperty>>> queryExpression)
             where TContext : DbContext
         => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
 
@@ -164,6 +225,24 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TParam3">The type of the third query parameter.</typeparam>
         /// <typeparam name="TParam4">The type of the fourth query parameter.</typeparam>
         /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, TParam1, TParam2, TParam3, TParam4, IEnumerable<TResult>> CompileQuery<
+            TContext, TParam1, TParam2, TParam3, TParam4, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, TParam1, TParam2, TParam3, TParam4, IIncludableQueryable<TResult, TProperty>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
+        /// <typeparam name="TParam2">The type of the second query parameter.</typeparam>
+        /// <typeparam name="TParam3">The type of the third query parameter.</typeparam>
+        /// <typeparam name="TParam4">The type of the fourth query parameter.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
         /// <param name="queryExpression">The LINQ query expression.</param>
         /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
         public static Func<TContext, TParam1, TParam2, TParam3, TParam4, TResult> CompileQuery<
@@ -187,6 +266,25 @@ namespace Microsoft.EntityFrameworkCore
         public static Func<TContext, TParam1, TParam2, TParam3, TParam4, TParam5, IEnumerable<TResult>> CompileQuery<
             TContext, TParam1, TParam2, TParam3, TParam4, TParam5, TResult>(
             [NotNull] Expression<Func<TContext, TParam1, TParam2, TParam3, TParam4, TParam5, IQueryable<TResult>>> queryExpression)
+            where TContext : DbContext
+        => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
+
+        /// <summary>
+        ///     Creates a compiled query delegate that when invoked will execute the specified LINQ query.
+        /// </summary>
+        /// <typeparam name="TContext">The target DbContext type.</typeparam>
+        /// <typeparam name="TParam1">The type of the first query parameter.</typeparam>
+        /// <typeparam name="TParam2">The type of the second query parameter.</typeparam>
+        /// <typeparam name="TParam3">The type of the third query parameter.</typeparam>
+        /// <typeparam name="TParam4">The type of the fourth query parameter.</typeparam>
+        /// <typeparam name="TParam5">The type of the fifth query parameter.</typeparam>
+        /// <typeparam name="TResult">The query result type.</typeparam>
+        /// <typeparam name="TProperty">The included property type.</typeparam>
+        /// <param name="queryExpression">The LINQ query expression.</param>
+        /// <returns>A delegate that can be invoked to execute the compiled query.</returns>
+        public static Func<TContext, TParam1, TParam2, TParam3, TParam4, TParam5, IEnumerable<TResult>> CompileQuery<
+            TContext, TParam1, TParam2, TParam3, TParam4, TParam5, TResult, TProperty>(
+            [NotNull] Expression<Func<TContext, TParam1, TParam2, TParam3, TParam4, TParam5, IIncludableQueryable<TResult, TProperty>>> queryExpression)
             where TContext : DbContext
         => new CompiledQuery<TContext, IEnumerable<TResult>>(queryExpression).Execute;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompiledQuerySqlServerTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -13,167 +11,186 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
             fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void DbSet_query()
         {
             base.DbSet_query();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]",
-                Sql);
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
         }
 
         public override void DbSet_query_first()
         {
             base.DbSet_query_first();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Query_ending_with_include()
+        {
+            base.Query_ending_with_include();
+            
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
-                Sql);
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]",
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
         }
 
         public override void Untyped_context()
         {
             base.Untyped_context();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]",
-                Sql);
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
         }
 
         public override void Query_with_single_parameter()
         {
             base.Query_with_single_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__customerID='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
-
-@__customerID='ANATR' (Size = 4000)
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID",
-                Sql);
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void First_query_with_single_parameter()
         {
             base.First_query_with_single_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__customerID='ALFKI' (Size = 4000)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
-
-@__customerID='ANATR' (Size = 4000)
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 4000)
 
 SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID",
-                Sql);
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_two_parameters()
         {
             base.Query_with_two_parameters();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__customerID='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
-
-@__customerID='ANATR' (Size = 4000)
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID",
-                Sql);
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_three_parameters()
         {
             base.Query_with_three_parameters();
 
-            Assert.Equal(
+            AssertSql(
                 @"@__customerID='ALFKI' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID
-
-@__customerID='ANATR' (Size = 4000)
+WHERE [c].[CustomerID] = @__customerID",
+                //
+                @"@__customerID='ANATR' (Size = 4000)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = @__customerID",
-                Sql);
+WHERE [c].[CustomerID] = @__customerID");
         }
 
         public override void Query_with_array_parameter()
         {
             base.Query_with_array_parameter();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]",
-                Sql);
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
         }
 
         public override void Query_with_contains()
         {
             base.Query_with_contains();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (N'ALFKI')
-
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+WHERE [c].[CustomerID] IN (N'ALFKI')",
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] IN (N'ANATR')",
-                Sql);
+WHERE [c].[CustomerID] IN (N'ANATR')");
         }
 
         public override void Query_with_closure()
         {
             base.Query_with_closure();
 
-            Assert.Equal(
+            AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] = N'ALFKI'
-
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'",
-                Sql);
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'");
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
- Added overloads of CompileQuery that resolve for queries returning IIncludableQueryable.
