### PR TITLE
Add more testing of service registration and fix found issues

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/RelationalServiceCollectionExtensionsTest.cs
+++ b/src/EFCore.Relational.Specification.Tests/RelationalServiceCollectionExtensionsTest.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class RelationalServiceCollectionExtensionsTest : EntityFrameworkServiceCollectionExtensionsTest
+    {
+        protected RelationalServiceCollectionExtensionsTest(TestHelpers testHelpers)
+            : base(testHelpers)
+        {
+        }
+
+        [Fact]
+        public override void Required_services_are_registered_with_expected_lifetimes()
+        {
+            LifetimeTest(EntityFrameworkServicesBuilder.CoreServices, EntityFrameworkRelationalServicesBuilder.CoreServices);
+        }
+    }
+}

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -42,7 +42,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     /// </summary>
     public class EntityFrameworkRelationalServicesBuilder : EntityFrameworkServicesBuilder
     {
-        private static readonly IDictionary<Type, ServiceCharacteristics> _relationalServices
+        /// <summary>
+        ///     <para>
+        ///         This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///         directly from your code. This API may change or be removed in future releases.
+        ///     </para>
+        ///     <para>
+        ///         This dictionary is exposed for testing and provider-validation only.
+        ///         It should not be used from application code.
+        ///     </para>
+        /// </summary>
+        public static readonly IDictionary<Type, ServiceCharacteristics> RelationalServices
             = new Dictionary<Type, ServiceCharacteristics>
             {
                 { typeof(IKeyValueIndexFactorySource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -98,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         protected override ServiceCharacteristics GetServiceCharacteristics(Type serviceType)
         {
             ServiceCharacteristics characteristics;
-            return _relationalServices.TryGetValue(serviceType, out characteristics)
+            return RelationalServices.TryGetValue(serviceType, out characteristics)
                 ? characteristics
                 : base.GetServiceCharacteristics(serviceType);
         }

--- a/src/EFCore.Specification.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/src/EFCore.Specification.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,10 +14,8 @@ namespace Microsoft.EntityFrameworkCore
     {
         private readonly TestHelpers _testHelpers;
 
-        protected EntityFrameworkServiceCollectionExtensionsTest(TestHelpers testHelpers)
-        {
-            _testHelpers = testHelpers;
-        }
+        protected EntityFrameworkServiceCollectionExtensionsTest(TestHelpers testHelpers) 
+            => _testHelpers = testHelpers;
 
         [Fact]
         public void Calling_AddEntityFramework_explicitly_does_not_change_services()
@@ -34,6 +34,33 @@ namespace Microsoft.EntityFrameworkCore
             AssertServicesSame(
                 AddServices(new ServiceCollection()),
                 AddServices(AddServices(new ServiceCollection())));
+        }
+
+        [Fact]
+        public virtual void Required_services_are_registered_with_expected_lifetimes()
+        {
+            LifetimeTest(EntityFrameworkServicesBuilder.CoreServices);
+        }
+
+        protected virtual void LifetimeTest(
+            params IDictionary<Type, EntityFrameworkServicesBuilder.ServiceCharacteristics>[] serviceDefinitions)
+        {
+            var services = AddServices(new ServiceCollection());
+
+            foreach (var coreService in serviceDefinitions.SelectMany(e => e))
+            {
+                var registered = services.Where(s => s.ServiceType == coreService.Key).ToList();
+
+                if (coreService.Value.MultipleRegistrations)
+                {
+                    Assert.All(registered, s => Assert.Equal(coreService.Value.Lifetime, s.Lifetime));
+                }
+                else
+                {
+                    Assert.Equal(1, registered.Count);
+                    Assert.Equal(coreService.Value.Lifetime, registered[0].Lifetime);
+                }
+            }
         }
 
         protected virtual void AssertServicesSame(IServiceCollection services1, IServiceCollection services2)

--- a/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryFixture.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(nameof(BuiltInDataTypesInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
             _serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override InMemoryTestStore CreateTestStore()

--- a/test/EFCore.InMemory.FunctionalTests/FindInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/FindInMemoryTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseInMemoryDatabase(nameof(FindInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -160,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
             }
 
             public override InMemoryTestStore CreateTestStore()

--- a/test/EFCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoadInMemoryTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseInMemoryDatabase(DatabaseName)

--- a/test/EFCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseInMemoryDatabase(nameof(NotificationEntitiesInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsOwnedQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsOwnedQueryInMemoryFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInternalServiceProvider(serviceProvider)

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInternalServiceProvider(serviceProvider)

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(DatabaseName)

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryFixture.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(DatabaseName)

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindQueryInMemoryFixture.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
-                    .BuildServiceProvider())
+                    .BuildServiceProvider(validateScopes: true))
                 .Options;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NullKeysInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NullKeysInMemoryTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkInMemoryDatabase()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseInMemoryDatabase(nameof(NullKeysInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/Query/OneToOneQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OneToOneQueryInMemoryFixture.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(nameof(OneToOneQueryInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryFixture.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(new TestLoggerFactory())
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(nameof(OwnedQueryInMemoryFixture))

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryFixture.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore
             _serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _optionsBuilder = new DbContextOptionsBuilder()
                 .UseInMemoryDatabase(nameof(UpdatesInMemoryFixture))

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqlServerTestStore CreateTestStore()

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -365,7 +365,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), b => b.ApplyConfiguration())

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
                 _serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
             }
 
             protected abstract string DatabaseName { get; }

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -1461,7 +1461,7 @@ WHERE 0 = 1",
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName), b => b.ApplyConfiguration())

--- a/test/EFCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
                     .UseInternalServiceProvider(new ServiceCollection()
                         .AddEntityFrameworkSqlServer()
                         .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                        .BuildServiceProvider())
+                        .BuildServiceProvider(validateScopes: true))
                     .Options;
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerFixture.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqlServerTestStore CreateTestStore()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _testDatabase = SqlServerTestStore.GetNorthwindStore();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NavigationTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NavigationTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             var connStrBuilder = new SqlConnectionStringBuilder(TestEnvironment.DefaultConnection)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .AddEntityFrameworkSqlServer()
                             .AddSingleton(_modelSourceFactory(OnModelCreating))
                             .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                            .BuildServiceProvider()))
+                            .BuildServiceProvider(validateScopes: true)))
                 .UseSqlServer(
                     _testStore.ConnectionString,
                     b =>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSprocQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSprocQuerySqlServerFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                    .BuildServiceProvider())
+                    .BuildServiceProvider(validateScopes: true))
                 .UseSqlServer(_testStore.ConnectionString, b => b.ApplyConfiguration())
                 .Options;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullKeysSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullKeysSqlServerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .UseInternalServiceProvider(new ServiceCollection()
                         .AddEntityFrameworkSqlServer()
                         .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                        .BuildServiceProvider())
+                        .BuildServiceProvider(validateScopes: true))
                     .Options;
 
                 _testStore = SqlServerTestStore.GetOrCreateShared(name, EnsureCreated);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .EnableSensitiveDataLogging()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OneToOneQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OneToOneQuerySqlServerFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                     .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                    .BuildServiceProvider())
+                    .BuildServiceProvider(validateScopes: true))
                 .Options;
 
             using (var context = new DbContext(_options))

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .AddEntityFrameworkSqlServer()
                         .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                         .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                        .BuildServiceProvider())
+                        .BuildServiceProvider(validateScopes: true))
                 .Options;
 
             using (var context = new DbContext(_options))

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -68,7 +68,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlServer()
                     .AddSingleton<ILoggerFactory>(loggingFactory)
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 using (var context = new Bug6091Context(serviceProvider, testStore.ConnectionString))
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerServiceCollectionExtensionsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class SqlServerServiceCollectionExtensionsTest : EntityFrameworkServiceCollectionExtensionsTest
+    public class SqlServerServiceCollectionExtensionsTest : RelationalServiceCollectionExtensionsTest
     {
         public SqlServerServiceCollectionExtensionsTest()
             : base(SqlServerTestHelpers.Instance)

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
             _serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlServer()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         protected virtual string DatabaseName => "PartialUpdateSqlServerTest";

--- a/test/EFCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqliteTestStore CreateTestStore()

--- a/test/EFCore.Sqlite.FunctionalTests/FindSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/FindSqliteTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlite()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdatesSqliteTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore
                     _serviceProvider = new ServiceCollection()
                         .AddEntityFrameworkSqlite()
                         .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                        .BuildServiceProvider();
+                        .BuildServiceProvider(validateScopes: true);
                 }
 
                 public override SqliteTestStore CreateTestStore()

--- a/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoadSqliteTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlite()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))

--- a/test/EFCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlite()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqliteFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseSqlite(_connectionString)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseSqlite(_connectionString)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FunkyDataQuerySqliteFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqliteTestStore CreateTestStore()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _options = new DbContextOptionsBuilder()
                 .UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName))

--- a/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceRelationshipsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceRelationshipsQuerySqliteFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override InheritanceRelationshipsContext CreateContext(SqliteTestStore testStore)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceSqliteFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqliteTestStore CreateTestStore()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/MappingQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/MappingQuerySqliteFixture.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlite()
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _testDatabase = SqliteTestStore.GetNorthwindStore();
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindQuerySqliteFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .AddEntityFrameworkSqlite()
                             .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                             .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                            .BuildServiceProvider()))
+                            .BuildServiceProvider(validateScopes: true)))
                 .UseSqlite(
                     _testStore.ConnectionString,
                     b => ConfigureOptions(b).SuppressForeignKeyEnforcement())

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullKeysSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullKeysSqliteTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var serviceProvider = new ServiceCollection()
                     .AddEntityFrameworkSqlite()
                     .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                    .BuildServiceProvider();
+                    .BuildServiceProvider(validateScopes: true);
 
                 _options = new DbContextOptionsBuilder()
                     .UseSqlite(SqliteTestStore.CreateConnectionString("StringsContext"))

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NullSemanticsQuerySqliteFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqliteTestStore CreateTestStore()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OneToOneQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OneToOneQuerySqliteFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _testStore = SqliteTestStore.CreateScratch();
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
                 .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
 
             _testStore = SqliteTestStore.CreateScratch();
 

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteServiceCollectionExtensionsTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteServiceCollectionExtensionsTest.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class SqliteServiceCollectionExtensionsTest : EntityFrameworkServiceCollectionExtensionsTest
+    public class SqliteServiceCollectionExtensionsTest : RelationalServiceCollectionExtensionsTest
     {
         public SqliteServiceCollectionExtensionsTest()
             : base(SqliteTestHelpers.Instance)

--- a/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
             _serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkSqlite()
                 .AddSingleton(TestModelSource.GetFactory(OnModelCreating))
-                .BuildServiceProvider();
+                .BuildServiceProvider(validateScopes: true);
         }
 
         public override SqliteTestStore CreateTestStore() =>


### PR DESCRIPTION
Issue #7469

* Specification tests added to be run by providers to ensure all services are registered with the correct scope.
* Updated many functional tests to build the service provider using scope validation. (Better done like this than in a single test, since it makes it more likely all services will be covered.)
* Fixed some places where dependency objects were registered with the wrong scope.
