### PR TITLE
RevEng: Scaffold ForSqlServerIsClustered correctly for PK/Index

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -30,6 +30,17 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             return false;
         }
 
+        public override string GenerateFluentApi(IKey key, IAnnotation annotation, string language)
+        {
+            Check.NotNull(key, nameof(key));
+            Check.NotNull(annotation, nameof(annotation));
+            Check.NotNull(language, nameof(language));
+
+            return annotation.Name == SqlServerAnnotationNames.Clustered && language == "CSharp"
+                ? $".{nameof(SqlServerIndexBuilderExtensions.ForSqlServerIsClustered)}({((bool)annotation.Value == false ? "false" : "")})"
+                : null;
+        }
+
         public override string GenerateFluentApi(IIndex index, IAnnotation annotation, string language)
         {
             Check.NotNull(index, nameof(index));

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -566,9 +566,9 @@ ORDER BY object_schema_name(i.object_id), object_name(i.object_id), i.name, ic.k
                             Name = indexName
                         };
 
-                        if (typeDesc == "CLUSTERED")
+                        if (typeDesc == "NONCLUSTERED")
                         {
-                            primaryKey[SqlServerAnnotationNames.Clustered] = true;
+                            primaryKey[SqlServerAnnotationNames.Clustered] = false;
                         }
 
                         Debug.Assert(table.PrimaryKey == null);
@@ -662,6 +662,7 @@ ORDER BY object_schema_name(i.object_id), object_name(i.object_id), i.name, ic.k
                         if (typeDesc == "CLUSTERED")
                         {
                             uniqueConstraint[SqlServerAnnotationNames.Clustered] = true;
+                            table.PrimaryKey?.RemoveAnnotation(SqlServerAnnotationNames.Clustered);
                         }
 
                         table.UniqueConstraints.Add(uniqueConstraint);

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -353,7 +353,7 @@ CREATE TABLE "OneToOneFKToUniqueKeyPrincipal" (
 	"SomePrincipalColumn" nvarchar (20) NOT NULL,
 	"OneToOneFKToUniqueKeyPrincipalUniqueKey1" "int" NOT NULL,
 	"OneToOneFKToUniqueKeyPrincipalUniqueKey2" "int" NOT NULL,
-	CONSTRAINT "PK_OneToOneFKToUniqueKeyPrincipal" PRIMARY KEY CLUSTERED 
+	CONSTRAINT "PK_OneToOneFKToUniqueKeyPrincipal" PRIMARY KEY NONCLUSTERED
 	(
 		"OneToOneFKToUniqueKeyPrincipalID1", "OneToOneFKToUniqueKeyPrincipalID2"
 	),

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
@@ -407,7 +407,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFktoUniqueKeyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFktoUniqueKeyPrincipalId1, e.OneToOneFktoUniqueKeyPrincipalId2 });
+                entity.HasKey(e => new { e.OneToOneFktoUniqueKeyPrincipalId1, e.OneToOneFktoUniqueKeyPrincipalId2 })
+                    .ForSqlServerIsClustered(false);
 
                 entity.ToTable("OneToOneFKToUniqueKeyPrincipal");
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AttributesContext.cs
@@ -128,7 +128,8 @@ namespace E2ETest.Namespace.SubDir
 
             modelBuilder.Entity<OneToOneFktoUniqueKeyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFktoUniqueKeyPrincipalId1, e.OneToOneFktoUniqueKeyPrincipalId2 });
+                entity.HasKey(e => new { e.OneToOneFktoUniqueKeyPrincipalId1, e.OneToOneFktoUniqueKeyPrincipalId2 })
+                    .ForSqlServerIsClustered(false);
 
                 entity.HasIndex(e => new { e.OneToOneFktoUniqueKeyPrincipalUniqueKey1, e.OneToOneFktoUniqueKeyPrincipalUniqueKey2 })
                     .HasName("UK_OneToOneFKToUniqueKeyPrincipal")

--- a/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -91,7 +93,7 @@ CREATE TABLE [dbo].[Denali] ( id int );";
             Assert.Equal("dbo", pkIndex.Table.Schema);
             Assert.Equal("Place1", pkIndex.Table.Name);
             Assert.StartsWith("PK__Place1", pkIndex.Name);
-            //Assert.False(pkIndex.SqlServer().IsClustered);
+            Assert.False((bool?)pkIndex[SqlServerAnnotationNames.Clustered]);
             Assert.Equal(new List<string> { "Id" }, pkIndex.Columns.Select(ic => ic.Name).ToList());
         }
 
@@ -142,14 +144,14 @@ CREATE TABLE [dbo].[Denali] ( id int );";
                 nonClustered =>
                 {
                     Assert.Equal("IX_Location", nonClustered.Name);
-                    //Assert.False(nonClustered.GetAnnotations().SingleOrDefault(a => a.Name == SqlServerAnnotationNames.Clustered)?.Value);
+                    Assert.Null(nonClustered[SqlServerAnnotationNames.Clustered]);
                     Assert.Equal("Location", nonClustered.Columns.Select(ic => ic.Name).Single());
                 },
                 clusteredIndex =>
                 {
                     Assert.Equal("IX_Location_Name", clusteredIndex.Name);
                     Assert.False(clusteredIndex.IsUnique);
-                    //Assert.True(clusteredIndex.SqlServer().IsClustered);
+                    Assert.True((bool?)clusteredIndex[SqlServerAnnotationNames.Clustered]);
                     Assert.Equal(new List<string> { "Location", "Name" }, clusteredIndex.Columns.Select(ic => ic.Name).ToList());
                 });
         }


### PR DESCRIPTION
Resolves #8687 

Rules followed 
- If PK is marked as "CLUSTERED" don't do anything. That is default behavior for SqlServer.
- If some other index/unique constraint is marked as clustered then output `ForSqlServerIsClustered()` for index. PK will be non clustered by default.
- If PK is marked as "NONCLUSTERED" and there is no other Clustered index then we explicitly output `ForSqlServerIsClustered(false)` on PK.

