### PR TITLE
[WIP] Benchmarks: Use BenchmarkDotNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# BenchmarkDotNet Results
+[Bb]enchmarkDotNet.Artifacts/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/EFCore.sln
+++ b/EFCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore", "src\EFCore\EFCore.csproj", "{715C38E9-B2F5-4DB2-8025-0C6492DEBDD4}"
 EndProject

--- a/test/EFCore.Benchmarks.EF6/EFCore.Benchmarks.EF6.csproj
+++ b/test/EFCore.Benchmarks.EF6/EFCore.Benchmarks.EF6.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.Benchmarks.EF6</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks.EF6</RootNamespace>
     <NoWarn>$(NoWarn);xUnit1005</NoWarn>
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.Benchmarks.EF6/Program.cs
+++ b/test/EFCore.Benchmarks.EF6/Program.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Running;
+using Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query;
+using Microsoft.EntityFrameworkCore.Benchmarks.v2;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+
+            var benchmarkSummaryProcessor = new BenchmarkSummaryProcessor();
+            
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<SimpleQueryTests>());
+        }
+    }
+}

--- a/test/EFCore.Benchmarks.EF6/Properties/AssemblyInfo.cs
+++ b/test/EFCore.Benchmarks.EF6/Properties/AssemblyInfo.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using BenchmarkDotNet.Attributes;
+using Microsoft.EntityFrameworkCore.Benchmarks.v2;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: BenchmarkJob]
+[assembly: MemoryDiagnoser]

--- a/test/EFCore.Benchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EFCore.Benchmarks.EF6/Query/SimpleQueryTests.cs
@@ -4,329 +4,218 @@
 using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore.Benchmarks.EF6.Models.Orders;
+using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 using Xunit;
+
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
     [SqlServerRequired]
-    public class SimpleQueryTests : IClassFixture<SimpleQueryTests.SimpleQueryFixture>
+    public class SimpleQueryTests
     {
-        private readonly SimpleQueryFixture _fixture;
+        private static readonly SimpleQueryFixture _fixture = new SimpleQueryFixture();
 
-        public SimpleQueryTests(SimpleQueryFixture fixture)
+        private OrdersContext _context;
+
+        [Params(true, false)]
+        public bool Async;
+
+        [Params(true, false)]
+        public bool Tracking;
+
+        [GlobalSetup]
+        public void GlobalSetup()
         {
-            _fixture = fixture;
+            _context = _fixture.CreateContext();
+
+            Assert.Equal(1000, _context.Products.Count());
+            Assert.Equal(1000, _context.Customers.Count());
+            Assert.Equal(2000, _context.Orders.Count());
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On - Sync (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off - Sync (10 queries)", false, false, 10)]
-        [BenchmarkVariation("Tracking On - Async (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off - Async (10 queries)", false, true, 10)]
-        public async Task LoadAll(IMetricCollector collector, bool tracking, bool async, int queriesPerIteration)
+        [GlobalCleanup]
+        public void GlobalCleanup()
         {
-            using (var context = _fixture.CreateContext())
+            _context.Dispose();
+        }
+
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task LoadAll()
+        {
+            var query = _context.Products
+                .ApplyTracking(Tracking);
+
+            if (Async)
             {
-                var query = context.Products
-                    .ApplyTracking(tracking);
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
-
-                Assert.Equal(1000, query.Count());
-                Assert.False(tracking && (queriesPerIteration != 1), "Multiple queries per iteration not valid for tracking queries");
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On - Sync (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off - Sync (10 queries)", false, false, 10)]
-        [BenchmarkVariation("Tracking On - Async (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off - Async (10 queries)", false, true, 10)]
-        public async Task Where(IMetricCollector collector, bool tracking, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task Where()
         {
-            using (var context = _fixture.CreateContext())
+            var query = _context.Products
+                .ApplyTracking(Tracking)
+                .Where(p => p.Retail < 15);
+
+            if (Async)
             {
-                var query = context.Products
-                    .ApplyTracking(tracking)
-                    .Where(p => p.Retail < 15);
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
-
-                Assert.Equal(500, query.Count());
-                Assert.False(tracking && (queriesPerIteration != 1), "Multiple queries per iteration not valid for tracking queries");
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On - Sync (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off - Sync (10 queries)", false, false, 10)]
-        [BenchmarkVariation("Tracking On - Async (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off - Async (10 queries)", false, true, 10)]
-        public async Task OrderBy(IMetricCollector collector, bool tracking, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task OrderBy()
         {
-            using (var context = _fixture.CreateContext())
+            var query = _context.Products
+                        .ApplyTracking(Tracking)
+                        .OrderBy(p => p.Retail);
+
+            if (Async)
             {
-                var query = context.Products
-                    .ApplyTracking(tracking)
-                    .OrderBy(p => p.Retail);
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
-
-                Assert.Equal(1000, query.Count());
-                Assert.False(tracking && (queriesPerIteration != 1), "Multiple queries per iteration not valid for tracking queries");
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Sync (100 queries)", false, 100)]
-        [BenchmarkVariation("Async (100 queries)", true, 100)]
-        public async Task Count(IMetricCollector collector, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task Count()
         {
-            using (var context = _fixture.CreateContext())
+            var query = _context.Products;
+
+            if (Async)
             {
-                var query = context.Products;
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.CountAsync();
-                        }
-                        else
-                        {
-                            query.Count();
-                        }
-                    }
-                }
-
-                Assert.Equal(1000, query.Count());
+                await query.CountAsync();
+            }
+            else
+            {
+                query.Count();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On - Sync (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off - Sync (10 queries)", false, false, 10)]
-        [BenchmarkVariation("Tracking On - Async (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off - Async (10 queries)", false, true, 10)]
-        public async Task SkipTake(IMetricCollector collector, bool tracking, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task SkipTake()
         {
-            using (var context = _fixture.CreateContext())
+            var query = _context.Products
+                .ApplyTracking(Tracking)
+                .OrderBy(p => p.ProductId)
+                .Skip(500)
+                .Take(500);
+
+            if (Async)
             {
-                var query = context.Products
-                    .ApplyTracking(tracking)
-                    .OrderBy(p => p.ProductId)
-                    .Skip(500).Take(500);
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
-
-                Assert.Equal(500, query.Count());
-                Assert.False(tracking && (queriesPerIteration != 1), "Multiple queries per iteration not valid for tracking queries");
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Sync (10 queries)", false, 10)]
-        [BenchmarkVariation("Async (10 queries)", true, 10)]
-        public async Task GroupBy(IMetricCollector collector, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task GroupBy()
         {
-            using (var context = _fixture.CreateContext())
-            {
-                var query = context.Products
-                    .GroupBy(p => p.Retail)
-                    .Select(g => new
-                    {
-                        Retail = g.Key,
-                        Products = g
-                    });
-
-                using (collector.StartCollection())
+            var query = _context.Products
+                .GroupBy(p => p.Retail)
+                .Select(g => new
                 {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
+                    Retail = g.Key,
+                    Products = g
+                });
 
-                var result = query.ToList();
-                Assert.Equal(10, result.Count);
-                Assert.All(result, g => Assert.Equal(100, g.Products.Count()));
+            if (Async)
+            {
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On - Sync (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off - Sync (1 query)", false, false, 1)]
-        [BenchmarkVariation("Tracking On - Async (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off - Async (1 query)", false, true, 1)]
-        public async Task Include(IMetricCollector collector, bool tracking, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task Include()
         {
-            using (var context = _fixture.CreateContext())
+            var query = _context.Customers
+                .ApplyTracking(Tracking)
+                .Include(c => c.Orders);
+
+            if (Async)
             {
-                var query = context.Customers
-                    .ApplyTracking(tracking)
-                    .Include(c => c.Orders);
-
-                using (collector.StartCollection())
-                {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
-
-                var result = query.ToList();
-                Assert.Equal(1000, result.Count);
-                Assert.Equal(2000, result.SelectMany(c => c.Orders).Count());
-                Assert.False(tracking && (queriesPerIteration != 1), "Multiple queries per iteration not valid for tracking queries");
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Sync (10 queries)", false, 10)]
-        [BenchmarkVariation("Async (10 queries)", true, 10)]
-        public async Task Projection(IMetricCollector collector, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task Projection()
         {
-            using (var context = _fixture.CreateContext())
-            {
-                var query = context.Products
-                    .Select(p => new
-                    {
-                        p.ProductId,
-                        p.Name,
-                        p.Description,
-                        p.SKU,
-                        p.Retail,
-                        p.CurrentPrice,
-                        p.ActualStockLevel
-                    });
-
-                using (collector.StartCollection())
+            var query = _context.Products
+                .Select(p => new
                 {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
+                    p.ProductId,
+                    p.Name,
+                    p.Description,
+                    p.SKU,
+                    p.Retail,
+                    p.CurrentPrice,
+                    p.ActualStockLevel
+                });
 
-                Assert.Equal(1000, query.Count());
+            if (Async)
+            {
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Sync (10 queries)", false, 10)]
-        [BenchmarkVariation("Async (10 queries)", true, 10)]
-        public async Task ProjectionAcrossNavigation(IMetricCollector collector, bool async, int queriesPerIteration)
+        [BenchmarkDotNet.Attributes.Benchmark]
+        public async Task ProjectionAcrossNavigation()
         {
-            using (var context = _fixture.CreateContext())
-            {
-                var query = context.Orders
-                    .Select(o => new
-                    {
-                        CustomerTitle = o.Customer.Title,
-                        CustomerFirstName = o.Customer.FirstName,
-                        CustomerLastName = o.Customer.LastName,
-                        OrderDate = o.Date, o.OrderDiscount,
-                        OrderDiscountReason = o.DiscountReason,
-                        OrderTax = o.Tax,
-                        OrderSpecialRequests = o.SpecialRequests
-                    });
-
-                using (collector.StartCollection())
+            var query = _context.Orders
+                .Select(o => new
                 {
-                    for (var i = 0; i < queriesPerIteration; i++)
-                    {
-                        if (async)
-                        {
-                            await query.ToListAsync();
-                        }
-                        else
-                        {
-                            query.ToList();
-                        }
-                    }
-                }
+                    CustomerTitle = o.Customer.Title,
+                    CustomerFirstName = o.Customer.FirstName,
+                    CustomerLastName = o.Customer.LastName,
+                    OrderDate = o.Date,
+                    o.OrderDiscount,
+                    OrderDiscountReason = o.DiscountReason,
+                    OrderTax = o.Tax,
+                    OrderSpecialRequests = o.SpecialRequests
+                });
 
-                Assert.Equal(2000, query.Count());
+            if (Async)
+            {
+                await query.ToListAsync();
+            }
+            else
+            {
+                query.ToList();
             }
         }
 
-        public class SimpleQueryFixture : OrdersFixture
+        private class SimpleQueryFixture : OrdersFixture
         {
             public SimpleQueryFixture()
                 : base("Perf_Query_Simple_EF6", 1000, 1000, 2, 2)

--- a/test/EFCore.Benchmarks.EF6/config.json
+++ b/test/EFCore.Benchmarks.EF6/config.json
@@ -5,6 +5,6 @@
       "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
     },
     "benchmarkDatabase": "Server=(localdb)\\mssqllocaldb;Trusted_Connection=True;MultipleActiveResultSets=true;",
-    "productReportingVersion": "EF6"
+    "productVersion": "EF6"
   }
 }

--- a/test/EFCore.Benchmarks.EFCore/config.json
+++ b/test/EFCore.Benchmarks.EFCore/config.json
@@ -5,6 +5,6 @@
       "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
     },
     "benchmarkDatabase": "Server=(localdb)\\mssqllocaldb;Trusted_Connection=True;MultipleActiveResultSets=true;",
-    "productReportingVersion": "EF Core"
+    "productVersion": "EF Core"
   }
 }

--- a/test/EFCore.Benchmarks/BenchmarkConfig.cs
+++ b/test/EFCore.Benchmarks/BenchmarkConfig.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
                     RunIterations = bool.Parse(config["benchmarks:runIterations"]),
                     ResultDatabases = resultDatabasesSection.GetChildren().Select(s => s.Value).ToArray(),
                     BenchmarkDatabase = config["benchmarks:benchmarkDatabase"],
-                    ProductReportingVersion = config["benchmarks:productReportingVersion"],
+                    ProductVersion = config["benchmarks:productVersion"],
                     CustomData = config["benchmarks:customData"]
                 };
             });
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         public bool RunIterations { get; private set; }
         public IEnumerable<string> ResultDatabases { get; private set; }
         public string BenchmarkDatabase { get; private set; }
-        public string ProductReportingVersion { get; private set; }
+        public string ProductVersion { get; private set; }
         public string CustomData { get; private set; }
     }
 }

--- a/test/EFCore.Benchmarks/BenchmarkRunSummary.cs
+++ b/test/EFCore.Benchmarks/BenchmarkRunSummary.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         public string TestMethod { get; set; }
         public string Variation { get; set; }
         public string MachineName { get; set; }
-        public string ProductReportingVersion { get; set; }
+        public string ProductVersion { get; set; }
         public string Framework { get; set; }
         public string Architecture { get; set; }
         public string CustomData { get; set; }

--- a/test/EFCore.Benchmarks/BenchmarkTestCaseRunner.cs
+++ b/test/EFCore.Benchmarks/BenchmarkTestCaseRunner.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
                 TestClass = TestCase.TestMethod.TestClass.Class.Name.Split('.').Last(),
                 TestMethod = TestCase.TestMethodName,
                 Variation = TestCase.Variation,
-                ProductReportingVersion = BenchmarkConfig.Instance.ProductReportingVersion,
+                ProductVersion = BenchmarkConfig.Instance.ProductVersion,
                 RunStarted = DateTime.UtcNow,
                 MachineName = _machineName,
                 Framework = GetFramework(),

--- a/test/EFCore.Benchmarks/EFCore.Benchmarks.csproj
+++ b/test/EFCore.Benchmarks/EFCore.Benchmarks.csproj
@@ -3,15 +3,26 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <!-- New Framework must be added and not replaced. -->
+    <!-- Old frameworks are here for benchmark runs of older versions. -->
+    <TargetFrameworks>net461;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Benchmarks</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp1.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/test/EFCore.Benchmarks/SqlServerBenchmarkResultProcessor.cs
+++ b/test/EFCore.Benchmarks/SqlServerBenchmarkResultProcessor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
             ,[TestMethod]
             ,[Variation]
             ,[MachineName]
-            ,[ProductReportingVersion]
+            ,[ProductVersion]
             ,[Framework]
             ,[Architecture]
             ,[CustomData]
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
            ,@TestMethod
            ,@Variation
            ,@MachineName
-           ,@ProductReportingVersion
+           ,@ProductVersion
            ,@Framework
            ,@Architecture
            ,@CustomData
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
 		[TestMethod] [nvarchar](max) NULL,
 		[Variation] [nvarchar](max) NULL,
 		[MachineName] [nvarchar](max) NULL,
-		[ProductReportingVersion] [nvarchar](max) NULL,
+		[ProductVersion] [nvarchar](max) NULL,
 		[Framework] [nvarchar](max) NULL,
 		[Architecture] [nvarchar](max) NULL,
 		[CustomData] [nvarchar](max) NULL,
@@ -119,7 +119,7 @@ ELSE IF NOT EXISTS (SELECT * FROM syscolumns WHERE name = 'Architecture')
             cmd.Parameters.AddWithValue("@TestMethod", summary.TestMethod);
             cmd.Parameters.AddWithValue("@Variation", summary.Variation);
             cmd.Parameters.AddWithValue("@MachineName", summary.MachineName);
-            cmd.Parameters.AddWithValue("@ProductReportingVersion", summary.ProductReportingVersion);
+            cmd.Parameters.AddWithValue("@ProductVersion", summary.ProductVersion);
             cmd.Parameters.AddWithValue("@Framework", summary.Framework);
             cmd.Parameters.AddWithValue("@Architecture", summary.Architecture);
             cmd.Parameters.Add("@CustomData", SqlDbType.NVarChar).Value = (object)summary.CustomData ?? DBNull.Value;

--- a/test/EFCore.Benchmarks/v2/BenchmarkJobAttribute.cs
+++ b/test/EFCore.Benchmarks/v2/BenchmarkJobAttribute.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.v2
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class BenchmarkJobAttribute : Attribute, IConfigSource
+    {
+        public BenchmarkJobAttribute()
+        {
+            var job = new Job("BenchmarkJob");
+            job.Env.Gc.Force = true;
+
+            if (!BenchmarkConfig.Instance.RunIterations)
+            {
+                job.Run.RunStrategy = RunStrategy.ColdStart;
+                job.Run.TargetCount = 1;
+            }
+
+            Config = ManualConfig.CreateEmpty().With(job);
+        }
+
+        public IConfig Config { get; }
+    }
+}

--- a/test/EFCore.Benchmarks/v2/BenchmarkResult.cs
+++ b/test/EFCore.Benchmarks/v2/BenchmarkResult.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.v2
+{
+    public class BenchmarkResult
+    {
+        // Machine info
+        public string MachineName { get; set; }
+        public string Framework { get; set; }
+        public string Architecture { get; set; }
+
+        // Test info
+        public string TestClassFullName { get; set; }
+        public string TestClass { get; set; }
+        public string TestMethodName { get; set; }
+        public string Variation { get; set; }
+
+        public string EfVersion { get; set; }
+        public string CustomData { get; set; }
+
+        // Run data
+        public DateTime ReportingTime { get; set; }
+        public int WarmupIterations { get; set; }
+        public int MainIterations { get; set; }
+
+        // Result info
+        // Computation time
+        public double TimeElapsedMean { get; set; }
+        public double TimeElapsedPercentile90 { get; set; }
+        public double TimeElapsedPercentile95 { get; set; }
+        public double TimeElapsedStandardError { get; set; }
+        public double TimeElapsedStandardDeviation { get; set; }
+
+        // Allocated Memory
+        public double MemoryAllocated { get; set; }
+    }
+}

--- a/test/EFCore.Benchmarks/v2/BenchmarkSummaryProcessor.cs
+++ b/test/EFCore.Benchmarks/v2/BenchmarkSummaryProcessor.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Reports;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.v2
+{
+    public class BenchmarkSummaryProcessor
+    {
+        private static readonly string _machineName = GetMachineName();
+        private static readonly string _framework = GetFramework();
+        private static readonly SqlServerBenchmarkResultProcessorv2 _resultProcessor = new SqlServerBenchmarkResultProcessorv2();
+        private static readonly BenchmarkConfig _benchmarkConfig = BenchmarkConfig.Instance;
+
+        private static string GetMachineName()
+        {
+            var config = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
+            return config["computerName"];
+        }
+
+        private static string GetFramework()
+        {
+#if NET461
+            return ".NET Framework";
+#elif NETCOREAPP1_1
+            return ".NET Core 1.1";
+#elif NETCOREAPP2_0
+            return ".NET Core 2.0";
+#else
+#error target frameworks need to be updated.
+#endif
+        }
+
+        public void Process(Summary summary)
+        {
+            if (_benchmarkConfig.RunIterations)
+            {
+                foreach (var benchmarkReport in summary.Reports)
+                {
+                    var benchmarkResult = new BenchmarkResult
+                    {
+                        MachineName = _machineName,
+                        Framework = _framework,
+                        Architecture = summary.HostEnvironmentInfo.Architecture,
+                        EfVersion = _benchmarkConfig.ProductVersion,
+                        CustomData = _benchmarkConfig.CustomData,
+                        ReportingTime = DateTime.UtcNow,
+                        Variation = string.Join(
+                            ", ",
+                            benchmarkReport.Benchmark.Parameters.Items
+                                .OrderBy(pi => pi.Name)
+                                .Select(pi => $"{pi.Name}={pi.Value}")),
+                        // ReSharper disable once PossibleNullReferenceException
+                        TimeElapsedMean = benchmarkReport.ResultStatistics.Mean / 1E6,
+                        TimeElapsedPercentile90 = benchmarkReport.ResultStatistics.Percentiles.P90 / 1E6,
+                        TimeElapsedPercentile95 = benchmarkReport.ResultStatistics.Percentiles.P95 / 1E6,
+                        TimeElapsedStandardDeviation = benchmarkReport.ResultStatistics.StandardDeviation / 1E6,
+                        TimeElapsedStandardError = benchmarkReport.ResultStatistics.StandardError / 1E6,
+                        MemoryAllocated = benchmarkReport.GcStats.BytesAllocatedPerOperation * 1.0 / 1024,
+                        // ReSharper disable once PossibleNullReferenceException
+                        TestClassFullName = benchmarkReport.Benchmark.Target.Method.DeclaringType.FullName,
+                        TestClass = benchmarkReport.Benchmark.Target.Method.DeclaringType.Name,
+                        TestMethodName = benchmarkReport.Benchmark.Target.Method.Name,
+                        WarmupIterations = benchmarkReport.AllMeasurements.Count(m => m.IterationMode == IterationMode.MainWarmup),
+                        MainIterations = benchmarkReport.AllMeasurements.Count(m => m.IterationMode == IterationMode.MainTarget)
+                    };
+
+                    foreach (var database in _benchmarkConfig.ResultDatabases)
+                    {
+                        _resultProcessor.SaveSummary(database, benchmarkResult);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/EFCore.Benchmarks/v2/SqlServerBenchmarkResultProcessorv2.cs
+++ b/test/EFCore.Benchmarks/v2/SqlServerBenchmarkResultProcessorv2.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.SqlClient;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.v2
+{
+    public class SqlServerBenchmarkResultProcessorv2
+    {
+        private static readonly string _insertCommand =
+            @"INSERT INTO [dbo].[BenchmarkDotNetRuns]
+           ([MachineName]
+            ,[Framework]
+            ,[Architecture]
+            ,[TestClassFullName]
+            ,[TestClass]
+            ,[TestMethodName]
+            ,[Variation]
+            ,[EfVersion]
+            ,[CustomData]
+            ,[ReportingTime]
+            ,[WarmupIterations]
+            ,[MainIterations]
+            ,[TimeElapsedMean]
+            ,[TimeElapsedPercentile90]
+            ,[TimeElapsedPercentile95]
+            ,[TimeElapsedStandardError]
+            ,[TimeElapsedStandardDeviation]
+            ,[MemoryAllocated])
+     VALUES
+           (@MachineName
+           ,@Framework
+           ,@Architecture
+           ,@TestClassFullName
+           ,@TestClass
+           ,@TestMethodName
+           ,@Variation
+           ,@EfVersion
+           ,@CustomData
+           ,@ReportingTime
+           ,@WarmupIterations
+           ,@MainIterations
+           ,@TimeElapsedMean
+           ,@TimeElapsedPercentile90
+           ,@TimeElapsedPercentile95
+           ,@TimeElapsedStandardError
+           ,@TimeElapsedStandardDeviation
+           ,@MemoryAllocated)";
+
+        private static readonly string _tableCreationCommand =
+            @"IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='benchmarkdotnetruns' and xtype='U')
+	CREATE TABLE [dbo].[BenchmarkDotNetRuns](
+		[Id] [int] IDENTITY(1,1) NOT NULL PRIMARY KEY,
+		[MachineName] [nvarchar](max) NULL,
+		[Framework] [nvarchar](max) NULL,
+		[Architecture] [nvarchar](max) NULL,
+		[TestClassFullName] [nvarchar](max) NULL,
+		[TestClass] [nvarchar](max) NULL,
+		[TestMethodName] [nvarchar](max) NULL,
+		[Variation] [nvarchar](max) NULL,
+		[EfVersion] [nvarchar](max) NULL,
+		[CustomData] [nvarchar](max) NULL,
+		[ReportingTime] [datetime2](7) NOT NULL,
+		[WarmupIterations] [int] NOT NULL,
+		[MainIterations] [int] NOT NULL,
+		[TimeElapsedMean] [float] NOT NULL,
+		[TimeElapsedPercentile90] [float] NOT NULL,
+		[TimeElapsedPercentile95] [float] NOT NULL,
+		[TimeElapsedStandardError] [float] NOT NULL,
+		[TimeElapsedStandardDeviation] [float] NOT NULL,
+		[MemoryAllocated] [float] NOT NULL)
+ELSE IF NOT EXISTS (SELECT * FROM syscolumns WHERE name = 'Architecture')
+	ALTER TABLE [dbo].[BenchmarkDotNetRuns] ADD [Architecture] nvarchar(max) NULL";
+
+        public void SaveSummary(string connectionString, BenchmarkResult result)
+        {
+            using (var conn = new SqlConnection(connectionString))
+            {
+                conn.Open();
+                EnsureRunsTableCreated(conn);
+                WriteResultRecord(result, conn);
+            }
+        }
+
+        private void EnsureRunsTableCreated(SqlConnection conn)
+        {
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = _tableCreationCommand;
+            cmd.ExecuteNonQuery();
+        }
+
+        private static void WriteResultRecord(BenchmarkResult summary, SqlConnection conn)
+        {
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = _insertCommand;
+
+            cmd.Parameters.AddWithValue("@MachineName", summary.MachineName);
+            cmd.Parameters.AddWithValue("@Framework", summary.Framework);
+            cmd.Parameters.AddWithValue("@Architecture", summary.Architecture);
+
+            cmd.Parameters.AddWithValue("@TestClassFullName", summary.TestClassFullName);
+            cmd.Parameters.AddWithValue("@TestClass", summary.TestClass);
+            cmd.Parameters.AddWithValue("@TestMethodName", summary.TestMethodName);
+            cmd.Parameters.AddWithValue("@Variation", summary.Variation);
+
+            cmd.Parameters.AddWithValue("@EfVersion", summary.EfVersion);
+            cmd.Parameters.Add("@CustomData", SqlDbType.NVarChar).Value = (object)summary.CustomData ?? DBNull.Value;
+
+            cmd.Parameters.AddWithValue("@ReportingTime", summary.ReportingTime);
+            cmd.Parameters.AddWithValue("@WarmupIterations", summary.WarmupIterations);
+            cmd.Parameters.AddWithValue("@MainIterations", summary.MainIterations);
+
+            cmd.Parameters.AddWithValue("@TimeElapsedMean", summary.TimeElapsedMean);
+            cmd.Parameters.AddWithValue("@TimeElapsedPercentile90", summary.TimeElapsedPercentile90);
+            cmd.Parameters.AddWithValue("@TimeElapsedPercentile95", summary.TimeElapsedPercentile95);
+            cmd.Parameters.AddWithValue("@TimeElapsedStandardError", summary.TimeElapsedStandardError);
+            cmd.Parameters.AddWithValue("@TimeElapsedStandardDeviation", summary.TimeElapsedStandardDeviation);
+            cmd.Parameters.AddWithValue("@MemoryAllocated", summary.MemoryAllocated);
+
+            cmd.ExecuteNonQuery();
+        }
+    }
+}


### PR DESCRIPTION
**This is prototype for initial feedback**

This converts `SimpleQueryTests` in EF6 to use new framework.
Benchmarks are run as console app. So nomore xunit tests.
For older version we don't need to run in each commit since they shouldn't change. They will be moved out to different solution. It will be still possible to run them manually as console app.
The current version associated benchmark will be made sure to run with build.cmd

Benchmarks are run in following way.
- Invoke `GlobalSetup`
- Invoke Benchmark method multiple times and compute results.
- Invoke `GlobalCleanup`

Framework collects data for the Benchmark method so it is isolated as much as possible by moving work of setting up etc in Global* methods.

We make sanity check on results in `GlobalCleanup` it is just to make sure we ran against correct database so our results are not totally false.

Needs feedback on
- Is the coding style looks good and flexible enough for us to convert to it?
- Anymore data to store from run?
- Anymore patterns to minimize the benchmark method to actual thing being benchmarked?

This will not be merged till all benchmark changes are made to avoid breaking current benchmark runs.
