### PR TITLE
Revert setting default log level

### DIFF
--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -286,7 +285,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             serviceCollection
                 .AddMemoryCache()
-                .AddLogging(b => b.SetMinimumLevel(LogLevel.Debug));
+                .AddLogging();
 
             serviceCollection.TryAdd(new ServiceDescriptor(
                 typeof(DbContextOptions<TContext>), 


### PR DESCRIPTION
Because we now redirect ILoggerFactory in a slightly different way it means that this is not needed when not using an ASP.NET application. When using an ASP.NET application you will get whatever filtering, etc, was setup for ASP.NET. This is different from 1.1 and may be confusing, but doesn't seem unreasonable.

Issue #9192
