### PR TITLE
Prevent Collection was modified; enumeration operation may not execute.

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -607,7 +607,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         {
                             if (principalToDependent.IsCollection())
                             {
-                                var dependents = ((IEnumerable)navigationValue).Cast<object>();
+                                var dependents = ((IEnumerable)navigationValue).Cast<object>().ToList();
                                 foreach (var dependentEntity in dependents)
                                 {
                                     var dependentEntry = stateManager.TryGetEntry(dependentEntity);


### PR DESCRIPTION
Issue #8101

Happens when entities are inconsistently fixed up and do shenanigans in setters. (May also happen in other scenarios, but I was able to repro it this way.) Fix is to do defensive copy.
