### PR TITLE
Fix test ordering issue

### DIFF
--- a/src/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -427,7 +427,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                             join dynamic efItem in efItems on l2oItem.CustomerID equals efItem.CustomerID
                             select new { l2oItem, efItem })
                         {
-                            Assert.Equal(pair.l2oItem.Orders, pair.efItem.Orders);
+                            Assert.Equal(
+                                ((ICollection<Order>)pair.l2oItem.Orders).OrderBy(e => e.OrderID),
+                                ((ICollection<Order>)pair.efItem.Orders).OrderBy(e => e.OrderID));
                         }
                     },
                 entryCount: 34);


### PR DESCRIPTION
Issue #9039

Navigation properties do not have defined order, so test should not rely on it.
