### PR TITLE
Fix IsModified issues

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -125,6 +125,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             foreach (var property in entityType.GetProperties())
             {
                 if (property.GetOriginalValueIndex() >= 0
+                    && !entry.IsConceptualNull(property)
                     && !Equals(entry[property], entry.GetOriginalValue(property)))
                 {
                     entry.SetPropertyModified(property);

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -358,7 +358,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     StateManager.Notify.StateChanged(this, currentState, fromQuery: false);
                 }
             }
-            else if (currentState != EntityState.Detached
+            else if (currentState == EntityState.Modified
                      && changeState
                      && !isModified
                      && !_stateData.AnyPropertiesFlagged(PropertyFlag.TemporaryOrModified))
@@ -705,7 +705,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 && EntityState != EntityState.Detached)
                             {
                                 _stateData.FlagProperty(propertyIndex.Value, PropertyFlag.Null, isFlagged: true);
-                                SetPropertyModified(asProperty, changeState: true, isModified: true, isConceptualNull: true);
+
+                                if (setModified)
+                                {
+                                    SetPropertyModified(asProperty, changeState: true, isModified: true, isConceptualNull: true);
+                                }
                             }
                             writeValue = false;
                         }
@@ -852,7 +856,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 }
                             }
                         }
-                        else
+                        else if (EntityState != EntityState.Modified
+                                 || IsModified(property))
                         {
                             fks.Add(foreignKey);
                         }
@@ -876,7 +881,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             else
             {
                 var property = EntityType.GetProperties().FirstOrDefault(
-                    p => _stateData.IsPropertyFlagged(p.GetIndex(), PropertyFlag.Null));
+                    p => (EntityState != EntityState.Modified
+                          || IsModified(p))
+                         && _stateData.IsPropertyFlagged(p.GetIndex(), PropertyFlag.Null));
 
                 if (property != null)
                 {

--- a/src/EFCore/ChangeTracking/PropertyEntry.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry.cs
@@ -44,8 +44,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public override bool IsModified
         {
-            get { return InternalEntry.IsModified(Metadata); }
-            set { InternalEntry.SetPropertyModified(Metadata, changeState: true, isModified: value); }
+            get => InternalEntry.IsModified(Metadata);
+            set => InternalEntry.SetPropertyModified(Metadata, changeState: true, isModified: value);
         }
 
         /// <summary>
@@ -55,8 +55,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual bool IsTemporary
         {
-            get { return InternalEntry.HasTemporaryValue(Metadata); }
-            set { InternalEntry.MarkAsTemporary(Metadata, value); }
+            get => InternalEntry.HasTemporaryValue(Metadata);
+            set => InternalEntry.MarkAsTemporary(Metadata, value);
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual object OriginalValue
         {
-            get { return InternalEntry.GetOriginalValue(Metadata); }
-            [param: CanBeNull] set { InternalEntry.SetOriginalValue(Metadata, value); }
+            get => InternalEntry.GetOriginalValue(Metadata);
+            [param: CanBeNull] set => InternalEntry.SetOriginalValue(Metadata, value);
         }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Xunit;
@@ -13,101 +14,349 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     public class PropertyEntryTest
     {
         [Fact]
+        public void Setting_IsModified_should_not_be_dependent_on_other_properties()
+        {
+            Guid id;
+
+            using (var context = new UserContext())
+            {
+                id = context.Add(new User { Name = "A", LongName = "B" }).Entity.Id;
+
+                context.SaveChanges();
+            }
+
+            using (var context = new UserContext())
+            {
+                var user = context.Attach(new User { Id = id, Name = "NewA", LongName = "NewB" }).Entity;
+
+                context.Entry(user).Property(x => x.Name).IsModified = false;
+                context.Entry(user).Property(x => x.LongName).IsModified = true;
+
+                Assert.False(context.Entry(user).Property(x => x.Name).IsModified);
+                Assert.True(context.Entry(user).Property(x => x.LongName).IsModified);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new UserContext())
+            {
+                var user = context.Find<User>(id);
+
+                Assert.Equal("A", user.Name);
+                Assert.Equal("NewB", user.LongName);
+            }
+        }
+
+        [Fact]
+        public void SetValues_with_IsModified_can_mark_a_set_of_values_as_changed()
+        {
+            Guid id;
+
+            using (var context = new UserContext())
+            {
+                id = context.Add(new User { Name = "A", LongName = "B" }).Entity.Id;
+
+                context.SaveChanges();
+            }
+
+            using (var context = new UserContext())
+            {
+                var disconnectedEntity = new User { Id = id, LongName = "NewLongName" };
+                var trackedEntity = context.Find<User>(id);
+
+                Assert.Equal("A", trackedEntity.Name);
+                Assert.Equal("B", trackedEntity.LongName);
+
+                var entry = context.Entry(trackedEntity);
+
+                entry.CurrentValues.SetValues(disconnectedEntity);
+
+                Assert.Equal("A", trackedEntity.Name);
+                Assert.Equal("NewLongName", trackedEntity.LongName);
+
+                Assert.False(entry.Property(e => e.Id).IsModified);
+                Assert.True(entry.Property(e => e.Name).IsModified);
+                Assert.True(entry.Property(e => e.LongName).IsModified);
+
+                var internalEntry = entry.GetInfrastructure();
+
+                Assert.False(internalEntry.IsConceptualNull(entry.Property(e => e.Id).Metadata));
+                Assert.True(internalEntry.IsConceptualNull(entry.Property(e => e.Name).Metadata));
+                Assert.False(internalEntry.IsConceptualNull(entry.Property(e => e.LongName).Metadata));
+
+                foreach (var property in entry.Properties)
+                {
+                    property.IsModified = property.Metadata.Name == "LongName";
+                }
+
+                Assert.False(entry.Property(e => e.Id).IsModified);
+                Assert.False(entry.Property(e => e.Name).IsModified);
+                Assert.True(entry.Property(e => e.LongName).IsModified);
+
+                Assert.False(internalEntry.IsConceptualNull(entry.Property(e => e.Id).Metadata));
+                Assert.False(internalEntry.IsConceptualNull(entry.Property(e => e.Name).Metadata));
+                Assert.False(internalEntry.IsConceptualNull(entry.Property(e => e.LongName).Metadata));
+
+                context.SaveChanges();
+            }
+        }
+
+        private class User
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+            public string LongName { get; set; }
+        }
+
+        private class UserContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(GetType().FullName);
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<User>(
+                    b =>
+                        {
+                            b.Property(e => e.Name).IsRequired();
+                            b.Property(e => e.LongName).IsRequired();
+                        });
+            }
+        }
+
+        [Fact]
+        public void Setting_IsModified_is_not_reset_by_OriginalValues()
+        {
+            Guid id;
+            using (var context = new UserContext())
+            {
+                id = context.Add(new User { Id = Guid.NewGuid(), Name = "A", LongName = "B" }).Entity.Id;
+
+                context.SaveChanges();
+            }
+
+            using (var context = new UserContext())
+            {
+                var user = context.Update(new User { Id = id }).Entity;
+
+                user.Name = "A2";
+                user.LongName = "B2";
+
+                context.Entry(user).Property(x => x.Name).IsModified = false;
+                Assert.False(context.Entry(user).Property(x => x.Name).IsModified);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new UserContext())
+            {
+                var user = context.Find<User>(id);
+
+                Assert.Equal("A", user.Name);
+                Assert.Equal("B2", user.LongName);
+            }
+        }
+
+        [Fact]
         public void Can_get_name()
         {
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                new Wotty { Id = 1, Primate = "Monkey" });
+            using (var context = new PrimateContext())
+            {
+                var entry = context
+                    .Entry(new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" })
+                    .GetInfrastructure();
 
-            Assert.Equal("Primate", new PropertyEntry(entry, "Primate").Metadata.Name);
+                entry.SetEntityState(EntityState.Unchanged);
+
+                Assert.Equal("Primate", new PropertyEntry(entry, "Primate").Metadata.Name);
+            }
         }
 
         [Fact]
         public void Can_get_current_value()
         {
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                new Wotty { Id = 1, Primate = "Monkey" });
+            using (var context = new PrimateContext())
+            {
+                var entry = context
+                    .Entry(new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" })
+                    .GetInfrastructure();
 
-            Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").CurrentValue);
+                entry.SetEntityState(EntityState.Unchanged);
+
+                Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").CurrentValue);
+                Assert.Equal("Tarsier", new PropertyEntry(entry, "RequiredPrimate").CurrentValue);
+            }
         }
 
         [Fact]
         public void Can_set_current_value()
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
+                
+                new PropertyEntry(entry, "Primate").CurrentValue = "Chimp";
+                new PropertyEntry(entry, "RequiredPrimate").CurrentValue = "Bushbaby";
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Bushbaby", entity.RequiredPrimate);
 
-            new PropertyEntry(entry, "Primate").CurrentValue = "Chimp";
+                context.ChangeTracker.DetectChanges();
 
-            Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Bushbaby", entity.RequiredPrimate);
+            }
         }
 
         [Fact]
         public void Can_set_current_value_to_null()
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
+                new PropertyEntry(entry, "Primate").CurrentValue = null;
+                new PropertyEntry(entry, "RequiredPrimate").CurrentValue = null;
 
-            new PropertyEntry(entry, "Primate").CurrentValue = null;
+                Assert.Null(entity.Primate);
+                Assert.True(entry.IsConceptualNull(new PropertyEntry(entry, "RequiredPrimate").Metadata));
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
 
-            Assert.Null(entity.Primate);
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Null(entity.Primate);
+                Assert.True(entry.IsConceptualNull(new PropertyEntry(entry, "RequiredPrimate").Metadata));
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+            }
         }
 
         [Fact]
         public void Can_set_and_get_original_value()
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
+                Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Equal("Tarsier", new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
 
-            Assert.Equal("Monkey", new PropertyEntry(entry, "Primate").OriginalValue);
+                new PropertyEntry(entry, "Primate").OriginalValue = "Chimp";
+                new PropertyEntry(entry, "RequiredPrimate").OriginalValue = "Bushbaby";
 
-            new PropertyEntry(entry, "Primate").OriginalValue = "Chimp";
+                Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Equal("Monkey", entity.Primate);
 
-            Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
-            Assert.Equal("Monkey", entity.Primate);
+                Assert.Equal("Bushbaby", new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Equal("Monkey", entity.Primate);
+
+                Assert.Equal("Bushbaby", new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+            }
+        }
+
+        [Fact]
+        public void Can_set_and_get_original_value_starting_null()
+        {
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1 };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
+
+                Assert.Null(new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+
+                new PropertyEntry(entry, "Primate").OriginalValue = "Chimp";
+                new PropertyEntry(entry, "RequiredPrimate").OriginalValue = "Bushbaby";
+
+                Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(entity.Primate);
+
+                Assert.Equal("Bushbaby", new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+                Assert.Null(entity.RequiredPrimate);
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Equal("Chimp", new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(entity.Primate);
+
+                Assert.Equal("Bushbaby", new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+                Assert.Null(entity.RequiredPrimate);
+            }
         }
 
         [Fact]
         public void Can_set_original_value_to_null()
         {
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                new Wotty { Id = 1, Primate = "Monkey" });
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1, Primate = "Monkey", RequiredPrimate = "Tarsier" };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
 
-            new PropertyEntry(entry, "Primate").OriginalValue = null;
+                new PropertyEntry(entry, "Primate").OriginalValue = null;
+                new PropertyEntry(entry, "RequiredPrimate").OriginalValue = null;
 
-            Assert.Null(new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.Null(new PropertyEntry(entry, "Primate").OriginalValue);
+                Assert.Null(new PropertyEntry(entry, "RequiredPrimate").OriginalValue);
+            }
         }
 
         [Fact]
         public void Can_set_and_clear_modified_on_Modified_entity()
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1 };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Modified);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(BuildModel(), EntityState.Modified, entity);
-            Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
 
-            new PropertyEntry(entry, "Primate").IsModified = false;
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                context.ChangeTracker.DetectChanges();
 
-            new PropertyEntry(entry, "Primate").IsModified = true;
-            Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                new PropertyEntry(entry, "Primate").IsModified = false;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = false;
+
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                new PropertyEntry(entry, "Primate").IsModified = true;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = true;
+
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                context.ChangeTracker.DetectChanges();
+
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+            }
         }
 
         [Theory]
@@ -115,16 +364,33 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         [InlineData(EntityState.Deleted)]
         public void Can_set_and_clear_modified_on_Added_or_Deleted_entity(EntityState initialState)
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1 };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(initialState);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(BuildModel(), initialState, entity);
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
 
-            new PropertyEntry(entry, "Primate").IsModified = true;
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                new PropertyEntry(entry, "Primate").IsModified = true;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = true;
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
 
-            new PropertyEntry(entry, "Primate").IsModified = false;
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                context.ChangeTracker.DetectChanges();
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                new PropertyEntry(entry, "Primate").IsModified = false;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = false;
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                context.ChangeTracker.DetectChanges();
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+            }
         }
 
         [Theory]
@@ -132,50 +398,106 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         [InlineData(EntityState.Unchanged)]
         public void Can_set_and_clear_modified_on_Unchanged_or_Detached_entity(EntityState initialState)
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1 };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(initialState);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(BuildModel(), initialState, entity);
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
 
-            new PropertyEntry(entry, "Primate").IsModified = true;
-            Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                new PropertyEntry(entry, "Primate").IsModified = true;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = true;
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
 
-            new PropertyEntry(entry, "Primate").IsModified = false;
-            Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                context.ChangeTracker.DetectChanges();
+                Assert.True(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.True(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                new PropertyEntry(entry, "Primate").IsModified = false;
+                new PropertyEntry(entry, "RequiredPrimate").IsModified = false;
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+
+                context.ChangeTracker.DetectChanges();
+                Assert.False(new PropertyEntry(entry, "Primate").IsModified);
+                Assert.False(new PropertyEntry(entry, "RequiredPrimate").IsModified);
+            }
         }
+
         [Fact]
         public void Can_reject_changes_when_clearing_modified_flag()
         {
-            var entity = new Wotty { Id = 1, Primate = "Monkey", Marmate = "Bovril" };
+            using (var context = new PrimateContext())
+            {
+                var entity = new Wotty { Id = 1, Primate = "Monkey", Marmate = "Bovril", RequiredPrimate = "Tarsier" };
+                var entry = context.Entry(entity).GetInfrastructure();
+                entry.SetEntityState(EntityState.Unchanged);
 
-            var entry = InMemoryTestHelpers.Instance.CreateInternalEntry(
-                BuildModel(),
-                EntityState.Unchanged,
-                entity);
+                var primateEntry = new PropertyEntry(entry, "Primate");
+                primateEntry.OriginalValue = "Chimp";
+                primateEntry.IsModified = true;
 
-            var primateEntry = new PropertyEntry(entry, "Primate");
-            primateEntry.OriginalValue = "Chimp";
-            primateEntry.IsModified = true;
+                var marmateEntry = new PropertyEntry(entry, "Marmate");
+                marmateEntry.OriginalValue = "Marmite";
+                marmateEntry.IsModified = true;
 
-            var marmateEntry = new PropertyEntry(entry, "Marmate");
-            marmateEntry.OriginalValue = "Marmite";
-            marmateEntry.IsModified = true;
+                var requiredEntry = new PropertyEntry(entry, "RequiredPrimate");
+                requiredEntry.OriginalValue = "Bushbaby";
+                requiredEntry.IsModified = true;
 
-            Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal("Monkey", entity.Primate);
-            Assert.Equal("Bovril", entity.Marmate);
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Monkey", entity.Primate);
+                Assert.Equal("Bovril", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
 
-            primateEntry.IsModified = false;
+                context.ChangeTracker.DetectChanges();
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Monkey", entity.Primate);
+                Assert.Equal("Bovril", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
 
-            Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal("Chimp", entity.Primate);
-            Assert.Equal("Bovril", entity.Marmate);
+                primateEntry.IsModified = false;
 
-            marmateEntry.IsModified = false;
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Bovril", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
 
-            Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal("Chimp", entity.Primate);
-            Assert.Equal("Marmite", entity.Marmate);
+                context.ChangeTracker.DetectChanges();
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Bovril", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+
+                marmateEntry.IsModified = false;
+
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Marmite", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+
+                context.ChangeTracker.DetectChanges();
+                Assert.Equal(EntityState.Modified, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Marmite", entity.Marmate);
+                Assert.Equal("Tarsier", entity.RequiredPrimate);
+
+                requiredEntry.IsModified = false;
+
+                Assert.Equal(EntityState.Unchanged, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Marmite", entity.Marmate);
+                Assert.Equal("Bushbaby", entity.RequiredPrimate);
+
+                context.ChangeTracker.DetectChanges();
+                Assert.Equal(EntityState.Unchanged, entry.EntityState);
+                Assert.Equal("Chimp", entity.Primate);
+                Assert.Equal("Marmite", entity.Marmate);
+                Assert.Equal("Bushbaby", entity.RequiredPrimate);
+            }
         }
 
         [Fact]
@@ -488,6 +810,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             public int Id { get; set; }
             public string Primate { get; set; }
+            public string RequiredPrimate { get; set; }
             public string Marmate { get; set; }
         }
 
@@ -588,25 +911,54 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
         }
 
-        public IMutableModel BuildModel(
-            ChangeTrackingStrategy fullNotificationStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications)
+        public static IMutableModel BuildModel(
+            ChangeTrackingStrategy fullNotificationStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications,
+            ModelBuilder builder = null)
         {
-            var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+            builder = builder ?? InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
             builder.HasChangeTrackingStrategy(fullNotificationStrategy);
 
-            builder.Entity<Wotty>()
-                .HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+            builder.Entity<Wotty>(
+                b =>
+                    {
+                        b.Property(e => e.RequiredPrimate).IsRequired();
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+                    });
 
-            builder.Entity<NotifyingWotty>()
-                .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
 
-            builder.Entity<FullyNotifyingWotty>()
-                .HasChangeTrackingStrategy(fullNotificationStrategy)
-                .Property(e => e.ConcurrentPrimate)
-                .IsConcurrencyToken();
+            builder.Entity<NotifyingWotty>(
+                b =>
+                    {
+                        b.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
+                    });
+
+
+            builder.Entity<FullyNotifyingWotty>(
+                b =>
+                    {
+                        b.HasChangeTrackingStrategy(fullNotificationStrategy);
+                        b.Property(e => e.ConcurrentPrimate).IsConcurrencyToken();
+
+                    });
 
             return builder.Model;
+        }
+
+        private class PrimateContext : DbContext
+        {
+            private readonly ChangeTrackingStrategy _fullNotificationStrategy;
+
+            public PrimateContext(ChangeTrackingStrategy fullNotificationStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications)
+            {
+                _fullNotificationStrategy = fullNotificationStrategy;
+            }
+
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(GetType().FullName);
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder) 
+                => BuildModel(_fullNotificationStrategy, modelBuilder);
         }
     }
 }


### PR DESCRIPTION
Issues #7798, #8265, #8465

These issues were due to incorrect handling of nulls/conceptual nulls for required but nullable properties, in particular when attaching an entity with a required property that starts off null.
