### PR TITLE
Tools: More DbContext info

### DIFF
--- a/src/EFCore.Design/Design/Internal/ContextInfo.cs
+++ b/src/EFCore.Design/Design/Internal/ContextInfo.cs
@@ -7,7 +7,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 {
     public class ContextInfo
     {
+        public virtual string ProviderName { get; [param: NotNull] set; }
         public virtual string DatabaseName { get; [param: NotNull] set; }
         public virtual string DataSource { get; [param: NotNull] set; }
+        public virtual string Options { get; [param: NotNull] set; }
     }
 }

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -165,12 +166,19 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         {
             using (var context = CreateContext(contextType))
             {
+                var info = new ContextInfo();
+
+                var provider = context.GetService<IDatabaseProvider>();
+                info.ProviderName = provider.Name;
+
                 var connection = context.Database.GetDbConnection();
-                return new ContextInfo
-                {
-                    DatabaseName = connection.Database,
-                    DataSource = connection.DataSource
-                };
+                info.DataSource = connection.DataSource;
+                info.DatabaseName = connection.Database;
+
+                var options = context.GetService<IDbContextOptions>();
+                info.Options = options.BuildOptionsFragment().Trim();
+
+                return info;
             }
         }
 

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -155,11 +155,13 @@ namespace Microsoft.EntityFrameworkCore.Design
 
         private IDictionary GetContextInfoImpl([CanBeNull] string contextType)
         {
-            var databaseInfo = _contextOperations.Value.GetContextInfo(contextType);
+            var info = _contextOperations.Value.GetContextInfo(contextType);
             return new Hashtable
             {
-                ["DatabaseName"] = databaseInfo.DatabaseName,
-                ["DataSource"] = databaseInfo.DataSource
+                ["ProviderName"] = info.ProviderName,
+                ["DatabaseName"] = info.DatabaseName,
+                ["DataSource"] = info.DataSource,
+                ["Options"] = info.Options
             };
         }
 

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.PowerShell2.psd1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.PowerShell2.psd1
@@ -61,6 +61,7 @@
         'Add-Migration',
         'Drop-Database',
         'Enable-Migrations',
+        'Get-DbContext',
         'Remove-Migration',
         'Scaffold-DbContext',
         'Script-Migration',

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.PowerShell2.psm1
@@ -22,6 +22,11 @@ function Enable-Migrations
     throw $versionErrorMessage
 }
 
+function Get-DbContext
+{
+    throw $versionErrorMessage
+}
+
 function Remove-Migration
 {
     throw $versionErrorMessage

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psd1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psd1
@@ -61,6 +61,7 @@
         'Add-Migration',
         'Drop-Database',
         'Enable-Migrations',
+        'Get-DbContext',
         'Remove-Migration',
         'Scaffold-DbContext',
         'Script-Migration',

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -146,6 +146,50 @@ function Enable-Migrations
 }
 
 #
+# Get-DbContext
+#
+
+Register-TabExpansion Get-DbContext @{
+    Context = { param($x) GetContextTypes $x.Project $x.StartupProject }
+    Project = { GetProjects }
+    StartupProject = { GetProjects }
+}
+
+<#
+.SYNOPSIS
+    Gets information about a DbContext type.
+
+.DESCRIPTION
+    Gets information about a DbContext type.
+
+.PARAMETER Context
+    The DbContext to use.
+
+.PARAMETER Project
+    The project to use.
+
+.PARAMETER StartupProject
+    The startup project to use. Defaults to the solution's startup project.
+
+.LINK
+    about_EntityFrameworkCore
+#>
+function Get-DbContext
+{
+    [CmdletBinding(PositionalBinding = $false)]
+    param([string] $Context, [string] $Project, [string] $StartupProject)
+
+    $dteProject = GetProject $Project
+    $dteStartupProject = GetStartupProject $StartupProject $dteProject
+
+    $params = 'dbcontext', 'info', '--json'
+    $params += GetParams $Context
+
+    # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
+    return (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json
+}
+
+#
 # Remove-Migration
 #
 

--- a/src/EFCore.Tools/tools/about_EntityFrameworkCore.help.txt
+++ b/src/EFCore.Tools/tools/about_EntityFrameworkCore.help.txt
@@ -24,6 +24,8 @@ LONG DESCRIPTION
 
         Drop-Database               Drops the database.
 
+        Get-DbContext               Gets information about a DbContext type.
+
         Remove-Migration            Removes the last migration.
 
         Scaffold-DbContext          Scaffolds a DbContext and entity types for a database.
@@ -35,6 +37,7 @@ LONG DESCRIPTION
 SEE ALSO
     Add-Migration
     Drop-Database
+    Get-DbContext
     Remove-Migration
     Scaffold-DbContext
     Script-Migration

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -523,11 +522,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
             if (diagnostics.GetLogBehavior(definition.EventId, definition.Level) != WarningBehavior.Ignore)
             {
                 definition.Log(
-                    diagnostics, 
-                    ProductInfo.GetVersion(), 
-                    context.GetType().ShortDisplayName(), 
+                    diagnostics,
+                    ProductInfo.GetVersion(),
+                    context.GetType().ShortDisplayName(),
                     context.Database.ProviderName,
-                    BuildOptionsFragment(contextOptions));
+                    contextOptions.BuildOptionsFragment());
             }
 
             if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
@@ -542,19 +541,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
         }
 
-        private static string BuildOptionsFragment(DbContextOptions contextOptions)
-        {
-            var builder = new StringBuilder();
-            foreach (var extension in contextOptions.Extensions)
-            {
-                builder.Append(extension.LogFragment);
-
-            }
-            var fragment = builder.ToString();
-
-            return string.IsNullOrWhiteSpace(fragment) ? "None" : fragment;
-        }
-
         private static string ContextInitialized(EventDefinitionBase definition, EventData payload)
         {
             var d = (EventDefinition<string, string, string, string>)definition;
@@ -563,7 +549,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 ProductInfo.GetVersion(),
                 p.Context.GetType().ShortDisplayName(),
                 p.Context.Database.ProviderName,
-                BuildOptionsFragment(p.ContextOptions));
+                p.ContextOptions.BuildOptionsFragment());
 
         }
     }

--- a/src/EFCore/Extensions/Internal/DbContextOptionsExtensions.cs
+++ b/src/EFCore/Extensions/Internal/DbContextOptionsExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class DbContextOptionsExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string BuildOptionsFragment([NotNull] this IDbContextOptions contextOptions)
+        {
+            var builder = new StringBuilder();
+            foreach (var extension in contextOptions.Extensions)
+            {
+                builder.Append(extension.LogFragment);
+
+            }
+            var fragment = builder.ToString();
+
+            return string.IsNullOrWhiteSpace(fragment) ? "None" : fragment;
+        }
+    }
+}

--- a/src/ef/Commands/DbContextInfoCommand.cs
+++ b/src/ef/Commands/DbContextInfoCommand.cs
@@ -27,15 +27,19 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private static void ReportJsonResult(IDictionary result)
         {
             Reporter.WriteData("{");
+            Reporter.WriteData("  \"providerName\": \"" + Json.Escape(result["ProviderName"] as string) + "\",");
             Reporter.WriteData("  \"databaseName\": \"" + Json.Escape(result["DatabaseName"] as string) + "\",");
-            Reporter.WriteData("  \"dataSource\": \"" + Json.Escape(result["DataSource"] as string) + "\"");
+            Reporter.WriteData("  \"dataSource\": \"" + Json.Escape(result["DataSource"] as string) + "\",");
+            Reporter.WriteData("  \"options\": \"" + Json.Escape(result["Options"] as string) + "\"");
             Reporter.WriteData("}");
         }
 
         private static void ReportResult(IDictionary result)
         {
+            Reporter.WriteData(Resources.ProviderName(result["ProviderName"]));
             Reporter.WriteData(Resources.DatabaseName(result["DatabaseName"]));
             Reporter.WriteData(Resources.DataSource(result["DataSource"]));
+            Reporter.WriteData(Resources.Options(result["Options"]));
         }
     }
 }

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -419,6 +419,22 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
                 GetString("DesignNotFound", nameof(startupProject)),
                 startupProject);
 
+        /// <summary>
+        ///     Provider name: {provider}
+        /// </summary>
+        public static string ProviderName([CanBeNull] object provider)
+            => string.Format(
+                GetString("ProviderName", nameof(provider)),
+                provider);
+
+        /// <summary>
+        ///     Options: {options}
+        /// </summary>
+        public static string Options([CanBeNull] object options)
+            => string.Format(
+                GetString("Options", nameof(options)),
+                options);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -303,4 +303,10 @@
   <data name="DesignNotFound" xml:space="preserve">
     <value>Your startup project '{startupProject}' doesn't reference Microsoft.EntityFrameworkCore.Design. This package is required for the Entity Framework Core Tools to work. Ensure your startup project is correct, install the package, and try again.</value>
   </data>
+  <data name="ProviderName" xml:space="preserve">
+    <value>Provider name: {provider}</value>
+  </data>
+  <data name="Options" xml:space="preserve">
+    <value>Options: {options}</value>
+  </data>
 </root>

--- a/test/ef.Tests/SimpleProjectTest.cs
+++ b/test/ef.Tests/SimpleProjectTest.cs
@@ -120,8 +120,10 @@ namespace Microsoft.EntityFrameworkCore.Tools
         public void GetContextInfo_returns_connection_string()
         {
             var info = _project.Executor.GetContextInfo("SimpleContext");
+            Assert.Equal("Microsoft.EntityFrameworkCore.SqlServer", info["ProviderName"]);
             Assert.Equal(@"(localdb)\MSSQLLocalDB", info["DataSource"]);
             Assert.Equal("SimpleProject.SimpleContext", info["DatabaseName"]);
+            Assert.Equal("None", info["Options"]);
         }
 
         public class SimpleProject : IDisposable


### PR DESCRIPTION
Enhances `dotnet ef dbcontext info` command and adds Get-DbContext.

The following information is available:
- Provider name
- Database server (was already on CLI)
- Database name (was already on CLI)
- DbContextOptions (reuses the Logging format)

Resolves #9052

Example PMC usage:
```
PM> Get-DbContext | Format-List
providerName : Microsoft.EntityFrameworkCore.Sqlite
databaseName : main
dataSource   : ConsoleApp1.db
options      : SuppressForeignKeyEnforcement NoTracking
```

@ajcvickers @divega Should we take this in 2.0.0 or wait?