### PR TITLE
Fix #8944 - Change QueryCompilationContext.QueryAnnotations to ICollection

### DIFF
--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -249,8 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(queryModel, nameof(queryModel));
 
-            QueryCompilationContext.QueryAnnotations
-                = _queryAnnotationExtractor.ExtractQueryAnnotations(queryModel);
+            QueryCompilationContext.AddAnnotations(_queryAnnotationExtractor.ExtractQueryAnnotations(queryModel));
         }
 
         /// <summary>

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -901,5 +901,10 @@
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IExecutionStrategy",
       "MemberId": "T1 Execute<T0, T1>(T0 state, System.Func<Microsoft.EntityFrameworkCore.DbContext, T0, T1> operation, System.Func<Microsoft.EntityFrameworkCore.DbContext, T0, Microsoft.EntityFrameworkCore.Storage.ExecutionResult<T1>> verifySucceeded)",
       "Kind": "Addition"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.QueryCompilationContext",
+      "MemberId": "public virtual System.Void set_QueryAnnotations(System.Collections.Generic.IReadOnlyCollection<Microsoft.EntityFrameworkCore.Query.ResultOperators.IQueryAnnotation> value)",
+      "Kind": "Removal"
     }
   ]


### PR DESCRIPTION
- Simplified the whole thing. QueryAnnotations is IReadOnlyCollection and AddAnnotations method remains.
