### PR TITLE
Improve literal generation for various types

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -588,7 +588,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             return _typeMapping != null
                    && (value == null
-                       || _typeMapping.ClrType.IsAssignableFrom(value.GetType()))
+                       || _typeMapping.ClrType.IsInstanceOfType(value))
                 ? _typeMapping
                 : Dependencies.RelationalTypeMapper.GetMappingForValue(value);
         }

--- a/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data;
+using System.Globalization;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -39,8 +40,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => new DoubleTypeMapping(storeType, DbType);
 
         /// <summary>
-        ///     Gets the string format to be used to generate SQL literals of this type.
+        ///     Generates the SQL representation of a literal value.
         /// </summary>
-        protected override string SqlLiteralFormatString => "{0}E0";
+        /// <param name="value">The literal value.</param>
+        /// <returns>
+        ///     The generated string.
+        /// </returns>
+        protected override string GenerateNonNullSqlLiteral(object value)
+        {
+            return ((double)value).ToString("G17", CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Xunit;
+// ReSharper disable CompareOfFloatsByEqualityOperator
+// ReSharper disable InconsistentNaming
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -365,6 +367,130 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        protected virtual void Can_query_using_any_nullable_data_type_as_literal_helper(bool strictEquality)
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<BuiltInNullableDataTypes>().Add(
+                    new BuiltInNullableDataTypes
+                    {
+                        Id = 12,
+                        PartitionId = 1,
+                        TestNullableInt16 = -1234,
+                        TestNullableInt32 = -123456789,
+                        TestNullableInt64 = -1234567890123456789L,
+                        TestNullableDouble = -1.23456789,
+                        TestNullableDecimal = -1234567890.01M,
+                        TestNullableDateTime = Fixture.DefaultDateTime,
+                        TestNullableDateTimeOffset = new DateTimeOffset(new DateTime(), TimeSpan.FromHours(-8.0)),
+                        TestNullableTimeSpan = new TimeSpan(0, 10, 9, 8, 7),
+                        TestNullableSingle = -1.234F,
+                        TestNullableBoolean = true,
+                        TestNullableByte = 255,
+                        TestNullableUnsignedInt16 = 1234,
+                        TestNullableUnsignedInt32 = 1234565789U,
+                        TestNullableUnsignedInt64 = 12345678901234567890UL,
+                        TestNullableCharacter = 'a',
+                        TestNullableSignedByte = -128,
+                        Enum64 = Enum64.SomeValue,
+                        Enum32 = Enum32.SomeValue,
+                        Enum16 = Enum16.SomeValue,
+                        Enum8 = Enum8.SomeValue
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12);
+                var entityType = context.Model.FindEntityType(typeof(BuiltInNullableDataTypes));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableInt16 == -1234));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableInt32 == -123456789));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableInt64 == -1234567890123456789L));
+
+                Assert.Same(
+                    entity,
+                    strictEquality
+                        ? context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableDouble == -1.23456789)
+                        : context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && -e.TestNullableDouble + -1.23456789 < 1E-5));
+
+                Assert.Same(
+                    entity,
+                    context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableDouble != 1E18));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableDecimal == -1234567890.01M));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableDateTime == Fixture.DefaultDateTime));
+
+                if (entityType.FindProperty("TestNullableDateTimeOffset") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableDateTimeOffset == new DateTimeOffset(new DateTime(), TimeSpan.FromHours(-8.0))));
+                }
+
+                if (entityType.FindProperty("TestNullableTimeSpan") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableTimeSpan == new TimeSpan(0, 10, 9, 8, 7)));
+                }
+
+                Assert.Same(
+                    entity,
+                    strictEquality
+                        ? context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableSingle == -1.234F)
+                        : context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && -e.TestNullableSingle + -1.234F < 1E-5));
+
+                Assert.Same(
+                    entity,
+                    context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableSingle != 1E-8));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableBoolean == true));
+
+                if (entityType.FindProperty("TestNullableByte") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableByte == 255));
+                }
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.Enum64 == Enum64.SomeValue));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.Enum32 == Enum32.SomeValue));
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.Enum16 == Enum16.SomeValue));
+
+                if (entityType.FindProperty("Enum8") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.Enum8 == Enum8.SomeValue));
+                }
+
+                if (entityType.FindProperty("TestUnsignedInt16") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableUnsignedInt16 == 1234));
+                }
+
+                if (entityType.FindProperty("TestUnsignedInt32") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableUnsignedInt32 == 1234565789U));
+                }
+
+                if (entityType.FindProperty("TestUnsignedInt64") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableUnsignedInt64 == 1234567890123456789UL));
+                }
+
+                if (entityType.FindProperty("TestCharacter") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableCharacter == 'a'));
+                }
+
+                if (entityType.FindProperty("TestSignedByte") != null)
+                {
+                    Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 12 && e.TestNullableSignedByte == -128));
+                }
+            }
+        }
+
         [Fact]
         public virtual void Can_query_with_null_parameters_using_any_nullable_data_type()
         {
@@ -679,6 +805,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        // ReSharper disable once UnusedParameter.Local
         private static void AssertEqualIfMapped<T>(IEntityType entityType, T expected, Expression<Func<T>> actual)
         {
             if (entityType.FindProperty(((MemberExpression)actual.Body).Member.Name) != null)

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
@@ -2,31 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data;
-using System.Globalization;
 using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>
-    ///     <para>
-    ///         Represents the mapping between a .NET <see cref="float" /> type and a database type.
-    ///     </para>
-    ///     <para>
-    ///         This type is typically used by database providers (and other extensions). It is generally
-    ///         not used in application code.
-    ///     </para>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class FloatTypeMapping : RelationalTypeMapping
+    public class SqlServerDoubleTypeMapping : DoubleTypeMapping
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="FloatTypeMapping" /> class.
+        ///     Initializes a new instance of the <see cref="SqlServerDoubleTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
-        public FloatTypeMapping(
+        public SqlServerDoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, typeof(float), dbType)
+            : base(storeType, dbType)
         {
         }
 
@@ -37,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new FloatTypeMapping(storeType, DbType);
+            => new SqlServerDoubleTypeMapping(storeType, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.
@@ -48,7 +42,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </returns>
         protected override string GenerateNonNullSqlLiteral(object value)
         {
-            return ((float)value).ToString("R", CultureInfo.InvariantCulture);
+            var literal = base.GenerateNonNullSqlLiteral(value);
+
+            if (!literal.Contains("E")
+                && !literal.Contains("e"))
+            {
+                return literal + "E0";
+            }
+
+            return literal;
         }
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
@@ -2,31 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data;
-using System.Globalization;
 using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.Storage
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
     /// <summary>
-    ///     <para>
-    ///         Represents the mapping between a .NET <see cref="float" /> type and a database type.
-    ///     </para>
-    ///     <para>
-    ///         This type is typically used by database providers (and other extensions). It is generally
-    ///         not used in application code.
-    ///     </para>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class FloatTypeMapping : RelationalTypeMapping
+    public class SqlServerFloatTypeMapping : FloatTypeMapping
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="FloatTypeMapping" /> class.
+        ///     Initializes a new instance of the <see cref="SqlServerFloatTypeMapping" /> class.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
-        public FloatTypeMapping(
+        public SqlServerFloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, typeof(float), dbType)
+            : base(storeType, dbType)
         {
         }
 
@@ -37,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new FloatTypeMapping(storeType, DbType);
+            => new SqlServerFloatTypeMapping(storeType, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.
@@ -48,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </returns>
         protected override string GenerateNonNullSqlLiteral(object value)
         {
-            return ((float)value).ToString("R", CultureInfo.InvariantCulture);
+            return $"CAST({base.GenerateNonNullSqlLiteral(value)} AS {StoreType})";
         }
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -70,11 +70,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly SqlServerDateTimeTypeMapping _datetime2 = new SqlServerDateTimeTypeMapping("datetime2", dbType: DbType.DateTime2);
 
-        private readonly DoubleTypeMapping _double = new DoubleTypeMapping("float"); // Note: "float" is correct SQL Server type to map to CLR-type double
+        private readonly DoubleTypeMapping _double = new SqlServerDoubleTypeMapping("float"); // Note: "float" is correct SQL Server type to map to CLR-type double
 
         private readonly SqlServerDateTimeOffsetTypeMapping _datetimeoffset = new SqlServerDateTimeOffsetTypeMapping("datetimeoffset");
 
-        private readonly FloatTypeMapping _real = new FloatTypeMapping("real"); // Note: "real" is correct SQL Server type to map to CLR-type float
+        private readonly FloatTypeMapping _real = new SqlServerFloatTypeMapping("real"); // Note: "real" is correct SQL Server type to map to CLR-type float
 
         private readonly GuidTypeMapping _uniqueidentifier = new GuidTypeMapping("uniqueidentifier", DbType.Guid);
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 // ReSharper disable UnusedParameter.Local
 // ReSharper disable PossibleInvalidOperationException
@@ -20,10 +21,11 @@ namespace Microsoft.EntityFrameworkCore
     [SqlServerCondition(SqlServerCondition.IsNotSqlAzure)]
     public class BuiltInDataTypesSqlServerTest : BuiltInDataTypesTestBase<BuiltInDataTypesSqlServerFixture>
     {
-        public BuiltInDataTypesSqlServerTest(BuiltInDataTypesSqlServerFixture fixture)
+        public BuiltInDataTypesSqlServerTest(BuiltInDataTypesSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]
@@ -309,6 +311,12 @@ WHERE [e].[Time] = @__timeSpan_0",
                 decimal? param40 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Numeric == param40));
             }
+        }
+
+        [Fact]
+        public virtual void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            Can_query_using_any_nullable_data_type_as_literal_helper(strictEquality: true);
         }
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -211,7 +211,7 @@ INNER JOIN (
     FROM [Order Details] AS [o]
     WHERE [o].[Quantity] > @___quantity_1
 ) AS [t] ON [c.Orders].[OrderID] = [t].[OrderID]
-WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([t].[Discount] < 10E0)");
+WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__TenantPrefix_0)) = @__TenantPrefix_0)) OR (@__TenantPrefix_0 = N'')) AND ([t].[Discount] < CAST(10 AS real))");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.Functions.cs
@@ -549,7 +549,7 @@ WHERE FLOOR([od].[UnitPrice]) > 10.0");
             AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE POWER([od].[Discount], 2E0) > 0.0500000007450581E0");
+WHERE POWER([od].[Discount], 2E0) > 0.05000000074505806E0");
         }
 
         public override void Where_math_round()
@@ -619,7 +619,7 @@ WHERE ([od].[OrderID] = 11077) AND (EXP([od].[Discount]) > 1E0)");
             AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG10([od].[Discount]) < 0E0)");
+WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > CAST(0 AS real))) AND (LOG10([od].[Discount]) < 0E0)");
         }
 
         public override void Where_math_log()
@@ -629,7 +629,7 @@ WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG10([od].[Di
             AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG([od].[Discount]) < 0E0)");
+WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > CAST(0 AS real))) AND (LOG([od].[Discount]) < 0E0)");
         }
 
         public override void Where_math_log_new_base()
@@ -639,7 +639,7 @@ WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG([od].[Disc
             AssertSql(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > 0E0)) AND (LOG([od].[Discount], 7E0) < 0E0)");
+WHERE (([od].[OrderID] = 11077) AND ([od].[Discount] > CAST(0 AS real))) AND (LOG([od].[Discount], 7E0) < 0E0)");
         }
 
         public override void Where_math_sqrt()

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -11,6 +12,8 @@ namespace Microsoft.EntityFrameworkCore
         private readonly DbContextOptions _options;
         private readonly SqliteTestStore _testStore;
 
+        public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
+
         public BuiltInDataTypesSqliteFixture()
         {
             _testStore = SqliteTestStore.CreateScratch();
@@ -18,10 +21,12 @@ namespace Microsoft.EntityFrameworkCore
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
+                .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
                 .BuildServiceProvider();
 
             _options = new DbContextOptionsBuilder()
                 .UseSqlite(_testStore.Connection)
+                .EnableSensitiveDataLogging()
                 .UseInternalServiceProvider(serviceProvider)
                 .Options;
 

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -8,20 +8,52 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTypesSqliteFixture>
     {
-        public BuiltInDataTypesSqliteTest(BuiltInDataTypesSqliteFixture fixture)
+        public BuiltInDataTypesSqliteTest(BuiltInDataTypesSqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            fixture.TestSqlLoggerFactory.Clear();
+            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]
         public virtual void Can_perform_query_with_ansi_strings()
         {
             Can_perform_query_with_ansi_strings_test(supportsAnsi: false);
+        }
+
+        [Fact]
+        public virtual void Can_query_using_any_nullable_data_type_as_literal()
+        {
+            Can_query_using_any_nullable_data_type_as_literal_helper(strictEquality: false);
+        }
+
+        [Fact(Skip = "See issue #8205")]
+        public virtual void Can_insert_and_query_decimal()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<BuiltInNullableDataTypes>().Add(
+                    new BuiltInNullableDataTypes
+                    {
+                        Id = 13,
+                        TestNullableDecimal = 3m
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 13);
+
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 13 && e.TestNullableDecimal == 3m));
+            }
         }
 
         [Fact]


### PR DESCRIPTION

Resolve #8259 Self-contained type mappings so no more binding errors since we have mapping for every clr type.

Resolves https://github.com/aspnet/EntityFramework/issues/8270
After much discussion with @bricelam we ended up with
float -> Use `ToString("R")` which is roundtrip-able. 
double -> R faces issue on x64 so docs suggest using "G17"
Removed "E0" suffix for relational provider.

Resolves https://github.com/aspnet/EntityFramework/issues/8905
float in SqlServer -> Always cast to real while generating literal
double in SqlServer -> if the literal does not have E then append E0 (to make it double literal)
Since Long literals are used in migrations too we cannot cast them always. It has to be done based on functions in query.
