### PR TITLE
Fix table splitting for derived types in the update pipeline.

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/TableSplittingTestBase.cs
@@ -1,0 +1,105 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class TableSplittingTestBase<TTestStore>
+        where TTestStore : TestStore
+    {
+        [Fact]
+        public void Can_query_shared()
+        {
+            using (var store = CreateTestStore(OnModelCreating))
+            {
+                using (var context = CreateContext(store, OnModelCreating))
+                {
+                    Assert.Equal(4, context.Set<Operator>().ToList().Count);
+                }
+            }
+        }
+
+        [Fact(Skip = "#8973")]
+        public void Can_query_shared_derived()
+        {
+            using (var store = CreateTestStore(OnModelCreating))
+            {
+                using (var context = CreateContext(store, OnModelCreating))
+                {
+                    Assert.Equal(1, context.Set<FuelTank>().ToList().Count);
+                }
+            }
+        }
+
+        [Fact]
+        public void Can_use_with_redundant_relationships()
+        {
+            Test_roundtrip(OnModelCreating);
+        }
+
+        [Fact]
+        public void Can_use_with_chained_relationships()
+        {
+            Test_roundtrip(modelBuilder =>
+                {
+                    OnModelCreating(modelBuilder);
+                    modelBuilder.Entity<FuelTank>(eb =>
+                        {
+                            eb.Ignore(e => e.Vehicle);
+                        });
+                });
+        }
+
+        [Fact]
+        public void Can_use_with_fanned_relationships()
+        {
+            Test_roundtrip(modelBuilder =>
+                {
+                    OnModelCreating(modelBuilder);
+                    modelBuilder.Entity<FuelTank>(eb =>
+                        {
+                            eb.Ignore(e => e.Engine);
+                        });
+                    modelBuilder.Entity<CombustionEngine>(eb =>
+                        {
+                            eb.Ignore(e => e.FuelTank);
+                        });
+                });
+        }
+
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            TransportationContext.OnModelCreatingBase(modelBuilder);
+
+            modelBuilder.Entity<Vehicle>(eb =>
+                {
+                    eb.HasDiscriminator<string>("Discriminator");
+                    eb.Property<string>("Discriminator").HasColumnName("Discriminator");
+                    eb.ToTable("Vehicles");
+                });
+
+            modelBuilder.Entity<Engine>().ToTable("Vehicles");
+            modelBuilder.Entity<Operator>().ToTable("Vehicles");
+            modelBuilder.Entity<FuelTank>().ToTable("Vehicles");
+        }
+
+        protected void Test_roundtrip(Action<ModelBuilder> onModelCreating)
+        {
+            using (var store = CreateTestStore(onModelCreating))
+            {
+                using (var context = CreateContext(store, onModelCreating))
+                {
+                    context.AssertSeeded();
+                }
+            }
+        }
+
+        protected static readonly string DatabaseName = "TableSplittingTest";
+        public abstract TTestStore CreateTestStore(Action<ModelBuilder> onModelCreating);
+        public abstract TransportationContext CreateContext(TTestStore testStore, Action<ModelBuilder> onModelCreating);
+    }
+}

--- a/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -1,13 +1,34 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public static class RelationalPropertyExtensions
     {
         public static bool IsColumnNullable([NotNull] this IProperty property)
-            => property.DeclaringEntityType.BaseType != null || property.IsNullable;
+        {
+            if (property.DeclaringEntityType.BaseType != null
+                || property.IsNullable)
+            {
+                return true;
+            }
+
+            if (property.IsPrimaryKey())
+            {
+                return false;
+            }
+
+            var pk = property.DeclaringEntityType.FindPrimaryKey();
+            return pk != null
+                   && property.DeclaringEntityType.FindForeignKeys(pk.Properties)
+                       .Any(fk => fk.PrincipalKey.IsPrimaryKey()
+                                  && fk.PrincipalEntityType.BaseType != null
+                                  && fk.DeclaringEntityType.Relational().TableName == fk.PrincipalEntityType.Relational().TableName
+                                  && fk.DeclaringEntityType.Relational().Schema == fk.PrincipalEntityType.Relational().Schema);
+        }
     }
 }

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -647,20 +647,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 firstEntityType, secondEntityType, keyValue, firstConflictingValues, secondConflictingValues, columns);
 
         /// <summary>
-        ///     There are '{mappedEntityTypeCount}' entity types sharing the table '{tableName}', but only '{entryCount}' entries with the same key values have been marked as '{state}'. The missing entities should be assignable to {missingEntityTypes}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
+        ///     The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
-        public static string SharedRowEntryCountMismatch([CanBeNull] object mappedEntityTypeCount, [CanBeNull] object tableName, [CanBeNull] object entryCount, [CanBeNull] object state, [CanBeNull] object missingEntityTypes)
+        public static string SharedRowEntryCountMismatch([CanBeNull] object entityType, [CanBeNull] object tableName, [CanBeNull] object missingEntityType, [CanBeNull] object state)
             => string.Format(
-                GetString("SharedRowEntryCountMismatch", nameof(mappedEntityTypeCount), nameof(tableName), nameof(entryCount), nameof(state), nameof(missingEntityTypes)),
-                mappedEntityTypeCount, tableName, entryCount, state, missingEntityTypes);
+                GetString("SharedRowEntryCountMismatch", nameof(entityType), nameof(tableName), nameof(missingEntityType), nameof(state)),
+                entityType, tableName, missingEntityType, state);
 
         /// <summary>
-        ///     There are '{mappedEntityTypeCount}' entity types sharing the table '{tableName}', but only '{entryCount}' entries with the same key values '{keyValue}' have been marked as '{state}'. The missing entities should be assignable to {missingEntityTypes}.
+        ///     The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.
         /// </summary>
-        public static string SharedRowEntryCountMismatchSensitive([CanBeNull] object mappedEntityTypeCount, [CanBeNull] object tableName, [CanBeNull] object entryCount, [CanBeNull] object keyValue, [CanBeNull] object state, [CanBeNull] object missingEntityTypes)
+        public static string SharedRowEntryCountMismatchSensitive([CanBeNull] object entityType, [CanBeNull] object tableName, [CanBeNull] object missingEntityType, [CanBeNull] object keyValue, [CanBeNull] object state)
             => string.Format(
-                GetString("SharedRowEntryCountMismatchSensitive", nameof(mappedEntityTypeCount), nameof(tableName), nameof(entryCount), nameof(keyValue), nameof(state), nameof(missingEntityTypes)),
-                mappedEntityTypeCount, tableName, entryCount, keyValue, state, missingEntityTypes);
+                GetString("SharedRowEntryCountMismatchSensitive", nameof(entityType), nameof(tableName), nameof(missingEntityType), nameof(keyValue), nameof(state)),
+                entityType, tableName, missingEntityType, keyValue, state);
 
         /// <summary>
         ///     Cannot set default value '{value}' of type '{valueType}' on property '{property}' of type '{propertyType}' in entity type '{entityType}'.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -350,10 +350,10 @@
     <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values '{firstConflictingValues}' and '{secondConflictingValues}' mapped to {columns}.</value>
   </data>
   <data name="SharedRowEntryCountMismatch" xml:space="preserve">
-    <value>There are '{mappedEntityTypeCount}' entity types sharing the table '{tableName}', but only '{entryCount}' entries with the same key values have been marked as '{state}'. The missing entities should be assignable to {missingEntityTypes}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
+    <value>The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>
   <data name="SharedRowEntryCountMismatchSensitive" xml:space="preserve">
-    <value>There are '{mappedEntityTypeCount}' entity types sharing the table '{tableName}', but only '{entryCount}' entries with the same key values '{keyValue}' have been marked as '{state}'. The missing entities should be assignable to {missingEntityTypes}.</value>
+    <value>The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.</value>
   </data>
   <data name="IncorrectDefaultValueType" xml:space="preserve">
     <value>Cannot set default value '{value}' of type '{valueType}' on property '{property}' of type '{propertyType}' in entity type '{entityType}'.</value>

--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var people = context.Set<OwnedPerson>().ToList();
-                
+
                 Assert.Equal(4, people.Count);
                 Assert.True(people.All(p => p.PersonAddress != null));
                 Assert.True(people.OfType<Branch>().All(b => b.BranchAddress != null));
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.True(people.OfType<LeafB>().All(b => b.LeafBAddress != null));
             }
         }
-        
+
         [Fact]
         public virtual void Query_for_branch_type_loads_all_owned_navs()
         {

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class CombustionEngine : Engine
+    {
+        public FuelTank FuelTank { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as CombustionEngine;
+            return other != null
+                   && base.Equals(other)
+                   && Equals(FuelTank, other.FuelTank);
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class Engine
+    {
+        public string VehicleName { get; set; }
+        public string Description { get; set; }
+        public PoweredVehicle Vehicle { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as Engine;
+            return other != null
+                   && VehicleName == other.VehicleName
+                   && Description == other.Description;
+        }
+
+        public override int GetHashCode() => VehicleName.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class FuelTank
+    {
+        public string VehicleName { get; set; }
+        public string FuelType { get; set; }
+        public string Capacity { get; set; }
+        public PoweredVehicle Vehicle { get; set; }
+        public CombustionEngine Engine { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as FuelTank;
+            return other != null
+                   && VehicleName == other.VehicleName
+                   && FuelType == other.FuelType
+                   && Capacity == other.Capacity;
+        }
+
+        public override int GetHashCode() => VehicleName.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class LicensedOperator : Operator
+    {
+        public string LicenseType { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as LicensedOperator;
+            return other != null
+                   && base.Equals(other)
+                   && LicenseType == other.LicenseType;
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class Operator
+    {
+        public string VehicleName { get; set; }
+        public string Name { get; set; }
+        public Vehicle Vehicle { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as Operator;
+            return other != null
+                   && VehicleName == other.VehicleName
+                   && Name == other.Name;
+        }
+
+        public override int GetHashCode() => VehicleName.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class PoweredVehicle : Vehicle
+    {
+        public Engine Engine { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as PoweredVehicle;
+            return other != null
+                   && base.Equals(other)
+                   && Equals(Engine, other.Engine);
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class TransportationContext : DbContext
+    {
+        public TransportationContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Vehicle> Vehicles { get; set; }
+        public DbSet<Operator> Operators { get; set; }
+
+        public static void OnModelCreatingBase(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Vehicle>(eb =>
+                {
+                    eb.HasKey(e => e.Name);
+                });
+            modelBuilder.Entity<Engine>(eb =>
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne(e => e.Engine)
+                        .HasForeignKey<Engine>(e => e.VehicleName);
+                });
+            modelBuilder.Entity<CombustionEngine>();
+
+            modelBuilder.Entity<Operator>(eb =>
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne(e => e.Operator)
+                        .HasForeignKey<Operator>(e => e.VehicleName);
+                });
+            modelBuilder.Entity<LicensedOperator>();
+
+            modelBuilder.Entity<FuelTank>(eb =>
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Engine)
+                        .WithOne(e => e.FuelTank)
+                        .HasForeignKey<FuelTank>(e => e.VehicleName);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne()
+                        .HasForeignKey<FuelTank>(e => e.VehicleName);
+                });
+        }
+
+        public void Seed()
+        {
+            Vehicles.AddRange(CreateVehicles());
+            SaveChanges();
+        }
+
+        public void AssertSeeded()
+        {
+            Assert.Equal(CreateVehicles().OrderBy(v => v.Name).ToList(), Load(Vehicles).OrderBy(v => v.Name).ToList());
+        }
+
+        // TODO: Instead use derived includes when available
+        public DbSet<Vehicle> Load(DbSet<Vehicle> vehicles)
+        {
+            foreach (var vehicle in vehicles)
+            {
+                Load(vehicle);
+            }
+
+            return vehicles;
+        }
+
+        private void Load(Vehicle vehicle)
+        {
+            if (vehicle != null)
+            {
+                switch (vehicle)
+                {
+                    case PoweredVehicle v:
+                        Entry(v).Reference(e => e.Engine).Load();
+                        Load(v.Engine);
+                        goto default;
+                    default:
+                        Entry(vehicle).Reference(e => e.Operator).Load();
+                        break;
+                }
+            }
+        }
+
+        private void Load(Engine engine)
+        {
+            if (engine != null)
+            {
+                switch (engine)
+                {
+                    case CombustionEngine en:
+                        en.FuelTank = Set<FuelTank>().SingleOrDefault(f => f.VehicleName == en.VehicleName);
+                        break;
+                }
+            }
+        }
+
+        protected IEnumerable<Vehicle> CreateVehicles()
+        {
+            return new List<Vehicle>
+            {
+                new Vehicle
+                {
+                    Name = "Trek Pro Fit Madone 6 Series",
+                    SeatingCapacity = 1,
+                    Operator = new Operator { Name = "Lance Armstrong", VehicleName = "Trek Pro Fit Madone 6 Series" }
+                },
+                new PoweredVehicle
+                {
+                    Name = "1984 California Car",
+                    SeatingCapacity = 34,
+                    Operator = new LicensedOperator { Name = "Albert Williams", LicenseType = "Muni Transit", VehicleName = "1984 California Car" }
+                },
+                new PoweredVehicle
+                {
+                    Name = "P85 2012 Tesla Model S Performance Edition",
+                    SeatingCapacity = 5,
+                    Engine = new Engine { Description = "416 hp three phase, four pole AC induction", VehicleName = "P85 2012 Tesla Model S Performance Edition" },
+                    Operator = new LicensedOperator { Name = "Elon Musk", LicenseType = "Driver", VehicleName = "P85 2012 Tesla Model S Performance Edition" }
+                },
+                new PoweredVehicle
+                {
+                    Name = "North American X-15A-2",
+                    SeatingCapacity = 1,
+                    Engine = new CombustionEngine
+                    {
+                        Description = "Reaction Motors XLR99 throttleable, restartable liquid-propellant rocket engine",
+                        FuelTank = new FuelTank { FuelType = "Liquid oxygen and anhydrous ammonia", Capacity = "11250 kg", VehicleName = "North American X-15A-2" },
+                        VehicleName = "North American X-15A-2"
+                    },
+                    Operator = new LicensedOperator { Name = "William J. Knight", LicenseType = "Air Force Test Pilot", VehicleName = "North American X-15A-2" }
+                }
+            };
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
@@ -1,0 +1,20 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class Vehicle
+    {
+        public string Name { get; set; }
+        public int SeatingCapacity { get; set; }
+        public Operator Operator { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as Vehicle;
+            return other != null
+                && Name == other.Name
+                && SeatingCapacity == other.SeatingCapacity
+                && Equals(Operator, other.Operator);
+        }
+
+        public override int GetHashCode() => Name.GetHashCode();
+    }
+}

--- a/src/EFCore/Metadata/Internal/KeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/KeyExtensions.cs
@@ -49,6 +49,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static int IndexOf([NotNull] this IKey key, IProperty property)
+        {
+            var index = 0;
+            for (; index < key.Properties.Count && key.Properties[index] != property; index++)
+            {
+            }
+            return index == key.Properties.Count ? -1 : index;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static string ToDebugString([NotNull] this IKey key, bool singleLine = true, [NotNull] string indent = "")
         {
             var builder = new StringBuilder();

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore
 
             VerifyError(
                 RelationalStrings.IncompatibleTableKeyNameMismatch(
-                    "Table", nameof(B), nameof(A), "PK_Table", "{'Id'}", "Key", "{'Id'}"),
+                    "Table", nameof(A), nameof(B), "Key", "{'Id'}", "PK_Table", "{'Id'}"),
                 modelBuilder.Model);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -12,9 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         public OwnedQuerySqlServerTest(OwnedQuerySqlServerFixture fixture)
         {
             _fixture = fixture;
+            fixture.TestSqlLoggerFactory.Clear();
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_for_base_type_loads_all_owned_navs()
         {
             base.Query_for_base_type_loads_all_owned_navs();
@@ -22,7 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql("");
         }
 
-        [Fact(Skip = "#8907")]
+
+        [Fact(Skip = "#8973")]
         public override void Query_for_branch_type_loads_all_owned_navs()
         {
             base.Query_for_branch_type_loads_all_owned_navs();
@@ -30,21 +32,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql("");
         }
 
-        [Fact(Skip = "#8907")]
         public override void Query_for_leaf_type_loads_all_owned_navs()
         {
             base.Query_for_leaf_type_loads_all_owned_navs();
 
-            AssertSql("");
+            AssertSql(@"SELECT [o].[Id], [o].[Discriminator], [o].[Id], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[Id], [o].[Id], [o].[BranchAddress_Country_Name], [o].[Id], [o].[Id], [o].[PersonAddress_Country_Name]
+FROM [OwnedPerson] AS [o]
+WHERE [o].[Discriminator] = N'LeafA'");
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_when_group_by()
         {
             base.Query_when_group_by();
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_when_subquery()
         {
             base.Query_when_subquery();

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class TableSplittingSqlServerTest : TableSplittingTestBase<SqlServerTestStore>
+    {
+        private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
+        public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
+
+        public override SqlServerTestStore CreateTestStore(Action<ModelBuilder> onModelCreating)
+            => SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+                {
+                    var optionsBuilder = new DbContextOptionsBuilder()
+                        .UseSqlServer(_connectionString, b => b.ApplyConfiguration().CommandTimeout(300))
+                        .EnableSensitiveDataLogging()
+                        .UseInternalServiceProvider(BuildServiceProvider(onModelCreating));
+
+                    using (var context = new TransportationContext(optionsBuilder.Options))
+                    {
+                        context.Database.EnsureCreated();
+                        context.Seed();
+                    }
+                });
+
+        public override TransportationContext CreateContext(SqlServerTestStore testStore, Action<ModelBuilder> onModelCreating)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder()
+                .UseSqlServer(testStore.Connection, b => b.ApplyConfiguration().CommandTimeout(300))
+                .EnableSensitiveDataLogging()
+                .UseInternalServiceProvider(BuildServiceProvider(onModelCreating));
+
+            var context = new TransportationContext(optionsBuilder.Options);
+            context.Database.UseTransaction(testStore.Transaction);
+            return context;
+        }
+
+        private IServiceProvider BuildServiceProvider(Action<ModelBuilder> onModelCreating)
+            => new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddSingleton(TestModelSource.GetFactory(onModelCreating))
+                .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                .BuildServiceProvider();
+    }
+}

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal("ParentId", property1.SqlServer().ColumnName);
                 var property2 = modelBuilder.Model.FindEntityType(typeof(DisjointChildSubclass2)).FindProperty("ParentId");
                 Assert.True(property2.IsForeignKey());
-                Assert.Equal("ParentId1", property2.SqlServer().ColumnName);
+                Assert.Equal("DisjointChildSubclass2_ParentId", property2.SqlServer().ColumnName);
             }
 
             public class Parent

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Xunit;
@@ -14,31 +14,25 @@ namespace Microsoft.EntityFrameworkCore.Query
             _fixture = fixture;
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_for_base_type_loads_all_owned_navs()
         {
             base.Query_for_base_type_loads_all_owned_navs();
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_for_branch_type_loads_all_owned_navs()
         {
             base.Query_for_branch_type_loads_all_owned_navs();
         }
 
-        [Fact(Skip = "#8907")]
-        public override void Query_for_leaf_type_loads_all_owned_navs()
-        {
-            base.Query_for_leaf_type_loads_all_owned_navs();
-        }
-
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_when_group_by()
         {
             base.Query_when_group_by();
         }
 
-        [Fact(Skip = "#8907")]
+        [Fact(Skip = "#8973")]
         public override void Query_when_subquery()
         {
             base.Query_when_subquery();

--- a/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TableSplittingSqliteTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class TableSplittingSqliteTest : TableSplittingTestBase<SqliteTestStore>
+    {
+        public override SqliteTestStore CreateTestStore(Action<ModelBuilder> onModelCreating)
+            => SqliteTestStore.GetOrCreateShared(DatabaseName, false, true, () =>
+                {
+                    var optionsBuilder = new DbContextOptionsBuilder()
+                        .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))
+                        .EnableSensitiveDataLogging()
+                        .UseInternalServiceProvider(BuildServiceProvider(onModelCreating));
+
+                    using (var context = new TransportationContext(optionsBuilder.Options))
+                    {
+                        context.Database.EnsureClean();
+                        context.Seed();
+                    }
+                });
+
+        public override TransportationContext CreateContext(SqliteTestStore testStore, Action<ModelBuilder> onModelCreating)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder()
+                .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))
+                .EnableSensitiveDataLogging()
+                .UseInternalServiceProvider(BuildServiceProvider(onModelCreating));
+
+            return new TransportationContext(optionsBuilder.Options);
+        }
+
+        private IServiceProvider BuildServiceProvider(Action<ModelBuilder> onModelCreating)
+            => new ServiceCollection()
+                .AddEntityFrameworkSqlite()
+                .AddSingleton(TestModelSource.GetFactory(onModelCreating))
+                .BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
Make the columns nullable for dependent types involved in table splitting.
When uniquifying column names use the declaring entity type name as prefix.

Fixes #8907