### PR TITLE
Benchmarks: Update FixUpTests to create new data every iteration

### DIFF
--- a/benchmarks/EFCore.Benchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -26,12 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.ChangeTracker
             protected abstract bool AutoDetectChanges { get; }
 
             [GlobalSetup]
-            public virtual void CreateData()
+            public virtual void CheckData()
             {
-                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
-
                 using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
@@ -44,6 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EF6.ChangeTracker
             {
                 Context = _fixture.CreateContext();
                 Context.Configuration.AutoDetectChangesEnabled = AutoDetectChanges;
+
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
             }
 
             [IterationCleanup]

--- a/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/FixupTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/ChangeTracker/FixupTests.cs
@@ -26,12 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             public bool AutoDetectChanges { get; set; }
 
             [GlobalSetup]
-            public virtual void CreateData()
+            public virtual void CheckData()
             {
-                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
-
                 using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
@@ -44,6 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore1.ChangeTracker
             {
                 Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
+
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
             }
 
             [IterationCleanup]

--- a/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/FixupTests.cs
+++ b/benchmarks/EFCore.Benchmarks.EFCore2/ChangeTracker/FixupTests.cs
@@ -26,12 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             public bool AutoDetectChanges { get; set; }
 
             [GlobalSetup]
-            public virtual void CreateData()
+            public virtual void CheckData()
             {
-                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
-
                 using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
@@ -44,6 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore2.ChangeTracker
             {
                 Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
+
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
             }
 
             [IterationCleanup]

--- a/benchmarks/EFCore.Benchmarks/BenchmarkSummaryProcessor.cs
+++ b/benchmarks/EFCore.Benchmarks/BenchmarkSummaryProcessor.cs
@@ -57,16 +57,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
                                 benchmarkReport.Benchmark.Parameters.Items
                                     .OrderBy(pi => pi.Name)
                                     .Select(pi => $"{pi.Name}={pi.Value}")),
-                            // ReSharper disable once PossibleNullReferenceException
                             TimeElapsedMean = benchmarkReport.ResultStatistics.Mean / 1E6,
                             TimeElapsedPercentile90 = benchmarkReport.ResultStatistics.Percentiles.P90 / 1E6,
                             TimeElapsedPercentile95 = benchmarkReport.ResultStatistics.Percentiles.P95 / 1E6,
                             TimeElapsedStandardDeviation = benchmarkReport.ResultStatistics.StandardDeviation / 1E6,
                             TimeElapsedStandardError = benchmarkReport.ResultStatistics.StandardError / 1E6,
                             MemoryAllocated = benchmarkReport.GcStats.BytesAllocatedPerOperation * 1.0 / 1024,
-                            // ReSharper disable once PossibleNullReferenceException
-                            TestClassFullName = benchmarkReport.Benchmark.Target.Method.DeclaringType.FullName,
-                            TestClass = benchmarkReport.Benchmark.Target.Method.DeclaringType.Name,
+                            TestClassFullName = benchmarkReport.Benchmark.Target.Type.FullName,
+                            TestClass = benchmarkReport.Benchmark.Target.Type.Name,
                             TestMethodName = benchmarkReport.Benchmark.Target.Method.Name,
                             WarmupIterations = benchmarkReport.AllMeasurements.Count(m => m.IterationMode == IterationMode.MainWarmup),
                             MainIterations = benchmarkReport.AllMeasurements.Count(m => m.IterationMode == IterationMode.MainTarget)
@@ -80,14 +78,14 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
                     else
                     {
                         // ReSharper disable once PossibleNullReferenceException
-                        var testName = $"{benchmarkReport.Benchmark.Target.Method.DeclaringType.FullName}.{benchmarkReport.Benchmark.Target.Method.Name}";
+                        var testName = $"{benchmarkReport.Benchmark.Target.Type.FullName}.{benchmarkReport.Benchmark.Target.Method.Name}";
                         var variation = string.Join(
                             ", ",
                             benchmarkReport.Benchmark.Parameters.Items
                                 .OrderBy(pi => pi.Name)
                                 .Select(pi => $"{pi.Name}={pi.Value}"));
 
-                        Console.WriteLine($"##teamcity[testIgnored name='{testName}[{variation}]' message='Benchmark did not run correctly so no results are found.']");
+                        Console.WriteLine($"##teamcity[testIgnored name='{testName}|[{variation}|]' message='Benchmark did not run correctly. No results will be saved.']");
                     }
                 }
             }

--- a/test/EFCore.Benchmarks.EFCore/ChangeTracker/FixupTests.cs
+++ b/test/EFCore.Benchmarks.EFCore/ChangeTracker/FixupTests.cs
@@ -26,12 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             public bool AutoDetectChanges { get; set; }
 
             [GlobalSetup]
-            public virtual void CreateData()
+            public virtual void CheckData()
             {
-                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
-
                 using (var context = _fixture.CreateContext())
                 {
                     Assert.Equal(5000, context.Customers.Count());
@@ -44,6 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.EFCore.ChangeTracker
             {
                 Context = _fixture.CreateContext();
                 Context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
+
+                Customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
+                OrdersWithoutPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: false);
+                OrdersWithPk = _fixture.CreateOrders(Customers, ordersPerCustomer: 2, setPrimaryKeys: true);
             }
 
             [IterationCleanup]


### PR DESCRIPTION
Find the type running benchmark correctly when benchmark method is on base type
Escape output in teamcity
