### PR TITLE
Fix parameter extracting of already parameter expressions

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -354,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             if (parameterValue is Expression parameterExpression)
             {
-                return parameterExpression;
+                return ExtractParameters(parameterExpression);
             }
 
             if (!_parameterize)


### PR DESCRIPTION
When extracting parameters for caching the already created parameter expression is returnet directly instead of extracting the parameters.

Fixing #8909

@anpete I'm not finding any existing test-cases for `ParameterExtractingExpressionVisitor`, do you have any test-class where I can add more test in? Or can a validation for hashcode calculation be added to example the https://github.com/aspnet/EntityFramework/blob/f45292f2fd1a0edc2c364dccac00cb242b6808ae/src/EFCore.Specification.Tests/Query/QueryTestBase.cs#L4144 method?