### PR TITLE
Query: Translate new overloads of Trim/TrimStart/TrimEnd in netcoreapp2.0

### DIFF
--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.Functions.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.Functions.cs
@@ -8,10 +8,19 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
+
 // ReSharper disable InconsistentNaming
+// ReSharper disable StringStartsWithIsCultureSpecific
+// ReSharper disable StringEndsWithIsCultureSpecific
+// ReSharper disable StringCompareIsCultureSpecific.1
+// ReSharper disable StringCompareToIsCultureSpecific
+// ReSharper disable CompareOfFloatsByEqualityOperator
+// ReSharper disable ConditionIsAlwaysTrueOrFalse
+// ReSharper disable SpecifyACultureInStringConversionExplicitly
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
+    // ReSharper disable once UnusedTypeParameter
     public abstract partial class QueryTestBase<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
@@ -901,7 +910,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void TrimStart_in_predicate()
+        public virtual void TrimStart_without_arguments_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.TrimStart() == "Owner"),
@@ -909,7 +918,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void TrimStart_with_arguments_in_predicate()
+        public virtual void TrimStart_with_char_argument_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimStart('O') == "wner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimStart_with_char_array_argument_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.TrimStart('O', 'w') == "ner"),
@@ -917,7 +934,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void TrimEnd_in_predicate()
+        public virtual void TrimEnd_without_arguments_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.TrimEnd() == "Owner"),
@@ -925,7 +942,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void TrimEnd_with_arguments_in_predicate()
+        public virtual void TrimEnd_with_char_argument_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.TrimEnd('r') == "Owne"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void TrimEnd_with_char_array_argument_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.TrimEnd('e', 'r') == "Own"),
@@ -933,7 +958,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Trim_in_predicate()
+        public virtual void Trim_without_argument_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.Trim() == "Owner"),
@@ -941,7 +966,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Trim_with_arguments_in_predicate()
+        public virtual void Trim_with_char_argument_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactTitle.Trim('O') == "wner"),
+                entryCount: 17);
+        }
+
+        [ConditionalFact]
+        public virtual void Trim_with_char_array_argument_in_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactTitle.Trim('O', 'r') == "wne"),

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimEndTranslator.cs
@@ -14,7 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringTrimEndTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _methodInfo
+        // Method defined in netcoreapp2.0 only
+        private static readonly MethodInfo _methodInfoWithoutArgs
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new Type[] { });
+
+        // Method defined in netstandard2.0
+        private static readonly MethodInfo _methodInfoWithCharArrayArg
             = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char[]) });
 
         /// <summary>
@@ -23,11 +28,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_methodInfo.Equals(methodCallExpression.Method)
+            if (_methodInfoWithoutArgs?.Equals(methodCallExpression.Method) == true
+                || _methodInfoWithCharArrayArg.Equals(methodCallExpression.Method)
                 // SqlServer RTRIM does not take arguments
                 && ((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0)
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
+
                 return new SqlFunctionExpression("RTRIM", methodCallExpression.Type, sqlArguments);
             }
 

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringTrimStartTranslator.cs
@@ -14,7 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqlServerStringTrimStartTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _methodInfo
+        // Method defined in netcoreapp2.0 only
+        private static readonly MethodInfo _methodInfoWithoutArgs
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new Type[] { });
+
+        // Method defined in netstandard2.0
+        private static readonly MethodInfo _methodInfoWithCharArrayArg
             = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new[] { typeof(char[]) });
 
         /// <summary>
@@ -23,11 +28,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_methodInfo.Equals(methodCallExpression.Method)
+            if (_methodInfoWithoutArgs?.Equals(methodCallExpression.Method) == true
+                || _methodInfoWithCharArrayArg.Equals(methodCallExpression.Method)
                 // SqlServer LTRIM does not take arguments
                 && ((methodCallExpression.Arguments[0] as ConstantExpression)?.Value as Array)?.Length == 0)
             {
                 var sqlArguments = new[] { methodCallExpression.Object };
+
                 return new SqlFunctionExpression("LTRIM", methodCallExpression.Type, sqlArguments);
             }
 

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -14,7 +15,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
     /// </summary>
     public class SqliteStringTrimEndTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo _methodInfo
+        // Method defined in netcoreapp2.0 only
+        private static readonly MethodInfo _methodInfoWithoutArgs
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new Type[] { });
+
+        // Method defined in netcoreapp2.0 only
+        private static readonly MethodInfo _methodInfoWithCharArg
+            = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char) });
+
+        // Method defined in netstandard2.0
+        private static readonly MethodInfo _methodInfoWithCharArrayArg
             = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char[]) });
 
         /// <summary>
@@ -23,13 +33,32 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            if (_methodInfo.Equals(methodCallExpression.Method))
+            var methodInfo = methodCallExpression.Method;
+
+            if (_methodInfoWithoutArgs?.Equals(methodInfo) == true
+                || _methodInfoWithCharArg?.Equals(methodInfo) == true
+                || _methodInfoWithCharArrayArg.Equals(methodInfo))
             {
                 var sqlArguments = new List<Expression> { methodCallExpression.Object };
-                var charactersToTrim = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value as char[];
-                if (charactersToTrim?.Length > 0)
+
+                if (methodCallExpression.Arguments.Count == 1)
                 {
-                    sqlArguments.Add(Expression.Constant(new string(charactersToTrim), typeof(string)));
+                    var constantValue = (methodCallExpression.Arguments[0] as ConstantExpression)?.Value;
+                    var charactersToTrim = new List<char>();
+
+                    if (constantValue is char singleChar)
+                    {
+                        charactersToTrim.Add(singleChar);
+                    }
+                    else if (constantValue is char[] charArray)
+                    {
+                        charactersToTrim.AddRange(charArray);
+                    }
+
+                    if (charactersToTrim.Count > 0)
+                    {
+                        sqlArguments.Add(Expression.Constant(new string(charactersToTrim.ToArray()), typeof(string)));
+                    }
                 }
 
                 return new SqlFunctionExpression("rtrim", methodCallExpression.Type, sqlArguments);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Functions.cs
@@ -1038,102 +1038,85 @@ FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(nvarchar(max), [o].[OrderID] % 1)) <> N'10')");
         }
 
-
-
-
-
-
-
-
-
-
-
-        /*
-
-
-
-
-
-                public override void Substring_with_constant()
-                {
-                    base.Substring_with_constant();
-
-                    AssertSql(
-                        @"SELECT TOP(1) SUBSTRING([c].[ContactName], 2, 3)
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID]");
-                }
-
-                public override void Substring_with_closure()
-                {
-                    base.Substring_with_closure();
-
-                    AssertSql(
-                        @"@__start_0='2'
-
-        SELECT TOP(1) SUBSTRING([c].[ContactName], @__start_0 + 1, 3)
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID]");
-                }
-
-                public override void Substring_with_client_eval()
-                {
-                    base.Substring_with_client_eval();
-
-                    AssertSql(
-                        @"SELECT TOP(1) [c].[ContactName]
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID]");
-                }
-
-                public override void IsNullOrEmpty_in_predicate()
-                {
-                    base.IsNullOrEmpty_in_predicate();
-
-                    AssertSql(
-                        @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-        FROM [Customers] AS [c]
-        WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
-                }
-
-                public override void IsNullOrEmpty_in_projection()
-                {
-                    base.IsNullOrEmpty_in_projection();
-
-                    AssertSql(
-                        @"SELECT [c].[CustomerID] AS [Id], CASE
-            WHEN [c].[Region] IS NULL OR ([c].[Region] = N'')
-            THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-        END AS [Value]
-        FROM [Customers] AS [c]");
-                }
-
-                public override void IsNullOrEmpty_negated_in_projection()
-                {
-                    base.IsNullOrEmpty_negated_in_projection();
-
-                    AssertSql(
-                        @"SELECT [c].[CustomerID] AS [Id], CASE
-            WHEN [c].[Region] IS NOT NULL AND ([c].[Region] <> N'')
-            THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-        END AS [Value]
-        FROM [Customers] AS [c]");
-                }
-
-                public override void IsNullOrWhiteSpace_in_predicate()
-                {
-                    base.IsNullOrWhiteSpace_in_predicate();
-
-                    AssertSql(
-                        @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-        FROM [Customers] AS [c]
-        WHERE [c].[Region] IS NULL OR (LTRIM(RTRIM([c].[Region])) = N'')");
-                }
-
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Failing after netcoreapp2.0 upgrade")]
-        public override void TrimStart_in_predicate()
+        public override void Substring_with_constant()
         {
-            base.TrimStart_in_predicate();
+            base.Substring_with_constant();
+
+            AssertSql(
+                @"SELECT TOP(1) SUBSTRING([c].[ContactName], 2, 3)
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Substring_with_closure()
+        {
+            base.Substring_with_closure();
+
+            AssertSql(
+                @"@__start_0='2'
+
+SELECT TOP(1) SUBSTRING([c].[ContactName], @__start_0 + 1, 3)
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Substring_with_client_eval()
+        {
+            base.Substring_with_client_eval();
+
+            AssertSql(
+                @"SELECT TOP(1) [c].[ContactName]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void IsNullOrEmpty_in_predicate()
+        {
+            base.IsNullOrEmpty_in_predicate();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
+        }
+
+        public override void IsNullOrEmpty_in_projection()
+        {
+            base.IsNullOrEmpty_in_projection();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Id], CASE
+    WHEN [c].[Region] IS NULL OR ([c].[Region] = N'')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END AS [Value]
+FROM [Customers] AS [c]");
+        }
+
+        public override void IsNullOrEmpty_negated_in_projection()
+        {
+            base.IsNullOrEmpty_negated_in_projection();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Id], CASE
+    WHEN [c].[Region] IS NOT NULL AND ([c].[Region] <> N'')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END AS [Value]
+FROM [Customers] AS [c]");
+        }
+
+        public override void IsNullOrWhiteSpace_in_predicate()
+        {
+            base.IsNullOrWhiteSpace_in_predicate();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NULL OR (LTRIM(RTRIM([c].[Region])) = N'')");
+        }
+
+        public override void TrimStart_without_arguments_in_predicate()
+        {
+            base.TrimStart_without_arguments_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1141,19 +1124,27 @@ FROM [Customers] AS [c]
 WHERE LTRIM([c].[ContactTitle]) = N'Owner'");
         }
 
-        public override void TrimStart_with_arguments_in_predicate()
+        public override void TrimStart_with_char_argument_in_predicate()
         {
-            base.TrimStart_with_arguments_in_predicate();
+            base.TrimStart_with_char_argument_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]");
         }
 
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Failing after netcoreapp2.0 upgrade")]
-        public override void TrimEnd_in_predicate()
+        public override void TrimStart_with_char_array_argument_in_predicate()
         {
-            base.TrimEnd_in_predicate();
+            base.TrimStart_with_char_array_argument_in_predicate();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void TrimEnd_without_arguments_in_predicate()
+        {
+            base.TrimEnd_without_arguments_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1161,18 +1152,27 @@ FROM [Customers] AS [c]
 WHERE RTRIM([c].[ContactTitle]) = N'Owner'");
         }
 
-        public override void TrimEnd_with_arguments_in_predicate()
+        public override void TrimEnd_with_char_argument_in_predicate()
         {
-            base.TrimEnd_with_arguments_in_predicate();
+            base.TrimEnd_with_char_argument_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]");
         }
 
-        public override void Trim_in_predicate()
+        public override void TrimEnd_with_char_array_argument_in_predicate()
         {
-            base.Trim_in_predicate();
+            base.TrimEnd_with_char_array_argument_in_predicate();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Trim_without_argument_in_predicate()
+        {
+            base.Trim_without_argument_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1180,29 +1180,22 @@ FROM [Customers] AS [c]
 WHERE LTRIM(RTRIM([c].[ContactTitle])) = N'Owner'");
         }
 
-        public override void Trim_with_arguments_in_predicate()
+        public override void Trim_with_char_argument_in_predicate()
         {
-            base.Trim_with_arguments_in_predicate();
+            base.Trim_with_char_argument_in_predicate();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]");
         }
 
+        public override void Trim_with_char_array_argument_in_predicate()
+        {
+            base.Trim_with_char_array_argument_in_predicate();
 
-
-
-
-
-
-
-
-
-
-
-
-            */
-
-
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QuerySqliteTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QuerySqliteTest : QueryTestBase<NorthwindQuerySqliteFixture>
     {
+        // ReSharper disable once UnusedParameter.Local
         public QuerySqliteTest(NorthwindQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
@@ -44,10 +44,9 @@ WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')",
                 Sql);
         }
 
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Failing after netcoreapp2.0 upgrade")]
-        public override void TrimStart_in_predicate()
+        public override void TrimStart_without_arguments_in_predicate()
         {
-            base.TrimStart_in_predicate();
+            base.TrimStart_without_arguments_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -56,9 +55,20 @@ WHERE ltrim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
-        public override void TrimStart_with_arguments_in_predicate()
+        public override void TrimStart_with_char_argument_in_predicate()
         {
-            base.TrimStart_with_arguments_in_predicate();
+            base.TrimStart_with_char_argument_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ltrim(""c"".""ContactTitle"", 'O') = 'wner'",
+                Sql);
+        }
+
+        public override void TrimStart_with_char_array_argument_in_predicate()
+        {
+            base.TrimStart_with_char_array_argument_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -67,10 +77,9 @@ WHERE ltrim(""c"".""ContactTitle"", 'Ow') = 'ner'",
                 Sql);
         }
 
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Failing after netcoreapp2.0 upgrade")]
-        public override void TrimEnd_in_predicate()
+        public override void TrimEnd_without_arguments_in_predicate()
         {
-            base.TrimEnd_in_predicate();
+            base.TrimEnd_without_arguments_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -79,9 +88,20 @@ WHERE rtrim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
-        public override void TrimEnd_with_arguments_in_predicate()
+        public override void TrimEnd_with_char_argument_in_predicate()
         {
-            base.TrimEnd_with_arguments_in_predicate();
+            base.TrimEnd_with_char_argument_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE rtrim(""c"".""ContactTitle"", 'r') = 'Owne'",
+                Sql);
+        }
+
+        public override void TrimEnd_with_char_array_argument_in_predicate()
+        {
+            base.TrimEnd_with_char_array_argument_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -90,9 +110,9 @@ WHERE rtrim(""c"".""ContactTitle"", 'er') = 'Own'",
                 Sql);
         }
 
-        public override void Trim_in_predicate()
+        public override void Trim_without_argument_in_predicate()
         {
-            base.Trim_in_predicate();
+            base.Trim_without_argument_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -101,9 +121,20 @@ WHERE trim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
-        public override void Trim_with_arguments_in_predicate()
+        public override void Trim_with_char_argument_in_predicate()
         {
-            base.Trim_with_arguments_in_predicate();
+            base.Trim_with_char_argument_in_predicate();
+
+            Assert.Contains(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE trim(""c"".""ContactTitle"", 'O') = 'wner'",
+                Sql);
+        }
+
+        public override void Trim_with_char_array_argument_in_predicate()
+        {
+            base.Trim_with_char_array_argument_in_predicate();
 
             Assert.Contains(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""


### PR DESCRIPTION
Part of #8157 
