### PR TITLE
Query: Fix bug in IncludeCompiler where we would resolve an incorrect QSRE for grouped results.

### DIFF
--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -52,6 +52,41 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Fact]
+        public virtual void Query_when_group_by()
+        {
+            using (var context = CreateContext())
+            {
+                var people = context.Set<OwnedPerson>().GroupBy(op => op.Id).ToList();
+
+                Assert.Equal(4, people.Count);
+                Assert.True(people.SelectMany(p => p).All(p => p.PersonAddress != null));
+                Assert.True(people.SelectMany(p => p).OfType<Branch>().All(b => b.BranchAddress != null));
+                Assert.True(people.SelectMany(p => p).OfType<LeafA>().All(a => a.LeafAAddress != null));
+                Assert.True(people.SelectMany(p => p).OfType<LeafB>().All(b => b.LeafBAddress != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Query_when_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                var people 
+                    = context.Set<OwnedPerson>()
+                        .Distinct()
+                        .Take(5)
+                        .Select(op => new { op })
+                        .ToList();
+
+                Assert.Equal(4, people.Count);
+                Assert.True(people.All(p => p.op.PersonAddress != null));
+                Assert.True(people.Select(p => p.op).OfType<Branch>().All(b => b.BranchAddress != null));
+                Assert.True(people.Select(p => p.op).OfType<LeafA>().All(a => a.LeafAAddress != null));
+                Assert.True(people.Select(p => p.op).OfType<LeafB>().All(b => b.LeafBAddress != null));
+            }
+        }
+        
         protected abstract DbContext CreateContext();
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -58,23 +58,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
                 else
                 {
-                    var fromClauseBase = expression.ReferencedQuerySource as FromClauseBase;
-
-                    if (fromClauseBase != null)
+                    if (expression.ReferencedQuerySource is FromClauseBase fromClauseBase)
                     {
                         Visit(fromClauseBase.FromExpression);
                     }
-
-                    var joinClause = expression.ReferencedQuerySource as JoinClause;
-
-                    if (joinClause != null)
+                    
+                    if (expression.ReferencedQuerySource is JoinClause joinClause)
                     {
                         Visit(joinClause.InnerSequence);
                     }
 
-                    var groupJoinClause = expression.ReferencedQuerySource as GroupJoinClause;
-
-                    if (groupJoinClause != null)
+                    if (expression.ReferencedQuerySource is GroupJoinClause groupJoinClause)
                     {
                         if (groupJoinClause.JoinClause.Equals(_targetQuerySource))
                         {

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return;
             }
 
-            foreach (var includeLoadTree in CreateIncludeLoadTrees(queryModel.SelectClause.Selector))
+            foreach (var includeLoadTree in CreateIncludeLoadTrees(queryModel))
             {
                 includeLoadTree.Compile(
                     _queryCompilationContext,
@@ -111,8 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private IEnumerable<IncludeLoadTree> CreateIncludeLoadTrees(
-            Expression targetExpression)
+        private IEnumerable<IncludeLoadTree> CreateIncludeLoadTrees(QueryModel queryModel)
         {
             var querySourceTracingExpressionVisitor
                 = _querySourceTracingExpressionVisitorFactory.Create();
@@ -126,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var querySourceReferenceExpression
                     = querySourceTracingExpressionVisitor
                         .FindResultQuerySourceReferenceExpression(
-                            targetExpression,
+                            queryModel.GetOutputExpression(),
                             includeResultOperator.QuerySource);
 
                 if (querySourceReferenceExpression == null

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -38,6 +38,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql("");
         }
 
+        [Fact(Skip = "#8907")]
+        public override void Query_when_group_by()
+        {
+            base.Query_when_group_by();
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_when_subquery()
+        {
+            base.Query_when_subquery();
+        }
+
         protected override DbContext CreateContext() => _fixture.CreateContext();
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
@@ -32,6 +32,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Query_for_leaf_type_loads_all_owned_navs();
         }
 
+        [Fact(Skip = "#8907")]
+        public override void Query_when_group_by()
+        {
+            base.Query_when_group_by();
+        }
+
+        [Fact(Skip = "#8907")]
+        public override void Query_when_subquery()
+        {
+            base.Query_when_subquery();
+        }
+
         protected override DbContext CreateContext() => _fixture.CreateContext();
     }
 }


### PR DESCRIPTION
When GroupBy is in play we need to ensure we use ElementSelector and not SelectClause.Selector as the output expression.