### PR TITLE
Query: Allow more patterns of parameters on ExecuteSqlCommand

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 // ReSharper disable ConvertToConstant.Local
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -71,6 +72,76 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var actual = context.Database
                     .ExecuteSqlCommand(
                         @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}", city, contactTitle);
+
+                Assert.Equal(-1, actual);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_dbParameter_with_name()
+        {
+            var city = CreateDbParameter("@city", "London");
+
+            using (var context = CreateContext())
+            {
+                var actual = context.Database
+                    .ExecuteSqlCommand(
+                        @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city", city);
+
+                Assert.Equal(-1, actual);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_positional_dbParameter_with_name()
+        {
+            var city = CreateDbParameter("@city", "London");
+
+            using (var context = CreateContext())
+            {
+                var actual = context.Database
+                    .ExecuteSqlCommand(
+                        @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = {0}", city);
+
+                Assert.Equal(-1, actual);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_positional_dbParameter_without_name()
+        {
+            var city = CreateDbParameter(name: null, value: "London");
+
+            using (var context = CreateContext())
+            {
+                var actual = context.Database
+                    .ExecuteSqlCommand(
+                        @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = {0}", city);
+
+                Assert.Equal(-1, actual);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_dbParameters_mixed()
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            var cityParameter = CreateDbParameter("@city", city);
+            var contactTitleParameter = CreateDbParameter("@contactTitle", contactTitle);
+
+            using (var context = CreateContext())
+            {
+                var actual = context.Database
+                    .ExecuteSqlCommand(
+                        @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = @contactTitle", city, contactTitleParameter);
+
+                Assert.Equal(-1, actual);
+
+                actual = context.Database
+                    .ExecuteSqlCommand(
+                        @"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = {1}", cityParameter, contactTitle);
 
                 Assert.Equal(-1, actual);
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SqlExecutorSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SqlExecutorSqlServerTest.cs
@@ -10,11 +10,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class SqlExecutorSqlServerTest : SqlExecutorTestBase<NorthwindQuerySqlServerFixture>
     {
+        // ReSharper disable once UnusedParameter.Local
         public SqlExecutorSqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Executes_stored_procedure()
@@ -53,6 +54,52 @@ namespace Microsoft.EntityFrameworkCore.Query
 @p1='Sales Representative' (Size = 4000)
 
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
+        }
+
+        public override void Query_with_dbParameter_with_name()
+        {
+            base.Query_with_dbParameter_with_name();
+
+            AssertSql(
+                @"@city='London' (Nullable = false) (Size = 6)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city");
+        }
+
+        public override void Query_with_positional_dbParameter_with_name()
+        {
+            base.Query_with_positional_dbParameter_with_name();
+
+            AssertSql(
+                @"@city='London' (Nullable = false) (Size = 6)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city");
+        }
+
+        public override void Query_with_positional_dbParameter_without_name()
+        {
+            base.Query_with_positional_dbParameter_without_name();
+
+            AssertSql(
+                @"@p0='London' (Nullable = false) (Size = 6)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0");
+        }
+
+        public override void Query_with_dbParameters_mixed()
+        {
+            base.Query_with_dbParameters_mixed();
+
+            AssertSql(
+                @"@p0='London' (Size = 4000)
+@contactTitle='Sales Representative' (Nullable = false) (Size = 20)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @contactTitle",
+                //
+                @"@city='London' (Nullable = false) (Size = 6)
+@p0='Sales Representative' (Size = 4000)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @p0");
         }
 
         public override void Query_with_parameters_interpolated()


### PR DESCRIPTION
Resolves #8939 

@anpete 