### PR TITLE
Fix #7863 - Somehow a mismatch in the ShapedCommandContext entries resulting in KeyNotFoundException

### DIFF
--- a/src/EFCore.Relational/Query/Internal/ShaperCommandContext.cs
+++ b/src/EFCore.Relational/Query/Internal/ShaperCommandContext.cs
@@ -41,8 +41,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     foreach (var parameterValue in _parameterValues)
                     {
                         var value = parameterValue.Value;
-                        var otherValue = other._parameterValues[parameterValue.Key];
-
+                        
+                        if (!other._parameterValues.TryGetValue(parameterValue.Key, out var otherValue))
+                        {
+                            return false;
+                        }
+                   
                         if (value == null
                             != (otherValue == null))
                         {

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -180,6 +180,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Shaper_command_caching_when_parameter_names_different()
+        {
+            using (var context = CreateContext())
+            {
+                var inmemcheck = new InMemoryCheck();
+                var variableName = "test";
+                var differentVariableName = "test";
+
+                context.Set<Customer>().Where(e => e.CustomerID == "ALFKI")
+                    .Where(e2 => inmemcheck.Check(variableName, e2.CustomerID) || true).Count();
+
+                context.Set<Customer>().Where(e => e.CustomerID == "ALFKI")
+                    .Where(e2 => inmemcheck.Check(differentVariableName, e2.CustomerID) || true).Count();
+            }
+        }
+        
+        private class InMemoryCheck
+        {
+            private Dictionary<string, string> _data = new Dictionary<string, string>();
+            public bool Check(string input1, string input2)
+                => false;
+        }
+        
+        [ConditionalFact]
         public virtual void Entity_equality_self()
         {
             AssertQuery<Customer>(cs =>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -19,6 +17,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void Shaper_command_caching_when_parameter_names_different()
+        {
+            base.Shaper_command_caching_when_parameter_names_different();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [e]
+WHERE [e].[CustomerID] = N'ALFKI'",
+                //
+                @"SELECT COUNT(*)
+FROM [Customers] AS [e]
+WHERE [e].[CustomerID] = N'ALFKI'");            
         }
 
         public override void Lifting_when_subquery_nested_order_by_anonymous()


### PR DESCRIPTION
- Found an edge case where we can extract different parameters during parameterization but end up with a single query in query cache.
