### PR TITLE
[2.0.0] Fix to #9202 - Query: Exception when using Include on collection navigation for models also containing owned types

### DIFF
--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -112,6 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var querySourceMapping = new QuerySourceMapping();
                 var clonedParentQueryModel = _parentQueryModel.Clone(querySourceMapping);
+                _queryCompilationContext.UpdateMapping(querySourceMapping);
 
                 _queryCompilationContext.CloneAnnotations(querySourceMapping, clonedParentQueryModel);
 


### PR DESCRIPTION
Problem was that when processing include collection we clone the query model, which changes references of the individual query sources inside. In case of owned types we rely on the references to determine which entity type corresponds with a given query source (using a dictionary).
However, after cloning we were not populating the dictionary with the additional entries, so the owned types corresponding to those clones query sources could not be found.

Fix is to populate the QuerySourceEntityTypeMapping with entries for the cloned query sources - like we do in other places.