### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -12,6 +12,7 @@
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <DebugType Condition="'$(Configuration)' == 'Debug' AND '$(OS)' == 'Windows_NT'">full</DebugType>
     <NoWarn>$(NoWarn);xUnit1004</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.rd.xml" />


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings.