### PR TITLE
Fix #7901 - Max(), Min(), etc. do not differentiate between no results and zero

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -59,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             // Query events
             QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
             QueryPossibleUnintendedUseOfEqualsWarning,
+            QueryPossibleExceptionWithAggregateOperator,
 
             // Model validation events
             ModelValidationKeyDefaultValueWarning = CoreEventId.RelationalBaseId + 600,
@@ -405,6 +406,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId QueryPossibleUnintendedUseOfEqualsWarning = MakeQueryId(Id.QueryPossibleUnintendedUseOfEqualsWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         A query is using a possibly throwing aggregate operation in a sub-query.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId QueryPossibleExceptionWithAggregateOperator = MakeQueryId(Id.QueryPossibleExceptionWithAggregateOperator);
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
         private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);

--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -1045,6 +1045,27 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static void QueryPossibleExceptionWithAggregateOperator(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics)
+        {
+            var definition = RelationalStrings.LogQueryPossibleExceptionWithAggregateOperator;
+
+            definition.Log(diagnostics);
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new EventData(
+                        definition,
+                        (d, p) => ((EventDefinition)d).GenerateMessage()));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static void ModelValidationKeyDefaultValueWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
             [NotNull] IProperty property)

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -343,6 +343,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogPossibleUnintendedUseOfEquals")));
 
         /// <summary>
+        ///     Possible unintended use of a potentially throwing aggregate method (Min, Max, Average) in a subquery. Client-eval will be used and operator will throw if no data exist. Changing the subquery result type to a nullable type will allow full translation.
+        /// </summary>
+        public static readonly EventDefinition LogQueryPossibleExceptionWithAggregateOperator
+            = new EventDefinition(
+                RelationalEventId.QueryPossibleExceptionWithAggregateOperator,
+                LogLevel.Warning,
+                LoggerMessage.Define(
+                    LogLevel.Warning,
+                    RelationalEventId.QueryPossibleExceptionWithAggregateOperator,
+                    _resourceManager.GetString("LogQueryPossibleExceptionWithAggregateOperator")));
+
+        /// <summary>
         ///     The Include operation is not supported when calling a stored procedure.
         /// </summary>
         public static string StoredProcedureIncludeNotSupported
@@ -769,6 +781,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("UnsupportedPropertyType", nameof(entity), nameof(property), nameof(clrType)),
                 entity, property, clrType);
+
+        /// <summary>
+        ///     Sequence contains no elements.
+        /// </summary>
+        public static string NoElements
+            => GetString("NoElements");
 
         /// <summary>
         ///     An error occurred using the connection to database '{database}' on server '{server}'.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -240,6 +240,10 @@
     <value>Possible unintended use of method Equals(object) for arguments of different types in expression '{expression}'. This comparison will always return 'false'.</value>
     <comment>Warning RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning object</comment>
   </data>
+  <data name="LogQueryPossibleExceptionWithAggregateOperator" xml:space="preserve">
+    <value>Possible unintended use of a potentially throwing aggregate method (Min, Max, Average) in a subquery. Client evaluation will be used and operator will throw if no data exists. Changing the subquery result type to a nullable type will allow full translation.</value>
+    <comment>Warning RelationalEventId.QueryPossibleExceptionWithAggregateOperator</comment>
+  </data>
   <data name="StoredProcedureIncludeNotSupported" xml:space="preserve">
     <value>The Include operation is not supported when calling a stored procedure.</value>
   </data>
@@ -395,6 +399,9 @@
   </data>
   <data name="UnsupportedPropertyType" xml:space="preserve">
     <value>No mapping to a relational type can be found for property '{entity}.{property}' with the CLR type '{clrType}'.</value>
+  </data>
+  <data name="NoElements" xml:space="preserve">
+    <value>Sequence contains no elements.</value>
   </data>
   <data name="LogRelationalLoggerConnectionErrorAsDebug" xml:space="preserve">
     <value>An error occurred using the connection to database '{database}' on server '{server}'.</value>

--- a/src/EFCore.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EFCore.Relational/Query/AsyncQueryMethodProvider.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -139,7 +140,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [UsedImplicitly]
         private static async Task<TResult> GetResult<TResult>(
-            IAsyncEnumerable<ValueBuffer> valueBuffers,
+            IAsyncEnumerable<ValueBuffer> valueBuffers, 
+            bool throwOnNullResult,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -149,7 +151,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (await enumerator.MoveNext(cancellationToken))
                 {
                     return enumerator.Current[0] == null
-                        ? default(TResult)
+                        ? !throwOnNullResult 
+                            ? default(TResult) 
+                            : throw new InvalidOperationException(RelationalStrings.NoElements)
                         : (TResult)enumerator.Current[0];
                 }
             }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -18,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     public class ResultTransformingExpressionVisitor<TResult> : ExpressionVisitorBase
     {
         private readonly RelationalQueryCompilationContext _relationalQueryCompilationContext;
+        private readonly bool _throwOnNullResult;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,12 +27,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         public ResultTransformingExpressionVisitor(
             [NotNull] IQuerySource outerQuerySource,
-            [NotNull] RelationalQueryCompilationContext relationalQueryCompilationContext)
+            [NotNull] RelationalQueryCompilationContext relationalQueryCompilationContext,
+            bool throwOnNullResult)
         {
             Check.NotNull(outerQuerySource, nameof(outerQuerySource));
             Check.NotNull(relationalQueryCompilationContext, nameof(relationalQueryCompilationContext));
 
             _relationalQueryCompilationContext = relationalQueryCompilationContext;
+            _throwOnNullResult = throwOnNullResult;
         }
 
         /// <summary>
@@ -45,29 +49,40 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 _relationalQueryCompilationContext.QueryMethodProvider.ShapedQueryMethod))
             {
                 var queryArguments = node.Arguments.Take(2).ToList();
-                
+
                 return ResultOperatorHandler
                     .CallWithPossibleCancellationToken(
                         _relationalQueryCompilationContext.QueryMethodProvider
                             .GetResultMethod.MakeGenericMethod(typeof(TResult)),
                         Expression.Call(
                             _relationalQueryCompilationContext.QueryMethodProvider.QueryMethod,
-                            queryArguments));
+                            queryArguments),
+                        Expression.Constant(_throwOnNullResult));
             }
 
             if (node.Method.MethodIsClosedFormOf(
                 _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod))
             {
                 var sourceArgument = (MethodCallExpression)Visit(node.Arguments[1]);
+
                 if (sourceArgument.Method.MethodIsClosedFormOf(
                     _relationalQueryCompilationContext.QueryMethodProvider.GetResultMethod))
                 {
                     var getResultArgument = sourceArgument.Arguments[0];
-                    var newGetResultArgument = Expression.Call(
-                        _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod.MakeGenericMethod(typeof(ValueBuffer)),
-                        node.Arguments[0], getResultArgument, node.Arguments[2], node.Arguments[3]);
 
-                    return ResultOperatorHandler.CallWithPossibleCancellationToken(sourceArgument.Method, newGetResultArgument);
+                    var newGetResultArgument
+                        = Expression.Call(
+                            _relationalQueryCompilationContext.QueryMethodProvider.InjectParametersMethod
+                                .MakeGenericMethod(typeof(ValueBuffer)),
+                            node.Arguments[0],
+                            getResultArgument,
+                            node.Arguments[2],
+                            node.Arguments[3]);
+
+                    return ResultOperatorHandler.CallWithPossibleCancellationToken(
+                        sourceArgument.Method,
+                        newGetResultArgument,
+                        sourceArgument.Arguments[1]);
                 }
 
                 return sourceArgument;

--- a/src/EFCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/EFCore.Relational/Query/QueryMethodProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -121,14 +122,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .GetDeclaredMethod(nameof(GetResult));
 
         [UsedImplicitly]
-        private static TResult GetResult<TResult>(IEnumerable<ValueBuffer> valueBuffers)
+        private static TResult GetResult<TResult>(IEnumerable<ValueBuffer> valueBuffers, bool throwOnNullResult)
         {
             using (var enumerator = valueBuffers.GetEnumerator())
             {
                 if (enumerator.MoveNext())
                 {
                     return enumerator.Current[0] == null
-                        ? default(TResult)
+                        ? !throwOnNullResult 
+                            ? default(TResult) 
+                            : throw new InvalidOperationException(RelationalStrings.NoElements)
                         : (TResult)enumerator.Current[0];
                 }
             }

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.ResultOperators.cs
@@ -247,6 +247,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Average_on_float_column_in_subquery_with_cast()
+        {
+            AssertQuery<Order>(
+                os => os.Where(o => o.OrderID < 10300)
+                    .Select(o => new { o.OrderID, Sum = o.OrderDetails.Average(od => (float?)od.Discount) }),
+                e => e.OrderID);
+        }
+
+        [ConditionalFact]
         public virtual void Min_with_no_arg()
         {
             AssertSingleResult<Order>(os => os.Select(o => o.OrderID).Min());
@@ -256,6 +265,63 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Min_with_arg()
         {
             AssertSingleResult<Order>(os => os.Min(o => o.OrderID));
+        }
+
+        [ConditionalFact]
+        public virtual void Min_no_data()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Min_no_data_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => 
+                    context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Min(o => o.OrderID)).ToList());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Max_no_data()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Max_no_data_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => 
+                    context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Max(o => o.OrderID)).ToList());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Average_no_data()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => context.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Average_no_data_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Throws<InvalidOperationException>(() => 
+                    context.Customers.Select(c => c.Orders.Where(o => o.OrderID == -1).Average(o => o.OrderID)).ToList());
+            }
         }
 
         [ConditionalFact]

--- a/src/EFCore/Diagnostics/ExpressionEventData.cs
+++ b/src/EFCore/Diagnostics/ExpressionEventData.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
-        ///     The left <see cref="Expression" />.
+        ///     The <see cref="Expression" />.
         /// </summary>
         public virtual Expression Expression { get; }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.ResultOperators.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class QuerySqlServerTest
@@ -230,6 +233,26 @@ WHERE [od].[ProductID] = 1");
         public override void Average_on_float_column_in_subquery()
         {
             base.Average_on_float_column_in_subquery();
+
+            AssertContainsSql(
+                @"SELECT [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10300",
+                //
+                @"@_outer_OrderID='10248'
+
+SELECT CAST(AVG(CAST([od0].[Discount] AS real)) AS real)
+FROM [Order Details] AS [od0]
+WHERE @_outer_OrderID = [od0].[OrderID]");
+
+            Assert.Contains(
+                RelationalStrings.LogQueryPossibleExceptionWithAggregateOperator.GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log);
+        }
+
+        public override void Average_on_float_column_in_subquery_with_cast()
+        {
+            base.Average_on_float_column_in_subquery_with_cast();
 
             AssertSql(
                 @"SELECT [o].[OrderID], (


### PR DESCRIPTION
Max, Min and Average should throw "Sequence contains no elements" when there was no data returned and the result type is non-nullable. Updated relational result operator handling to do that.

- Added a warning for the subquery throwing case.