### PR TITLE
DiagnosticSource to 4.4.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
+    <DiagnosticSourceVersion>4.4.1-*</DiagnosticSourceVersion>
     <DependencyModelVersion>2.0.0-preview1-*</DependencyModelVersion>
     <EF6Version>6.1.3</EF6Version>
     <ImmutableCollectionsVersion>1.3.1</ImmutableCollectionsVersion>

--- a/src/EFCore/EFCore.csproj
+++ b/src/EFCore/EFCore.csproj
@@ -23,7 +23,7 @@ Microsoft.EntityFrameworkCore.DbSet
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticSourceVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Remotion.Linq" Version="$(RelinqVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(ImmutableCollectionsVersion)" />


### PR DESCRIPTION
This is a reaction to our Mirror build soon picking up a new version of DiagnosticSource.