### PR TITLE
UseDatabaseNames added to Scaffolding

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -44,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IEnumerable<string> schemas,
             [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
-            bool overwriteFiles)
+            bool overwriteFiles,
+            bool useDatabaseNames)
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -67,7 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 _rootNamespace,
                 dbContextClassName,
                 useDataAnnotations,
-                overwriteFiles);
+                overwriteFiles,
+                useDatabaseNames);
         }
     }
 }

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -321,10 +321,11 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var tableFilters = (IEnumerable<string>)args["tableFilters"];
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
+                var useDatabaseNames = (bool)args["useDatabaseNames"];
 
                 Execute(() => executor.ScaffoldContextImpl(provider,
                     connectionString, outputDir, dbContextClassName,
-                    schemaFilters, tableFilters, useDataAnnotations, overwriteFiles));
+                    schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames));
             }
         }
 
@@ -336,7 +337,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] IEnumerable<string> schemaFilters,
             [NotNull] IEnumerable<string> tableFilters,
             bool useDataAnnotations,
-            bool overwriteFiles)
+            bool overwriteFiles,
+            bool useDatabaseNames)
         {
             Check.NotNull(provider, nameof(provider));
             Check.NotNull(connectionString, nameof(connectionString));
@@ -345,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = _databaseOperations.Value.ScaffoldContext(
                 provider, connectionString, outputDir, dbContextClassName,
-                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles);
+                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames);
 
             return new Hashtable
             {

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpNamer.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpNamer.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     {
         private readonly Func<T, string> _nameGetter;
         private readonly ICSharpUtilities _cSharpUtilities;
+        private readonly Func<string, string> _singularizePluralizer;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -27,13 +28,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public CSharpNamer([NotNull] Func<T, string> nameGetter, [NotNull] ICSharpUtilities cSharpUtilities)
+        public CSharpNamer([NotNull] Func<T, string> nameGetter,
+            [NotNull] ICSharpUtilities cSharpUtilities,
+            [CanBeNull] Func<string, string> singularizePluralizer)
         {
             Check.NotNull(nameGetter, nameof(nameGetter));
             Check.NotNull(cSharpUtilities, nameof(cSharpUtilities));
 
             _nameGetter = nameGetter;
             _cSharpUtilities = cSharpUtilities;
+            _singularizePluralizer = singularizePluralizer;
         }
 
         /// <summary>
@@ -49,7 +53,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 return NameCache[item];
             }
 
-            var name = _cSharpUtilities.GenerateCSharpIdentifier(_nameGetter(item), null);
+            var name = _cSharpUtilities.GenerateCSharpIdentifier(
+                _nameGetter(item), existingIdentifiers: null, singularizePluralizer: _singularizePluralizer);
             NameCache.Add(item, name);
             return name;
         }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
@@ -19,8 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public CSharpUniqueNamer([NotNull] Func<T, string> nameGetter, [NotNull] ICSharpUtilities cSharpUtilities)
-            : this(nameGetter, null, cSharpUtilities)
+        public CSharpUniqueNamer(
+            [NotNull] Func<T, string> nameGetter,
+            [NotNull] ICSharpUtilities cSharpUtilities,
+            [CanBeNull] Func<string, string> singularizePluralizer)
+            : this(nameGetter, null, cSharpUtilities, singularizePluralizer)
         {
         }
 
@@ -30,8 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         /// </summary>
         public CSharpUniqueNamer([NotNull] Func<T, string> nameGetter,
             [CanBeNull] IEnumerable<string> usedNames,
-            [NotNull] ICSharpUtilities cSharpUtilities)
-            : base(nameGetter, cSharpUtilities)
+            [NotNull] ICSharpUtilities cSharpUtilities,
+            [CanBeNull] Func<string, string> singularizePluralizer)
+            : base(nameGetter, cSharpUtilities, singularizePluralizer)
         {
             if (usedNames != null)
             {

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
@@ -272,15 +272,19 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual string GenerateCSharpIdentifier(
-            string identifier, [CanBeNull] ICollection<string> existingIdentifiers)
-            => GenerateCSharpIdentifier(identifier, existingIdentifiers, Uniquifier);
+            string identifier,
+            [CanBeNull] ICollection<string> existingIdentifiers,
+            [CanBeNull] Func<string, string> singularizePluralizer)
+            => GenerateCSharpIdentifier(identifier, existingIdentifiers, singularizePluralizer, Uniquifier);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual string GenerateCSharpIdentifier(
-            string identifier, [CanBeNull] ICollection<string> existingIdentifiers,
+            string identifier,
+            [CanBeNull] ICollection<string> existingIdentifiers,
+            [CanBeNull] Func<string, string> singularizePluralizer,
             Func<string, ICollection<string>, string> uniquifier)
         {
             Check.NotNull(identifier, nameof(identifier));
@@ -305,6 +309,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             else if (IsCSharpKeyword(proposedIdentifier))
             {
                 proposedIdentifier = "_" + proposedIdentifier;
+            }
+
+            if (singularizePluralizer != null)
+            {
+                proposedIdentifier = singularizePluralizer(proposedIdentifier);
             }
 
             return uniquifier(proposedIdentifier, existingIdentifiers);

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpUtilities.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpUtilities.cs
@@ -12,8 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         string DelimitString([NotNull] string value);
         string EscapeString([NotNull] string str);
         string EscapeVerbatimString([NotNull] string str);
-        string GenerateCSharpIdentifier([NotNull] string identifier, [CanBeNull] ICollection<string> existingIdentifiers);
-        string GenerateCSharpIdentifier([NotNull] string identifier, [CanBeNull] ICollection<string> existingIdentifiers, [NotNull] Func<string, ICollection<string>, string> uniquifier);
+        string GenerateCSharpIdentifier([NotNull] string identifier, [CanBeNull] ICollection<string> existingIdentifiers, [CanBeNull] Func<string, string> singularizePluralizer);
+        string GenerateCSharpIdentifier([NotNull] string identifier, [CanBeNull] ICollection<string> existingIdentifiers, [CanBeNull] Func<string, string> singularizePluralizer, [NotNull] Func<string, ICollection<string>, string> uniquifier);
         string GenerateLiteral(bool value);
         string GenerateLiteral([NotNull] byte[] value);
         string GenerateLiteral(DateTime value);

--- a/src/EFCore.Design/Scaffolding/Internal/IModelScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IModelScaffolder.cs
@@ -17,6 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                [NotNull] string rootNamespace,
                [CanBeNull] string contextName,
                bool useDataAnnotations,
-               bool overwriteFiles);
+               bool overwriteFiles,
+               bool useDatabaseNames);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
@@ -10,5 +10,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     public interface IScaffoldingModelFactory
     {
         IModel Create([NotNull] string connectionString, [NotNull] IEnumerable<string> tables, [NotNull] IEnumerable<string> schemas);
+        bool UseDatabaseNames { get; set; }
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
@@ -9,7 +9,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
     public interface IScaffoldingModelFactory
     {
-        IModel Create([NotNull] string connectionString, [NotNull] IEnumerable<string> tables, [NotNull] IEnumerable<string> schemas);
-        bool UseDatabaseNames { get; set; }
+        IModel Create([NotNull] string connectionString, [NotNull] IEnumerable<string> tables, [NotNull] IEnumerable<string> schemas, bool useDatabaseNames);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/ModelScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ModelScaffolder.cs
@@ -79,8 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     DesignStrings.ContextClassNotValidCSharpIdentifier(contextName));
             }
 
-            _factory.UseDatabaseNames = useDatabaseNames;
-            var model = _factory.Create(connectionString, tables, schemas);
+            var model = _factory.Create(connectionString, tables, schemas, useDatabaseNames);
 
             if (model == null)
             {

--- a/src/EFCore.Design/Scaffolding/Internal/ModelScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ModelScaffolder.cs
@@ -62,7 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string rootNamespace,
             string contextName,
             bool useDataAnnotations,
-            bool overwriteFiles)
+            bool overwriteFiles,
+            bool useDatabaseNames)
         {
             Check.NotEmpty(connectionString, nameof(connectionString));
             Check.NotNull(tables, nameof(tables));
@@ -78,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     DesignStrings.ContextClassNotValidCSharpIdentifier(contextName));
             }
 
+            _factory.UseDatabaseNames = useDatabaseNames;
             var model = _factory.Create(connectionString, tables, schemas);
 
             if (model == null)
@@ -102,7 +104,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 @namespace += "." + string.Join(
                                   ".", relativeOutputPath
                                       .Split(_directorySeparatorChars, StringSplitOptions.RemoveEmptyEntries)
-                                      .Select(p => _cSharpUtilities.GenerateCSharpIdentifier(p, existingIdentifiers: null)));
+                                      .Select(p => _cSharpUtilities.GenerateCSharpIdentifier(
+                                          p,
+                                          existingIdentifiers: null,
+                                          singularizePluralizer: null)));
             }
 
             if (string.IsNullOrEmpty(contextName))
@@ -112,7 +117,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 var annotatedName = model.Scaffolding().DatabaseName;
                 if (!string.IsNullOrEmpty(annotatedName))
                 {
-                    contextName = _cSharpUtilities.GenerateCSharpIdentifier(annotatedName + DbContextSuffix, existingIdentifiers: null);
+                    contextName = _cSharpUtilities.GenerateCSharpIdentifier(
+                        annotatedName + DbContextSuffix,
+                        existingIdentifiers: null,
+                        singularizePluralizer: null);
                 }
             }
 

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -28,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         internal const string NavigationNameUniquifyingPattern = "{0}Navigation";
         internal const string SelfReferencingPrincipalEndNavigationNamePattern = "Inverse{0}";
 
-        public virtual bool UseDatabaseNames { get; set; }
 
         protected virtual IOperationReporter Reporter { get; }
         protected virtual IRelationalTypeMapper TypeMapper { get; }
@@ -74,7 +73,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _scaffoldingTypeMapper = scaffoldingTypeMapper;
         }
 
-        public virtual IModel Create(string connectionString, IEnumerable<string> tables, IEnumerable<string> schemas)
+        public virtual IModel Create(
+            string connectionString,
+            IEnumerable<string> tables,
+            IEnumerable<string> schemas,
+            bool useDatabaseNames)
         {
             Check.NotEmpty(connectionString, nameof(connectionString));
             Check.NotNull(tables, nameof(tables));
@@ -82,29 +85,29 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var databaseModel = _databaseModelFactory.Create(connectionString, tables, schemas);
 
-            return CreateFromDatabaseModel(databaseModel);
+            return CreateFromDatabaseModel(databaseModel, useDatabaseNames);
         }
 
-        protected virtual IModel CreateFromDatabaseModel([NotNull] DatabaseModel databaseModel)
+        protected virtual IModel CreateFromDatabaseModel([NotNull] DatabaseModel databaseModel, bool useDatabaseNames)
         {
             Check.NotNull(databaseModel, nameof(databaseModel));
 
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             _tableNamer = new CSharpUniqueNamer<DatabaseTable>(
-                UseDatabaseNames
+                useDatabaseNames
                     ? (Func<DatabaseTable, string>)(t => t.Name)
                     : t => CandidateNamingService.GenerateCandidateIdentifier(t.Name),
                 _cSharpUtilities,
-                UseDatabaseNames
+                useDatabaseNames
                     ? (Func<string, string>)null
                     : _pluralizer.Singularize);
             _dbSetNamer = new CSharpUniqueNamer<DatabaseTable>(
-                UseDatabaseNames
+                useDatabaseNames
                     ? (Func<DatabaseTable, string>)(t => t.Name)
                     : t => CandidateNamingService.GenerateCandidateIdentifier(t.Name),
                 _cSharpUtilities,
-                UseDatabaseNames
+                useDatabaseNames
                     ? (Func<string, string>)null
                     : _pluralizer.Pluralize);
             _columnNamers = new Dictionary<DatabaseTable, CSharpUniqueNamer<DatabaseColumn>>();

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -28,6 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         internal const string NavigationNameUniquifyingPattern = "{0}Navigation";
         internal const string SelfReferencingPrincipalEndNavigationNamePattern = "Inverse{0}";
 
+        public virtual bool UseDatabaseNames { get; set; }
+
         protected virtual IOperationReporter Reporter { get; }
         protected virtual IRelationalTypeMapper TypeMapper { get; }
         protected virtual ICandidateNamingService CandidateNamingService { get; }
@@ -35,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private Dictionary<DatabaseTable, CSharpUniqueNamer<DatabaseColumn>> _columnNamers;
         private readonly DatabaseTable _nullTable = new DatabaseTable();
         private CSharpUniqueNamer<DatabaseTable> _tableNamer;
+        private CSharpUniqueNamer<DatabaseTable> _dbSetNamer;
         private readonly IDatabaseModelFactory _databaseModelFactory;
         private readonly HashSet<DatabaseColumn> _unmappedColumns = new HashSet<DatabaseColumn>();
         private readonly IPluralizer _pluralizer;
@@ -89,8 +92,21 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             _tableNamer = new CSharpUniqueNamer<DatabaseTable>(
-                t => CandidateNamingService.GenerateCandidateIdentifier(t.Name),
-                _cSharpUtilities);
+                UseDatabaseNames
+                    ? (Func<DatabaseTable, string>)(t => t.Name)
+                    : t => CandidateNamingService.GenerateCandidateIdentifier(t.Name),
+                _cSharpUtilities,
+                UseDatabaseNames
+                    ? (Func<string, string>)null
+                    : _pluralizer.Singularize);
+            _dbSetNamer = new CSharpUniqueNamer<DatabaseTable>(
+                UseDatabaseNames
+                    ? (Func<DatabaseTable, string>)(t => t.Name)
+                    : t => CandidateNamingService.GenerateCandidateIdentifier(t.Name),
+                _cSharpUtilities,
+                UseDatabaseNames
+                    ? (Func<string, string>)null
+                    : _pluralizer.Pluralize);
             _columnNamers = new Dictionary<DatabaseTable, CSharpUniqueNamer<DatabaseColumn>>();
 
             VisitDatabaseModel(modelBuilder, databaseModel);
@@ -99,10 +115,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         }
 
         protected virtual string GetEntityTypeName([NotNull] DatabaseTable table)
-            => _pluralizer.Singularize(_tableNamer.GetName(Check.NotNull(table, nameof(table))));
+            => _tableNamer.GetName(Check.NotNull(table, nameof(table)));
 
         protected virtual string GetDbSetName([NotNull] DatabaseTable table)
-            => _pluralizer.Pluralize(_tableNamer.GetName(Check.NotNull(table, nameof(table))));
+            => _dbSetNamer.GetName(Check.NotNull(table, nameof(table)));
 
         protected virtual string GetPropertyName([NotNull] DatabaseColumn column)
         {
@@ -113,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             // TODO - need to clean up the way CSharpNamer & CSharpUniqueNamer work (see issue #1671)
             if (column.Table != null)
             {
-                usedNames.Add(_tableNamer.GetName(table));
+                usedNames.Add(GetEntityTypeName(table));
             }
 
             if (!_columnNamers.ContainsKey(table))
@@ -121,7 +137,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 _columnNamers.Add(
                     table,
                     new CSharpUniqueNamer<DatabaseColumn>(
-                        c => CandidateNamingService.GenerateCandidateIdentifier(c.Name), usedNames, _cSharpUtilities));
+                        c => CandidateNamingService.GenerateCandidateIdentifier(c.Name),
+                        usedNames,
+                        _cSharpUtilities,
+                        null));
             }
 
             return _columnNamers[table].GetName(column);
@@ -672,6 +691,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 _cSharpUtilities.GenerateCSharpIdentifier(
                     dependentEndNavigationPropertyCandidateName,
                     dependentEndExistingIdentifiers,
+                    null,
                     NavigationUniquifier);
 
             foreignKey.HasDependentToPrincipal(dependentEndNavigationPropertyName);
@@ -695,6 +715,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 _cSharpUtilities.GenerateCSharpIdentifier(
                     principalEndNavigationPropertyCandidateName,
                     principalEndExistingIdentifiers,
+                    null,
                     NavigationUniquifier);
 
             foreignKey.HasPrincipalToDependent(principalEndNavigationPropertyName);

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -336,6 +336,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 startupProject, targetFramework);
 
         /// <summary>
+        ///     Use table and column names directly from the database.
+        /// </summary>
+        public static string UseDatabaseNamesDescription
+            => GetString("UseDatabaseNamesDescription");
+
+        /// <summary>
         ///     Using project '{project}'.
         /// </summary>
         public static string UsingProject([CanBeNull] object project)

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -273,6 +273,9 @@
   <data name="UnsupportedFramework" xml:space="preserve">
     <value>Startup project '{startupProject}' targets framework '{targetFramework}'. The Entity Framework Core .NET Command Line Tools don't support this framework.</value>
   </data>
+  <data name="UseDatabaseNamesDescription" xml:space="preserve">
+    <value>Use table and column names directly from the database.</value>
+  </data>
   <data name="UsingProject" xml:space="preserve">
     <value>Using project '{project}'.</value>
   </data>

--- a/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandOption _outputDir;
         private CommandOption _schemas;
         private CommandOption _tables;
+        private CommandOption _useDatabaseNames;
         private CommandOption _json;
 
         public override void Configure(CommandLineApplication command)
@@ -31,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             _outputDir = command.Option("-o|--output-dir <PATH>", Resources.OutputDirDescription);
             _schemas = command.Option("--schema <SCHEMA_NAME>...", Resources.SchemasDescription);
             _tables = command.Option("-t|--table <TABLE_NAME>...", Resources.TablesDescription);
+            _useDatabaseNames = command.Option("--use-database-names", Resources.UseDatabaseNamesDescription);
             _json = Json.ConfigureOption(command);
 
             base.Configure(command);

--- a/src/ef/Commands/DbContextScaffoldCommand.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.cs
@@ -34,7 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 _schemas.Values,
                 _tables.Values,
                 _dataAnnotations.HasValue(),
-                _force.HasValue());
+                _force.HasValue(),
+                _useDatabaseNames.HasValue());
             if (_json.HasValue())
             {
                 ReportJsonResults(result);

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -26,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> schemaFilters,
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
-            bool overwriteFiles);
+            bool overwriteFiles,
+            bool useDatabaseNames);
 
         string ScriptMigration(string fromMigration, string toMigration, bool idempotent, string contextType);
     }

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -139,7 +139,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> schemaFilters,
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
-            bool overwriteFiles)
+            bool overwriteFiles,
+            bool useDatabaseNames)
             => InvokeOperation<IDictionary>("ScaffoldContext",
                 new Dictionary<string, object>
                 {
@@ -150,7 +151,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["schemaFilters"] = schemaFilters,
                     ["tableFilters"] = tableFilters,
                     ["useDataAnnotations"] = useDataAnnotations,
-                    ["overwriteFiles"] = overwriteFiles
+                    ["overwriteFiles"] = overwriteFiles,
+                    ["useDatabaseNames"] = useDatabaseNames
                 });
 
         public string ScriptMigration(

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -398,6 +398,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 file);
 
         /// <summary>
+        ///     Use table and column names directly from the database.
+        /// </summary>
+        public static string UseDatabaseNamesDescription
+            => GetString("UseDatabaseNamesDescription");
+
+        /// <summary>
         ///     Using working directory '{workingDirectory}'.
         /// </summary>
         public static string UsingWorkingDirectory([CanBeNull] object workingDirectory)

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -294,6 +294,9 @@
   <data name="WritingFile" xml:space="preserve">
     <value>Writing '{file}'...</value>
   </data>
+  <data name="UseDatabaseNamesDescription" xml:space="preserve">
+    <value>Use table and column names directly from the database.</value>
+  </data>
   <data name="UsingWorkingDirectory" xml:space="preserve">
     <value>Using working directory '{workingDirectory}'.</value>
   </data>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpNamerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpNamerTest.cs
@@ -13,9 +13,27 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("namespace", "_namespace")]
         [InlineData("@namespace", "@namespace")]
         [InlineData("8ball", "_8ball")]
-        public void Sanitizes_name(string input, string output)
+        public void Sanitizes_name_with_no_singularize_or_pluralize(string input, string output)
         {
-            Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities()).GetName(input));
+            Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities(), null).GetName(input));
+        }
+
+        [Theory]
+        [InlineData("Name ending with s", "Name_ending_with_")]
+        [InlineData("Name with no s at end", "Name_with_no_s_at_end")]
+        public void Sanitizes_name_with_singularizer(string input, string output)
+        {
+            var fakePluralizer = new FakePluralizer();
+            Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities(), fakePluralizer.Singularize).GetName(input));
+        }
+
+        [Theory]
+        [InlineData("Name ending with s", "Name_ending_with_s")]
+        [InlineData("Name with no s at end", "Name_with_no_s_at_ends")]
+        public void Sanitizes_name_with_pluralizer(string input, string output)
+        {
+            var fakePluralizer = new FakePluralizer();
+            Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities(), fakePluralizer.Pluralize).GetName(input));
         }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Returns_unique_name_for_type()
         {
-            var namer = new CSharpUniqueNamer<DatabaseColumn>(s => s.Name, new CSharpUtilities());
+            var namer = new CSharpUniqueNamer<DatabaseColumn>(s => s.Name, new CSharpUtilities(), null);
             var input1 = new DatabaseColumn
             {
                 Name = "Id"
@@ -31,11 +31,33 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Uses_comparer()
         {
-            var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities());
+            var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), null);
             var table1 = new DatabaseTable { Name = "A B C" };
             var table2 = new DatabaseTable { Name = "A_B_C" };
             Assert.Equal("A_B_C", namer.GetName(table1));
             Assert.Equal("A_B_C1", namer.GetName(table2));
+        }
+
+        [Theory]
+        [InlineData("Name ending with s", "Name_ending_with_")]
+        [InlineData("Name with no s at end", "Name_with_no_s_at_end")]
+        public void Singularizes_names(string input, string output)
+        {
+            var fakePluralizer = new FakePluralizer();
+            var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), fakePluralizer.Singularize);
+            var table = new DatabaseTable { Name = input };
+            Assert.Equal(output, namer.GetName(table));
+        }
+
+        [Theory]
+        [InlineData("Name ending with s", "Name_ending_with_s")]
+        [InlineData("Name with no s at end", "Name_with_no_s_at_ends")]
+        public void Pluralizes_names(string input, string output)
+        {
+            var fakePluralizer = new FakePluralizer();
+            var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), fakePluralizer.Pluralize);
+            var table = new DatabaseTable { Name = input };
+            Assert.Equal(output, namer.GetName(table));
         }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -890,7 +890,6 @@ namespace Microsoft.EntityFrameworkCore
                 new TestOperationReporter(),
                 new FakePluralizer());
 
-            // Note: factory.UseDatabaseNames == false;
             var model = factory.Create(info);
 
             Assert.Collection(
@@ -909,8 +908,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
             );
 
-            factory.UseDatabaseNames = true;
-            model = factory.Create(info);
+            model = factory.Create(info, true);
 
             Assert.Collection(
                 model.GetEntityTypes().OrderBy(t => t.Name).Cast<EntityType>(),
@@ -983,7 +981,7 @@ namespace Microsoft.EntityFrameworkCore
 
     public class FakeScaffoldingModelFactory : RelationalScaffoldingModelFactory
     {
-        public IModel Create(DatabaseModel databaseModel)
+        public IModel Create(DatabaseModel databaseModel, bool useDatabaseNames = false)
         {
             foreach (var sequence in databaseModel.Sequences)
             {
@@ -1020,7 +1018,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
-            return CreateFromDatabaseModel(databaseModel);
+            return CreateFromDatabaseModel(databaseModel, useDatabaseNames);
         }
 
         public FakeScaffoldingModelFactory(

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -890,6 +890,7 @@ namespace Microsoft.EntityFrameworkCore
                 new TestOperationReporter(),
                 new FakePluralizer());
 
+            // Note: factory.UseDatabaseNames == false;
             var model = factory.Create(info);
 
             Assert.Collection(
@@ -906,6 +907,25 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal("Post", entity.Name);
                         Assert.Equal("Posts", entity.Scaffolding().DbSetName);
                     }
+            );
+
+            factory.UseDatabaseNames = true;
+            model = factory.Create(info);
+
+            Assert.Collection(
+                model.GetEntityTypes().OrderBy(t => t.Name).Cast<EntityType>(),
+                entity =>
+                {
+                    Assert.Equal("Blog", entity.Relational().TableName);
+                    Assert.Equal("Blog", entity.Name);
+                    Assert.Equal("Blog", entity.Scaffolding().DbSetName);
+                },
+                entity =>
+                {
+                    Assert.Equal("Posts", entity.Relational().TableName);
+                    Assert.Equal("Posts", entity.Name);
+                    Assert.Equal("Posts", entity.Scaffolding().DbSetName);
+                }
             );
         }
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -47,7 +47,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                                 rootNamespace: "FakeNamespace",
                                 contextName: contextName,
                                 useDataAnnotations: false,
-                                overwriteFiles: false))
+                                overwriteFiles: false,
+                                useDatabaseNames: false))
                     .Message);
         }
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -93,7 +93,8 @@ namespace Microsoft.EntityFrameworkCore.ReverseEngineering
                     TestNamespace,
                     contextName: "AttributesContext",
                     useDataAnnotations: true,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
             var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(Path.Combine(TestProjectDir, TestSubDir)))
             {
@@ -134,7 +135,8 @@ namespace Microsoft.EntityFrameworkCore.ReverseEngineering
                     rootNamespace: TestNamespace,
                     contextName: null,
                     useDataAnnotations: false,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
             var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
             {
@@ -195,7 +197,8 @@ CREATE TABLE NonNullBoolWithDefault
                         rootNamespace: TestNamespace,
                         contextName: "NonNullBoolWithDefaultContext",
                         useDataAnnotations: false,
-                        overwriteFiles: false);
+                        overwriteFiles: false,
+                        useDatabaseNames: false);
 
 
                 var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
@@ -265,7 +268,8 @@ CREATE SEQUENCE NumericSequence
                         rootNamespace: TestNamespace,
                         contextName: "SequenceContext",
                         useDataAnnotations: false,
-                        overwriteFiles: false);
+                        overwriteFiles: false,
+                        useDatabaseNames: false);
 
                 var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
                 {
@@ -319,7 +323,8 @@ CREATE TABLE PrimaryKeyWithSequence (
                         rootNamespace: TestNamespace,
                         contextName: "PrimaryKeyWithSequenceContext",
                         useDataAnnotations: false,
-                        overwriteFiles: false);
+                        overwriteFiles: false,
+                        useDatabaseNames: false);
 
                 var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
                 {
@@ -368,7 +373,8 @@ CREATE INDEX Unicorn_Filtered_Index
                         rootNamespace: TestNamespace,
                         contextName: "FilteredIndexContext",
                         useDataAnnotations: false,
-                        overwriteFiles: false);
+                        overwriteFiles: false,
+                        useDatabaseNames: false);
 
                 var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
                 {
@@ -418,7 +424,8 @@ WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.History));
                         rootNamespace: TestNamespace,
                         contextName: "SystemVersionedContext",
                         useDataAnnotations: false,
-                        overwriteFiles: false);
+                        overwriteFiles: false,
+                        useDatabaseNames: false);
 
 
                 scratch.ExecuteNonQuery(@"

--- a/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
@@ -50,7 +50,8 @@ CREATE TABLE IF NOT EXISTS Dependent (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 
@@ -105,7 +106,8 @@ CREATE TABLE IF NOT EXISTS OneToManyDependent (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 
@@ -154,7 +156,8 @@ CREATE TABLE IF NOT EXISTS Users_Groups (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 
@@ -197,7 +200,8 @@ CREATE TABLE IF NOT EXISTS Users_Groups (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 
@@ -234,7 +238,8 @@ CREATE TABLE IF NOT EXISTS Users_Groups (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 var errorMessage = DesignStrings.UnableToGenerateEntityType("Alicia");
                 Assert.Collection(
@@ -266,7 +271,8 @@ CREATE TABLE IF NOT EXISTS Principal ( Id INT);");
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Collection(
                     _reporter.Messages,
@@ -330,7 +336,8 @@ CREATE TABLE IF NOT EXISTS String (
                     rootNamespace: "E2E.Sqlite",
                     contextName: null,
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 
@@ -368,7 +375,8 @@ CREATE TABLE IF NOT EXISTS Comment (
                     rootNamespace: "E2E.Sqlite",
                     contextName: "FkToAltKeyContext",
                     useDataAnnotations: UseDataAnnotations,
-                    overwriteFiles: false);
+                    overwriteFiles: false,
+                    useDatabaseNames: false);
 
                 Assert.Empty(_reporter.Messages);
 

--- a/test/EFCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
@@ -308,7 +308,7 @@ CREATE TABLE Gum ( A, B PRIMARY KEY,
         private IModel GetModel(string createSql)
         {
             _testStore.ExecuteNonQuery(createSql);
-            return _scaffoldingModelFactory.Create(_testStore.ConnectionString, Enumerable.Empty<string>(), Enumerable.Empty<string>());
+            return _scaffoldingModelFactory.Create(_testStore.ConnectionString, Enumerable.Empty<string>(), Enumerable.Empty<string>(), false);
         }
 
         public void Dispose() => _testStore.Dispose();


### PR DESCRIPTION
Fix for #6018 .

The `--use-database-names` flag can now be used to control whether scaffolding a) does or does not attempt to Pascalize the names from the database, and b) produces singularized/pluralized names.
