### PR TITLE
[2.0.0] Design: Remove OperationExecutor.GetContextType

### DIFF
--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -74,26 +74,6 @@ namespace Microsoft.EntityFrameworkCore.Design
                     rootNamespace));
         }
 
-        public class GetContextType : OperationBase
-        {
-            public GetContextType(
-                [NotNull] OperationExecutor executor,
-                [NotNull] object resultHandler,
-                [NotNull] IDictionary args)
-                : base(resultHandler)
-            {
-                Check.NotNull(executor, nameof(executor));
-                Check.NotNull(args, nameof(args));
-
-                var name = (string)args["name"];
-
-                Execute(() => executor.GetContextTypeImpl(name));
-            }
-        }
-
-        private string GetContextTypeImpl([CanBeNull] string name) =>
-            _contextOperations.Value.GetContextType(name).AssemblyQualifiedName;
-
         public class AddMigration : OperationBase
         {
             public AddMigration(

--- a/src/EFCore.Design/baseline.netcore.json
+++ b/src/EFCore.Design/baseline.netcore.json
@@ -8857,36 +8857,6 @@
       "GenericParameters": []
     },
     {
-      "Name": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+GetContextType",
-      "Visibility": "Public",
-      "Kind": "Class",
-      "BaseType": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+OperationBase",
-      "ImplementedInterfaces": [],
-      "Members": [
-        {
-          "Kind": "Constructor",
-          "Name": ".ctor",
-          "Parameters": [
-            {
-              "Name": "executor",
-              "Type": "Microsoft.EntityFrameworkCore.Design.OperationExecutor"
-            },
-            {
-              "Name": "resultHandler",
-              "Type": "System.Object"
-            },
-            {
-              "Name": "args",
-              "Type": "System.Collections.IDictionary"
-            }
-          ],
-          "Visibility": "Public",
-          "GenericParameter": []
-        }
-      ],
-      "GenericParameters": []
-    },
-    {
       "Name": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+AddMigration",
       "Visibility": "Public",
       "Kind": "Class",

--- a/src/EFCore.Design/baseline.netframework.json
+++ b/src/EFCore.Design/baseline.netframework.json
@@ -8909,36 +8909,6 @@
       "GenericParameters": []
     },
     {
-      "Name": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+GetContextType",
-      "Visibility": "Public",
-      "Kind": "Class",
-      "BaseType": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+OperationBase",
-      "ImplementedInterfaces": [],
-      "Members": [
-        {
-          "Kind": "Constructor",
-          "Name": ".ctor",
-          "Parameters": [
-            {
-              "Name": "executor",
-              "Type": "Microsoft.EntityFrameworkCore.Design.OperationExecutor"
-            },
-            {
-              "Name": "resultHandler",
-              "Type": "System.Object"
-            },
-            {
-              "Name": "args",
-              "Type": "System.Collections.IDictionary"
-            }
-          ],
-          "Visibility": "Public",
-          "GenericParameter": []
-        }
-      ],
-      "GenericParameters": []
-    },
-    {
       "Name": "Microsoft.EntityFrameworkCore.Design.OperationExecutor+AddMigration",
       "Visibility": "Public",
       "Kind": "Class",

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -14,7 +14,6 @@ namespace Microsoft.EntityFrameworkCore.Tools
         IEnumerable<IDictionary> GetMigrations(string contextType);
         void DropDatabase(string contextType);
         IDictionary GetContextInfo(string name);
-        string GetContextType(string name);
         void UpdateDatabase(string migration, string contextType);
         IEnumerable<IDictionary> GetContextTypes();
 

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -168,12 +168,5 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["idempotent"] = idempotent,
                     ["contextType"] = contextType
                 });
-
-        public string GetContextType(string name)
-            => InvokeOperation<string>("GetContextType",
-                new Dictionary<string, string>
-                {
-                    ["name"] = name
-                });
     }
 }

--- a/test/ef.Tests/SimpleProjectTest.cs
+++ b/test/ef.Tests/SimpleProjectTest.cs
@@ -96,13 +96,6 @@ namespace Microsoft.EntityFrameworkCore.Tools
         }
 
         [Fact]
-        public void GetContextType()
-        {
-            var contextTypeName = _project.Executor.GetContextType("SimpleContext");
-            Assert.StartsWith("SimpleProject.SimpleContext, ", contextTypeName);
-        }
-
-        [Fact]
         public void GetContextTypes()
         {
             var contextTypes = _project.Executor.GetContextTypes();


### PR DESCRIPTION
@vijayrkn Publish just calls `dotnet ef`, right? You don't use this?