### PR TITLE
Make sure the old dependent is removed when the new one is reference stealing using navigations and/or FK properties

### DIFF
--- a/src/EFCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry`.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual TProperty CurrentValue
         {
-            get { return this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata); }
+            get => InternalEntry.GetCurrentValue<TProperty>(Metadata);
             [param: CanBeNull] set { base.CurrentValue = value; }
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual TProperty OriginalValue
         {
-            get { return this.GetInfrastructure().GetOriginalValue<TProperty>(Metadata); }
+            get => InternalEntry.GetOriginalValue<TProperty>(Metadata);
             [param: CanBeNull] set { base.OriginalValue = value; }
         }
     }


### PR DESCRIPTION
If the FK was non-identifying make sure the properties are set to null instead of the dependent being removed.

Fixes #8137
