### PR TITLE
Log a message with EF version information

### DIFF
--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
     public class InMemoryOptionsExtension : IDbContextOptionsExtension
     {
         private string _storeName;
+        private string _logFragment;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -82,6 +84,27 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         /// </summary>
         public virtual void Validate(IDbContextOptions options)
         {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    builder.Append("StoreName=").Append(_storeName).Append(' ');
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
         }
     }
 }

--- a/src/EFCore.Relational.Specification.Tests/LoggingRelationalTest.cs
+++ b/src/EFCore.Relational.Specification.Tests/LoggingRelationalTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class LoggingRelationalTest<TBuilder, TExtension> : LoggingTestBase
+        where TBuilder : RelationalDbContextOptionsBuilder<TBuilder, TExtension>
+        where TExtension : RelationalOptionsExtension, new()
+    {
+        [Fact]
+        public void Logs_context_initialization_max_batch_size()
+        {
+            Assert.Equal(
+                ExpectedMessage("MaxBatchSize=10 " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.MaxBatchSize(10))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_command_timeout()
+        {
+            Assert.Equal(
+                ExpectedMessage("CommandTimeout=10 " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.CommandTimeout(10))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_relational_nulls()
+        {
+            Assert.Equal(
+                ExpectedMessage("UseRelationalNulls " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.UseRelationalNulls())));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_migrations_assembly()
+        {
+            Assert.Equal(
+                ExpectedMessage("MigrationsAssembly=A.B.C " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.MigrationsAssembly("A.B.C"))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_migrations_history_table()
+        {
+            Assert.Equal(
+                ExpectedMessage("MigrationsHistoryTable=MyHistory " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.MigrationsHistoryTable("MyHistory"))));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_migrations_history_table_schema()
+        {
+            Assert.Equal(
+                ExpectedMessage("MigrationsHistoryTable=mySchema.MyHistory " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => b.MigrationsHistoryTable("MyHistory", "mySchema"))));
+        }
+
+        protected abstract DbContextOptionsBuilder CreateOptionsBuilder(
+            Action<RelationalDbContextOptionsBuilder<TBuilder, TExtension>> relationalAction);
+
+        protected override DbContextOptionsBuilder CreateOptionsBuilder() => CreateOptionsBuilder(null);
+    }
+}

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Data.Common;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private string _migrationsHistoryTableName;
         private string _migrationsHistoryTableSchema;
         private Func<ExecutionStrategyDependencies, IExecutionStrategy> _executionStrategyFactory;
+        private string _logFragment;
 
         protected RelationalOptionsExtension()
         {
@@ -191,6 +194,58 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         public virtual void Validate(IDbContextOptions options)
         {
+        }
+
+        /// <summary>
+        ///     Creates a message fragment for logging typically containing information about 
+        ///     any useful non-default options that have been configured.
+        /// </summary>
+        public virtual string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    if (_commandTimeout != null)
+                    {
+                        builder.Append("CommandTimeout=").Append(_commandTimeout).Append(' ');
+                    }
+
+                    if (_maxBatchSize != null)
+                    {
+                        builder.Append("MaxBatchSize=").Append(_maxBatchSize).Append(' ');
+                    }
+
+                    if (_useRelationalNulls)
+                    {
+                        builder.Append("UseRelationalNulls ");
+                    }
+
+                    if (_migrationsAssembly != null)
+                    {
+                        builder.Append("MigrationsAssembly=").Append(_migrationsAssembly).Append(' ');
+                    }
+
+                    if (_migrationsHistoryTableName != null
+                        || _migrationsHistoryTableSchema != null)
+                    {
+                        builder.Append("MigrationsHistoryTable=");
+
+                        if (_migrationsHistoryTableSchema != null)
+                        {
+                            builder.Append(_migrationsHistoryTableSchema).Append('.');
+                        }
+
+                        builder.Append(_migrationsHistoryTableName ?? HistoryRepository.DefaultTableName).Append(' ');
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
         }
     }
 }

--- a/src/EFCore.Specification.Tests/LoggingTestBase.cs
+++ b/src/EFCore.Specification.Tests/LoggingTestBase.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class LoggingTestBase
+    {
+        [Fact]
+        public void Logs_context_initialization_default_options()
+        {
+            Assert.Equal(ExpectedMessage(DefaultOptions), ActualMessage(CreateOptionsBuilder()));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_no_tracking()
+        {
+            Assert.Equal(
+                ExpectedMessage("NoTracking " + DefaultOptions), 
+                ActualMessage(CreateOptionsBuilder().UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)));
+        }
+
+        [Fact]
+        public void Logs_context_initialization_sensitive_data_logging()
+        {
+            Assert.Equal(
+                ExpectedMessage("SensitiveDataLoggingEnabled " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder().EnableSensitiveDataLogging()));
+        }
+
+        protected virtual string ExpectedMessage(string optionsFragment)
+            => CoreStrings.LogContextInitialized.GenerateMessage(
+                ProductInfo.GetVersion(),
+                nameof(LoggingContext),
+                ProviderName,
+                optionsFragment ?? "None");
+
+
+        protected abstract DbContextOptionsBuilder CreateOptionsBuilder();
+
+        protected abstract string ProviderName { get; }
+
+        protected virtual string DefaultOptions => null;
+
+        protected virtual string ActualMessage(DbContextOptionsBuilder optionsBuilder)
+        {
+            var log = new List<Tuple<LogLevel, EventId, string>>();
+            using (var context = new LoggingContext(optionsBuilder.UseLoggerFactory(new ListLoggerFactory(log))))
+            {
+                var _ = context.Model;
+            }
+
+            return log.Single(t => t.Item2.Id == CoreEventId.ContextInitialized.Id).Item3;
+        }
+
+        protected class LoggingContext : DbContext
+        {
+            public LoggingContext(DbContextOptionsBuilder optionsBuilder)
+                : base(optionsBuilder.Options)
+            {
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/ListLogger.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/ListLogger.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class ListLogger : ILogger
     {
-        public ListLogger(List<Tuple<LogLevel, string>> logMessages)
+        public ListLogger(List<Tuple<LogLevel, EventId, string>> logMessages)
         {
             LogMessages = logMessages;
         }
 
-        public List<Tuple<LogLevel, string>> LogMessages { get; }
+        public List<Tuple<LogLevel, EventId, string>> LogMessages { get; }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
@@ -35,15 +35,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
             }
 
-            LogMessages.Add(new Tuple<LogLevel, string>(logLevel, message.ToString()));
+            LogMessages.Add(new Tuple<LogLevel, EventId, string>(logLevel, eventId, message.ToString()));
         }
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
-        public IDisposable BeginScope(object state)
-        {
-            throw new NotImplementedException();
-        }
+        public IDisposable BeginScope(object state) => throw new NotImplementedException();
 
         public IDisposable BeginScope<TState>(TState state) => null;
     }

--- a/src/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
@@ -4,37 +4,31 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using Moq;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class ListLoggerFactory : ILoggerFactory
     {
         private readonly Func<string, bool> _shouldCreateLogger;
-        private readonly List<Tuple<LogLevel, string>> _log;
+        private readonly List<Tuple<LogLevel, EventId, string>> _log;
 
-        public ListLoggerFactory(List<Tuple<LogLevel, string>> log)
+        public ListLoggerFactory(List<Tuple<LogLevel, EventId, string>> log)
             : this(log, null)
 
         {
         }
 
-        public ListLoggerFactory(List<Tuple<LogLevel, string>> log, Func<string, bool> shouldCreateLogger)
+        public ListLoggerFactory(List<Tuple<LogLevel, EventId, string>> log, Func<string, bool> shouldCreateLogger)
         {
             _log = log;
             _shouldCreateLogger = shouldCreateLogger;
         }
 
         public ILogger CreateLogger(string name)
-        {
-            if ((_shouldCreateLogger != null)
-                && !_shouldCreateLogger(name))
-            {
-                return Mock.Of<ILogger>();
-            }
-
-            return new ListLogger(_log);
-        }
+            => _shouldCreateLogger != null && !_shouldCreateLogger(name)
+                ? (ILogger)NullLogger.Instance
+                : new ListLogger(_log);
 
         public void AddProvider(ILoggerProvider provider)
         {

--- a/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EFCore.SqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
     {
         private long? _serviceProviderHash;
         private bool? _rowNumberPaging;
+        private string _logFragment;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -83,6 +85,32 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
             services.AddEntityFrameworkSqlServer();
 
             return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    builder.Append(base.LogFragment);
+
+                    if (_rowNumberPaging == true)
+                    {
+                        builder.Append("RowNumberPaging ");
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
         }
     }
 }

--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
     public class SqliteOptionsExtension : RelationalOptionsExtension
     {
         private bool _enforceForeignKeys = true;
+        private string _logFragment;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -72,6 +74,32 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
             services.AddEntityFrameworkSqlite();
 
             return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    builder.Append(base.LogFragment);
+
+                    if (!_enforceForeignKeys)
+                    {
+                        builder.Append("SuppressForeignKeyEnforcement ");
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
         }
     }
 }

--- a/src/EFCore/Diagnostics/ContextInitializedEventData.cs
+++ b/src/EFCore/Diagnostics/ContextInitializedEventData.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for context initialization events.
+    /// </summary>
+    public class ContextInitializedEventData : EventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="context"> The <see cref="DbContext" /> that is initialized. </param>
+        /// <param name="contextOptions"> The <see cref="DbContextOptions" /> being used. </param>
+        public ContextInitializedEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
+            [NotNull] DbContext context,
+            [NotNull] DbContextOptions contextOptions)
+            : base(eventDefinition, messageGenerator)
+        {
+            Context = context;
+            ContextOptions = contextOptions;
+        }
+
+        /// <summary>
+        ///     The <see cref="DbContext" /> that is initialized.
+        /// </summary>
+        public virtual DbContext Context { get; }
+
+        /// <summary>
+        ///     The <see cref="DbContextOptions" /> being used.
+        /// </summary>
+        public virtual DbContextOptions ContextOptions { get; }
+    }
+}

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -62,7 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             // Infrastucture events
             SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
             ServiceProviderCreated,
-            ManyServiceProvidersCreatedWarning
+            ManyServiceProvidersCreatedWarning,
+            ContextInitialized
         }
 
         private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
@@ -263,5 +264,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId ManyServiceProvidersCreatedWarning = MakeInfraId(Id.ManyServiceProvidersCreatedWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         A <see cref="DbContext"/> was initialized.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ContextInitializedEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId ContextInitialized = MakeInfraId(Id.ContextInitialized);
     }
 }

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -36,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private IDictionary<Type, Type> _replacedServices;
         private int? _maxPoolSize;
         private long? _serviceProviderHash;
+        private string _logFragment;
 
         private WarningsConfiguration _warningsConfiguration 
             = new WarningsConfiguration().TryWithExplicit(CoreEventId.IncludeIgnoredWarning, WarningBehavior.Throw);
@@ -374,6 +376,40 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             nameof(DbContextOptionsBuilder.UseInternalServiceProvider),
                             nameof(IMemoryCache)));
                 }
+            }
+        }
+
+        /// <summary>
+        ///     Creates a message fragment for logging typically containing information about 
+        ///     any useful non-default options that have been configured.
+        /// </summary>
+        public virtual string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    if (_queryTrackingBehavior != QueryTrackingBehavior.TrackAll)
+                    {
+                        builder.Append(_queryTrackingBehavior).Append(' ');
+                    }
+
+                    if (_sensitiveDataLoggingEnabled)
+                    {
+                        builder.Append("SensitiveDataLoggingEnabled ");
+                    }
+
+                    if (_maxPoolSize != null)
+                    {
+                        builder.Append("MaxPoolSize=").Append(_maxPoolSize).Append(' ');
+                    }
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
             }
         }
     }

--- a/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/IDbContextOptionsExtension.cs
@@ -42,5 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <param name="options"> The options being validated. </param>
         void Validate([NotNull] IDbContextOptions options);
+
+        /// <summary>
+        ///     Creates a message fragment for logging typically containing information about 
+        ///     any useful non-default options that have been configured.
+        /// </summary>
+        string LogFragment { get; }
     }
 }

--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -3,9 +3,9 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -31,16 +31,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] IEntityGraphAttacher entityGraphAttacher,
             [NotNull] IModel model,
             [NotNull] IAsyncQueryProvider queryProvider,
-            [NotNull] IStateManager stateManager)
+            [NotNull] IStateManager stateManager,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> infrastuctureLogger)
         {
-            Check.NotNull(changeDetector, nameof(changeDetector));
-            Check.NotNull(setSource, nameof(setSource));
-            Check.NotNull(entityFinderSource, nameof(entityFinderSource));
-            Check.NotNull(entityGraphAttacher, nameof(entityGraphAttacher));
-            Check.NotNull(model, nameof(model));
-            Check.NotNull(queryProvider, nameof(queryProvider));
-            Check.NotNull(stateManager, nameof(stateManager));
-
             ChangeDetector = changeDetector;
             SetSource = setSource;
             EntityFinderSource = entityFinderSource;
@@ -48,6 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
             Model = model;
             QueryProvider = queryProvider;
             StateManager = stateManager;
+            UpdateLogger = updateLogger;
+            InfrastructureLogger = infrastuctureLogger;
         }
 
         /// <summary>
@@ -91,5 +87,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public IEntityGraphAttacher EntityGraphAttacher { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Infrastructure> InfrastructureLogger { get; }
     }
 }

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
@@ -54,5 +55,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         IEntityGraphAttacher EntityGraphAttacher { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IDiagnosticsLogger<DbLoggerCategory.Infrastructure> InfrastructureLogger { get; }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -411,6 +411,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogManyServiceProvidersCreated")));
 
         /// <summary>
+        ///     Entity Framework Core {version} initialized '{contextType}' using provider '{provider}' with options: {options}
+        /// </summary>
+        public static readonly EventDefinition<string, string, string, string> LogContextInitialized
+            = new EventDefinition<string, string, string, string>(
+                CoreEventId.ContextInitialized,
+                LogLevel.Information,
+                LoggerMessage.Define<string, string, string, string>(
+                    LogLevel.Information,
+                    CoreEventId.ContextInitialized,
+                    _resourceManager.GetString("LogContextInitialized")));
+
+        /// <summary>
         ///     The database provider attempted to register an implementation of the '{service}' service. This is not a service defined by EF and as such must be registered as a provider-specific service using the 'TryAddProviderSpecificServices' method.
         /// </summary>
         public static string NotAnEFService([CanBeNull] object service)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -266,6 +266,10 @@
     <value>More than twenty 'IServiceProvider' instances have been created for internal use by Entity Framework. Consider reviewing calls on 'DbContextOptionsBuilder' that may require new service providers to be built.</value>
     <comment>Warning CoreEventId.ManyServiceProvidersCreatedWarning</comment>
   </data>
+  <data name="LogContextInitialized" xml:space="preserve">
+    <value>Entity Framework Core {version} initialized '{contextType}' using provider '{provider}' with options: {options}</value>
+    <comment>Information CoreEventId.ContextInitialized string string string string</comment>
+  </data>
   <data name="NotAnEFService" xml:space="preserve">
     <value>The database provider attempted to register an implementation of the '{service}' service. This is not a service defined by EF and as such must be registered as a provider-specific service using the 'TryAddProviderSpecificServices' method.</value>
   </data>

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -874,6 +874,11 @@
     },
     {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
+      "MemberId": "System.String get_LogFragment()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptionsExtension",
       "MemberId": "System.Void Validate(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options)",
       "Kind": "Addition"
     },

--- a/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class LoggingInMemoryTest : LoggingTestBase
+    {
+        protected override DbContextOptionsBuilder CreateOptionsBuilder()
+            => new DbContextOptionsBuilder().UseInMemoryDatabase("LoggingInMemoryTest");
+
+        protected override string ProviderName => "Microsoft.EntityFrameworkCore.InMemory";
+
+        protected override string DefaultOptions => "StoreName=LoggingInMemoryTest ";
+    }
+}

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -896,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var options = CreateOptions();
 
-            var log = new List<Tuple<LogLevel, string>>();
+            var log = new List<Tuple<LogLevel, EventId, string>>();
 
             var fakeConnection = new FakeRelationalConnection(options);
 
@@ -935,7 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 Assert.EndsWith(
                     @"[Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']
 Logged Command",
-                    item.Item2.Replace(Environment.NewLine, FileLineEnding));
+                    item.Item3.Replace(Environment.NewLine, FileLineEnding));
             }
         }
 
@@ -950,7 +950,7 @@ Logged Command",
 
             var options = CreateOptions(optionsExtension);
 
-            var log = new List<Tuple<LogLevel, string>>();
+            var log = new List<Tuple<LogLevel, EventId, string>>();
 
             var fakeConnection = new FakeRelationalConnection(options);
 
@@ -981,7 +981,7 @@ Logged Command",
 
             Assert.Equal(3, log.Count);
             Assert.Equal(LogLevel.Warning, log[0].Item1);
-            Assert.Equal(CoreStrings.LogSensitiveDataLoggingEnabled.GenerateMessage(), log[0].Item2);
+            Assert.Equal(CoreStrings.LogSensitiveDataLoggingEnabled.GenerateMessage(), log[0].Item3);
 
             Assert.Equal(LogLevel.Debug, log[1].Item1);
             Assert.Equal(LogLevel.Information, log[2].Item1);
@@ -991,7 +991,7 @@ Logged Command",
                 Assert.EndsWith(
                     @"[Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']
 Logged Command",
-                    item.Item2.Replace(Environment.NewLine, FileLineEnding));
+                    item.Item3.Replace(Environment.NewLine, FileLineEnding));
             }
         }
 
@@ -1010,7 +1010,7 @@ Logged Command",
 
             var relationalCommand = CreateRelationalCommand(
                 new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
-                    new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
+                    new ListLoggerFactory(new List<Tuple<LogLevel, EventId, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
                 parameters: new[]
@@ -1078,7 +1078,7 @@ Logged Command",
 
             var relationalCommand = CreateRelationalCommand(
                 new DiagnosticsLogger<DbLoggerCategory.Database.Command>(
-                    new ListLoggerFactory(new List<Tuple<LogLevel, string>>()),
+                    new ListLoggerFactory(new List<Tuple<LogLevel, EventId, string>>()),
                     new FakeLoggingOptions(false),
                     new ListDiagnosticSource(diagnostic)),
                 parameters: new[]

--- a/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var connection = new FakeRelationalConnection(
                 CreateOptions((FakeRelationalOptionsExtension)new FakeRelationalOptionsExtension().WithConnection(dbConnection)));
 
-            var loggerFactory = new ListLoggerFactory(new List<Tuple<LogLevel, string>>());
+            var loggerFactory = new ListLoggerFactory(new List<Tuple<LogLevel, EventId, string>>());
 
             var transaction = new RelationalTransaction(
                 connection,

--- a/test/EFCore.SqlServer.FunctionalTests/LoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoggingSqlServerTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class LoggingSqlServerTest : LoggingRelationalTest<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>
+    {
+        [Fact]
+        public void Logs_context_initialization_row_number_paging()
+        {
+            Assert.Equal(
+                ExpectedMessage("RowNumberPaging " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((SqlServerDbContextOptionsBuilder)b).UseRowNumberForPaging())));
+        }
+
+        protected override DbContextOptionsBuilder CreateOptionsBuilder(
+            Action<RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>> relationalAction)
+            => new DbContextOptionsBuilder().UseSqlServer("Data Source=LoggingSqlServerTest.db", relationalAction);
+
+        protected override string ProviderName => "Microsoft.EntityFrameworkCore.SqlServer";
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .ToList();
 
                 Assert.NotNull(customers);
-                Assert.StartsWith(
+                Assert.Contains(
                     @"    Compiling query model: 
 'from Customer <generated>_0 in DbSet<Customer>
 select [<generated>_0]'
@@ -79,7 +79,7 @@ select [<generated>_0]'
                         .ToList();
 
                 Assert.NotNull(customers);
-                Assert.StartsWith(
+                Assert.Contains(
                     @"    Compiling query model: 
 '(from Customer c in DbSet<Customer>
 select [c]).Include(""Orders"")'

--- a/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class LoggingSqliteTest : LoggingRelationalTest<SqliteDbContextOptionsBuilder, SqliteOptionsExtension>
+    {
+        [Fact]
+        public void Logs_context_initialization_no_FKs()
+        {
+            Assert.Equal(
+                ExpectedMessage("SuppressForeignKeyEnforcement " + DefaultOptions),
+                ActualMessage(CreateOptionsBuilder(b => ((SqliteDbContextOptionsBuilder)b).SuppressForeignKeyEnforcement())));
+        }
+
+        protected override DbContextOptionsBuilder CreateOptionsBuilder(
+            Action<RelationalDbContextOptionsBuilder<SqliteDbContextOptionsBuilder, SqliteOptionsExtension>> relationalAction)
+            => new DbContextOptionsBuilder().UseSqlite("Data Source=LoggingSqliteTest.db", relationalAction);
+
+        protected override string ProviderName => "Microsoft.EntityFrameworkCore.Sqlite";
+    }
+}

--- a/test/EFCore.Tests/DbContextOptionsTest.cs
+++ b/test/EFCore.Tests/DbContextOptionsTest.cs
@@ -110,6 +110,8 @@ namespace Microsoft.EntityFrameworkCore
             public virtual void Validate(IDbContextOptions options)
             {
             }
+
+            public virtual string LogFragment => "";
         }
 
         private class FakeDbContextOptionsExtension2 : IDbContextOptionsExtension
@@ -121,6 +123,8 @@ namespace Microsoft.EntityFrameworkCore
             public virtual void Validate(IDbContextOptions options)
             {
             }
+
+            public virtual string LogFragment => "";
         }
 
         [Fact]

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -2111,7 +2111,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Can_set_known_singleton_services_using_instance_sugar()
         {
-            var modelSource = Mock.Of<IModelSource>();
+            var modelSource = (IModelSource)new FakeModelSource();
 
             var services = new ServiceCollection()
                 .AddSingleton(modelSource);
@@ -2279,7 +2279,7 @@ namespace Microsoft.EntityFrameworkCore
         private class FakeModelSource : IModelSource
         {
             public virtual IModel GetModel(DbContext context, IConventionSetBuilder conventionSetBuilder, IModelValidator validator = null)
-                => null;
+                => new Model();
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -26,11 +26,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var property = new Property("A", typeof(int), null, null, entityType, ConfigurationSource.Convention, ConfigurationSource.Convention);
             var queryModel = new QueryModel(new MainFromClause("A", typeof(object), Expression.Constant("A")), new SelectClause(Expression.Constant("A")));
             var includeResultOperator = new IncludeResultOperator(new [] { "Foo" }, Expression.Constant("A"));
+            var options = new DbContextOptionsBuilder().UseInMemoryDatabase("D").Options;
 
             var fakeFactories = new Dictionary<Type, Func<object>>
             {
                 { typeof(Type), () => typeof(object) },
-                { typeof(DbContext), () => new DbContext(new DbContextOptionsBuilder().UseInMemoryDatabase("D").Options) },
+                { typeof(DbContext), () => new DbContext(options) },
+                { typeof(DbContextOptions), () => options },
                 { typeof(QueryModel), () => queryModel },
                 { typeof(string), () => "Fake" },
                 { typeof(IExpressionPrinter), () => new ExpressionPrinter() },

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -112,14 +112,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         protected ModelValidatorTest()
         {
-            Log = new List<Tuple<LogLevel, string>>();
+            Log = new List<Tuple<LogLevel, EventId, string>>();
             Logger = new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
                 new ListLoggerFactory(Log, l => l == DbLoggerCategory.Model.Validation.Name),
                 new LoggingOptions(),
                 new DiagnosticListener("Fake"));
         }
 
-        protected List<Tuple<LogLevel, string>> Log { get; }
+        protected List<Tuple<LogLevel, EventId, string>> Log { get; }
 
         protected IDiagnosticsLogger<DbLoggerCategory.Model.Validation> Logger { get; }
 
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             Assert.Equal(1, Log.Count);
             Assert.Equal(LogLevel.Warning, Log[0].Item1);
-            Assert.Equal(expectedMessage, Log[0].Item2);
+            Assert.Equal(expectedMessage, Log[0].Item3);
         }
 
         protected virtual void VerifyError(string expectedMessage, IModel model)

--- a/test/EFCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/EFCore.Tests/ServiceProviderCacheTest.cs
@@ -87,6 +87,8 @@ namespace Microsoft.EntityFrameworkCore
             public virtual void Validate(IDbContextOptions options)
             {
             }
+
+            public virtual string LogFragment => "";
         }
 
         private class FakeDbContextOptionsExtension2 : IDbContextOptionsExtension
@@ -98,6 +100,8 @@ namespace Microsoft.EntityFrameworkCore
             public virtual void Validate(IDbContextOptions options)
             {
             }
+
+            public virtual string LogFragment => "";
         }
     }
 }


### PR DESCRIPTION
Issue #8893

Message is logged on context initialization and looks something like:

Entity Framework Core 2.0.0-preview3 initialized 'LoggingContext' using provider 'Microsoft.EntityFrameworkCore.SqlServer' with options: NoTracking

Only options that are both non-default and simple to log are included. Providers get to participate.
