### PR TITLE
Fix to #3910 - Query: Support Include/ThenInclude for navigation on derived type

### DIFF
--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IEntityQueryModelVisitorFactory, InMemoryQueryModelVisitorFactory>()
                 .TryAdd<IEntityQueryableExpressionVisitorFactory, InMemoryEntityQueryableExpressionVisitorFactory>()
                 .TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>()
+                .TryAdd<IQueryCompilationContextFactory, InMemoryQueryCompilationContextFactory>()
                 .TryAddProviderSpecificServices(b => b
                     .TryAddSingleton<IInMemoryStoreCache, InMemoryStoreCache>()
                     .TryAddSingleton<IInMemoryTableFactory, InMemoryTableFactory>()

--- a/src/EFCore.InMemory/Query/InMemoryQueryCompilationContext.cs
+++ b/src/EFCore.InMemory/Query/InMemoryQueryCompilationContext.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using JetBrains.Annotations;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    /// <summary>
+    ///     An In-memory query compilation context. The primary data structure representing the state/components
+    ///     used during query compilation for In-memory provider.
+    /// </summary>
+    public class InMemoryQueryCompilationContext : QueryCompilationContext
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InMemoryQueryCompilationContext(
+            [NotNull] QueryCompilationContextDependencies dependencies,
+            [NotNull] ILinqOperatorProvider linqOperatorProvider,
+            bool trackQueryResults)
+            : base(dependencies, linqOperatorProvider, trackQueryResults)
+        {
+        }
+
+        /// <summary>
+        ///     Determines all query sources that require materialization.
+        /// </summary>
+        /// <param name="queryModelVisitor"> The query model visitor. </param>
+        /// <param name="queryModel"> The query model. </param>
+        public override void FindQuerySourcesRequiringMaterialization(
+            EntityQueryModelVisitor queryModelVisitor, 
+            QueryModel queryModel)
+        {
+            base.FindQuerySourcesRequiringMaterialization(queryModelVisitor, queryModel);
+
+            var visitor = new InMemoryIncludeTypeOperatorsCompensatingVisitor(this);
+            queryModel.TransformExpressions(visitor.Visit);
+        }
+
+        private class InMemoryIncludeTypeOperatorsCompensatingVisitor : ExpressionVisitorBase
+        {
+            private readonly QueryCompilationContext _queryCompilationContext;
+
+            private bool _insideIncludeMethod = false;
+
+            public InMemoryIncludeTypeOperatorsCompensatingVisitor(QueryCompilationContext queryCompilationContext)
+            {
+                _queryCompilationContext = queryCompilationContext;
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (IncludeCompiler.IsIncludeMethod(node))
+                {
+                    _insideIncludeMethod = true;
+                }
+
+                return base.VisitMethodCall(node);
+            }
+
+            protected override Expression VisitUnary(UnaryExpression node)
+            {
+                if (_insideIncludeMethod
+                    && node.NodeType == ExpressionType.TypeAs
+                    && node.Operand is QuerySourceReferenceExpression qsre)
+                {
+                    _queryCompilationContext.AddQuerySourceRequiringMaterialization(qsre.ReferencedQuerySource);
+                }
+
+                return base.VisitUnary(node);
+            }
+
+            protected override Expression VisitExtension(Expression extensionExpression)
+            {
+                if (extensionExpression is NullConditionalExpression nullConditional)
+                {
+                    Visit(nullConditional.Caller);
+                    Visit(nullConditional.AccessOperation);
+                }
+
+                return base.VisitExtension(extensionExpression);
+            }
+        }
+    }
+}

--- a/src/EFCore.InMemory/Query/InMemoryQueryCompilationContextFactory.cs
+++ b/src/EFCore.InMemory/Query/InMemoryQueryCompilationContextFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+
+    /// <summary>
+    ///     A relational factory for instances of <see cref="QueryCompilationContext" />.
+    /// </summary>
+    public class InMemoryQueryCompilationContextFactory : QueryCompilationContextFactory
+    {
+        public InMemoryQueryCompilationContextFactory([NotNull] QueryCompilationContextDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        public override QueryCompilationContext Create(bool async)
+            => new InMemoryQueryCompilationContext(
+                Dependencies,
+                async ? (ILinqOperatorProvider)new AsyncLinqOperatorProvider() : new LinqOperatorProvider(),
+                TrackQueryResults);
+    }
+}

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryFixtureBase.cs
@@ -33,6 +33,29 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Ignore(e => e.OneToMany_Optional)
                 .OwnsOne(e => e.OneToOne_Required_PK, Configure);
 
+            modelBuilder.Entity<InheritanceBase1>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceBase2>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceLeaf1>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceLeaf2>().Property(e => e.Id).ValueGeneratedNever();
+
+            // FK name needs to be explicitly provided because issue #9310
+            modelBuilder.Entity<InheritanceBase2>().HasOne(e => e.Reference).WithOne().HasForeignKey<InheritanceBase1>("InheritanceBase2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceBase2>().HasMany(e => e.Collection).WithOne();
+
+            modelBuilder.Entity<InheritanceDerived1>().HasBaseType<InheritanceBase1>();
+            modelBuilder.Entity<InheritanceDerived1>().HasOne(e => e.ReferenceSameType).WithOne().HasForeignKey<InheritanceLeaf1>("SameTypeReference_InheritanceDerived1Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasOne(e => e.ReferenceDifferentType).WithOne().HasForeignKey<InheritanceLeaf1>("DifferentTypeReference_InheritanceDerived1Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasMany(e => e.CollectionSameType).WithOne().IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasMany(e => e.CollectionDifferentType).WithOne().IsRequired(false);
+
+            modelBuilder.Entity<InheritanceDerived2>().HasBaseType<InheritanceBase1>();
+            modelBuilder.Entity<InheritanceDerived2>().HasOne(e => e.ReferenceSameType).WithOne().HasForeignKey<InheritanceLeaf1>("SameTypeReference_InheritanceDerived2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasOne(e => e.ReferenceDifferentType).WithOne().HasForeignKey<InheritanceLeaf2>("DifferentTypeReference_InheritanceDerived2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasMany(e => e.CollectionSameType).WithOne().IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasMany(e => e.CollectionDifferentType).WithOne().IsRequired(false);
+
+            modelBuilder.Entity<InheritanceLeaf2>().HasMany(e => e.BaseCollection).WithOne().IsRequired(false);
+
             modelBuilder.Entity<ComplexNavigationField>().HasKey(e => e.Name);
             modelBuilder.Entity<ComplexNavigationString>().HasKey(e => e.DefaultText);
             modelBuilder.Entity<ComplexNavigationGlobalization>().HasKey(e => e.Text);
@@ -189,6 +212,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return (IQueryable<TEntity>)GetLevelFour(context);
                 }
 
+                if (typeof(TEntity) == typeof(InheritanceBase1))
+                {
+                    return context.Set<TEntity>();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceBase2))
+                {
+                    return context.Set<TEntity>();
+                }
+
                 throw new NotImplementedException();
             }
 
@@ -227,6 +260,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (typeof(TEntity) == typeof(Level4))
                 {
                     return (IQueryable<TEntity>)GetExpectedLevelFour();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceBase1))
+                {
+                    return (IQueryable<TEntity>)InheritanceBaseOnes.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceBase2))
+                {
+                    return (IQueryable<TEntity>)InheritanceBaseTwos.AsQueryable();
                 }
 
                 throw new NotImplementedException();

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -22,7 +22,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 { typeof(Level1), e => e.Id },
                 { typeof(Level2), e => e.Id },
                 { typeof(Level3), e => e.Id },
-                { typeof(Level4), e => e.Id }
+                { typeof(Level4), e => e.Id },
+                { typeof(InheritanceBase1), e => e.Id },
+                { typeof(InheritanceBase2), e => e.Id },
+                { typeof(InheritanceDerived1), e => e.Id },
+                { typeof(InheritanceDerived2), e => e.Id },
+                { typeof(InheritanceLeaf1), e => e.Id },
+                { typeof(InheritanceLeaf2), e => e.Id }
             };
 
             var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>
@@ -65,6 +71,54 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Assert.Equal(e.Name, a.Name);
                             Assert.Equal(e.Level3_Optional_Id, a.Level3_Optional_Id);
                             Assert.Equal(e.Level3_Required_Id, a.Level3_Required_Id);
+                        }
+                },
+                {
+                    typeof(InheritanceBase1),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                        }
+                },
+                {
+                    typeof(InheritanceBase2),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                        }
+                },
+                {
+                    typeof(InheritanceDerived1),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                        }
+                },
+                {
+                    typeof(InheritanceDerived2),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                        }
+                },
+                {
+                    typeof(InheritanceLeaf1),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
+                        }
+                },
+                {
+                    typeof(InheritanceLeaf2),
+                    (e, a) =>
+                        {
+                            Assert.Equal(e.Id, a.Id);
+                            Assert.Equal(e.Name, a.Name);
                         }
                 }
             };
@@ -119,6 +173,29 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).IsRequired().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).IsRequired(false);
 
+            modelBuilder.Entity<InheritanceBase1>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceBase2>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceLeaf1>().Property(e => e.Id).ValueGeneratedNever();
+            modelBuilder.Entity<InheritanceLeaf2>().Property(e => e.Id).ValueGeneratedNever();
+
+            // FK name needs to be explicitly provided because issue #9310
+            modelBuilder.Entity<InheritanceBase2>().HasOne(e => e.Reference).WithOne().HasForeignKey<InheritanceBase1>("InheritanceBase2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceBase2>().HasMany(e => e.Collection).WithOne();
+
+            modelBuilder.Entity<InheritanceDerived1>().HasBaseType<InheritanceBase1>();
+            modelBuilder.Entity<InheritanceDerived1>().HasOne(e => e.ReferenceSameType).WithOne().HasForeignKey<InheritanceLeaf1>("SameTypeReference_InheritanceDerived1Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasOne(e => e.ReferenceDifferentType).WithOne().HasForeignKey<InheritanceLeaf1>("DifferentTypeReference_InheritanceDerived1Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasMany(e => e.CollectionSameType).WithOne().IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived1>().HasMany(e => e.CollectionDifferentType).WithOne().IsRequired(false);
+
+            modelBuilder.Entity<InheritanceDerived2>().HasBaseType<InheritanceBase1>();
+            modelBuilder.Entity<InheritanceDerived2>().HasOne(e => e.ReferenceSameType).WithOne().HasForeignKey<InheritanceLeaf1>("SameTypeReference_InheritanceDerived2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasOne(e => e.ReferenceDifferentType).WithOne().HasForeignKey<InheritanceLeaf2>("DifferentTypeReference_InheritanceDerived2Id").IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasMany(e => e.CollectionSameType).WithOne().IsRequired(false);
+            modelBuilder.Entity<InheritanceDerived2>().HasMany(e => e.CollectionDifferentType).WithOne().IsRequired(false);
+
+            modelBuilder.Entity<InheritanceLeaf2>().HasMany(e => e.BaseCollection).WithOne().IsRequired(false);
+
             modelBuilder.Entity<ComplexNavigationField>().HasKey(e => e.Name);
             modelBuilder.Entity<ComplexNavigationString>().HasKey(e => e.DefaultText);
             modelBuilder.Entity<ComplexNavigationGlobalization>().HasKey(e => e.Text);
@@ -167,6 +244,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (typeof(TEntity) == typeof(Level4))
                 {
                     return (IQueryable<TEntity>)LevelFours.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceBase1))
+                {
+                    return (IQueryable<TEntity>)InheritanceBaseOnes.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceBase2))
+                {
+                    return (IQueryable<TEntity>)InheritanceBaseTwos.AsQueryable();
                 }
 
                 throw new NotImplementedException();

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3604,5 +3604,110 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Empty(context.ChangeTracker.Entries());
             }
         }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_navigation_with_same_name_and_same_type()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceSameType, "ReferenceSameType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType, "ReferenceSameType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("ReferenceSameType"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_navigation_with_same_name_and_different_type()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceDifferentType, "ReferenceDifferentType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceDifferentType, "ReferenceDifferentType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("ReferenceDifferentType"),
+                expectedIncludes);
+       }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceDifferentType, "ReferenceDifferentType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceDifferentType, "ReferenceDifferentType"),
+                new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "BaseCollection", "ReferenceDifferentType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("ReferenceDifferentType.BaseCollection"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_collection_navigation_with_same_name_and_same_type()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.CollectionSameType, "CollectionSameType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.CollectionSameType, "CollectionSameType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("CollectionSameType"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_collection_navigation_with_same_name_and_different_type()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType, "CollectionDifferentType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType, "CollectionDifferentType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("CollectionDifferentType"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType, "CollectionDifferentType"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType, "CollectionDifferentType"),
+                new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "BaseCollection", "ReferenceDifferentType")
+            };
+
+            AssertIncludeQuery<InheritanceBase1>(
+                i1s => i1s.Include("CollectionDifferentType.BaseCollection"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void String_include_multiple_derived_navigations_complex()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<InheritanceBase2>(e => e.Reference, "Reference"),
+                new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType, "CollectionDifferentType", "Reference"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType, "CollectionDifferentType", "Reference"),
+
+                new ExpectedInclude<InheritanceBase2>(e => e.Collection, "Collection"),
+                new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceSameType, "ReferenceSameType", "Collection"),
+                new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType, "ReferenceSameType", "Collection"),
+            };
+
+            AssertIncludeQuery<InheritanceBase2>(
+                i2s => i2s.Include("Reference.CollectionDifferentType").Include("Collection.ReferenceSameType"),
+                expectedIncludes);
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
@@ -2057,7 +2058,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Client_side_equality_with_parameter_works_with_optional_navigations()
         {
-            var prm = "Marcus's Tag";
+            var prm = "Marcus' Tag";
 
             AssertQuery<Gear>(
                 gs => gs.Where(g => ClientEquals(g.Tag.Note, prm)),
@@ -2820,7 +2821,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var result = query.ToList();
 
                 Assert.Equal(1, result.Count);
-                Assert.Equal("Marcus's Tag", result[0].Note);
+                Assert.Equal("Marcus' Tag", result[0].Note);
             }
         }
 
@@ -2912,6 +2913,139 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(1, result.Count(r => r.Id == 1 && r.Gears.Count == 3));
                 Assert.Equal(1, result.Count(r => r.Id == 2 && r.Gears.Count == 0));
             }
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_string()
+        {
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.Include("DefeatedBy"),
+                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy") });
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_string_nested1()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy"),
+                new ExpectedInclude<Gear>(g => g.Squad, "Squad", "DefeatedBy"),
+            };
+
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.Include("DefeatedBy.Squad"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_string_nested2()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy"),
+                new ExpectedInclude<Officer>(o => o.Reports, "Reports", "DefeatedBy"),
+                new ExpectedInclude<Gear>(g => g.CityOfBirth, "CityOfBirth", "DefeatedBy.Reports"),
+            };
+
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.Include("DefeatedBy.Reports.CityOfBirth"),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_lambda()
+        {
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.Include((LocustCommander ll) => ll.DefeatedBy),
+                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy") });
+        }
+
+        [ConditionalFact]
+        public virtual void Include_reference_on_derived_type_using_lambda_with_tracking()
+        {
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.AsTracking().Include((LocustCommander ll) => ll.DefeatedBy),
+                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy, "DefeatedBy") },
+                entryCount: 7);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_on_derived_type_using_string()
+        {
+            AssertIncludeQuery<Gear>(
+                gs => gs.Include("Reports"),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_on_derived_type_using_lambda()
+        {
+            AssertIncludeQuery<Gear>(
+                gs => gs.Include((Officer g) => g.Reports),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+        [ConditionalFact]
+        public virtual void Include_base_navigation_on_derived_entity()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<Officer>(e => e.Tag, "Tag"),
+                new ExpectedInclude<Officer>(e => e.Weapons, "Weapons")
+            };
+
+            AssertIncludeQuery<Gear>(
+                gs => gs.Include((Officer g) => g.Tag).Include((Officer g) => g.Weapons),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_on_derived_multi_level()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<Officer>(e => e.Reports, "Reports"),
+                new ExpectedInclude<Gear>(e => e.Squad, "Squad", "Reports"),
+                new ExpectedInclude<Squad>(e => e.Missions, "Missions", "Reports.Squad")
+            };
+
+            AssertIncludeQuery<Gear>(
+                gs => gs.Include((Officer g) => g.Reports).ThenInclude(g => g.Squad.Missions),
+                expectedIncludes);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_on_derived_using_as_operator_throws()
+        {
+            Assert.Equal(
+                CoreStrings.InvalidIncludeLambdaExpression("g => (g As Officer).Reports"),
+                Assert.Throws<ArgumentException>(
+                    () =>
+                        {
+                            using (var context = CreateContext())
+                            {
+                                var query = context.Gears
+                                    .Include(g => (g as Officer).Reports)
+                                    .ToList();
+                            }
+                        }).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_and_invalid_navigation_using_string_throws()
+        {
+            Assert.Equal(
+                CoreStrings.IncludeBadNavigation("Foo", "Gear"),
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        {
+                            using (var context = CreateContext())
+                            {
+                                var query = context.Gears
+                                    .Include("Reports.Foo")
+                                    .ToList();
+                            }
+                        }).Message);
         }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Expression.Parameter(typeof(Order), "o"));
 
             Assert.Equal(
-                CoreStrings.InvalidComplexPropertyExpression(lambdaExpression.ToString()),
+                CoreStrings.InvalidIncludeLambdaExpression(lambdaExpression.ToString()),
                 Assert.Throws<ArgumentException>(
                     () =>
                         {

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -322,8 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region AssertIncludeQuery
 
-        public void 
-            AssertIncludeQuery<TItem1>(
+        public List<object> AssertIncludeQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             List<IExpectedInclude> expectedIncludes,
             Func<dynamic, object> elementSorter = null,
@@ -333,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => AssertIncludeQuery(query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
 
-        public void AssertIncludeQuery<TItem1>(
+        public List<object> AssertIncludeQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
@@ -344,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             => Fixture.QueryAsserter.AssertIncludeQuery(actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
 
-        public void AssertIncludeQuery<TItem1, TItem2>(
+        public List<object> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             List<IExpectedInclude> expectedIncludes,
             Func<dynamic, object> elementSorter = null,
@@ -355,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             => AssertIncludeQuery(query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
 
-        public void AssertIncludeQuery<TItem1, TItem2>(
+        public List<object> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
@@ -21,5 +21,10 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
         public DbSet<ComplexNavigationString> MultilingualStrings { get; set; }
         public DbSet<ComplexNavigationGlobalization> Globalizations { get; set; }
         public DbSet<ComplexNavigationLanguage> Languages { get; set; }
+
+        public DbSet<InheritanceBase1> InheritanceOne { get; set; }
+        public DbSet<InheritanceBase2> InheritanceTwo { get; set; }
+        public DbSet<InheritanceLeaf1> InheritanceLeafOne { get; set; }
+        public DbSet<InheritanceLeaf2> InheritanceLeafTwo { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
@@ -21,6 +21,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
         public IReadOnlyList<Level3> SplitLevelThrees { get; }
         public IReadOnlyList<Level4> SplitLevelFours { get; }
 
+        public IReadOnlyList<InheritanceBase1> InheritanceBaseOnes { get; }
+        public IReadOnlyList<InheritanceBase2> InheritanceBaseTwos { get; }
+        public IReadOnlyList<InheritanceLeaf1> InheritanceLeafOnes { get; }
+        public IReadOnlyList<InheritanceLeaf2> InheritanceLeafTwos { get; }
+
         public abstract IQueryable<TEntity> Set<TEntity>() where TEntity : class;
 
         public ComplexNavigationsData()
@@ -46,6 +51,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
 
             WireUpPart2(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
             WireUpInversePart2(SplitLevelOnes, SplitLevelTwos, SplitLevelThrees, SplitLevelFours, tableSplitting: true);
+
+            InheritanceBaseOnes = CreateInheritanceBaseOnes();
+            InheritanceBaseTwos = CreateInheritanceBaseTwos();
+            InheritanceLeafOnes = CreateInheritanceLeafOnes();
+            InheritanceLeafTwos = CreateInheritanceLeafTwos();
+
+            WireUpInheritancePart1(InheritanceBaseOnes, InheritanceBaseTwos, InheritanceLeafOnes, InheritanceLeafTwos);
+            WireUpInheritancePart2(InheritanceBaseTwos, InheritanceLeafTwos);
         }
 
         public static IReadOnlyList<Level1> CreateLevelOnes(bool tableSplitting)
@@ -170,6 +183,83 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             }
 
             return result;
+        }
+
+        public static IReadOnlyList<InheritanceBase1> CreateInheritanceBaseOnes()
+        {
+            var result = new List<InheritanceBase1>
+            {
+                new InheritanceDerived1 { Id = 1, Name = "ID1 01" },
+                new InheritanceDerived1 { Id = 2, Name = "ID1 02" },
+                new InheritanceDerived2 { Id = 3, Name = "ID2 01" }
+            };
+
+            return result;
+        }
+
+        public static IReadOnlyList<InheritanceBase2> CreateInheritanceBaseTwos()
+        {
+            var result = new List<InheritanceBase2>
+            {
+                new InheritanceBase2 { Id = 1, Name = "IB2 01" },
+            };
+
+            return result;
+        }
+
+        public static IReadOnlyList<InheritanceLeaf1> CreateInheritanceLeafOnes()
+        {
+            var result = new List<InheritanceLeaf1>
+            {
+                new InheritanceLeaf1 { Id = 1, Name = "IL1 01" },
+                new InheritanceLeaf1 { Id = 2, Name = "IL1 02" },
+                new InheritanceLeaf1 { Id = 3, Name = "IL1 03" }
+            };
+
+            return result;
+        }
+
+        public static IReadOnlyList<InheritanceLeaf2> CreateInheritanceLeafTwos()
+        {
+            var result = new List<InheritanceLeaf2>
+            {
+                new InheritanceLeaf2 { Id = 1, Name = "IL2 01" },
+            };
+
+            return result;
+        }
+
+        public static void WireUpInheritancePart1(
+            IReadOnlyList<InheritanceBase1> ib1s,
+            IReadOnlyList<InheritanceBase2> ib2s,
+            IReadOnlyList<InheritanceLeaf1> il1s,
+            IReadOnlyList<InheritanceLeaf2> il2s)
+        {
+            ib2s[0].Reference = ib1s[0];
+            ib2s[0].Collection = new List<InheritanceBase1> { ib1s[1], ib1s[2] };
+
+            ((InheritanceDerived1)ib1s[0]).ReferenceSameType = il1s[0];
+            ((InheritanceDerived1)ib1s[1]).ReferenceSameType = il1s[1];
+            ((InheritanceDerived2)ib1s[2]).ReferenceSameType = il1s[2];
+
+            ((InheritanceDerived1)ib1s[0]).ReferenceDifferentType = il1s[0];
+            ((InheritanceDerived1)ib1s[1]).ReferenceDifferentType = il1s[1];
+            ((InheritanceDerived2)ib1s[2]).ReferenceDifferentType = il2s[0];
+
+            ((InheritanceDerived1)ib1s[0]).CollectionSameType = new List<InheritanceLeaf1> { il1s[0] };
+            ((InheritanceDerived1)ib1s[1]).CollectionSameType = new List<InheritanceLeaf1>();
+            ((InheritanceDerived2)ib1s[2]).CollectionSameType = new List<InheritanceLeaf1> { il1s[1], il1s[2] };
+
+            ((InheritanceDerived1)ib1s[0]).CollectionDifferentType = new List<InheritanceLeaf1> { il1s[0] };
+            ((InheritanceDerived1)ib1s[1]).CollectionDifferentType = new List<InheritanceLeaf1> { il1s[1], il1s[2] };
+            ((InheritanceDerived2)ib1s[2]).CollectionDifferentType = new List<InheritanceLeaf2> { il2s[0] };
+        }
+
+        public static void WireUpInheritancePart2(
+            IReadOnlyList<InheritanceBase2> ib2s,
+            IReadOnlyList<InheritanceLeaf2> il2s)
+        {
+            il2s[0].BaseCollection = new List<InheritanceBase2> { ib2s[0] };
         }
 
         public static void WireUpPart1(
@@ -872,6 +962,22 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
                 context.Languages.Add(language);
                 context.Globalizations.Add(globalization);
             }
+
+            var ib1s = CreateInheritanceBaseOnes();
+            var ib2s = CreateInheritanceBaseTwos();
+            var il1s = CreateInheritanceLeafOnes();
+            var il2s = CreateInheritanceLeafTwos();
+
+            context.InheritanceOne.AddRange(ib1s);
+            context.InheritanceTwo.AddRange(ib2s);
+            context.InheritanceLeafOne.AddRange(il1s);
+            context.InheritanceLeafTwo.AddRange(il2s);
+
+            WireUpInheritancePart1(ib1s, ib2s, il1s, il2s);
+            context.SaveChanges();
+
+            WireUpInheritancePart2(ib2s, il2s);
+            context.SaveChanges();
 
             var mls1 = new ComplexNavigationString { DefaultText = "MLS1", Globalizations = globalizations.Take(3).ToList() };
             var mls2 = new ComplexNavigationString { DefaultText = "MLS2", Globalizations = globalizations.Skip(3).Take(3).ToList() };

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase1.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase1.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceBase1
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase2.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase2.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceBase2
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public InheritanceBase1 Reference { get; set; }
+        public List<InheritanceBase1> Collection { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived1.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived1.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceDerived1 : InheritanceBase1
+    {
+        public InheritanceLeaf1 ReferenceSameType { get; set; }
+        public InheritanceLeaf1 ReferenceDifferentType { get; set; }
+        public List<InheritanceLeaf1> CollectionSameType { get; set; }
+        public List<InheritanceLeaf1> CollectionDifferentType { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived2.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived2.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceDerived2 : InheritanceBase1
+    {
+        public InheritanceLeaf1 ReferenceSameType { get; set; }
+        public InheritanceLeaf2 ReferenceDifferentType { get; set; }
+        public List<InheritanceLeaf1> CollectionSameType { get; set; }
+        public List<InheritanceLeaf2> CollectionDifferentType { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf1.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf1.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceLeaf1
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf2.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf2.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
+{
+    public class InheritanceLeaf2
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public List<InheritanceBase2> BaseCollection { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -140,8 +140,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                 new CogTag { Id = Guid.Parse("DF36F493-463F-4123-83F9-6B135DEEB7BA"), Note = "Dom's Tag" },
                 new CogTag { Id = Guid.Parse("A8AD98F9-E023-4E2A-9A70-C2728455BD34"), Note = "Cole's Tag" },
                 new CogTag { Id = Guid.Parse("A7BE028A-0CF2-448F-AB55-CE8BC5D8CF69"), Note = "Paduk's Tag" },
-                new CogTag { Id = Guid.Parse("70534E05-782C-4052-8720-C2C54481CE5F"), Note = "Bairds's Tag" },
-                new CogTag { Id = Guid.Parse("34C8D86E-A4AC-4BE5-827F-584DDA348A07"), Note = "Marcus's Tag" },
+                new CogTag { Id = Guid.Parse("70534E05-782C-4052-8720-C2C54481CE5F"), Note = "Baird's Tag" },
+                new CogTag { Id = Guid.Parse("34C8D86E-A4AC-4BE5-827F-584DDA348A07"), Note = "Marcus' Tag" },
                 new CogTag { Id = Guid.Parse("B39A6FBA-9026-4D69-828E-FD7068673E57"), Note = "K.I.A." }
             };
 
@@ -237,11 +237,17 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             IReadOnlyList<Faction> factions)
         {
             squadMissions[0].Mission = missions[0];
+            squadMissions[0].MissionId = missions[0].Id;
             squadMissions[0].Squad = squads[0];
+            squadMissions[0].SquadId = squads[0].Id;
             squadMissions[1].Mission = missions[1];
+            squadMissions[1].MissionId = missions[1].Id;
             squadMissions[1].Squad = squads[0];
+            squadMissions[1].SquadId = squads[0].Id;
             squadMissions[2].Mission = missions[2];
+            squadMissions[2].MissionId = missions[2].Id;
             squadMissions[2].Squad = squads[1];
+            squadMissions[2].SquadId = squads[1].Id;
 
             missions[0].ParticipatingSquads = new List<SquadMission> { squadMissions[0] };
             missions[1].ParticipatingSquads = new List<SquadMission> { squadMissions[1] };

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -712,7 +712,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         #region AssertIncludeQuery
 
-        public void AssertIncludeQuery<TItem1>(
+        public List<object> AssertIncludeQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             List<IExpectedInclude> expectedIncludes,
             Func<dynamic, object> elementSorter = null,
@@ -722,7 +722,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             where TItem1 : class
             => AssertIncludeQuery(query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
 
-        public override void AssertIncludeQuery<TItem1>(
+        public override List<object> AssertIncludeQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
@@ -766,10 +766,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
 
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+
+                return actual;
             }
         }
 
-        public void AssertIncludeQuery<TItem1, TItem2>(
+        public List<object> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             List<IExpectedInclude> expectedIncludes,
             Func<dynamic, object> elementSorter = null,
@@ -780,7 +782,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             where TItem2 : class
             => AssertIncludeQuery(query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
 
-        public override void AssertIncludeQuery<TItem1, TItem2>(
+        public override List<object> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
@@ -829,6 +831,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 }
 
                 Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+
+                return actual;
             }
         }
 

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         #region AssertIncludeQuery
 
-        public abstract void AssertIncludeQuery<TItem1>(
+        public abstract List<object> AssertIncludeQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             int entryCount = 0)
             where TItem1 : class;
 
-        public abstract void AssertIncludeQuery<TItem1, TItem2>(
+        public abstract List<object> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1393,6 +1393,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 propertyAccessExpression);
 
         /// <summary>
+        ///     Lambda expression '{includeLambdaExpression}' is not valid for Include/ThenInclude result operator. The expression should represent a property access: 't =&gt; t.MyProperty'. Specify lambda parameter explicitly to access navigations on derived types: '(Derived t) =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.
+        /// </summary>
+        public static string InvalidIncludeLambdaExpression([CanBeNull] object includeLambdaExpression)
+            => string.Format(
+                GetString("InvalidIncludeLambdaExpression", nameof(includeLambdaExpression)),
+                includeLambdaExpression);
+
+        /// <summary>
         ///     The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.
         /// </summary>
         public static string AbstractLeafEntityType([CanBeNull] object entityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -637,6 +637,9 @@
   <data name="InvalidComplexPropertyExpression" xml:space="preserve">
     <value>The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.</value>
   </data>
+  <data name="InvalidIncludeLambdaExpression" xml:space="preserve">
+    <value>Lambda expression '{includeLambdaExpression}' is not valid for Include/ThenInclude result operator. The expression should represent a property access: 't =&gt; t.MyProperty'. Specify lambda parameter explicitly to access navigations on derived types: '(Derived t) =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.</value>
+  </data>
   <data name="AbstractLeafEntityType" xml:space="preserve">
     <value>The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.</value>
   </data>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CollectionNavigationIncludeExpressionRewriter.cs
@@ -72,18 +72,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 && properties[properties.Count - 1] is INavigation lastNavigation
                 && lastNavigation.IsCollection())
             {
-                // include doesn't handle navigations on derived class, so we can't leverage include pipeline for those cases
-                var expectedCallerType = querySource.ItemType;
-                foreach (var property in properties)
-                {
-                    if (expectedCallerType != property.DeclaringType.ClrType)
-                    {
-                        return expression;
-                    }
-
-                    expectedCallerType = property.ClrType;
-                }
-
                 var qsre = new QuerySourceReferenceExpression(querySource);
 
                 CollectionNavigationIncludeResultOperators.Add(

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNodeBase.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNodeBase.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class IncludeExpressionNodeBase : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual Type SourceEntityType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual LambdaExpression NavigationPropertyPathLambda { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected IncludeExpressionNodeBase(
+            MethodCallExpressionParseInfo parseInfo,
+            [NotNull] LambdaExpression navigationPropertyPathLambda)
+            : base(parseInfo, null, null)
+        {
+            NavigationPropertyPathLambda = navigationPropertyPathLambda;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+            => Source.Resolve(
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static IReadOnlyList<PropertyInfo> MatchIncludeLambdaPropertyAccess([NotNull] LambdaExpression includeLambda)
+        {
+            Check.NotNull(includeLambda, nameof(includeLambda));
+
+            var parameterExpression = includeLambda.Parameters.Single();
+            var propertyInfos = new List<PropertyInfo>();
+
+            var expression = includeLambda.Body;
+            while (expression != null)
+            {
+                expression = expression.RemoveConvert();
+                if (expression == parameterExpression)
+                {
+                    break;
+                }
+
+                if (expression is MemberExpression memberExpression)
+                {
+                    propertyInfos.Insert(0, (PropertyInfo)memberExpression.Member);
+                    expression = memberExpression.Expression;
+
+                    continue;
+                }
+
+                propertyInfos.Clear();
+                break;
+            }
+
+            if (propertyInfos.Count == 0)
+            {
+                throw new ArgumentException(
+                    CoreStrings.InvalidIncludeLambdaExpression(includeLambda));
+            }
+
+            return propertyInfos;
+        }
+    }
+}

--- a/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;
@@ -16,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ThenIncludeExpressionNode : ResultOperatorExpressionNodeBase
+    public class ThenIncludeExpressionNode : IncludeExpressionNodeBase
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,10 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
             EntityFrameworkQueryableExtensions.ThenIncludeAfterEnumerableMethodInfo,
-            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo
+            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo,
+            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterEnumerableMethodInfo,
+            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterReferenceMethodInfo,
         };
-
-        private readonly LambdaExpression _navigationPropertyPathLambda;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -37,9 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         public ThenIncludeExpressionNode(
             MethodCallExpressionParseInfo parseInfo,
             [NotNull] LambdaExpression navigationPropertyPathLambda)
-            : base(parseInfo, null, null)
+            : base(parseInfo, navigationPropertyPathLambda)
         {
-            _navigationPropertyPathLambda = navigationPropertyPathLambda;
         }
 
         /// <summary>
@@ -53,7 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
                 = (IncludeResultOperator)clauseGenerationContext.GetContextInfo(Source);
 
             includeResultOperator
-                .AppendToNavigationPath(_navigationPropertyPathLambda.GetComplexPropertyAccess());
+                .AppendToNavigationPath(
+                    MatchIncludeLambdaPropertyAccess(
+                        NavigationPropertyPathLambda));
 
             clauseGenerationContext.AddContextInfo(this, includeResultOperator);
         }
@@ -64,18 +64,5 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
             => null;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Expression Resolve(
-            ParameterExpression inputParameter,
-            Expression expressionToBeResolved,
-            ClauseGenerationContext clauseGenerationContext)
-            => Source.Resolve(
-                inputParameter,
-                expressionToBeResolved,
-                clauseGenerationContext);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3262,6 +3262,198 @@ INNER JOIN (
 ORDER BY [t].[c], [t].[Name], [t].[Id]");
         }
 
+        public override void String_include_multiple_derived_navigation_with_same_name_and_same_type()
+        {
+            base.String_include_multiple_derived_navigation_with_same_name_and_same_type();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name], [i.ReferenceSameType].[Id], [i.ReferenceSameType].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceSameType].[InheritanceDerived1Id], [i.ReferenceSameType].[InheritanceDerived1Id1], [i.ReferenceSameType].[InheritanceDerived2Id], [i.ReferenceSameType].[Name], [i.ReferenceSameType].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceSameType].[SameTypeReference_InheritanceDerived2Id], [i.ReferenceSameType0].[Id], [i.ReferenceSameType0].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceSameType0].[InheritanceDerived1Id], [i.ReferenceSameType0].[InheritanceDerived1Id1], [i.ReferenceSameType0].[InheritanceDerived2Id], [i.ReferenceSameType0].[Name], [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceOne] AS [i]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceSameType] ON [i].[Id] = [i.ReferenceSameType].[SameTypeReference_InheritanceDerived2Id]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceSameType0] ON [i].[Id] = [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived1Id]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')");
+        }
+
+        public override void String_include_multiple_derived_navigation_with_same_name_and_different_type()
+        {
+            base.String_include_multiple_derived_navigation_with_same_name_and_different_type();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name], [i.ReferenceDifferentType].[Id], [i.ReferenceDifferentType].[DifferentTypeReference_InheritanceDerived2Id], [i.ReferenceDifferentType].[InheritanceDerived2Id], [i.ReferenceDifferentType].[Name], [i.ReferenceDifferentType0].[Id], [i.ReferenceDifferentType0].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceDifferentType0].[InheritanceDerived1Id], [i.ReferenceDifferentType0].[InheritanceDerived1Id1], [i.ReferenceDifferentType0].[InheritanceDerived2Id], [i.ReferenceDifferentType0].[Name], [i.ReferenceDifferentType0].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceDifferentType0].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceOne] AS [i]
+LEFT JOIN [InheritanceLeafTwo] AS [i.ReferenceDifferentType] ON [i].[Id] = [i.ReferenceDifferentType].[DifferentTypeReference_InheritanceDerived2Id]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceDifferentType0] ON [i].[Id] = [i.ReferenceDifferentType0].[DifferentTypeReference_InheritanceDerived1Id]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')");
+        }
+
+        public override void String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains()
+        {
+            base.String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name], [i.ReferenceDifferentType].[Id], [i.ReferenceDifferentType].[DifferentTypeReference_InheritanceDerived2Id], [i.ReferenceDifferentType].[InheritanceDerived2Id], [i.ReferenceDifferentType].[Name], [i.ReferenceDifferentType0].[Id], [i.ReferenceDifferentType0].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceDifferentType0].[InheritanceDerived1Id], [i.ReferenceDifferentType0].[InheritanceDerived1Id1], [i.ReferenceDifferentType0].[InheritanceDerived2Id], [i.ReferenceDifferentType0].[Name], [i.ReferenceDifferentType0].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceDifferentType0].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceOne] AS [i]
+LEFT JOIN [InheritanceLeafTwo] AS [i.ReferenceDifferentType] ON [i].[Id] = [i.ReferenceDifferentType].[DifferentTypeReference_InheritanceDerived2Id]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceDifferentType0] ON [i].[Id] = [i.ReferenceDifferentType0].[DifferentTypeReference_InheritanceDerived1Id]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+ORDER BY [i.ReferenceDifferentType].[Id]",
+                //
+                @"SELECT [i.ReferenceDifferentType.BaseCollection].[Id], [i.ReferenceDifferentType.BaseCollection].[InheritanceLeaf2Id], [i.ReferenceDifferentType.BaseCollection].[Name]
+FROM [InheritanceTwo] AS [i.ReferenceDifferentType.BaseCollection]
+INNER JOIN (
+    SELECT DISTINCT [i.ReferenceDifferentType1].[Id]
+    FROM [InheritanceOne] AS [i0]
+    LEFT JOIN [InheritanceLeafTwo] AS [i.ReferenceDifferentType1] ON [i0].[Id] = [i.ReferenceDifferentType1].[DifferentTypeReference_InheritanceDerived2Id]
+    LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceDifferentType2] ON [i0].[Id] = [i.ReferenceDifferentType2].[DifferentTypeReference_InheritanceDerived1Id]
+    WHERE [i0].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t] ON [i.ReferenceDifferentType.BaseCollection].[InheritanceLeaf2Id] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void String_include_multiple_derived_collection_navigation_with_same_name_and_same_type()
+        {
+            base.String_include_multiple_derived_collection_navigation_with_same_name_and_same_type();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name]
+FROM [InheritanceOne] AS [i]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+ORDER BY [i].[Id]",
+                //
+                @"SELECT [i.CollectionSameType].[Id], [i.CollectionSameType].[DifferentTypeReference_InheritanceDerived1Id], [i.CollectionSameType].[InheritanceDerived1Id], [i.CollectionSameType].[InheritanceDerived1Id1], [i.CollectionSameType].[InheritanceDerived2Id], [i.CollectionSameType].[Name], [i.CollectionSameType].[SameTypeReference_InheritanceDerived1Id], [i.CollectionSameType].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i.CollectionSameType]
+INNER JOIN (
+    SELECT [i0].[Id]
+    FROM [InheritanceOne] AS [i0]
+    WHERE [i0].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t] ON [i.CollectionSameType].[InheritanceDerived1Id1] = [t].[Id]
+ORDER BY [t].[Id]",
+                //
+                @"SELECT [i.CollectionSameType0].[Id], [i.CollectionSameType0].[DifferentTypeReference_InheritanceDerived1Id], [i.CollectionSameType0].[InheritanceDerived1Id], [i.CollectionSameType0].[InheritanceDerived1Id1], [i.CollectionSameType0].[InheritanceDerived2Id], [i.CollectionSameType0].[Name], [i.CollectionSameType0].[SameTypeReference_InheritanceDerived1Id], [i.CollectionSameType0].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i.CollectionSameType0]
+INNER JOIN (
+    SELECT [i1].[Id]
+    FROM [InheritanceOne] AS [i1]
+    WHERE [i1].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t0] ON [i.CollectionSameType0].[InheritanceDerived2Id] = [t0].[Id]
+ORDER BY [t0].[Id]");
+        }
+
+        public override void String_include_multiple_derived_collection_navigation_with_same_name_and_different_type()
+        {
+            base.String_include_multiple_derived_collection_navigation_with_same_name_and_different_type();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name]
+FROM [InheritanceOne] AS [i]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+ORDER BY [i].[Id]",
+                //
+                @"SELECT [i.CollectionDifferentType].[Id], [i.CollectionDifferentType].[DifferentTypeReference_InheritanceDerived1Id], [i.CollectionDifferentType].[InheritanceDerived1Id], [i.CollectionDifferentType].[InheritanceDerived1Id1], [i.CollectionDifferentType].[InheritanceDerived2Id], [i.CollectionDifferentType].[Name], [i.CollectionDifferentType].[SameTypeReference_InheritanceDerived1Id], [i.CollectionDifferentType].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i.CollectionDifferentType]
+INNER JOIN (
+    SELECT [i0].[Id]
+    FROM [InheritanceOne] AS [i0]
+    WHERE [i0].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t] ON [i.CollectionDifferentType].[InheritanceDerived1Id] = [t].[Id]
+ORDER BY [t].[Id]",
+                //
+                @"SELECT [i.CollectionDifferentType0].[Id], [i.CollectionDifferentType0].[DifferentTypeReference_InheritanceDerived2Id], [i.CollectionDifferentType0].[InheritanceDerived2Id], [i.CollectionDifferentType0].[Name]
+FROM [InheritanceLeafTwo] AS [i.CollectionDifferentType0]
+INNER JOIN (
+    SELECT [i1].[Id]
+    FROM [InheritanceOne] AS [i1]
+    WHERE [i1].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t0] ON [i.CollectionDifferentType0].[InheritanceDerived2Id] = [t0].[Id]
+ORDER BY [t0].[Id]");
+        }
+
+        public override void String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains()
+        {
+            base.String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[Discriminator], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1], [i].[Name]
+FROM [InheritanceOne] AS [i]
+WHERE [i].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+ORDER BY [i].[Id]",
+                //
+                @"SELECT [i.CollectionDifferentType].[Id], [i.CollectionDifferentType].[DifferentTypeReference_InheritanceDerived1Id], [i.CollectionDifferentType].[InheritanceDerived1Id], [i.CollectionDifferentType].[InheritanceDerived1Id1], [i.CollectionDifferentType].[InheritanceDerived2Id], [i.CollectionDifferentType].[Name], [i.CollectionDifferentType].[SameTypeReference_InheritanceDerived1Id], [i.CollectionDifferentType].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i.CollectionDifferentType]
+INNER JOIN (
+    SELECT [i0].[Id]
+    FROM [InheritanceOne] AS [i0]
+    WHERE [i0].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t] ON [i.CollectionDifferentType].[InheritanceDerived1Id] = [t].[Id]
+ORDER BY [t].[Id]",
+                //
+                @"SELECT [i.CollectionDifferentType0].[Id], [i.CollectionDifferentType0].[DifferentTypeReference_InheritanceDerived2Id], [i.CollectionDifferentType0].[InheritanceDerived2Id], [i.CollectionDifferentType0].[Name]
+FROM [InheritanceLeafTwo] AS [i.CollectionDifferentType0]
+INNER JOIN (
+    SELECT [i1].[Id]
+    FROM [InheritanceOne] AS [i1]
+    WHERE [i1].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t0] ON [i.CollectionDifferentType0].[InheritanceDerived2Id] = [t0].[Id]
+ORDER BY [t0].[Id], [i.CollectionDifferentType0].[Id]",
+                //
+                @"SELECT [i.CollectionDifferentType.BaseCollection].[Id], [i.CollectionDifferentType.BaseCollection].[InheritanceLeaf2Id], [i.CollectionDifferentType.BaseCollection].[Name]
+FROM [InheritanceTwo] AS [i.CollectionDifferentType.BaseCollection]
+INNER JOIN (
+    SELECT DISTINCT [i.CollectionDifferentType1].[Id], [t1].[Id] AS [Id0]
+    FROM [InheritanceLeafTwo] AS [i.CollectionDifferentType1]
+    INNER JOIN (
+        SELECT [i2].[Id]
+        FROM [InheritanceOne] AS [i2]
+        WHERE [i2].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+    ) AS [t1] ON [i.CollectionDifferentType1].[InheritanceDerived2Id] = [t1].[Id]
+) AS [t2] ON [i.CollectionDifferentType.BaseCollection].[InheritanceLeaf2Id] = [t2].[Id]
+ORDER BY [t2].[Id0], [t2].[Id]");
+        }
+
+        public override void String_include_multiple_derived_navigations_complex()
+        {
+            base.String_include_multiple_derived_navigations_complex();
+
+            AssertSql(
+                @"SELECT [i].[Id], [i].[InheritanceLeaf2Id], [i].[Name], [t].[Id], [t].[Discriminator], [t].[InheritanceBase2Id], [t].[InheritanceBase2Id1], [t].[Name]
+FROM [InheritanceTwo] AS [i]
+LEFT JOIN (
+    SELECT [i.Reference].*
+    FROM [InheritanceOne] AS [i.Reference]
+    WHERE [i.Reference].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+) AS [t] ON [i].[Id] = [t].[InheritanceBase2Id]
+ORDER BY [t].[Id], [i].[Id]",
+                //
+                @"SELECT [i.Reference.CollectionDifferentType].[Id], [i.Reference.CollectionDifferentType].[DifferentTypeReference_InheritanceDerived1Id], [i.Reference.CollectionDifferentType].[InheritanceDerived1Id], [i.Reference.CollectionDifferentType].[InheritanceDerived1Id1], [i.Reference.CollectionDifferentType].[InheritanceDerived2Id], [i.Reference.CollectionDifferentType].[Name], [i.Reference.CollectionDifferentType].[SameTypeReference_InheritanceDerived1Id], [i.Reference.CollectionDifferentType].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i.Reference.CollectionDifferentType]
+INNER JOIN (
+    SELECT DISTINCT [t0].[Id]
+    FROM [InheritanceTwo] AS [i0]
+    LEFT JOIN (
+        SELECT [i.Reference0].*
+        FROM [InheritanceOne] AS [i.Reference0]
+        WHERE [i.Reference0].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+    ) AS [t0] ON [i0].[Id] = [t0].[InheritanceBase2Id]
+) AS [t1] ON [i.Reference.CollectionDifferentType].[InheritanceDerived1Id] = [t1].[Id]
+ORDER BY [t1].[Id]",
+                //
+                @"SELECT [i.Collection].[Id], [i.Collection].[Discriminator], [i.Collection].[InheritanceBase2Id], [i.Collection].[InheritanceBase2Id1], [i.Collection].[Name], [i.ReferenceSameType].[Id], [i.ReferenceSameType].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceSameType].[InheritanceDerived1Id], [i.ReferenceSameType].[InheritanceDerived1Id1], [i.ReferenceSameType].[InheritanceDerived2Id], [i.ReferenceSameType].[Name], [i.ReferenceSameType].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceSameType].[SameTypeReference_InheritanceDerived2Id], [i.ReferenceSameType0].[Id], [i.ReferenceSameType0].[DifferentTypeReference_InheritanceDerived1Id], [i.ReferenceSameType0].[InheritanceDerived1Id], [i.ReferenceSameType0].[InheritanceDerived1Id1], [i.ReferenceSameType0].[InheritanceDerived2Id], [i.ReferenceSameType0].[Name], [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived1Id], [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceOne] AS [i.Collection]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceSameType] ON [i.Collection].[Id] = [i.ReferenceSameType].[SameTypeReference_InheritanceDerived2Id]
+LEFT JOIN [InheritanceLeafOne] AS [i.ReferenceSameType0] ON [i.Collection].[Id] = [i.ReferenceSameType0].[SameTypeReference_InheritanceDerived1Id]
+INNER JOIN (
+    SELECT DISTINCT [i2].[Id], [t4].[Id] AS [Id0]
+    FROM [InheritanceTwo] AS [i2]
+    LEFT JOIN (
+        SELECT [i.Reference2].*
+        FROM [InheritanceOne] AS [i.Reference2]
+        WHERE [i.Reference2].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+    ) AS [t4] ON [i2].[Id] = [t4].[InheritanceBase2Id]
+) AS [t5] ON [i.Collection].[InheritanceBase2Id1] = [t5].[Id]
+WHERE [i.Collection].[Discriminator] IN (N'InheritanceDerived2', N'InheritanceDerived1', N'InheritanceBase1')
+ORDER BY [t5].[Id0], [t5].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3854,7 +3854,7 @@ ORDER BY [t3].[Id]");
             base.Project_collection_navigation_with_inheritance2();
 
             AssertSql(
-                @"SELECT [h].[Id], [t0].[Nickname], [t0].[SquadId]
+                @"SELECT [h].[Id], [h].[CapitalName], [h].[Discriminator], [h].[Name], [h].[CommanderName], [h].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Factions] AS [h]
 LEFT JOIN (
     SELECT [h.Commander].*
@@ -3866,21 +3866,28 @@ LEFT JOIN (
     FROM [Gears] AS [h.Commander.DefeatedBy]
     WHERE [h.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
-WHERE [h].[Discriminator] = N'LocustHorde'",
+WHERE [h].[Discriminator] = N'LocustHorde'
+ORDER BY [t0].[Nickname], [t0].[SquadId]",
                 //
-                @"@_outer_Nickname='Marcus' (Size = 4000)
-@_outer_SquadId='1'
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
-                //
-                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
-@_outer_SquadId='' (Nullable = false) (DbType = Int32)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+                @"SELECT [h.Commander.DefeatedBy.Reports].[Nickname], [h.Commander.DefeatedBy.Reports].[SquadId], [h.Commander.DefeatedBy.Reports].[AssignedCityName], [h.Commander.DefeatedBy.Reports].[CityOrBirthName], [h.Commander.DefeatedBy.Reports].[Discriminator], [h.Commander.DefeatedBy.Reports].[FullName], [h.Commander.DefeatedBy.Reports].[HasSoulPatch], [h.Commander.DefeatedBy.Reports].[LeaderNickname], [h.Commander.DefeatedBy.Reports].[LeaderSquadId], [h.Commander.DefeatedBy.Reports].[Rank]
+FROM [Gears] AS [h.Commander.DefeatedBy.Reports]
+INNER JOIN (
+    SELECT DISTINCT [t2].[Nickname], [t2].[SquadId]
+    FROM [Factions] AS [h0]
+    LEFT JOIN (
+        SELECT [h.Commander0].*
+        FROM [LocustLeaders] AS [h.Commander0]
+        WHERE [h.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t1] ON [h0].[CommanderName] = [t1].[Name]
+    LEFT JOIN (
+        SELECT [h.Commander.DefeatedBy0].*
+        FROM [Gears] AS [h.Commander.DefeatedBy0]
+        WHERE [h.Commander.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t2] ON ([t1].[DefeatedByNickname] = [t2].[Nickname]) AND ([t1].[DefeatedBySquadId] = [t2].[SquadId])
+    WHERE [h0].[Discriminator] = N'LocustHorde'
+) AS [t3] ON ([h.Commander.DefeatedBy.Reports].[LeaderNickname] = [t3].[Nickname]) AND ([h.Commander.DefeatedBy.Reports].[LeaderSquadId] = [t3].[SquadId])
+WHERE [h.Commander.DefeatedBy.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t3].[Nickname], [t3].[SquadId]");
         }
 
         public override void Project_collection_navigation_with_inheritance3()
@@ -3888,7 +3895,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].
             base.Project_collection_navigation_with_inheritance3();
 
             AssertSql(
-                @"SELECT [f].[Id], [t0].[Nickname], [t0].[SquadId]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -3900,21 +3907,222 @@ LEFT JOIN (
     FROM [Gears] AS [f.Commander.DefeatedBy]
     WHERE [f.Commander.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t0] ON ([t].[DefeatedByNickname] = [t0].[Nickname]) AND ([t].[DefeatedBySquadId] = [t0].[SquadId])
-WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')",
+WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
+ORDER BY [t0].[Nickname], [t0].[SquadId]",
                 //
-                @"@_outer_Nickname='Marcus' (Size = 4000)
-@_outer_SquadId='1'
+                @"SELECT [f.Commander.DefeatedBy.Reports].[Nickname], [f.Commander.DefeatedBy.Reports].[SquadId], [f.Commander.DefeatedBy.Reports].[AssignedCityName], [f.Commander.DefeatedBy.Reports].[CityOrBirthName], [f.Commander.DefeatedBy.Reports].[Discriminator], [f.Commander.DefeatedBy.Reports].[FullName], [f.Commander.DefeatedBy.Reports].[HasSoulPatch], [f.Commander.DefeatedBy.Reports].[LeaderNickname], [f.Commander.DefeatedBy.Reports].[LeaderSquadId], [f.Commander.DefeatedBy.Reports].[Rank]
+FROM [Gears] AS [f.Commander.DefeatedBy.Reports]
+INNER JOIN (
+    SELECT DISTINCT [t2].[Nickname], [t2].[SquadId]
+    FROM [Factions] AS [f0]
+    LEFT JOIN (
+        SELECT [f.Commander0].*
+        FROM [LocustLeaders] AS [f.Commander0]
+        WHERE [f.Commander0].[Discriminator] = N'LocustCommander'
+    ) AS [t1] ON [f0].[CommanderName] = [t1].[Name]
+    LEFT JOIN (
+        SELECT [f.Commander.DefeatedBy0].*
+        FROM [Gears] AS [f.Commander.DefeatedBy0]
+        WHERE [f.Commander.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t2] ON ([t1].[DefeatedByNickname] = [t2].[Nickname]) AND ([t1].[DefeatedBySquadId] = [t2].[SquadId])
+    WHERE ([f0].[Discriminator] = N'LocustHorde') AND ([f0].[Discriminator] = N'LocustHorde')
+) AS [t3] ON ([f.Commander.DefeatedBy.Reports].[LeaderNickname] = [t3].[Nickname]) AND ([f.Commander.DefeatedBy.Reports].[LeaderSquadId] = [t3].[SquadId])
+WHERE [f.Commander.DefeatedBy.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t3].[Nickname], [t3].[SquadId]");
+        }
 
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))",
+        public override void Include_reference_on_derived_type_using_string()
+        {
+            base.Include_reference_on_derived_type_using_string();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeaders] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gears] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_reference_on_derived_type_using_string_nested1()
+        {
+            base.Include_reference_on_derived_type_using_string_nested1();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [l.DefeatedBy.Squad].[Id], [l.DefeatedBy.Squad].[InternalNumber], [l.DefeatedBy.Squad].[Name]
+FROM [LocustLeaders] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gears] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+LEFT JOIN [Squads] AS [l.DefeatedBy.Squad] ON [t].[SquadId] = [l.DefeatedBy.Squad].[Id]
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_reference_on_derived_type_using_string_nested2()
+        {
+            base.Include_reference_on_derived_type_using_string_nested2();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeaders] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gears] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [t].[Nickname], [t].[SquadId]",
                 //
-                @"@_outer_Nickname='' (Size = 4000) (DbType = String)
-@_outer_SquadId='' (Nullable = false) (DbType = Int32)
+                @"SELECT [l.DefeatedBy.Reports].[Nickname], [l.DefeatedBy.Reports].[SquadId], [l.DefeatedBy.Reports].[AssignedCityName], [l.DefeatedBy.Reports].[CityOrBirthName], [l.DefeatedBy.Reports].[Discriminator], [l.DefeatedBy.Reports].[FullName], [l.DefeatedBy.Reports].[HasSoulPatch], [l.DefeatedBy.Reports].[LeaderNickname], [l.DefeatedBy.Reports].[LeaderSquadId], [l.DefeatedBy.Reports].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+FROM [Gears] AS [l.DefeatedBy.Reports]
+INNER JOIN [Cities] AS [g.CityOfBirth] ON [l.DefeatedBy.Reports].[CityOrBirthName] = [g.CityOfBirth].[Name]
+INNER JOIN (
+    SELECT DISTINCT [t0].[Nickname], [t0].[SquadId]
+    FROM [LocustLeaders] AS [l0]
+    LEFT JOIN (
+        SELECT [l.DefeatedBy0].*
+        FROM [Gears] AS [l.DefeatedBy0]
+        WHERE [l.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t0] ON ([l0].[DefeatedByNickname] = [t0].[Nickname]) AND ([l0].[DefeatedBySquadId] = [t0].[SquadId])
+    WHERE [l0].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+) AS [t1] ON ([l.DefeatedBy.Reports].[LeaderNickname] = [t1].[Nickname]) AND ([l.DefeatedBy.Reports].[LeaderSquadId] = [t1].[SquadId])
+WHERE [l.DefeatedBy.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t1].[Nickname], [t1].[SquadId]");
+        }
 
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        public override void Include_reference_on_derived_type_using_lambda()
+        {
+            base.Include_reference_on_derived_type_using_lambda();
+
+            AssertSql(
+                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeaders] AS [ll]
+LEFT JOIN (
+    SELECT [ll.DefeatedBy].*
+    FROM [Gears] AS [ll.DefeatedBy]
+    WHERE [ll.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([ll].[DefeatedByNickname] = [t].[Nickname]) AND ([ll].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_reference_on_derived_type_using_lambda_with_tracking()
+        {
+            base.Include_reference_on_derived_type_using_lambda_with_tracking();
+
+            AssertSql(
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeaders] AS [l]
+LEFT JOIN (
+    SELECT [l.DefeatedBy].*
+    FROM [Gears] AS [l.DefeatedBy]
+    WHERE [l.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([l].[DefeatedByNickname] = [t].[Nickname]) AND ([l].[DefeatedBySquadId] = [t].[SquadId])
+WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Include_collection_on_derived_type_using_string()
+        {
+            base.Include_collection_on_derived_type_using_string();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override void Include_collection_on_derived_type_using_lambda()
+        {
+            base.Include_collection_on_derived_type_using_lambda();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                //
+                @"SELECT [g.Reports].[Nickname], [g.Reports].[SquadId], [g.Reports].[AssignedCityName], [g.Reports].[CityOrBirthName], [g.Reports].[Discriminator], [g.Reports].[FullName], [g.Reports].[HasSoulPatch], [g.Reports].[LeaderNickname], [g.Reports].[LeaderSquadId], [g.Reports].[Rank]
+FROM [Gears] AS [g.Reports]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([g.Reports].[LeaderNickname] = [t].[Nickname]) AND ([g.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [g.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override void Include_base_navigation_on_derived_entity()
+        {
+            base.Include_base_navigation_on_derived_entity();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Tag].[Id], [g.Tag].[GearNickName], [g.Tag].[GearSquadId], [g.Tag].[Note]
+FROM [Gears] AS [g]
+LEFT JOIN [Tags] AS [g.Tag] ON ([g].[Nickname] = [g.Tag].[GearNickName]) AND ([g].[SquadId] = [g.Tag].[GearSquadId])
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[FullName]",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT DISTINCT [g0].[FullName]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Tags] AS [g.Tag0] ON ([g0].[Nickname] = [g.Tag0].[GearNickName]) AND ([g0].[SquadId] = [g.Tag0].[GearSquadId])
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[FullName]");
+        }
+
+        public override void Include_on_derived_multi_level()
+        {
+            base.Include_on_derived_multi_level();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                //
+                @"SELECT [g.Reports].[Nickname], [g.Reports].[SquadId], [g.Reports].[AssignedCityName], [g.Reports].[CityOrBirthName], [g.Reports].[Discriminator], [g.Reports].[FullName], [g.Reports].[HasSoulPatch], [g.Reports].[LeaderNickname], [g.Reports].[LeaderSquadId], [g.Reports].[Rank], [g.Squad].[Id], [g.Squad].[InternalNumber], [g.Squad].[Name]
+FROM [Gears] AS [g.Reports]
+INNER JOIN [Squads] AS [g.Squad] ON [g.Reports].[SquadId] = [g.Squad].[Id]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([g.Reports].[LeaderNickname] = [t].[Nickname]) AND ([g.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [g.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[Nickname], [t].[SquadId], [g.Squad].[Id]",
+                //
+                @"SELECT [g.Squad.Missions].[SquadId], [g.Squad.Missions].[MissionId]
+FROM [SquadMissions] AS [g.Squad.Missions]
+INNER JOIN (
+    SELECT DISTINCT [g.Squad0].[Id], [t0].[Nickname], [t0].[SquadId]
+    FROM [Gears] AS [g.Reports0]
+    INNER JOIN [Squads] AS [g.Squad0] ON [g.Reports0].[SquadId] = [g.Squad0].[Id]
+    INNER JOIN (
+        SELECT [g1].[Nickname], [g1].[SquadId]
+        FROM [Gears] AS [g1]
+        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear')
+    ) AS [t0] ON ([g.Reports0].[LeaderNickname] = [t0].[Nickname]) AND ([g.Reports0].[LeaderSquadId] = [t0].[SquadId])
+    WHERE [g.Reports0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t1] ON [g.Squad.Missions].[SquadId] = [t1].[Id]
+ORDER BY [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
It was not possible to specify include on a derived type. Include was very strict when computing navigation paths from Include method and generated code wasn't accounting for type discrepancies between caller and navigation.

Fix is to allow specifying include on derived types using string overload:
entities.Include("DerivedProperty")

or using lambda and specifying parameter type explicitly
entities.Include((Derived e) => e.DerivedProperty)

Made tweaks to the logic that computes navigation paths - now it looks for navigation on derived types also.
Added additional checks to the generated code (_Include method fixup)

old:

    fixup: (QueryContext queryContext | SomeEntity entity | Object[] included) =>
    {
        return !(bool ReferenceEquals(included[0], null))
        {
            return entity.Navigation = (OtherEntity)included[0]
        }
         : default(OtherEntity)
    }

new:

    fixup: (QueryContext queryContext | SomeEntity entity | Object[] included) =>
    {
        return !(bool ReferenceEquals(included[0], null)) && (entity is DerivedEntity) ?
        {
            return ((DerivedEntity)entity).DerivedNavigation = (OtherEntity)included[0]
        }
         : default(OtherEntity)
    }

This also allows to reuse include pipeline to project collection navigations on derived types (before it was producing N+1 queries)

For string based include, since there is no way to provide the type that the navigation is declared on, we aggressively include properties - if multiple derived types declare a property with the same name, they will all be included.