### PR TITLE
Test: Update EOL pattern

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -19,6 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class FromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
     {
+        private static readonly string EOL = Environment.NewLine;
+
         protected FromSqlQueryTestBase(TFixture fixture)
         {
             Fixture = fixture;
@@ -228,12 +230,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var actual = context.Set<Customer>()
                     .FromSql(
-                        @"
-    
-
-
-SELECT
-* FROM ""Customers""")
+                        EOL +
+                        @"    " + EOL +
+                        EOL +
+                        EOL +
+                        @"SELECT" + EOL +
+                        @"* FROM ""Customers""")
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArray();
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -98,7 +98,8 @@ namespace MyNamespace
     }
 }
 ",
-                migrationCode);
+                migrationCode,
+                ignoreLineEndingDifferences: true);
 
             var migrationMetadataCode = generator.GenerateMetadata(
                 "MyNamespace",
@@ -132,7 +133,8 @@ namespace MyNamespace
     }
 }
 ",
-                migrationMetadataCode);
+                migrationMetadataCode,
+                ignoreLineEndingDifferences: true);
 
             var build = new BuildSource
             {
@@ -215,7 +217,7 @@ namespace MyNamespace
         }
     }
 }
-", modelSnapshotCode);
+", modelSnapshotCode, ignoreLineEndingDifferences: true);
 
             var snapshot = CompileModelSnapshot(modelSnapshotCode, "MyNamespace.MySnapshot");
             Assert.Equal(1, snapshot.Model.GetEntityTypes().Count());

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -2033,7 +2033,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
             generator.Generate("builder", model, builder);
             var code = builder.ToString();
 
-            Assert.Equal(expectedCode, code);
+            Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);
 
             var build = new BuildSource
             {

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -12,9 +11,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 {
     public class MigrationCommandListBuilderTest
     {
-        private const string FileLineEnding = @"
-";
-
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -36,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 Statement2
 Statement3
 ",
-                commandList[0].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[0].CommandText,
+                ignoreLineEndingDifferences: true);
         }
 
         [Theory]
@@ -63,14 +60,16 @@ Statement3
             Assert.Equal(
                 @"Statement1
 ",
-                commandList[0].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[0].CommandText,
+                ignoreLineEndingDifferences: true);
 
             Assert.Equal(suppressTransaction, commandList[1].TransactionSuppressed);
             Assert.Equal(
                 @"Statement2
 Statement3
 ",
-                commandList[1].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[1].CommandText,
+                ignoreLineEndingDifferences: true);
 
             Assert.Equal(suppressTransaction, commandList[2].TransactionSuppressed);
             Assert.Equal(
@@ -78,7 +77,8 @@ Statement3
 Statement5
 Statement6
 ",
-                commandList[2].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[2].CommandText,
+                ignoreLineEndingDifferences: true);
         }
 
         [Theory]
@@ -104,14 +104,16 @@ Statement6
             Assert.Equal(
                 @"Statement1
 ",
-                commandList[0].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[0].CommandText,
+                ignoreLineEndingDifferences: true);
 
             Assert.Equal(suppressTransaction, commandList[1].TransactionSuppressed);
             Assert.Equal(
                 @"Statement2
 Statement3
 ",
-                commandList[1].CommandText.Replace(Environment.NewLine, FileLineEnding));
+                commandList[1].CommandText,
+                ignoreLineEndingDifferences: true);
         }
 
         private MigrationCommandListBuilder CreateBuilder()

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -31,8 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
     public class RelationalCommandTest
     {
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
         [Fact]
         public void Configures_DbCommand()
@@ -933,9 +932,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             foreach (var item in log)
             {
                 Assert.EndsWith(
-                    @"[Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']
-Logged Command",
-                    item.Message.Replace(Environment.NewLine, FileLineEnding));
+                    @"[Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']" + EOL +
+                    @"Logged Command",
+                    item.Message);
             }
         }
 
@@ -989,9 +988,9 @@ Logged Command",
             foreach (var item in log.Skip(1))
             {
                 Assert.EndsWith(
-                    @"[Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']
-Logged Command",
-                    item.Message.Replace(Environment.NewLine, FileLineEnding));
+                    @"[Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']" + EOL +
+                    @"Logged Command",
+                    item.Message);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -59,7 +59,8 @@ namespace Microsoft.EntityFrameworkCore
                     @"SELECT [e].[Int]
 FROM [MappedNullableDataTypes] AS [e]
 WHERE [e].[Time] = '00:01:02'",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -83,7 +84,8 @@ WHERE [e].[Time] = '00:01:02'",
 SELECT [e].[Int]
 FROM [MappedNullableDataTypes] AS [e]
 WHERE [e].[Time] = @__timeSpan_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -371,7 +373,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='80' (Size = 1)
 @p28='0x595A5B5C' (Nullable = false) (Size = 8000)
 @p29='" + entity.VarcharMax + "' (Nullable = false) (Size = -1) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -380,7 +383,7 @@ WHERE [e].[Time] = @__timeSpan_0",
         }
 
         private string DumpParameters()
-            => Fixture.TestSqlLoggerFactory.Parameters.Single().Replace(", ", FileLineEnding);
+            => Fixture.TestSqlLoggerFactory.Parameters.Single().Replace(", ", EOL);
 
         private static void AssertMappedDataTypes(MappedDataTypes entity, int id)
         {
@@ -494,7 +497,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='80' (Nullable = true) (Size = 1)
 @p28='0x595A5B5C' (Size = 8000)
 @p29='C' (Size = 8000) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -613,7 +617,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='' (DbType = Byte)
 @p28='' (Size = 8000) (DbType = Binary)
 @p29='' (Size = 8000)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -681,7 +686,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p11='Int' (Size = 3)
 @p12='0x0B0C0D' (Size = 3)
 @p13='Tha' (Size = 3) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -752,7 +758,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p11='' (Size = 3) (DbType = String)
 @p12='' (Size = 3) (DbType = Binary)
 @p13='' (Size = 3)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -798,7 +805,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p5='85.5'
 @p6='83.3'
 @p7='103.3'",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -847,7 +855,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p1='102.2'
 @p2='101.1'
 @p3='103.3'",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -914,7 +923,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='80' (Size = 1)
 @p28='0x595A5B5C' (Size = 8000)
 @p29='C' (Size = 8000) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1033,7 +1043,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='80' (Nullable = true) (Size = 1)
 @p28='0x595A5B5C' (Size = 8000)
 @p29='C' (Size = 8000) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1152,7 +1163,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p27='' (DbType = Byte)
 @p28='' (Size = 8000) (DbType = Binary)
 @p29='' (Size = 8000)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1221,7 +1233,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p11='Int' (Size = 3)
 @p12='0x0B0C0D' (Size = 3)
 @p13='Tha' (Size = 3) (DbType = AnsiString)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1292,7 +1305,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p11='' (Size = 3) (DbType = String)
 @p12='' (Size = 3) (DbType = Binary)
 @p13='' (Size = 3)",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1338,7 +1352,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p5='83.3'
 @p6='77'
 @p7='103.3'",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1388,7 +1403,8 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p1='101.1'
 @p2='77'
 @p3='103.3'",
-                parameters);
+                parameters,
+                ignoreLineEndingDifferences: true);
 
             using (var context = CreateContext())
             {
@@ -1794,7 +1810,7 @@ WHERE [e].[Time] = @__timeSpan_0",
                 builder.AppendLine();
             }
 
-            var actual = builder.ToString().Replace(Environment.NewLine, FileLineEnding);
+            var actual = builder.ToString();
 
             const string expected = @"BinaryForeignKeyDataType.BinaryKeyDataTypeId ---> [nullable varbinary] [MaxLength = 900]
 BinaryForeignKeyDataType.Id ---> [int] [Precision = 10 Scale = 0]
@@ -2028,11 +2044,10 @@ UnicodeDataTypes.StringDefault ---> [nullable nvarchar] [MaxLength = -1]
 UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 ";
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
         }
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;    
 
         [Fact]
         public void Can_get_column_types_from_built_model()
@@ -2056,7 +2071,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             }
         }
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class BuiltInDataTypesSqlServerFixture : BuiltInDataTypesFixtureBase
         {

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -177,7 +177,8 @@ SET NOCOUNT ON;
 UPDATE [Sample] SET [Name] = @p0, [RowVersion] = @p1
 WHERE [UniqueNo] = @p2 AND [RowVersion] = @p3;
 SELECT @@ROWCOUNT;",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity()
@@ -195,7 +196,8 @@ VALUES (@p0, @p1, @p2);
 SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void MaxLengthAttribute_throws_while_inserting_value_longer_than_max_length()
@@ -224,7 +226,8 @@ VALUES (@p0, @p1, @p2);
 SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void RequiredAttribute_for_navigation_throws_while_inserting_null_value()
@@ -232,13 +235,11 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
             Assert.Contains(
-                @"@p1='1'
-",
+                @"@p1='1'" + EOL,
                 Sql);
 
             Assert.Contains(
-                @"@p1='' (Nullable = false) (DbType = Int32)
-",
+                @"@p1='' (Nullable = false) (DbType = Int32)" + EOL,
                 Sql);
         }
 
@@ -268,7 +269,8 @@ VALUES (@p0, @p1, @p2);
 SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void StringLengthAttribute_throws_while_inserting_value_longer_than_max_length()
@@ -293,7 +295,8 @@ VALUES (@p0);
 SELECT [Id], [Timestamp]
 FROM [Two]
 WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void TimestampAttribute_throws_if_value_in_database_changed()
@@ -304,10 +307,9 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();",
             // row version value is not stable.
         }
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class DataAnnotationSqlServerFixture : DataAnnotationFixtureBase
         {

--- a/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/FindSqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -78,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -91,7 +90,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -112,7 +111,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -125,7 +124,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [IntKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -146,7 +145,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [StringKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -159,7 +158,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [StringKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -181,7 +180,7 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
 FROM [CompositeKey] AS [e]
-WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
+WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -195,7 +194,7 @@ WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
 
 SELECT TOP(1) [e].[Id1], [e].[Id2], [e].[Foo]
 FROM [CompositeKey] AS [e]
-WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
+WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -216,7 +215,7 @@ WHERE ([e].[Id1] = @__get_Item_0) AND ([e].[Id2] = @__get_Item_1)", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -229,7 +228,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -250,7 +249,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -263,7 +262,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -276,7 +275,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -289,7 +288,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -310,7 +309,7 @@ WHERE ([e].[Discriminator] = N'DerivedType') AND ([e].[Id] = @__get_Item_0)", Sq
 
 SELECT TOP(1) [e].[Id], [e].[Discriminator], [e].[Foo], [e].[Boo]
 FROM [BaseType] AS [e]
-WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql);
+WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__get_Item_0)", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -331,7 +330,7 @@ WHERE [e].[Discriminator] IN (N'DerivedType', N'BaseType') AND ([e].[Id] = @__ge
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [ShadowKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -344,13 +343,10 @@ WHERE [e].[Id] = @__get_Item_0", Sql);
 
 SELECT TOP(1) [e].[Id], [e].[Foo]
 FROM [ShadowKey] AS [e]
-WHERE [e].[Id] = @__get_Item_0", Sql);
+WHERE [e].[Id] = @__get_Item_0", Sql, ignoreLineEndingDifferences: true);
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class FindSqlServerFixture : FindFixtureBase
         {

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -31,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -47,7 +47,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -63,7 +64,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -79,7 +81,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -95,7 +98,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -111,7 +115,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id]
 FROM [SinglePkToPk] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -127,7 +132,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -143,7 +149,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -159,7 +166,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -175,7 +183,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -191,7 +200,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -207,7 +217,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id]
 FROM [SinglePkToPk] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -241,7 +252,8 @@ WHERE [e].[Id] = @__get_Item_0",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -255,7 +267,8 @@ WHERE 0 = 1",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -271,7 +284,8 @@ WHERE 0 = 1",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -287,7 +301,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -303,7 +318,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -319,7 +335,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -335,7 +352,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -351,7 +369,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -367,7 +386,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -383,7 +403,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -459,7 +480,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -475,7 +497,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -491,7 +514,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -507,7 +531,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -523,7 +548,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -539,7 +565,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id]
 FROM [SinglePkToPk] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -555,7 +582,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -571,7 +599,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -587,7 +616,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -603,7 +633,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -619,7 +650,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -635,7 +667,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -651,7 +684,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -667,7 +701,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -683,7 +718,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -699,7 +735,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -715,7 +752,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -731,7 +769,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -747,7 +786,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -763,7 +803,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -779,7 +820,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -795,7 +837,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -851,7 +894,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Child] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -867,7 +911,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -883,7 +928,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -899,7 +945,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [Single] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -915,7 +962,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildAk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -931,7 +979,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[AlternateId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -947,7 +996,8 @@ WHERE [e].[AlternateId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[AlternateId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -963,7 +1013,8 @@ WHERE [e].[AlternateId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [SingleAk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -979,7 +1030,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildAk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -995,7 +1047,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[AlternateId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1011,7 +1064,8 @@ WHERE [e].[AlternateId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[AlternateId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1027,7 +1081,8 @@ WHERE [e].[AlternateId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [SingleAk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1061,7 +1116,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1075,7 +1131,8 @@ WHERE 0 = 1",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1091,7 +1148,8 @@ WHERE 0 = 1",
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildShadowFk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1107,7 +1165,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1123,7 +1182,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1139,7 +1199,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [SingleShadowFk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1155,7 +1216,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT [e].[Id], [e].[ParentId]
 FROM [ChildShadowFk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1171,7 +1233,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1187,7 +1250,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE [e].[Id] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1203,7 +1267,8 @@ WHERE [e].[Id] = @__get_Item_0",
 SELECT TOP(2) [e].[Id], [e].[ParentId]
 FROM [SingleShadowFk] AS [e]
 WHERE [e].[ParentId] = @__get_Item_0",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1237,7 +1302,8 @@ WHERE [e].[ParentId] = @__get_Item_0",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1251,7 +1317,8 @@ WHERE 0 = 1",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1268,7 +1335,8 @@ WHERE 0 = 1",
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [ChildCompositeKey] AS [e]
 WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1285,7 +1353,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1302,7 +1371,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
 SELECT [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1319,7 +1389,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [SingleCompositeKey] AS [e]
 WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1336,7 +1407,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
 SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [ChildCompositeKey] AS [e]
 WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1353,7 +1425,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1370,7 +1443,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
 SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1387,7 +1461,8 @@ WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
 SELECT TOP(2) [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
 FROM [SingleCompositeKey] AS [e]
 WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1421,7 +1496,8 @@ WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Ite
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
@@ -1435,16 +1511,14 @@ WHERE 0 = 1",
                     @"SELECT TOP(2) [e].[Id], [e].[AlternateId]
 FROM [Parent] AS [e]
 WHERE 0 = 1",
-                    Sql);
+                    Sql,
+                    ignoreLineEndingDifferences: true);
             }
         }
 
         protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
-        protected override void RecordLog() => Sql = Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
-
-        private const string FileLineEnding = @"
-";
+        protected override void RecordLog() => Sql = Fixture.TestSqlLoggerFactory.Sql;
 
         private string Sql { get; set; }
 

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -18,9 +18,6 @@ namespace Microsoft.EntityFrameworkCore
     [SqlServerCondition(SqlServerCondition.IsNotSqlAzure)]
     public class MigrationsSqlServerTest : MigrationsTestBase<MigrationsSqlServerFixture>
     {
-        private const string FileLineEnding = @"
-";
-
         public MigrationsSqlServerTest(MigrationsSqlServerFixture fixture)
             : base(fixture)
         {
@@ -43,7 +40,8 @@ END;
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_no_migration_script()
@@ -63,7 +61,8 @@ END;
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_up_scripts()
@@ -117,7 +116,8 @@ VALUES (N'00000000000003_Migration3', N'7.0.0-test');
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_one_up_script()
@@ -135,7 +135,8 @@ VALUES (N'00000000000002_Migration2', N'7.0.0-test');
 GO
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_up_script_using_names()
@@ -153,7 +154,8 @@ VALUES (N'00000000000002_Migration2', N'7.0.0-test');
 GO
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_idempotent_up_scripts()
@@ -228,7 +230,8 @@ END;
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_down_scripts()
@@ -255,7 +258,8 @@ WHERE [MigrationId] = N'00000000000001_Migration1';
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_idempotent_down_scripts()
@@ -294,7 +298,8 @@ END;
 GO
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_one_down_script()
@@ -312,7 +317,8 @@ WHERE [MigrationId] = N'00000000000002_Migration2';
 GO
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_down_script_using_names()
@@ -330,7 +336,8 @@ WHERE [MigrationId] = N'00000000000002_Migration2';
 GO
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_get_active_provider()
@@ -350,7 +357,8 @@ CreatedTable
     ColumnWithDefaultToDrop int NULL DEFAULT ((0))
     ColumnWithDefaultToAlter int NULL DEFAULT ((1))
 ",
-                sql.Replace(Environment.NewLine, FileLineEnding));
+                sql,
+                ignoreLineEndingDifferences: true);
         }
 
         protected override async Task AssertSecondMigrationAsync(DbConnection connection)
@@ -362,7 +370,8 @@ CreatedTable
     Id int NOT NULL
     ColumnWithDefaultToAlter int NULL
 ",
-                sql.Replace(Environment.NewLine, FileLineEnding));
+                sql,
+                ignoreLineEndingDifferences: true);
         }
 
         private async Task<string> GetDatabaseSchemaAsync(DbConnection connection)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -21,6 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class AsyncSimpleQuerySqlServerTest : AsyncSimpleQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
+        private static readonly string EOL = Environment.NewLine;
+
         public AsyncSimpleQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
@@ -35,32 +37,32 @@ namespace Microsoft.EntityFrameworkCore.Query
             await base.ToList_on_nav_in_projection_is_async();
 
             Assert.Contains(
-                @"_SelectAsync(
-            source: IAsyncEnumerable<Customer> _ShapedQuery(
-                queryContext: queryContext, 
-                shaperCommandContext: SelectExpression: 
-                    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-                    FROM [Customers] AS [c]
-                    WHERE [c].[CustomerID] = N'ALFKI', 
-                shaper: BufferedEntityShaper<Customer>), 
-            selector: (Customer c | CancellationToken ct) => Task<<>f__AnonymousType17<Customer, List<Order>>> _ExecuteAsync(
-                taskFactories: new Func<Task<object>>[]{ () => Task<object> _ToObjectTask(Task<List<Order>> ToList((IAsyncEnumerable<Order>)EnumerableAdapter<Order> _ToEnumerable(IAsyncEnumerable<Order> _InjectParameters(
-                                    queryContext: queryContext, 
-                                    source: IAsyncEnumerable<Order> _ShapedQuery(
-                                        queryContext: queryContext, 
-                                        shaperCommandContext: SelectExpression: 
-                                            SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-                                            FROM [Orders] AS [o]
-                                            WHERE @_outer_CustomerID = [o].[CustomerID], 
-                                        shaper: BufferedEntityShaper<Order>), 
-                                    parameterNames: new string[]{ ""_outer_CustomerID"" }, 
-                                    parameterValues: new object[]{ string GetValueFromEntity(
-                                            clrPropertyGetter: ClrPropertyGetter<Customer, string>, 
-                                            entity: c) })))) }, 
-                selector: (Object[] results) => new <>f__AnonymousType17<Customer, List<Order>>(
-                    c, 
-                    (List<Order>)results[0]
-                )))",
+                @"_SelectAsync(" + EOL +
+                @"            source: IAsyncEnumerable<Customer> _ShapedQuery(" + EOL +
+                @"                queryContext: queryContext, " + EOL +
+                @"                shaperCommandContext: SelectExpression: " + EOL +
+                @"                    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]" + EOL +
+                @"                    FROM [Customers] AS [c]" + EOL +
+                @"                    WHERE [c].[CustomerID] = N'ALFKI', " + EOL +
+                @"                shaper: BufferedEntityShaper<Customer>), " + EOL +
+                @"            selector: (Customer c | CancellationToken ct) => Task<<>f__AnonymousType17<Customer, List<Order>>> _ExecuteAsync(" + EOL +
+                @"                taskFactories: new Func<Task<object>>[]{ () => Task<object> _ToObjectTask(Task<List<Order>> ToList((IAsyncEnumerable<Order>)EnumerableAdapter<Order> _ToEnumerable(IAsyncEnumerable<Order> _InjectParameters(" + EOL +
+                @"                                    queryContext: queryContext, " + EOL +
+                @"                                    source: IAsyncEnumerable<Order> _ShapedQuery(" + EOL +
+                @"                                        queryContext: queryContext, " + EOL +
+                @"                                        shaperCommandContext: SelectExpression: " + EOL +
+                @"                                            SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]" + EOL +
+                @"                                            FROM [Orders] AS [o]" + EOL +
+                @"                                            WHERE @_outer_CustomerID = [o].[CustomerID], " + EOL +
+                @"                                        shaper: BufferedEntityShaper<Order>), " + EOL +
+                @"                                    parameterNames: new string[]{ ""_outer_CustomerID"" }, " + EOL +
+                @"                                    parameterValues: new object[]{ string GetValueFromEntity(" + EOL +
+                @"                                            clrPropertyGetter: ClrPropertyGetter<Customer, string>, " + EOL +
+                @"                                            entity: c) })))) }, " + EOL +
+                @"                selector: (Object[] results) => new <>f__AnonymousType17<Customer, List<Order>>(" + EOL +
+                @"                    c, " + EOL +
+                @"                    (List<Order>)results[0]" + EOL +
+                @"                )))",
                 Fixture.TestSqlLoggerFactory.Log);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,7 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]
 WHERE [c].[ContactName] LIKE N'%M%'",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void String_Like_Identity()
@@ -35,7 +35,8 @@ WHERE [c].[ContactName] LIKE N'%M%'",
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]
 WHERE [c].[ContactName] LIKE [c].[ContactName]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void String_Like_Literal_With_Escape()
@@ -46,12 +47,10 @@ WHERE [c].[ContactName] LIKE [c].[ContactName]",
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]
 WHERE [c].[ContactName] LIKE N'!%' ESCAPE N'!'",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
@@ -43,7 +43,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"@p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void From_sql_queryable_stored_procedure_reprojection()
@@ -72,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"@p0='ALFKI' (Size = 4000)
 
 [dbo].[CustOrderHist] @CustomerID = @p0",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void From_sql_queryable_stored_procedure_take()
@@ -98,11 +100,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.From_sql_queryable_with_multiple_stored_procedures();
 
             Assert.StartsWith(
-                @"[dbo].[Ten Most Expensive Products]
-
-[dbo].[Ten Most Expensive Products]
-
-[dbo].[Ten Most Expensive Products]",
+                @"[dbo].[Ten Most Expensive Products]" + EOL +
+                EOL +
+                @"[dbo].[Ten Most Expensive Products]" + EOL +
+                EOL +
+                @"[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
@@ -111,17 +113,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.From_sql_queryable_stored_procedure_and_select();
 
             Assert.StartsWith(
-                @"[dbo].[Ten Most Expensive Products]
-
-SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
-FROM (
-    SELECT * FROM Products
-) AS [p]
-
-SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
-FROM (
-    SELECT * FROM Products
-) AS [p]",
+                @"[dbo].[Ten Most Expensive Products]" + EOL +
+                EOL +
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]" + EOL +
+                @"FROM (" + EOL +
+                @"    SELECT * FROM Products" + EOL +
+                @") AS [p]" + EOL +
+                EOL +
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]" + EOL +
+                @"FROM (" + EOL +
+                @"    SELECT * FROM Products" + EOL +
+                @") AS [p]",
                 Sql);
         }
 
@@ -130,23 +132,22 @@ FROM (
             base.From_sql_queryable_select_and_stored_procedure();
 
             Assert.StartsWith(
-                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
-FROM (
-    SELECT * FROM Products
-) AS [p]
-
-[dbo].[Ten Most Expensive Products]
-
-[dbo].[Ten Most Expensive Products]",
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]" + EOL +
+                @"FROM (" + EOL +
+                @"    SELECT * FROM Products" + EOL +
+                @") AS [p]" + EOL +
+                EOL +
+                @"[dbo].[Ten Most Expensive Products]" + EOL +
+                EOL +
+                @"[dbo].[Ten Most Expensive Products]",
                 Sql);
         }
 
         protected override string TenMostExpensiveProductsSproc => "[dbo].[Ten Most Expensive Products]";
         protected override string CustomerOrderHistorySproc => "[dbo].[CustOrderHist] @CustomerID = {0}";
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,7 +26,8 @@ WHERE CASE
     WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END = [c].[NullableBool]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void String_ends_with_not_equals_nullable_column()
@@ -42,15 +42,13 @@ WHERE (CASE
     WHEN (RIGHT([c].[FirstName], LEN([c2].[LastName])) = [c2].[LastName]) OR ([c2].[LastName] = N'')
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END <> [c].[NullableBool]) OR [c].[NullableBool] IS NULL",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,6 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class GearsOfWarQuerySqlServerTest : GearsOfWarQueryTestBase<GearsOfWarQuerySqlServerFixture>
     {
+        private static readonly string EOL = Environment.NewLine;
+
         // ReSharper disable once UnusedParameter.Local
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -394,10 +397,10 @@ ORDER BY [t1].[FullName]");
 FROM [Tags] AS [t]");
 
             Assert.Contains(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
-FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Id] IS NOT NULL AND [g.Tag].[Id] IN (",
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]" + EOL +
+                @"FROM [Gears] AS [g]" + EOL +
+                @"LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])" + EOL +
+                @"WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Id] IS NOT NULL AND [g.Tag].[Id] IN (",
                 Fixture.TestSqlLoggerFactory.SqlStatements[1]);
         }
 
@@ -410,11 +413,11 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Id] IS NOT NULL
 FROM [Tags] AS [t]");
 
             Assert.Contains(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
-FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.CityOfBirth].[Location] IS NOT NULL AND [g.Tag].[Id] IN (",
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]" + EOL +
+                @"FROM [Gears] AS [g]" + EOL +
+                @"LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])" + EOL +
+                @"INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]" + EOL +
+                @"WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.CityOfBirth].[Location] IS NOT NULL AND [g.Tag].[Id] IN (",
                 Fixture.TestSqlLoggerFactory.SqlStatements[1]);
         }
 
@@ -427,10 +430,10 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.CityOfBirth].[Locatio
 FROM [Tags] AS [t]");
 
             Assert.Contains(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Id] IS NOT NULL AND [g.Tag].[Id] IN (",
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]" + EOL +
+                @"FROM [Gears] AS [g]" + EOL +
+                @"LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])" + EOL +
+                @"WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g.Tag].[Id] IS NOT NULL AND [g.Tag].[Id] IN (",
                 Fixture.TestSqlLoggerFactory.SqlStatements[1]);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeOneToOneSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeOneToOneSqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"SELECT [a].[Id], [a].[City], [a].[Street], [a.Resident].[Id], [a.Resident].[Name]
 FROM [Address] AS [a]
 INNER JOIN [Person] AS [a.Resident] ON [a].[Id] = [a.Resident].[Id]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Include_person_shadow()
@@ -38,7 +38,8 @@ INNER JOIN [Person] AS [a.Resident] ON [a].[Id] = [a.Resident].[Id]",
                 @"SELECT [a].[Id], [a].[City], [a].[PersonId], [a].[Street], [a.Resident].[Id], [a.Resident].[Name]
 FROM [Address2] AS [a]
 INNER JOIN [Person2] AS [a.Resident] ON [a].[PersonId] = [a.Resident].[Id]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Include_address()
@@ -49,7 +50,8 @@ INNER JOIN [Person2] AS [a.Resident] ON [a].[PersonId] = [a.Resident].[Id]",
                 @"SELECT [p].[Id], [p].[Name], [p.Address].[Id], [p.Address].[City], [p.Address].[Street]
 FROM [Person] AS [p]
 LEFT JOIN [Address] AS [p.Address] ON [p].[Id] = [p.Address].[Id]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Include_address_shadow()
@@ -60,13 +62,11 @@ LEFT JOIN [Address] AS [p.Address] ON [p].[Id] = [p.Address].[Id]",
                 @"SELECT [p].[Id], [p].[Name], [p.Address].[Id], [p.Address].[City], [p.Address].[PersonId], [p.Address].[Street]
 FROM [Person2] AS [p]
 LEFT JOIN [Address2] AS [p.Address] ON [p].[Id] = [p.Address].[PersonId]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.SqlStatements.Last().Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.SqlStatements.Last();
 
         public class OneToOneQuerySqlServerFixture : OneToOneQueryFixtureBase
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -16,7 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[CompanyName]
 FROM [dbo].[Customers] AS [c]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void All_employees()
@@ -26,7 +26,8 @@ FROM [dbo].[Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [e].[EmployeeID], [e].[City]
 FROM [dbo].[Employees] AS [e]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void All_orders()
@@ -36,7 +37,8 @@ FROM [dbo].[Employees] AS [e]",
             Assert.Equal(
                 @"SELECT [o].[OrderID], [o].[ShipVia]
 FROM [dbo].[Orders] AS [o]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Project_nullable_enum()
@@ -46,7 +48,8 @@ FROM [dbo].[Orders] AS [o]",
             Assert.Equal(
                 @"SELECT [o].[ShipVia]
 FROM [dbo].[Orders] AS [o]",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public MappingQuerySqlServerTest(MappingQuerySqlServerFixture fixture)
@@ -55,10 +58,7 @@ FROM [dbo].[Orders] AS [o]",
             Fixture.TestSqlLoggerFactory.Clear();
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class MappingQuerySqlServerFixture : MappingQueryFixtureBase
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -12,8 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryLoggingSqlServerTest : IClassFixture<IncludeSqlServerFixture>
     {
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
         public QueryLoggingSqlServerTest(IncludeSqlServerFixture fixture)
         {
@@ -34,12 +33,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.NotNull(customers);
                 Assert.Contains(
-                    @"    Compiling query model: 
-'from Customer <generated>_0 in DbSet<Customer>
-select [<generated>_0]'
-    Optimized query model: 
-'from Customer <generated>_0 in DbSet<Customer>",
-                    Fixture.TestSqlLoggerFactory.Log.Replace(Environment.NewLine, FileLineEnding));
+                    @"    Compiling query model: " + EOL +
+                    @"'from Customer <generated>_0 in DbSet<Customer>" + EOL +
+                    @"select [<generated>_0]'" + EOL +
+                    @"    Optimized query model: " + EOL +
+                    @"'from Customer <generated>_0 in DbSet<Customer>",
+                    Fixture.TestSqlLoggerFactory.Log);
             }
         }
 
@@ -89,14 +88,14 @@ select [<generated>_0]'
 
                 Assert.NotNull(customers);
                 Assert.Contains(
-                    @"    Compiling query model: 
-'(from Customer c in DbSet<Customer>
-select [c]).Include(""Orders"")'
-    Including navigation: '[c].Orders'
-    Optimized query model: 
-'from Customer c in DbSet<Customer>"
+                    @"    Compiling query model: " + EOL +
+                    @"'(from Customer c in DbSet<Customer>" + EOL +
+                    @"select [c]).Include(""Orders"")'" + EOL +
+                    @"    Including navigation: '[c].Orders'" + EOL +
+                    @"    Optimized query model: " + EOL +
+                    @"'from Customer c in DbSet<Customer>"
                     ,
-                    Fixture.TestSqlLoggerFactory.Log.Replace(Environment.NewLine, FileLineEnding));
+                    Fixture.TestSqlLoggerFactory.Log);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/WarningsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/WarningsSqlServerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
 
@@ -23,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"SELECT TOP(2) [x].[OrderID], [x].[CustomerID], [x].[EmployeeID], [x].[OrderDate]
 FROM [Orders] AS [x]
 WHERE [x].[OrderID] = 10248",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Paging_operation_without_orderby_issues_warning()
@@ -76,9 +76,6 @@ WHERE [x].[OrderID] = 10248",
             Assert.Contains(CoreStrings.LogPossibleUnintendedReferenceComparison.GenerateMessage("[c].Orders", "[c].Orders"), Fixture.TestSqlLoggerFactory.Log);
         }
 
-        private const string FileLineEnding = @"
-";
-
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
@@ -194,12 +194,9 @@ DEFAULT VALUES;
 
         protected override string CloseDelimeter => "]";
 
-        private const string FileLineEnding = @"
-";
-
         private void AssertBaseline(string expected, string actual)
         {
-            Assert.Equal(expected.Replace(FileLineEnding, Environment.NewLine), actual);
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -101,35 +101,35 @@ namespace Microsoft.EntityFrameworkCore
             base.ConcurrencyCheckAttribute_throws_if_value_in_database_changed();
 
             Assert.Contains(
-                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion""
-FROM ""Sample"" AS ""r""
-WHERE ""r"".""UniqueNo"" = 1
-LIMIT 1",
+                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion""" + EOL +
+                @"FROM ""Sample"" AS ""r""" + EOL +
+                @"WHERE ""r"".""UniqueNo"" = 1" + EOL +
+                @"LIMIT 1",
                 Sql);
 
             Assert.Contains(
-                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion""
-FROM ""Sample"" AS ""r""
-WHERE ""r"".""UniqueNo"" = 1
-LIMIT 1
-
-@p2='1' (DbType = String)
-@p0='ModifiedData' (Nullable = false)
-@p1='00000000-0000-0000-0003-000000000001' (DbType = String)
-@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
-
-UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
-WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
-SELECT changes();
-
-@p2='1' (DbType = String)
-@p0='ChangedData' (Nullable = false)
-@p1='00000000-0000-0000-0002-000000000001' (DbType = String)
-@p3='00000001-0000-0000-0000-000000000001' (DbType = String)
-
-UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1
-WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;
-SELECT changes();",
+                @"SELECT ""r"".""UniqueNo"", ""r"".""MaxLengthProperty"", ""r"".""Name"", ""r"".""RowVersion""" + EOL +
+                @"FROM ""Sample"" AS ""r""" + EOL +
+                @"WHERE ""r"".""UniqueNo"" = 1" + EOL +
+                @"LIMIT 1" + EOL +
+                EOL +
+                @"@p2='1' (DbType = String)" + EOL +
+                @"@p0='ModifiedData' (Nullable = false)" + EOL +
+                @"@p1='00000000-0000-0000-0003-000000000001' (DbType = String)" + EOL +
+                @"@p3='00000001-0000-0000-0000-000000000001' (DbType = String)" + EOL +
+                EOL +
+                @"UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1" + EOL +
+                @"WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;" + EOL +
+                @"SELECT changes();" + EOL +
+                EOL +
+                @"@p2='1' (DbType = String)" + EOL +
+                @"@p0='ChangedData' (Nullable = false)" + EOL +
+                @"@p1='00000000-0000-0000-0002-000000000001' (DbType = String)" + EOL +
+                @"@p3='00000001-0000-0000-0000-000000000001' (DbType = String)" + EOL +
+                EOL +
+                @"UPDATE ""Sample"" SET ""Name"" = @p0, ""RowVersion"" = @p1" + EOL +
+                @"WHERE ""UniqueNo"" = @p2 AND ""RowVersion"" = @p3;" + EOL +
+                @"SELECT changes();",
                 Sql);
         }
 
@@ -138,15 +138,15 @@ SELECT changes();",
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
             Assert.Contains(
-                @"@p0='' (DbType = String)
-@p1='Third' (Nullable = false)
-@p2='00000000-0000-0000-0000-000000000003' (DbType = String)
-
-INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
-VALUES (@p0, @p1, @p2);
-SELECT ""UniqueNo""
-FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
+                @"@p0='' (DbType = String)" + EOL +
+                @"@p1='Third' (Nullable = false)" + EOL +
+                @"@p2='00000000-0000-0000-0000-000000000003' (DbType = String)" + EOL +
+                EOL +
+                @"INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")" + EOL +
+                @"VALUES (@p0, @p1, @p2);" + EOL +
+                @"SELECT ""UniqueNo""" + EOL +
+                @"FROM ""Sample""" + EOL +
+                @"WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
                 Sql);
         }
 
@@ -164,13 +164,11 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
             Assert.Contains(
-                @"@p1='1' (DbType = String)
-",
+                @"@p1='1' (DbType = String)" + EOL,
                 Sql);
 
             Assert.Contains(
-                @"@p1='' (Nullable = false) (DbType = String)
-",
+                @"@p1='' (Nullable = false) (DbType = String)" + EOL,
                 Sql);
         }
 
@@ -179,27 +177,27 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
             Assert.Contains(
-                @"@p0='' (DbType = String)
-@p1='ValidString' (Nullable = false)
-@p2='00000000-0000-0000-0000-000000000001' (DbType = String)
-
-INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
-VALUES (@p0, @p1, @p2);
-SELECT ""UniqueNo""
-FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
+                @"@p0='' (DbType = String)" + EOL +
+                @"@p1='ValidString' (Nullable = false)" + EOL +
+                @"@p2='00000000-0000-0000-0000-000000000001' (DbType = String)" + EOL +
+                EOL +
+                @"INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")" + EOL +
+                @"VALUES (@p0, @p1, @p2);" + EOL +
+                @"SELECT ""UniqueNo""" + EOL +
+                @"FROM ""Sample""" + EOL +
+                @"WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
                 Sql);
 
             Assert.Contains(
-                @"@p0='' (DbType = String)
-@p1='' (Nullable = false) (DbType = String)
-@p2='00000000-0000-0000-0000-000000000002' (DbType = String)
-
-INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")
-VALUES (@p0, @p1, @p2);
-SELECT ""UniqueNo""
-FROM ""Sample""
-WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
+                @"@p0='' (DbType = String)" + EOL +
+                @"@p1='' (Nullable = false) (DbType = String)" + EOL +
+                @"@p2='00000000-0000-0000-0000-000000000002' (DbType = String)" + EOL +
+                EOL +
+                @"INSERT INTO ""Sample"" (""MaxLengthProperty"", ""Name"", ""RowVersion"")" + EOL +
+                @"VALUES (@p0, @p1, @p2);" + EOL +
+                @"SELECT ""UniqueNo""" + EOL +
+                @"FROM ""Sample""" + EOL +
+                @"WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
                 Sql);
         }
 
@@ -221,10 +219,9 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
             }
         }
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class DataAnnotationSqliteFixture : DataAnnotationFixtureBase
         {

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -13,9 +13,6 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class MigrationsSqliteTest : MigrationsTestBase<MigrationsSqliteFixture>
     {
-        private const string FileLineEnding = @"
-";
-
         public MigrationsSqliteTest(MigrationsSqliteFixture fixture)
             : base(fixture)
         {
@@ -32,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore
 );
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_no_migration_script()
@@ -46,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore
 );
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_up_scripts()
@@ -75,7 +74,8 @@ INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"")
 VALUES ('00000000000003_Migration3', '7.0.0-test');
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_one_up_script()
@@ -89,7 +89,8 @@ INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"")
 VALUES ('00000000000002_Migration2', '7.0.0-test');
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_up_script_using_names()
@@ -103,7 +104,8 @@ INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"")
 VALUES ('00000000000002_Migration2', '7.0.0-test');
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_idempotent_up_scripts()
@@ -127,7 +129,8 @@ DELETE FROM ""__EFMigrationsHistory""
 WHERE ""MigrationId"" = '00000000000001_Migration1';
 
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_one_down_script()
@@ -141,7 +144,8 @@ DELETE FROM ""__EFMigrationsHistory""
 WHERE ""MigrationId"" = '00000000000002_Migration2';
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_down_script_using_names()
@@ -155,7 +159,8 @@ DELETE FROM ""__EFMigrationsHistory""
 WHERE ""MigrationId"" = '00000000000002_Migration2';
 
 ",
-                Sql);
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         public override void Can_generate_idempotent_down_scripts()
@@ -180,7 +185,8 @@ CreatedTable
     ColumnWithDefaultToDrop INTEGER NULL DEFAULT 0
     ColumnWithDefaultToAlter INTEGER NULL DEFAULT 1
 ",
-                sql.Replace(Environment.NewLine, FileLineEnding));
+                sql,
+                ignoreLineEndingDifferences: true);
         }
 
         protected override void BuildSecondMigration(MigrationBuilder migrationBuilder)
@@ -208,7 +214,8 @@ CreatedTable
     ColumnWithDefaultToDrop INTEGER NULL DEFAULT 0
     ColumnWithDefaultToAlter INTEGER NULL DEFAULT 1
 ",
-                sql.Replace(Environment.NewLine, FileLineEnding));
+                sql,
+                ignoreLineEndingDifferences: true);
         }
 
         private string GetDatabaseSchemaAsync(DbConnection connection)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/MappingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/MappingQuerySqliteTest.cs
@@ -19,8 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.All_customers();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""CompanyName""
-FROM ""Customers"" AS ""c""",
+                @"SELECT ""c"".""CustomerID"", ""c"".""CompanyName""" + EOL +
+                @"FROM ""Customers"" AS ""c""",
                 Sql);
         }
 
@@ -29,8 +29,8 @@ FROM ""Customers"" AS ""c""",
             base.All_employees();
 
             Assert.Contains(
-                @"SELECT ""e"".""EmployeeID"", ""e"".""City""
-FROM ""Employees"" AS ""e""",
+                @"SELECT ""e"".""EmployeeID"", ""e"".""City""" + EOL +
+                @"FROM ""Employees"" AS ""e""",
                 Sql);
         }
 
@@ -39,8 +39,8 @@ FROM ""Employees"" AS ""e""",
             base.All_orders();
 
             Assert.Contains(
-                @"SELECT ""o"".""OrderID"", ""o"".""ShipVia""
-FROM ""Orders"" AS ""o""",
+                @"SELECT ""o"".""OrderID"", ""o"".""ShipVia""" + EOL +
+                @"FROM ""Orders"" AS ""o""",
                 Sql);
         }
 
@@ -49,15 +49,14 @@ FROM ""Orders"" AS ""o""",
             base.Project_nullable_enum();
 
             Assert.Contains(
-                @"SELECT ""o"".""ShipVia""
-FROM ""Orders"" AS ""o""",
+                @"SELECT ""o"".""ShipVia""" + EOL +
+                @"FROM ""Orders"" AS ""o""",
                 Sql);
         }
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
 
         public class MappingQuerySqliteFixture : MappingQueryFixtureBase
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -22,15 +22,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Take_Skip();
 
             Assert.Contains(
-                @"SELECT ""t"".*
-FROM (
-    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-    FROM ""Customers"" AS ""c""
-    ORDER BY ""c"".""ContactName""
-    LIMIT @__p_0
-) AS ""t""
-ORDER BY ""t"".""ContactName""
-LIMIT -1 OFFSET @__p_1",
+                @"SELECT ""t"".*" + EOL +
+                @"FROM (" + EOL +
+                @"    SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"    FROM ""Customers"" AS ""c""" + EOL +
+                @"    ORDER BY ""c"".""ContactName""" + EOL +
+                @"    LIMIT @__p_0" + EOL +
+                @") AS ""t""" + EOL +
+                @"ORDER BY ""t"".""ContactName""" + EOL +
+                @"LIMIT -1 OFFSET @__p_1",
                 Sql);
         }
 
@@ -39,9 +39,9 @@ LIMIT -1 OFFSET @__p_1",
             base.IsNullOrWhiteSpace_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')",
                 Sql);
         }
 
@@ -50,9 +50,9 @@ WHERE ""c"".""Region"" IS NULL OR (trim(""c"".""Region"") = '')",
             base.TrimStart_without_arguments_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE ltrim(""c"".""ContactTitle"") = 'Owner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE ltrim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
@@ -61,9 +61,9 @@ WHERE ltrim(""c"".""ContactTitle"") = 'Owner'",
             base.TrimStart_with_char_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE ltrim(""c"".""ContactTitle"", 'O') = 'wner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE ltrim(""c"".""ContactTitle"", 'O') = 'wner'",
                 Sql);
         }
 
@@ -72,9 +72,9 @@ WHERE ltrim(""c"".""ContactTitle"", 'O') = 'wner'",
             base.TrimStart_with_char_array_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE ltrim(""c"".""ContactTitle"", 'Ow') = 'ner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE ltrim(""c"".""ContactTitle"", 'Ow') = 'ner'",
                 Sql);
         }
 
@@ -83,9 +83,9 @@ WHERE ltrim(""c"".""ContactTitle"", 'Ow') = 'ner'",
             base.TrimEnd_without_arguments_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE rtrim(""c"".""ContactTitle"") = 'Owner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE rtrim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
@@ -94,9 +94,9 @@ WHERE rtrim(""c"".""ContactTitle"") = 'Owner'",
             base.TrimEnd_with_char_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE rtrim(""c"".""ContactTitle"", 'r') = 'Owne'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE rtrim(""c"".""ContactTitle"", 'r') = 'Owne'",
                 Sql);
         }
 
@@ -105,9 +105,9 @@ WHERE rtrim(""c"".""ContactTitle"", 'r') = 'Owne'",
             base.TrimEnd_with_char_array_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE rtrim(""c"".""ContactTitle"", 'er') = 'Own'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE rtrim(""c"".""ContactTitle"", 'er') = 'Own'",
                 Sql);
         }
 
@@ -116,9 +116,9 @@ WHERE rtrim(""c"".""ContactTitle"", 'er') = 'Own'",
             base.Trim_without_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE trim(""c"".""ContactTitle"") = 'Owner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE trim(""c"".""ContactTitle"") = 'Owner'",
                 Sql);
         }
 
@@ -127,9 +127,9 @@ WHERE trim(""c"".""ContactTitle"") = 'Owner'",
             base.Trim_with_char_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE trim(""c"".""ContactTitle"", 'O') = 'wner'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE trim(""c"".""ContactTitle"", 'O') = 'wner'",
                 Sql);
         }
 
@@ -138,9 +138,9 @@ WHERE trim(""c"".""ContactTitle"", 'O') = 'wner'",
             base.Trim_with_char_array_argument_in_predicate();
 
             Assert.Contains(
-                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
-FROM ""Customers"" AS ""c""
-WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'",
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""" + EOL +
+                @"FROM ""Customers"" AS ""c""" + EOL +
+                @"WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'",
                 Sql);
         }
 
@@ -149,15 +149,14 @@ WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'",
             base.Sum_with_coalesce();
 
             Assert.Contains(
-                @"SELECT SUM(COALESCE(""p"".""UnitPrice"", 0.0))
-FROM ""Products"" AS ""p""
-WHERE ""p"".""ProductID"" < 40",
+                @"SELECT SUM(COALESCE(""p"".""UnitPrice"", 0.0))" + EOL +
+                @"FROM ""Products"" AS ""p""" + EOL +
+                @"WHERE ""p"".""ProductID"" < 40",
                 Sql);
         }
 
-        private const string FileLineEnding = @"
-";
+        private static readonly string EOL = Environment.NewLine;
 
-        private string Sql => Fixture.TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
+        private string Sql => Fixture.TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteMigrationSqlGeneratorTest.cs
@@ -13,9 +13,6 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class SqliteMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
     {
-        private const string FileLineEnding = @"
-";
-
         [Fact]
         public virtual void It_lifts_foreign_key_additions()
         {
@@ -46,7 +43,8 @@ namespace Microsoft.EntityFrameworkCore
     FOREIGN KEY (""FlavorId"") REFERENCES ""Flavor"" (""Id"")
 );
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -73,7 +71,8 @@ namespace Microsoft.EntityFrameworkCore
     ""Event"" TEXT NOT NULL DEFAULT '2015-04-12 17:05:00'
 );
 ",
-                Sql.Replace(Environment.NewLine, FileLineEnding));
+                Sql,
+                ignoreLineEndingDifferences: true);
         }
 
         [Theory]

--- a/test/EFCore.Tests/Utilities/IndentedStringBuilderTest.cs
+++ b/test/EFCore.Tests/Utilities/IndentedStringBuilderTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 {
     public class IndentedStringBuilderTest
     {
-        private readonly string _nl = Environment.NewLine;
+        private static readonly string EOL = Environment.NewLine;
 
         [Fact]
         public void Append_at_start_with_indent()
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 indentedStringBuilder.AppendLine();
             }
 
-            Assert.Equal($"Foo{_nl}    Foo{_nl}", indentedStringBuilder.ToString());
+            Assert.Equal($"Foo{EOL}    Foo{EOL}", indentedStringBuilder.ToString());
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 indentedStringBuilder.AppendLine("Foo");
             }
 
-            Assert.Equal("    Foo" + _nl, indentedStringBuilder.ToString());
+            Assert.Equal("    Foo" + EOL, indentedStringBuilder.ToString());
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
                 indentedStringBuilder.AppendLine("Foo");
             }
 
-            Assert.Equal($"Foo{_nl}    Foo{_nl}", indentedStringBuilder.ToString());
+            Assert.Equal($"Foo{EOL}    Foo{EOL}", indentedStringBuilder.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Uses `ignoreLineEndingDifferences` on `Equal` and `Environment.NewLine` with `StartsWith`, `Contains` & `EndsWith`.

Fixes #9147