### PR TITLE
Fix to #8492 - Query: incorrect sql generated for query with owned entities, left join and predicate using inner qsre

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -81,10 +81,41 @@ WHERE ([l1].[Id] IS NOT NULL AND [l1].[Id] IS NOT NULL) AND [l1].[Id] IS NOT NUL
             base.Nested_group_join_with_take();
         }
 
-        [ConditionalFact(Skip = "issue #8492")]
+        [ConditionalFact]
         public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection2()
         {
             base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
+
+            AssertSql(
+                @"SELECT [t1].[Id]
+FROM (
+    SELECT DISTINCT [l1].*
+    FROM [Level1] AS [l1]
+    LEFT JOIN (
+        SELECT [t].*
+        FROM [Level1] AS [t]
+        WHERE [t].[Id] IS NOT NULL
+    ) AS [t0] ON [l1].[Id] = [t0].[OneToOne_Required_PK_Level1_Optional_Id]
+    WHERE ([t0].[OneToOne_Required_PK_Name] <> N'Foo') OR [t0].[OneToOne_Required_PK_Name] IS NULL
+) AS [t1]");
+        }
+
+        [ConditionalFact]
+        public override void Result_operator_nav_prop_reference_optional_via_DefaultIfEmpty()
+        {
+            base.Result_operator_nav_prop_reference_optional_via_DefaultIfEmpty();
+
+            AssertSql(
+                @"SELECT SUM(CASE
+    WHEN [t0].[Id] IS NULL
+    THEN 0 ELSE [t0].[OneToOne_Required_PK_Level1_Required_Id]
+END)
+FROM [Level1] AS [l1]
+LEFT JOIN (
+    SELECT [t].*
+    FROM [Level1] AS [t]
+    WHERE [t].[Id] IS NOT NULL
+) AS [t0] ON [l1].[Id] = [t0].[OneToOne_Required_PK_Level1_Optional_Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqliteTest.cs
@@ -18,11 +18,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.Nested_group_join_with_take();
         }
-
-        [ConditionalFact(Skip = "issue #8492")]
-        public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection2()
-        {
-            base.Explicit_GroupJoin_in_subquery_with_unrelated_projection2();
-        }
     }
 }


### PR DESCRIPTION
Problem was that for queries with owned types that were using GroupJoin-SelectMany-DefaultIfEmpty pattern we were not able to find the owned entity type behind the groupjoin subquery qsre.
Usually (i.e. in case of navigations) we look for the entity type in the lookup on QueryCompilationContext, but if the groupjoin is created manually then this lookup was not populated with entry for the groupjoin subquery.

Fix is to populate the lookup with entry for groupjoin subquery qsre. We do it in nav rewrite, which also populates other entries for owned types.
