### PR TITLE
Fix #7783 - Calling IQueryable-producing methods inside expression tree throws exception when outer is enumerated

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -102,6 +102,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             if (_partialEvaluationInfo.IsEvaluatableExpression(methodCallExpression))
             {
+                if (_queryableTypeInfo.IsAssignableFrom(methodCallExpression.Type))
+                {
+                    var queryable = (IQueryable)Evaluate(methodCallExpression, out _);
+
+                    return ExtractParameters(queryable.Expression);
+                }
+
                 return TryExtractParameter(methodCallExpression);
             }
 


### PR DESCRIPTION
Tweaked parameterizer to detect and handle this particular case of queryable composition.
