### PR TITLE
Disable travis testing on Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 mono: none
 os:
   - linux
-  - osx
+#  - osx
 osx_image: xcode8.1
 branches:
   only:


### PR DESCRIPTION
#8642 happens a lot on osx to decrease the value of travis to us. We can re-enable it once we fix the issue.