### PR TITLE
Benchmarks: Limit no. of runs for slow running benchmarks on EF6

### DIFF
--- a/benchmarks/EFCore.Benchmarks.EF6/InitializationTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/InitializationTests.cs
@@ -15,6 +15,8 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks.TestHelpers
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class InitializationTests
     {
         private ColdStartSandbox _sandbox;

--- a/benchmarks/EFCore.Benchmarks.EF6/Program.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Program.cs
@@ -18,10 +18,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<InitializationTests>());
 
             // ChangeTracker
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariations>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariations>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariation>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariation>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariationsWithAutoDetectChangesOn>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariationsWithAutoDetectChangesOff>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariationsWithAutoDetectChangesOn>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariationsWithAutoDetectChangesOff>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariationsWithAutoDetectChangesOn>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariationsWithAutoDetectChangesOff>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariationsWithAutoDetectChangesOn>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariationsWithAutoDetectChangesOff>());
 
             // Query
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FuncletizationTests>());

--- a/benchmarks/EFCore.Benchmarks.EF6/Properties/AssemblyInfo.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Properties/AssemblyInfo.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using BenchmarkDotNet.Attributes;
-using Microsoft.EntityFrameworkCore.Benchmarks;
-
-[assembly: BenchmarkJob]
-[assembly: MemoryDiagnoser]

--- a/benchmarks/EFCore.Benchmarks.EF6/Query/FuncletizationTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Query/FuncletizationTests.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class FuncletizationTests
     {
         private static readonly FuncletizationFixture _fixture = new FuncletizationFixture();

--- a/benchmarks/EFCore.Benchmarks.EF6/Query/NavigationsQueryTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Query/NavigationsQueryTests.cs
@@ -9,8 +9,12 @@ using Microsoft.EntityFrameworkCore.Benchmarks.EF6.Models.AdventureWorks;
 using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 using Xunit;
 
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed
+
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class NavigationsQueryTests
     {
         private AdventureWorksContext _context;

--- a/benchmarks/EFCore.Benchmarks.EF6/Query/QueryCompilationTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Query/QueryCompilationTests.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class QueryCompilationTests
     {
         private static readonly QueryCompilationFixture _fixture = new QueryCompilationFixture();

--- a/benchmarks/EFCore.Benchmarks.EF6/Query/RawSqlQueryTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Query/RawSqlQueryTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class RawSqlQueryTests
     {
         private static readonly RawSqlQueryFixture _fixture = new RawSqlQueryFixture();

--- a/benchmarks/EFCore.Benchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/Query/SimpleQueryTests.cs
@@ -12,6 +12,8 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.Query
 {
+    [BenchmarkJob]
+    [MemoryDiagnoser]
     public class SimpleQueryTests
     {
         private static readonly SimpleQueryFixture _fixture = new SimpleQueryFixture();

--- a/benchmarks/EFCore.Benchmarks.EF6/SingleRunBenchmarkJobAttribute.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/SingleRunBenchmarkJobAttribute.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6
+{
+    public class SingleRunBenchmarkJobAttribute : Attribute, IConfigSource
+    {
+        public SingleRunBenchmarkJobAttribute()
+        {
+            var job = new Job("BenchmarkJob");
+            job.Env.Gc.Force = true;
+            job.Run.UnrollFactor = 1;
+            job.Run.InvocationCount = 1;
+            job.Run.WarmupCount = 1;
+            job.Run.TargetCount = 1;
+            job.Run.RunStrategy = RunStrategy.Monitoring;
+
+            if (!BenchmarkConfig.Instance.RunIterations)
+            {
+                job.Run.RunStrategy = RunStrategy.ColdStart;
+                job.Run.TargetCount = 1;
+            }
+
+            Config = ManualConfig.CreateEmpty().With(job);
+        }
+
+        public IConfig Config { get; }
+    }
+}

--- a/benchmarks/EFCore.Benchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
         {
             protected static readonly SimpleUpdatePipelineFixture Fixture = new SimpleUpdatePipelineFixture();
             protected OrdersContext Context;
-            protected DbContextTransaction Transaction;
+            private DbContextTransaction _transaction;
             private int _recordsAffected = -1;
 
             [Params(true, false)]
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
             public virtual void InitializeContext()
             {
                 Context = Fixture.CreateContext();
-                Transaction = Context.Database.BeginTransaction();
+                _transaction = Context.Database.BeginTransaction();
             }
 
             [IterationCleanup]
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
                     Assert.Equal(1000, _recordsAffected);
                 }
 
-                Transaction.Dispose();
+                _transaction.Dispose();
                 Context.Dispose();
             }
 
@@ -50,6 +50,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
             }
         }
 
+        [BenchmarkJob]
+        [MemoryDiagnoser]
         public class Insert : Base
         {
             [IterationSetup]
@@ -62,6 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
             }
         }
 
+        [BenchmarkJob]
+        [MemoryDiagnoser]
         public class Update : Base
         {
             [IterationSetup]
@@ -76,6 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
             }
         }
 
+        [BenchmarkJob]
+        [MemoryDiagnoser]
         public class Delete : Base
         {
             [IterationSetup]
@@ -87,6 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.UpdatePipeline
             }
         }
 
+        [BenchmarkJob]
+        [MemoryDiagnoser]
         public class Mixed : Base
         {
             [IterationSetup]

--- a/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/DbSetOperationTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/DbSetOperationTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
     {
         public abstract class Base
         {
-            protected readonly DbSetOperationFixture Fixture = new DbSetOperationFixture();
+            private readonly DbSetOperationFixture _fixture = new DbSetOperationFixture();
             protected List<Customer> CustomersWithoutPk;
             protected List<Customer> CustomersWithPk;
             protected OrdersContext Context;
@@ -23,14 +23,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             [GlobalSetup]
             public virtual void CreateCustomers()
             {
-                CustomersWithoutPk = Fixture.CreateCustomers(20000, setPrimaryKeys: false);
-                CustomersWithPk = Fixture.CreateCustomers(20000, setPrimaryKeys: true);
+                CustomersWithoutPk = _fixture.CreateCustomers(20000, setPrimaryKeys: false);
+                CustomersWithPk = _fixture.CreateCustomers(20000, setPrimaryKeys: true);
             }
 
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 

--- a/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/FixupTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/FixupTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
     {
         public abstract class Base
         {
-            protected static readonly FixupFixture Fixture = new FixupFixture();
+            private static readonly FixupFixture _fixture = new FixupFixture();
             protected List<Customer> Customers;
             protected List<Order> OrdersWithoutPk;
             protected List<Order> OrdersWithPk;
@@ -28,11 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             [GlobalSetup]
             public virtual void CreateData()
             {
-                Customers = Fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
 
-                using (var context = Fixture.CreateContext())
+                using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
                     Assert.Equal(10000, context.Orders.Count());
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             }
         }
 
-        public class ChildVariation : Base
+        public class ChildVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             }
         }
 
-        public class ParentVariation : Base
+        public class ParentVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()

--- a/benchmarks/EFCore.Benchmarks.EFCore1/Program.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/Program.cs
@@ -23,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1
             // ChangeTracker
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariations>());
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariations>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariation>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariation>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariations>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariations>());
 
             // Query
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FuncletizationTests>());

--- a/benchmarks/EFCore.Benchmarks.EFCore1/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.UpdatePipeline
         {
             protected static readonly SimpleUpdatePipelineFixture Fixture = new SimpleUpdatePipelineFixture();
             protected OrdersContext Context;
-            protected IDbContextTransaction Transaction;
+            private IDbContextTransaction _transaction;
             private int _recordsAffected = -1;
 
             [Params(true, false)]
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.UpdatePipeline
             public virtual void InitializeContext()
             {
                 Context = Fixture.CreateContext(Batching);
-                Transaction = Context.Database.BeginTransaction();
+                _transaction = Context.Database.BeginTransaction();
             }
 
             [IterationCleanup]
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.UpdatePipeline
                     Assert.Equal(1000, _recordsAffected);
                 }
 
-                Transaction.Dispose();
+                _transaction.Dispose();
                 Context.Dispose();
             }
 

--- a/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/DbSetOperationTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/DbSetOperationTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
     {
         public abstract class Base
         {
-            protected readonly DbSetOperationFixture Fixture = new DbSetOperationFixture();
+            private readonly DbSetOperationFixture _fixture = new DbSetOperationFixture();
             protected List<Customer> CustomersWithoutPk;
             protected List<Customer> CustomersWithPk;
             protected OrdersContext Context;
@@ -23,14 +23,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             [GlobalSetup]
             public virtual void CreateCustomers()
             {
-                CustomersWithoutPk = Fixture.CreateCustomers(20000, setPrimaryKeys: false);
-                CustomersWithPk = Fixture.CreateCustomers(20000, setPrimaryKeys: true);
+                CustomersWithoutPk = _fixture.CreateCustomers(20000, setPrimaryKeys: false);
+                CustomersWithPk = _fixture.CreateCustomers(20000, setPrimaryKeys: true);
             }
 
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 

--- a/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/FixupTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/FixupTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
     {
         public abstract class Base
         {
-            protected static readonly FixupFixture Fixture = new FixupFixture();
+            private static readonly FixupFixture _fixture = new FixupFixture();
             protected List<Customer> Customers;
             protected List<Order> OrdersWithoutPk;
             protected List<Order> OrdersWithPk;
@@ -28,11 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             [GlobalSetup]
             public virtual void CreateData()
             {
-                Customers = Fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
 
-                using (var context = Fixture.CreateContext())
+                using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
                     Assert.Equal(10000, context.Orders.Count());
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             }
         }
 
-        public class ChildVariation : Base
+        public class ChildVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             }
         }
 
-        public class ParentVariation : Base
+        public class ParentVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()

--- a/benchmarks/EFCore.Benchmarks.EFCore2/Program.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore2/Program.cs
@@ -23,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2
             // ChangeTracker
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariations>());
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariations>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariation>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariation>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariations>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariations>());
 
             // Query
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FuncletizationTests>());

--- a/benchmarks/EFCore.Benchmarks.EFCore2/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore2/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.UpdatePipeline
         {
             protected static readonly SimpleUpdatePipelineFixture Fixture = new SimpleUpdatePipelineFixture();
             protected OrdersContext Context;
-            protected IDbContextTransaction Transaction;
+            private IDbContextTransaction _transaction;
             private int _recordsAffected = -1;
 
             [Params(true, false)]
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.UpdatePipeline
             public virtual void InitializeContext()
             {
                 Context = Fixture.CreateContext(Batching);
-                Transaction = Context.Database.BeginTransaction();
+                _transaction = Context.Database.BeginTransaction();
             }
 
             [IterationCleanup]
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.UpdatePipeline
                     Assert.Equal(1000, _recordsAffected);
                 }
 
-                Transaction.Dispose();
+                _transaction.Dispose();
                 Context.Dispose();
             }
 

--- a/benchmarks/EFCore.Benchmarks/ColdStartSandbox.cs
+++ b/benchmarks/EFCore.Benchmarks/ColdStartSandbox.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
         public T CreateInstance<T>(params object[] args)
             => (T)CreateInstance(typeof(T), args);
 
-        public object CreateInstance(Type type, params object[] args)
+        private object CreateInstance(Type type, params object[] args)
         {
             HandleDisposed();
 

--- a/test/EFCore.Benchmarks.EFCore/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/ChangeTracker/DbSetOperationTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
     {
         public abstract class Base
         {
-            protected readonly DbSetOperationFixture Fixture = new DbSetOperationFixture();
+            private readonly DbSetOperationFixture _fixture = new DbSetOperationFixture();
             protected List<Customer> CustomersWithoutPk;
             protected List<Customer> CustomersWithPk;
             protected OrdersContext Context;
@@ -23,14 +23,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             [GlobalSetup]
             public virtual void CreateCustomers()
             {
-                CustomersWithoutPk = Fixture.CreateCustomers(20000, setPrimaryKeys: false);
-                CustomersWithPk = Fixture.CreateCustomers(20000, setPrimaryKeys: true);
+                CustomersWithoutPk = _fixture.CreateCustomers(20000, setPrimaryKeys: false);
+                CustomersWithPk = _fixture.CreateCustomers(20000, setPrimaryKeys: true);
             }
 
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 

--- a/test/EFCore.Benchmarks.EFCore/ChangeTracker/FixupTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/ChangeTracker/FixupTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
     {
         public abstract class Base
         {
-            protected static readonly FixupFixture Fixture = new FixupFixture();
+            private static readonly FixupFixture _fixture = new FixupFixture();
             protected List<Customer> Customers;
             protected List<Order> OrdersWithoutPk;
             protected List<Order> OrdersWithPk;
@@ -28,11 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             [GlobalSetup]
             public virtual void CreateData()
             {
-                Customers = Fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = Fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
 
-                using (var context = Fixture.CreateContext())
+                using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
                     Assert.Equal(10000, context.Orders.Count());
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             [IterationSetup]
             public virtual void InitializeContext()
             {
-                Context = Fixture.CreateContext();
+                Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
             }
 
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             }
         }
 
-        public class ChildVariation : Base
+        public class ChildVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             }
         }
 
-        public class ParentVariation : Base
+        public class ParentVariations : Base
         {
             [IterationSetup]
             public override void InitializeContext()

--- a/test/EFCore.Benchmarks.EFCore/Program.cs
+++ b/test/EFCore.Benchmarks.EFCore/Program.cs
@@ -23,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore
             // ChangeTracker
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.AddDataVariations>());
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<DbSetOperationTests.ExistingDataVariations>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariation>());
-            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariation>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ChildVariations>());
+            benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FixupTests.ParentVariations>());
 
             // Query
             benchmarkSummaryProcessor.Process(BenchmarkRunner.Run<FuncletizationTests>());

--- a/test/EFCore.Benchmarks.EFCore/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.UpdatePipeline
         {
             protected static readonly SimpleUpdatePipelineFixture Fixture = new SimpleUpdatePipelineFixture();
             protected OrdersContext Context;
-            protected IDbContextTransaction Transaction;
+            private IDbContextTransaction _transaction;
             private int _recordsAffected = -1;
 
             [Params(true, false)]
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.UpdatePipeline
             public virtual void InitializeContext()
             {
                 Context = Fixture.CreateContext(Batching);
-                Transaction = Context.Database.BeginTransaction();
+                _transaction = Context.Database.BeginTransaction();
             }
 
             [IterationCleanup]
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.UpdatePipeline
                     Assert.Equal(1000, _recordsAffected);
                 }
 
-                Transaction.Dispose();
+                _transaction.Dispose();
                 Context.Dispose();
             }
 


### PR DESCRIPTION
AutoDetectChanges=true is super slow on EF6. Running those 8 mins tests for multiple iterations causes timeouts.

Resolves #9304 