### PR TITLE
[SMALL] Fix to #9223 - Query: ArgumentNullException when using ternary operator with null comparison in the test expression

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -277,9 +277,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 if (ifTrue.IsComparisonOperation()
                     || ifFalse.IsComparisonOperation())
                 {
-                    return Expression.OrElse(
-                        Expression.AndAlso(test, ifTrue),
-                        Expression.AndAlso(Invert(test), ifFalse));
+                    var invertedTest = Invert(test);
+                    if (invertedTest != null)
+                    {
+                        return Expression.OrElse(
+                            Expression.AndAlso(test, ifTrue),
+                            Expression.AndAlso(invertedTest, ifFalse));
+                    }
                 }
 
                 return expression.Update(test, ifTrue, ifFalse);
@@ -290,7 +294,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
         private static Expression Invert(Expression test)
         {
-            if (test.IsComparisonOperation())
+            if (test.IsComparisonOperation()
+                || test is IsNullExpression)
             {
                 if (test is BinaryExpression binaryOperation)
                 {

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -595,5 +595,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(o => new { LongOrder = (long)o.OrderID, ShortOrder = (short)o.OrderID, Order = o.OrderID }),
                 assertOrder: true);
         }
+
+        [ConditionalFact]
+        public virtual void Select_conditional_with_null_comparison_in_test()
+        {
+            AssertQueryScalar<Order>(
+                os => from o in os
+                      where o.CustomerID == "ALFKI"
+                      select o.CustomerID == null ? true : o.OrderID < 100);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -545,5 +545,18 @@ FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI'
 ORDER BY [Order]");
         }
+
+        public override void Select_conditional_with_null_comparison_in_test()
+        {
+            base.Select_conditional_with_null_comparison_in_test();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [o].[CustomerID] IS NULL OR ([o].[CustomerID] IS NOT NULL AND ([o].[OrderID] < 100))
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'ALFKI'");
+        }
     }
 }


### PR DESCRIPTION
Problem was that try to optimize conditionals with logical iftrue/iffalse but the logic around but the logic was not robust enough. We can return null from Invert(...) method which throws the exception seen here, and then that null result is used to construct the Expression, which throws the error.

Fix is to also apply Invert for null comparison (which is a separate node, and not only comparison expressions), as well as only try to apply the optimization if the Invert returns a valid result (i.e. not null)