### PR TITLE
SqlServer Migrations: Clean up memory-optimized table mechanics

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -594,7 +594,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                            && s.IsUnicode() == t.IsUnicode()
                            && sAnnotations.ColumnType == tAnnotations.ColumnType
                            && sAnnotations.ComputedColumnSql == tAnnotations.ComputedColumnSql
-                           && sAnnotations.DefaultValue == tAnnotations.DefaultValue
+                           && Equals(sAnnotations.DefaultValue, tAnnotations.DefaultValue)
                            && sAnnotations.DefaultValueSql == tAnnotations.DefaultValueSql;
                 });
 

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -50,11 +50,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     SqlServerAnnotationNames.Clustered,
                     isClustered.Value);
             }
-
-            foreach (var annotation in ForRemove(key))
-            {
-                yield return annotation;
-            }
         }
 
         /// <summary>
@@ -70,18 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     SqlServerAnnotationNames.Clustered,
                     isClustered.Value);
             }
-
-            foreach (var annotation in ForRemove(index))
-            {
-                yield return annotation;
-            }
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override IEnumerable<IAnnotation> For(IForeignKey foreignKey) => ForRemove(foreignKey);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -94,11 +78,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 yield return new Annotation(
                     SqlServerAnnotationNames.ValueGenerationStrategy,
                     SqlServerValueGenerationStrategy.IdentityColumn);
-            }
-
-            foreach (var annotation in ForRemove(property))
-            {
-                yield return annotation;
             }
         }
 
@@ -123,62 +102,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         public override IEnumerable<IAnnotation> ForRemove(IEntityType entityType)
         {
             if (IsMemoryOptimized(entityType))
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.MemoryOptimized,
-                    true);
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override IEnumerable<IAnnotation> ForRemove(IKey key)
-        {
-            if (IsMemoryOptimized(key.DeclaringEntityType))
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.MemoryOptimized,
-                    true);
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override IEnumerable<IAnnotation> ForRemove(IIndex index)
-        {
-            if (IsMemoryOptimized(index.DeclaringEntityType))
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.MemoryOptimized,
-                    true);
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override IEnumerable<IAnnotation> ForRemove(IForeignKey foreignKey)
-        {
-            if (IsMemoryOptimized(foreignKey.DeclaringEntityType))
-            {
-                yield return new Annotation(
-                    SqlServerAnnotationNames.MemoryOptimized,
-                    true);
-            }
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override IEnumerable<IAnnotation> ForRemove(IProperty property)
-        {
-            if (IsMemoryOptimized(property.DeclaringEntityType))
             {
                 yield return new Annotation(
                     SqlServerAnnotationNames.MemoryOptimized,

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 builder
                     .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                    .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                    .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
             }
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Generate(addColumnOperation, model, builder, terminate: false);
                 builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
                 CreateIndexes(indexesToRebuild, builder);
-                builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
 
                 return;
             }
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CreateIndexes(indexesToRebuild, builder);
             }
 
-            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(operation.Name);
 
             Rename(qualifiedName.ToString(), operation.NewName, "INDEX", builder);
-            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(RenameSequenceOperation operation, IModel model, MigrationCommandListBuilder builder)
@@ -383,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Name));
         }
 
         protected override void Generate(
@@ -412,7 +412,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         })
                 .ToList();
 
-            var memoryOptimized = IsMemoryOptimized(operation);
+            var memoryOptimized = IsMemoryOptimized(operation, model, operation.Schema, operation.Table);
             if (memoryOptimized)
             {
                 builder.Append("ALTER TABLE ")
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(EnsureSchemaOperation operation, IModel model, MigrationCommandListBuilder builder)
@@ -675,7 +675,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         protected override void Generate(
@@ -693,7 +693,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            var memoryOptimized = IsMemoryOptimized(operation);
+            var memoryOptimized = IsMemoryOptimized(operation, model, operation.Schema, operation.Table);
             if (memoryOptimized)
             {
                 builder
@@ -741,7 +741,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 builder
                     .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
-                    .EndCommand(suppressTransaction: IsMemoryOptimized(operation));
+                    .EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
             }
         }
 
@@ -769,7 +769,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder.EndCommand();
         }
 
-        protected override void Generate([NotNull] SqlOperation operation, [CanBeNull] IModel model, [NotNull] MigrationCommandListBuilder builder)
+        protected override void Generate(SqlOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
@@ -1171,6 +1171,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
             }
         }
+
+        private bool IsMemoryOptimized(Annotatable annotatable, IModel model, string schema, string tableName)
+            => annotatable[SqlServerAnnotationNames.MemoryOptimized] as bool?
+                ?? FindEntityTypes(model, schema, tableName)?.Any(t => t.SqlServer().IsMemoryOptimized) == true;
 
         private static bool IsMemoryOptimized(Annotatable annotatable)
             => annotatable[SqlServerAnnotationNames.MemoryOptimized] as bool? == true;

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -349,7 +349,6 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         ClrType = typeof(string)
                     },
-                    [SqlServerAnnotationNames.MemoryOptimized] = true
                 });
 
             Assert.Equal(
@@ -785,14 +784,13 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void CreateIndexOperation_memoryOptimized_unique_nullable()
         {
             Generate(
-                modelBuilder => modelBuilder.Entity("People").Property<string>("Name"),
+                modelBuilder => modelBuilder.Entity("People").ForSqlServerIsMemoryOptimized().Property<string>("Name"),
                 new CreateIndexOperation
                 {
                     Name = "IX_People_Name",
                     Table = "People",
                     Columns = new[] { "Name" },
                     IsUnique = true,
-                    [SqlServerAnnotationNames.MemoryOptimized] = true
                 });
 
             Assert.Equal(
@@ -804,7 +802,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void CreateIndexOperation_memoryOptimized_unique_nullable_with_filter()
         {
             Generate(
-                modelBuilder => modelBuilder.Entity("People").Property<string>("Name"),
+                modelBuilder => modelBuilder.Entity("People").ForSqlServerIsMemoryOptimized().Property<string>("Name"),
                 new CreateIndexOperation
                 {
                     Name = "IX_People_Name",
@@ -812,7 +810,6 @@ namespace Microsoft.EntityFrameworkCore
                     Columns = new[] { "Name" },
                     IsUnique = true,
                     Filter = "[Name] IS NOT NULL AND <> ''",
-                    [SqlServerAnnotationNames.MemoryOptimized] = true
                 });
 
             Assert.Equal(
@@ -824,14 +821,13 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void CreateIndexOperation_memoryOptimized_unique_nonclustered_not_nullable()
         {
             Generate(
-                modelBuilder => modelBuilder.Entity("People").Property<string>("Name").IsRequired(),
+                modelBuilder => modelBuilder.Entity("People").ForSqlServerIsMemoryOptimized().Property<string>("Name").IsRequired(),
                 new CreateIndexOperation
                 {
                     Name = "IX_People_Name",
                     Table = "People",
                     Columns = new[] { "Name" },
                     IsUnique = true,
-                    [SqlServerAnnotationNames.MemoryOptimized] = true,
                     [SqlServerAnnotationNames.Clustered] = false
                 });
 
@@ -901,11 +897,11 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void DropIndexOperation_memoryOptimized()
         {
             Generate(
+                modelBuilder => modelBuilder.Entity("People").ForSqlServerIsMemoryOptimized(),
                 new DropIndexOperation
                 {
                     Name = "IX_People_Name",
                     Table = "People",
-                    [SqlServerAnnotationNames.MemoryOptimized] = true
                 });
 
             Assert.Equal(

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -122,11 +121,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         }),
                 operations =>
                     {
-                        var alterDatabaseOperation = operations.OfType<AlterDatabaseOperation>().Single();
+                        Assert.Equal(2, operations.Count);
+
+                        var alterDatabaseOperation = Assert.IsType<AlterDatabaseOperation>(operations[0]);
                         Assert.True(IsMemoryOptimized(alterDatabaseOperation));
                         Assert.Null(IsMemoryOptimized(alterDatabaseOperation.OldDatabase));
 
-                        var alterTableOperation = operations.OfType<AlterTableOperation>().Single();
+                        var alterTableOperation = Assert.IsType<AlterTableOperation>(operations[1]);
                         Assert.Equal("Person", alterTableOperation.Name);
                         Assert.True(IsMemoryOptimized(alterTableOperation));
                         Assert.Null(IsMemoryOptimized(alterTableOperation.OldTable));
@@ -154,11 +155,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         }),
                 operations =>
                     {
-                        var alterDatabaseOperation = operations.OfType<AlterDatabaseOperation>().Single();
+                        Assert.Equal(2, operations.Count);
+
+                        var alterDatabaseOperation = Assert.IsType<AlterDatabaseOperation>(operations[0]);
                         Assert.Null(IsMemoryOptimized(alterDatabaseOperation));
                         Assert.True(IsMemoryOptimized(alterDatabaseOperation.OldDatabase));
 
-                        var alterTableOperation = operations.OfType<AlterTableOperation>().Single();
+                        var alterTableOperation = Assert.IsType<AlterTableOperation>(operations[1]);
                         Assert.Equal("Person", alterTableOperation.Name);
                         Assert.Null(IsMemoryOptimized(alterTableOperation));
                         Assert.True(IsMemoryOptimized(alterTableOperation.OldTable));
@@ -768,7 +771,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             x.Property<int>("Id");
                             x.HasKey("Id");
                             x.Property<int>("Value");
-                            x.ForSqlServerIsMemoryOptimized();
                             x.HasIndex("Value").HasName("IX_HorseVal").ForSqlServerIsClustered(true);
                         }),
                 target => target.Entity(
@@ -779,7 +781,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             x.Property<int>("Id");
                             x.HasKey("Id");
                             x.Property<int>("Value");
-                            x.ForSqlServerIsMemoryOptimized();
                         }),
                 operations =>
                     {
@@ -789,7 +790,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         Assert.Equal("dbo", operation.Schema);
                         Assert.Equal("Horse", operation.Table);
                         Assert.Equal("IX_HorseVal", operation.Name);
-                        Assert.True(IsMemoryOptimized(operation));
                         Assert.Null(operation[SqlServerAnnotationNames.Clustered]);
                     });
         }


### PR DESCRIPTION
For operations (`CREATE INDEX`, `ALTER COLUMN`, etc.) on memory-optimized tables, the backing model is now used to determine if it's for a memory-optimized table. This prevents unnecessary differences on non-table artifacts. For memory-optimized tables created out of band (i.e. without a backing entity type), you can manually add the `SqlServer:MemoryOptimized` annotation to get the appropriate behavior.

Fixes #6887