### PR TITLE
Remove reference to NETStandard.Library.NETFramework

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -20,8 +20,4 @@
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
-  <!-- TODO: Remove when TestDriven supports VS15.3+ -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETFrameworkPackageVersion)" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,6 @@
     <InternalAspNetCoreSdkVersion>2.0.1-*</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MoqVersion>4.7.49</MoqVersion>
-    <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
     <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
     <RelinqVersion>2.1.1</RelinqVersion>
     <RoslynVersion>2.3.0</RoslynVersion>


### PR DESCRIPTION
I don't think there's any customer impact to *not* take this in 2.0, since the reference is now added implicitly by the SDK when necessary.  Further, the reference was added with `PrivateAssets="All"` which means it shouldn't create a package reference in the nuspec.

However, if we want all our repos to be consistent for the 2.0 release, it should be removed.

@smitpatel or @bricelam: Can you verify whether this is still needed for TestDriven.NET?  I don't think it should be, since the SDK is now implicitly doing what we were doing explicitly before.