### PR TITLE
Post-process the snapshot model to remove/combine legacy provider-specific annotations

### DIFF
--- a/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -95,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             => services
                 .AddTransient<MigrationsScaffolderDependencies>()
                 .AddTransient<MigrationsScaffolder>()
+                .AddTransient<ISnapshotModelProcessor, SnapshotModelProcessor>()
                 .AddTransient(_ => contextServices.GetService<ICurrentDbContext>())
                 .AddTransient(_ => contextServices.GetService<IDatabaseProvider>())
                 .AddTransient(_ => contextServices.GetService<IDbContextOptions>())

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             }
 
             var modelSnapshot = Dependencies.MigrationsAssembly.ModelSnapshot;
-            var lastModel = modelSnapshot?.Model;
+            var lastModel = Dependencies.SnapshotModelProcessor.Process(modelSnapshot?.Model);
             var upOperations = Dependencies.MigrationsModelDiffer.GetDifferences(lastModel, Dependencies.Model);
             var downOperations = upOperations.Any()
                 ? Dependencies.MigrationsModelDiffer.GetDifferences(Dependencies.Model, lastModel)
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 var migration = migrations[migrations.Count - 1];
                 model = migration.TargetModel;
 
-                if (!Dependencies.MigrationsModelDiffer.HasDifferences(model, modelSnapshot.Model))
+                if (!Dependencies.MigrationsModelDiffer.HasDifferences(model, Dependencies.SnapshotModelProcessor.Process(modelSnapshot.Model)))
                 {
                     if (force)
                     {

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolderDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolderDependencies.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -55,6 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="historyRepository"> The history repository. </param>
         /// <param name="operationReporter"> The operation reporter. </param>
         /// <param name="databaseProvider"> The database provider. </param>
+        /// <param name="snapshotModelProcessor"> The snapshot model processor. </param>
         public MigrationsScaffolderDependencies(
             [NotNull] ICurrentDbContext currentDbContext,
             [NotNull] IModel model,
@@ -64,7 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             [NotNull] IMigrationsCodeGenerator migrationCodeGenerator,
             [NotNull] IHistoryRepository historyRepository,
             [NotNull] IOperationReporter operationReporter,
-            [NotNull] IDatabaseProvider databaseProvider)
+            [NotNull] IDatabaseProvider databaseProvider,
+            [NotNull] ISnapshotModelProcessor snapshotModelProcessor)
         {
             Check.NotNull(currentDbContext, nameof(currentDbContext));
             Check.NotNull(model, nameof(model));
@@ -75,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Check.NotNull(historyRepository, nameof(historyRepository));
             Check.NotNull(operationReporter, nameof(operationReporter));
             Check.NotNull(databaseProvider, nameof(databaseProvider));
+            Check.NotNull(snapshotModelProcessor, nameof(snapshotModelProcessor));
 
             CurrentDbContext = currentDbContext;
             Model = model;
@@ -85,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             HistoryRepository = historyRepository;
             OperationReporter = operationReporter;
             DatabaseProvider = databaseProvider;
+            SnapshotModelProcessor = snapshotModelProcessor;
         }
 
         /// <summary>
@@ -133,6 +138,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public IDatabaseProvider DatabaseProvider { get; }
 
         /// <summary>
+        ///     The snapshot model processor.
+        /// </summary>
+        public ISnapshotModelProcessor SnapshotModelProcessor { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="currentDbContext"> A replacement for the current dependency of this type. </param>
@@ -147,7 +157,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -164,7 +175,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -181,7 +193,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -198,7 +211,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -215,7 +229,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -232,7 +247,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 migrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -249,7 +265,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 historyRepository,
                 OperationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -266,7 +283,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 operationReporter,
-                DatabaseProvider);
+                DatabaseProvider,
+                SnapshotModelProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -283,6 +301,25 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 MigrationCodeGenerator,
                 HistoryRepository,
                 OperationReporter,
-                databaseProvider);
+                databaseProvider,
+                SnapshotModelProcessor);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="snapshotModelProcessor"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsScaffolderDependencies With([NotNull] ISnapshotModelProcessor snapshotModelProcessor)
+            => new MigrationsScaffolderDependencies(
+                CurrentDbContext,
+                Model,
+                MigrationsAssembly,
+                MigrationsModelDiffer,
+                MigrationsIdGenerator,
+                MigrationCodeGenerator,
+                HistoryRepository,
+                OperationReporter,
+                DatabaseProvider,
+                snapshotModelProcessor);
     }
 }

--- a/src/EFCore.Design/Migrations/Internal/ISnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/ISnapshotModelProcessor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+{
+    public interface ISnapshotModelProcessor
+    {
+        IModel Process([CanBeNull] IModel model);
+    }
+}

--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+{
+    public class SnapshotModelProcessor : ISnapshotModelProcessor
+    {
+        private readonly IOperationReporter _operationReporter;
+        private readonly HashSet<string> _relationalNames;
+
+        public SnapshotModelProcessor([NotNull] IOperationReporter operationReporter)
+        {
+            _operationReporter = operationReporter;
+            _relationalNames = new HashSet<string>(
+                typeof(RelationalAnnotationNames)
+                    .GetTypeInfo()
+                    .GetRuntimeFields()
+                    .Where(p => p.Name != nameof(RelationalAnnotationNames.Prefix))
+                    .Select(p => ((string)p.GetValue(null)).Substring(RelationalAnnotationNames.Prefix.Length - 1)));
+        }
+
+        public virtual IModel Process(IModel model)
+        {
+            if (model != null
+                && model.GetProductVersion()?.StartsWith("1.") == true)
+            {
+                ProcessElement(model);
+
+                foreach (var entityType in model.GetEntityTypes())
+                {
+                    ProcessElement(entityType);
+                    ProcessCollection(entityType.GetProperties());
+                    ProcessCollection(entityType.GetKeys());
+                    ProcessCollection(entityType.GetIndexes());
+
+                    foreach (var element in entityType.GetForeignKeys())
+                    {
+                        ProcessElement(element);
+                        ProcessElement(element.DependentToPrincipal);
+                        ProcessElement(element.PrincipalToDependent);
+                    }
+                }
+            }
+
+            return model;
+        }
+
+        private void ProcessCollection(IEnumerable<IAnnotatable> metadata)
+        {
+            foreach (var element in metadata)
+            {
+                ProcessElement(element);
+            }
+        }
+
+        private void ProcessElement(IAnnotatable metadata)
+        {
+            if (metadata is IMutableAnnotatable mutableMetadata)
+            {
+                foreach (var annotation in mutableMetadata.GetAnnotations().ToList())
+                {
+                    var colon = annotation.Name.IndexOf(':');
+                    if (colon > 0)
+                    {
+                        var stripped = annotation.Name.Substring(colon);
+                        if (_relationalNames.Contains(stripped))
+                        {
+                            mutableMetadata.RemoveAnnotation(annotation.Name);
+                            var relationalName = "Relational" + stripped;
+                            var duplicate = mutableMetadata.FindAnnotation(relationalName);
+
+                            if (duplicate == null)
+                            {
+                                mutableMetadata[relationalName] = annotation.Value;
+                            }
+                            else if (!Equals(duplicate.Value, annotation.Value))
+                            {
+                                _operationReporter.WriteWarning(
+                                    DesignStrings.MultipleAnnotationConflict(stripped.Substring(1)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -551,6 +551,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 indexName, columnNames);
 
         /// <summary>
+        ///     The annotation '{annotationName}' was specified twice with potentially different values. Specifying the same annotation multiple times for different providers is no longer supported. Review the generated Migration to ensure it is correct and, if necessary, edit the Migration to fix any issues.
+        /// </summary>
+        public static string MultipleAnnotationConflict([CanBeNull] object annotationName)
+            => string.Format(
+                GetString("MultipleAnnotationConflict", nameof(annotationName)),
+                annotationName);
+
+        /// <summary>
         ///     Sequence name cannot be null or empty. Entity Framework cannot model a sequence that does not have a name.
         /// </summary>
         public static string SequencesRequireName

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -330,6 +330,9 @@ Change your target project to the migrations project by using the Package Manage
   <data name="UnableToScaffoldIndexMissingProperty" xml:space="preserve">
     <value>Unable to scaffold the index '{indexName}'. The following columns could not be scaffolded: {columnNames}.</value>
   </data>
+  <data name="MultipleAnnotationConflict" xml:space="preserve">
+    <value>The annotation '{annotationName}' was specified twice with potentially different values. Specifying the same annotation multiple times for different providers is no longer supported. Review the generated Migration to ensure it is correct and, if necessary, edit the Migration to fix any issues.</value>
+  </data>
   <data name="SequencesRequireName" xml:space="preserve">
     <value>Sequence name cannot be null or empty. Entity Framework cannot model a sequence that does not have a name.</value>
   </data>

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -45,6 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var currentContext = new CurrentDbContext(new TContext());
             var idGenerator = new MigrationsIdGenerator();
             var code = new CSharpHelper();
+            var reporter = new TestOperationReporter();
 
             return new MigrationsScaffolder(
                 new MigrationsScaffolderDependencies(
@@ -66,8 +67,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                 new CSharpMigrationOperationGeneratorDependencies(code)),
                             new CSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(code)))),
                     new MockHistoryRepository(),
-                    new TestOperationReporter(),
-                    new MockProvider()));
+                    reporter,
+                    new MockProvider(),
+                    new SnapshotModelProcessor(reporter)));
         }
 
         private class GenericContext<T> : DbContext

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1,0 +1,192 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+{
+    public class SnapshotModelProcessorTest
+    {
+        [Fact]
+        public void Updates_provider_annotations_on_model()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+
+            var model = builder.Model;
+            ((Model)model).SetProductVersion("1.1.2");
+
+            var entityType = builder.Entity<Blog>().Metadata;
+            var property = builder.Entity<Blog>().Property(e => e.Id).Metadata;
+            var key = builder.Entity<Blog>().HasKey(e => e.Id).Metadata;
+
+            builder.Entity<Post>().Property(e => e.BlogId);
+            var foreignKey = builder.Entity<Blog>().HasMany(e => e.Posts).WithOne(e => e.Blog).HasForeignKey(e => e.BlogId).Metadata;
+            var nav1 = foreignKey.DependentToPrincipal;
+            var nav2 = foreignKey.PrincipalToDependent;
+
+            var index = builder.Entity<Post>().HasIndex(e => e.BlogId).Metadata;
+
+            AddAnnotations(model);
+            AddAnnotations(entityType);
+            AddAnnotations(property);
+            AddAnnotations(key);
+            AddAnnotations(foreignKey);
+            AddAnnotations(nav1);
+            AddAnnotations(nav2);
+            AddAnnotations(index);
+
+            var reporter = new TestOperationReporter();
+
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            AssertAnnotations(model);
+            AssertAnnotations(entityType);
+            AssertAnnotations(property);
+            AssertAnnotations(key);
+            AssertAnnotations(foreignKey);
+            AssertAnnotations(nav1);
+            AssertAnnotations(nav2);
+            AssertAnnotations(index);
+
+            Assert.Empty(reporter.Messages);
+        }
+
+        [Fact]
+        public void Warns_for_conflicting_annotations()
+        {
+            var model = new Model();
+            model.SetProductVersion("1.1.2");
+            model["Unicorn:DefaultSchema"] = "Value1";
+            model["Hippo:DefaultSchema"] = "Value2";
+
+            Assert.Equal(3, model.GetAnnotations().Count());
+
+            var reporter = new TestOperationReporter();
+
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            Assert.Equal(2, model.GetAnnotations().Count());
+
+            var actual = (string)model["Relational:DefaultSchema"];
+            Assert.True(actual == "Value1" || actual == "Value2");
+        }
+
+        [Fact]
+        public void Warns_for_conflicting_annotations_one_relational()
+        {
+            var model = new Model();
+            model.SetProductVersion("1.1.2");
+            model["Unicorn:DefaultSchema"] = "Value1";
+            model["Relational:DefaultSchema"] = "Value2";
+
+            Assert.Equal(3, model.GetAnnotations().Count());
+
+            var reporter = new TestOperationReporter();
+
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            Assert.Equal(2, model.GetAnnotations().Count());
+
+            var actual = (string)model["Relational:DefaultSchema"];
+            Assert.True(actual == "Value1" || actual == "Value2");
+        }
+
+        [Fact]
+        public void Does_not_warn_for_duplicate_non_conflicting_annotations()
+        {
+            var model = new Model();
+            model.SetProductVersion("1.1.2");
+            model["Unicorn:DefaultSchema"] = "Value";
+            model["Hippo:DefaultSchema"] = "Value";
+
+            Assert.Equal(3, model.GetAnnotations().Count());
+
+            var reporter = new TestOperationReporter();
+
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            Assert.Empty(reporter.Messages);
+
+            Assert.Equal(2, model.GetAnnotations().Count());
+            Assert.Equal("Value", (string)model["Relational:DefaultSchema"]);
+        }
+
+        [Fact]
+        public void Does_not_process_non_v1_models()
+        {
+            var model = new Model();
+            model.SetProductVersion("2.0.0");
+            model["Unicorn:DefaultSchema"] = "Value";
+
+            Assert.Equal(2, model.GetAnnotations().Count());
+
+            var reporter = new TestOperationReporter();
+
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            Assert.Empty(reporter.Messages);
+
+            Assert.Equal(2, model.GetAnnotations().Count());
+            Assert.Equal("Value", (string)model["Unicorn:DefaultSchema"]);
+        }
+
+        private class TestOperationReporter : IOperationReporter
+        {
+            public IList<string> Messages { get; } = new List<string>();
+
+            public void WriteWarning(string message) => Messages.Add(message);
+
+            public void WriteError(string message) => throw new NotImplementedException();
+            public void WriteInformation(string message) => throw new NotImplementedException();
+            public void WriteVerbose(string message) => throw new NotImplementedException();
+        }
+
+        private void AddAnnotations(IMutableAnnotatable element)
+        {
+            foreach (var annotationName in GetAnnotationNames()
+                .Select(a => "Unicorn" + a.Substring(RelationalAnnotationNames.Prefix.Length - 1)))
+            {
+                element[annotationName] = "Value";
+            }
+        }
+
+        private void AssertAnnotations(IMutableAnnotatable element)
+        {
+            foreach (var annotationName in GetAnnotationNames())
+            {
+                Assert.Equal("Value", (string)element[annotationName]);
+            }
+        }
+
+        private static IEnumerable<string> GetAnnotationNames()
+            => typeof(RelationalAnnotationNames)
+                .GetTypeInfo()
+                .GetRuntimeFields()
+                .Where(p => p.Name != nameof(RelationalAnnotationNames.Prefix))
+                .Select(p => (string)p.GetValue(null));
+
+        private class Blog
+        {
+            public int Id { get; set; }
+
+            public ICollection<Post> Posts { get; set; }
+        }
+
+        private class Post
+        {
+            public int BlogId { get; set; }
+            public Blog  Blog { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Issue #8925

Currently relies on the model elements from the snapshot being mutable, but API could return a new IModel instead if this ever becomes not true.
