### PR TITLE
Make HasDefaultValue set that a property is value generated even when…

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -429,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         public virtual string UnknownLiteral(object value)
         {
-            if (value == null)
+            if (value == null || value == DBNull.Value)
             {
                 return "null";
             }

--- a/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         protected virtual bool SetDefaultValue([CanBeNull] object value)
         {
-            if (value != null)
+            if (value != null && value != DBNull.Value)
             {
                 var valueType = value.GetType();
                 if (Property.ClrType.UnwrapNullableType() != valueType)

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -719,10 +719,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                                            && property.IsConcurrencyToken
                                            && property.ValueGenerated == ValueGenerated.OnAddOrUpdate;
             columnOperation.IsNullable = isNullable;
-            columnOperation.DefaultValue = annotations.DefaultValue
+
+            var defaultValue = annotations.DefaultValue;
+            columnOperation.DefaultValue = (defaultValue == DBNull.Value ? null : defaultValue)
                                            ?? (inline || isNullable
                                                ? null
                                                : GetDefaultValue(columnOperation.ClrType));
+
             columnOperation.DefaultValueSql = annotations.DefaultValueSql;
             columnOperation.ComputedColumnSql = annotations.ComputedColumnSql;
             columnOperation.AddAnnotations(migrationsAnnotations);

--- a/src/EFCore.Relational/RelationalPropertyBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalPropertyBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -140,25 +141,41 @@ namespace Microsoft.EntityFrameworkCore
             => (PropertyBuilder<TProperty>)HasComputedColumnSql((PropertyBuilder)propertyBuilder, sql);
 
         /// <summary>
-        ///     Configures the default value for the column that the property maps to when targeting a relational database.
+        ///     <para>
+        ///         Configures the default value for the column that the property maps
+        ///         to when targeting a relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no argument, this method tells EF that a column has a default
+        ///         value constraint of some sort without needing to specify exactly what it is.
+        ///         This can be useful when mapping EF to an existing database.
+        ///     </para>
         /// </summary>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
         /// <param name="value"> The default value of the column. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static PropertyBuilder HasDefaultValue(
             [NotNull] this PropertyBuilder propertyBuilder,
-            [CanBeNull] object value)
+            [CanBeNull] object value = null)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
             var internalPropertyBuilder = propertyBuilder.GetInfrastructure<InternalPropertyBuilder>();
-            internalPropertyBuilder.Relational(ConfigurationSource.Explicit).HasDefaultValue(value);
+            internalPropertyBuilder.Relational(ConfigurationSource.Explicit).HasDefaultValue(value ?? DBNull.Value);
 
             return propertyBuilder;
         }
 
         /// <summary>
-        ///     Configures the default value for the column that the property maps to when targeting a relational database.
+        ///     <para>
+        ///         Configures the default value for the column that the property maps
+        ///         to when targeting a relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no argument, this method tells EF that a column has a default
+        ///         value constraint of some sort without needing to specify exactly what it is.
+        ///         This can be useful when mapping EF to an existing database.
+        ///     </para>
         /// </summary>
         /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
@@ -166,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static PropertyBuilder<TProperty> HasDefaultValue<TProperty>(
             [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
-            [CanBeNull] object value)
+            [CanBeNull] object value = null)
             => (PropertyBuilder<TProperty>)HasDefaultValue((PropertyBuilder)propertyBuilder, value);
     }
 }

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1270,6 +1270,16 @@
       "Kind": "Removal"
     },
     {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalPropertyBuilderExtensions",
+      "MemberId": "public static Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder HasDefaultValue(this Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder propertyBuilder, System.Object value)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalPropertyBuilderExtensions",
+      "MemberId": "public static Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder<T0> HasDefaultValue<T0>(this Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder<T0> propertyBuilder, System.Object value)",
+      "Kind": "Removal"
+    },
+    {
       "TypeId": "public static class Microsoft.EntityFrameworkCore.RelationalModelBuilderExtensions",
       "MemberId": "public static Microsoft.EntityFrameworkCore.Metadata.RelationalSequenceBuilder HasSequence(this Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder, System.Type clrType, System.String name, System.String schema = null)",
       "Kind": "Removal"


### PR DESCRIPTION
… passing null or no arguments

Issues #8015, #7872

Setting null or passing no args to the fluent API now sets a sentinel indicating that the method has been called rather than removing the annotation. In most cases the result is functionally equivalent, but in some cases it will now force non-identity value generation without the need to specify what is actually happening in the database.
