### PR TITLE
Add PackageId to tools csproj 

### DIFF
--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>Microsoft.EntityFrameworkCore.Tools.DotNet</PackageId>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -31,6 +32,7 @@
     </ResolvePackageDependencies>
     <PropertyGroup>
       <NuspecProperties>
+        id=$(PackageId);
         version=$(PackageVersion);
         configuration=$(Configuration);
         runtimeFrameworkVersion=@(_PackageDefinitions-&gt;WithMetadataValue('Name', 'Microsoft.NETCore.App')-&gt;Metadata('Version'));

--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.EntityFrameworkCore.Tools.DotNet</id>
+    <id>$id$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <copyright>Copyright © Microsoft Corporation</copyright>

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>Microsoft.EntityFrameworkCore.Tools</PackageId>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -21,7 +22,11 @@
 
   <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
-      <NuspecProperties>version=$(PackageVersion);configuration=$(Configuration)</NuspecProperties>
+      <NuspecProperties>
+        id=$(PackageId);
+        version=$(PackageVersion);
+        configuration=$(Configuration)
+      </NuspecProperties>
     </PropertyGroup>
   </Target>
 

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.EntityFrameworkCore.Tools</id>
+    <id>$id$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <copyright>Copyright © Microsoft Corporation</copyright>


### PR DESCRIPTION
The aspnet/Universe repo-to-repo build graph tool doesn't correctly identify usages of EF's tools packages because NuGet reports their package ID incorrectly. This moves the package id in the csproj so the graph analyzer can detect any downstream usages of these packages.