### PR TITLE
Reliably close readers when running single result async queries

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -19,8 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected AsyncFromSqlQueryTestBase(TFixture fixture)
         {
             Fixture = fixture;
-            // #9074
-            Fixture.TestStore.CloseConnection();
             Fixture.TestSqlLoggerFactory.Clear();
         }
 
@@ -382,6 +380,7 @@ FROM ""Customers""")
         [Fact]
         public virtual async Task Include_closed_connection_opened_by_it_when_buffering()
         {
+            Fixture.TestStore.CloseConnection();
             using (var context = CreateContext())
             {
                 var connection = context.Database.GetDbConnection();

--- a/src/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/src/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore
                     });
         }
 
-        [Fact(Skip = "#9074")]
+        [Fact]
         public virtual Task Find_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.FindAsync(1));
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore
                     });
         }
 
-        [Fact(Skip = "#9074")]
+        [Fact]
         public virtual Task Count_logs_concurrent_access_async()
         {
             return ConcurrencyDetectorTest(c => c.Products.CountAsync());

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -6,14 +6,14 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable ReplaceWithSingleCallToAny
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = (from c in customerRepository.Find()
                        where orderRepository.Find().Any(o => o.CustomerID == c.CustomerID)
                        select c)
-                    .ToList();
+                        .ToList();
 
                 Assert.Equal(89, results.Count);
 
@@ -106,13 +106,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = (from c1_Orders in context.Orders
                        join _c1 in
                            (from c1 in
-                                (from c in context.Customers
-                                 orderby c.CustomerID
-                                 select c)
-                                .Take(2)
+                               (from c in context.Customers
+                                orderby c.CustomerID
+                                select c)
+                                   .Take(2)
                             from c2 in context.Customers
                             select EF.Property<string>(c1, "CustomerID"))
-                           .Distinct()
+                               .Distinct()
                            on EF.Property<string>(c1_Orders, "CustomerID") equals _c1
                        orderby _c1
                        select c1_Orders).ToList();
@@ -130,13 +130,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = (from c1_Orders in context.Orders
                        join _c1 in
                            (from c1 in
-                                (from c in context.Customers
-                                 orderby c.CustomerID
-                                 select c)
-                                .Take(2)
+                               (from c in context.Customers
+                                orderby c.CustomerID
+                                select c)
+                                   .Take(2)
                             from c2 in context.Customers
                             select new { CustomerID = EF.Property<string>(c1, "CustomerID") })
-                           .Distinct()
+                               .Distinct()
                            on EF.Property<string>(c1_Orders, "CustomerID") equals _c1.CustomerID
                        orderby _c1.CustomerID
                        select c1_Orders).ToList();
@@ -233,6 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs =>
                     from c in cs
 #pragma warning disable CS1718 // Comparison made to same variable
+                    // ReSharper disable once EqualExpressionComparison
                     where c == c
 #pragma warning restore CS1718 // Comparison made to same variable
                     select c.CustomerID);
@@ -807,9 +808,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                      from o in os
                      orderby c.CustomerID, o.OrderID
                      select new { c, o })
-                    .Take(1)
-                    .Cast<object>()
-                    .Single(),
+                        .Take(1)
+                        .Cast<object>()
+                        .Single(),
                 entryCount: 2);
         }
 
@@ -1193,11 +1194,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         CustomerId = c.CustomerID,
                         OrderIds
-                        = os.Where(
+                            = os.Where(
                                 o => o.CustomerID == c.CustomerID
                                      && o.OrderDate.Value.Year == 1997)
-                            .Select(o => o.OrderID)
-                            .OrderBy(o => o),
+                                .Select(o => o.OrderID)
+                                .OrderBy(o => o),
                         Customer = c
                     },
                 elementAsserter: (e, a) =>
@@ -1370,7 +1371,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     where e1.FirstName ==
                           (from e2 in es.OrderBy(e => e.EmployeeID)
                            select new { Foo = e2 })
-                          .First().Foo.FirstName
+                              .First().Foo.FirstName
                     select e1,
                 entryCount: 1);
         }
@@ -1384,7 +1385,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     where e1.FirstName ==
                           (from e2 in es.OrderBy(e => e.EmployeeID)
                            select e2)
-                          .FirstOrDefault().FirstName
+                              .FirstOrDefault().FirstName
                     select e1,
                 entryCount: 1);
         }
@@ -1398,7 +1399,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     where e1.FirstName ==
                           (from e2 in es.OrderBy(e => e.EmployeeID)
                            select new { Foo = e2 })
-                          .FirstOrDefault().Foo.FirstName
+                              .FirstOrDefault().Foo.FirstName
                     select e1,
                 entryCount: 1);
         }
@@ -1575,8 +1576,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     orderby c1.CustomerID
                     select c1,
                 cs => cs.SelectMany(
-                        c => (from c2 in (from c3 in cs select c3) select c2),
-                        (c, c1) => new { c, c1 }).OrderBy(t => t.c1.CustomerID, StringComparer.Ordinal)
+                    c => (from c2 in (from c3 in cs select c3) select c2),
+                    (c, c1) => new { c, c1 }).OrderBy(t => t.c1.CustomerID, StringComparer.Ordinal)
                     .Select(t => t.c1),
                 assertOrder: true,
                 entryCount: 91);
@@ -1984,8 +1985,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (os, cs) => os.Where(
                     o => o.OrderID <= 10250
                          && cs.OrderBy(
-                                 c => cs.Any(
-                                     c2 => c2.CustomerID == "ALFKI"))
+                             c => cs.Any(
+                                 c2 => c2.CustomerID == "ALFKI"))
                              .FirstOrDefault().City != "Nowhere"),
                 entryCount: 3);
         }
@@ -2447,8 +2448,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                where od.OrderID == o.OrderID
                                orderby o.OrderID
                                select o).First())
-                    .Take(2)
-                    .ToList();
+                        .Take(2)
+                        .ToList();
 
                 Assert.Equal(2, orderDetails.Count);
             }
@@ -2462,18 +2463,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var orderDetails
                     = (from od in context.Set<OrderDetail>().Where(od => od.OrderID == 10344)
                        where (
-                                 from o in context.Set<Order>()
-                                 where od.OrderID == o.OrderID
-                                 select (
-                                     from c in context.Set<Customer>()
-                                     where o.CustomerID == c.CustomerID
-                                     select c
-                                 ).Single()
-                             ).Single()
-                             .City == "Seattle"
+                           from o in context.Set<Order>()
+                           where od.OrderID == o.OrderID
+                           select (
+                               from c in context.Set<Customer>()
+                               where o.CustomerID == c.CustomerID
+                               select c
+                               ).Single()
+                           ).Single()
+                           .City == "Seattle"
                        select od)
-                    .Take(2)
-                    .ToList();
+                        .Take(2)
+                        .ToList();
 
                 Assert.Equal(2, orderDetails.Count);
             }
@@ -2487,18 +2488,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var orderDetails
                     = (from od in context.Set<OrderDetail>()
                        where (
-                                 from o in context.Set<Order>()
-                                 where od.OrderID == o.OrderID
-                                 select (
-                                     from c in context.Set<Customer>()
-                                     where o.CustomerID == c.CustomerID
-                                     select c
-                                 ).FirstOrDefault()
-                             ).FirstOrDefault()
-                             .City == "Seattle"
+                           from o in context.Set<Order>()
+                           where od.OrderID == o.OrderID
+                           select (
+                               from c in context.Set<Customer>()
+                               where o.CustomerID == c.CustomerID
+                               select c
+                               ).FirstOrDefault()
+                           ).FirstOrDefault()
+                           .City == "Seattle"
                        select od)
-                    .Take(2)
-                    .ToList();
+                        .Take(2)
+                        .ToList();
 
                 Assert.Equal(2, orderDetails.Count);
             }
@@ -2536,12 +2537,32 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                ((IInfrastructure<IServiceProvider>)context).Instance.GetService<IConcurrencyDetector>().EnterCriticalSection();
+                context.Database.EnsureCreated();
 
-                Assert.Equal(
-                    CoreStrings.ConcurrentMethodInvocation,
-                    Assert.Throws<InvalidOperationException>(
-                        () => context.Customers.ToList()).Message);
+                using (var synchronizationEvent = new ManualResetEventSlim(false))
+                {
+                    using (var blockingSemaphore = new SemaphoreSlim(0))
+                    {
+                        var blockingTask = Task.Run(() =>
+                            context.Customers.Select(
+                                c => Process(c, synchronizationEvent, blockingSemaphore)).ToList());
+
+                        var throwingTask = Task.Run(() =>
+                            {
+                                synchronizationEvent.Wait();
+                                Assert.Equal(
+                                    CoreStrings.ConcurrentMethodInvocation,
+                                    Assert.Throws<InvalidOperationException>(
+                                        () => context.Customers.ToList()).Message);
+                            });
+
+                        throwingTask.Wait();
+
+                        blockingSemaphore.Release(1);
+
+                        blockingTask.Wait();
+                    }
+                }
             }
         }
 
@@ -2550,13 +2571,41 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                ((IInfrastructure<IServiceProvider>)context).Instance.GetService<IConcurrencyDetector>().EnterCriticalSection();
+                context.Database.EnsureCreated();
 
-                Assert.Equal(
-                    CoreStrings.ConcurrentMethodInvocation,
-                    Assert.Throws<InvalidOperationException>(
-                        () => context.Customers.First()).Message);
+                using (var synchronizationEvent = new ManualResetEventSlim(false))
+                {
+                    using (var blockingSemaphore = new SemaphoreSlim(0))
+                    {
+                        var blockingTask = Task.Run(() =>
+                            context.Customers.Select(
+                                c => Process(c, synchronizationEvent, blockingSemaphore)).ToList());
+
+                        var throwingTask = Task.Run(() =>
+                            {
+                                synchronizationEvent.Wait();
+                                Assert.Equal(
+                                    CoreStrings.ConcurrentMethodInvocation,
+                                    Assert.Throws<InvalidOperationException>(
+                                        () => context.Customers.First()).Message);
+                            });
+
+                        throwingTask.Wait();
+
+                        blockingSemaphore.Release(1);
+
+                        blockingTask.Wait();
+                    }
+                }
             }
+        }
+
+        private Customer Process(Customer c, ManualResetEventSlim e, SemaphoreSlim s)
+        {
+            e.Set();
+            s.Wait();
+            s.Release(1);
+            return c;
         }
 
         [ConditionalFact]

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -440,7 +440,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = Expression.Call(
                         LinqOperatorProvider.ToSequence
                             .MakeGenericMethod(type ?? _expression.Type),
-                        _expression);
+                        Expression.Lambda(_expression));
             }
         }
 

--- a/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -304,8 +304,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IAsyncEnumerable<T> _ToSequence<T>(Task<T> task)
-            => new TaskResultAsyncEnumerable<T>(task);
+        private static IAsyncEnumerable<T> _ToSequence<T>(Func<Task<T>> getElement)
+            => new TaskResultAsyncEnumerable<T>(getElement);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -313,24 +313,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         private sealed class TaskResultAsyncEnumerable<T> : IAsyncEnumerable<T>
         {
-            private readonly Task<T> _task;
+            private readonly Func<Task<T>> _getElement;
 
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            public TaskResultAsyncEnumerable([NotNull] Task<T> task)
+            public TaskResultAsyncEnumerable([NotNull] Func<Task<T>> getElement)
             {
-                Check.NotNull(task, nameof(task));
+                Check.NotNull(getElement, nameof(getElement));
 
-                _task = task;
+                _getElement = getElement;
             }
 
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            public IAsyncEnumerator<T> GetEnumerator() => new Enumerator(_task);
+            public IAsyncEnumerator<T> GetEnumerator() => new Enumerator(_getElement());
 
             private sealed class Enumerator : IAsyncEnumerator<T>
             {

--- a/src/EFCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/EFCore/Query/Internal/LinqOperatorProvider.cs
@@ -288,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         [UsedImplicitly]
         // ReSharper disable once InconsistentNaming
-        private static IEnumerable<T> _ToSequence<T>(T element) => new[] { element };
+        private static IEnumerable<T> _ToSequence<T>(Func<T> getElement) => new[] { getElement() };
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/ResultOperatorHandler.cs
+++ b/src/EFCore/Query/ResultOperatorHandler.cs
@@ -386,12 +386,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Expression.Call(
                                 entityQueryModelVisitor.LinqOperatorProvider.ToSequence
                                     .MakeGenericMethod(methodCallExpression.Arguments[0].Type.GetSequenceType()),
-                                CallWithPossibleCancellationToken(
-                                    (choiceResultOperator.ReturnDefaultWhenEmpty
-                                        ? entityQueryModelVisitor.LinqOperatorProvider.LastOrDefault
-                                        : entityQueryModelVisitor.LinqOperatorProvider.Last)
-                                    .MakeGenericMethod(methodCallExpression.Arguments[0].Type.GetSequenceType()),
-                                    methodCallExpression.Arguments[0])),
+                                Expression.Lambda(
+                                    CallWithPossibleCancellationToken(
+                                        (choiceResultOperator.ReturnDefaultWhenEmpty
+                                            ? entityQueryModelVisitor.LinqOperatorProvider.LastOrDefault
+                                            : entityQueryModelVisitor.LinqOperatorProvider.Last)
+                                            .MakeGenericMethod(methodCallExpression.Arguments[0].Type.GetSequenceType()),
+                                        methodCallExpression.Arguments[0]))),
                             methodCallExpression.Arguments[1]
                         });
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -15,7 +15,6 @@ using Xunit;
 using Xunit.Abstractions;
 
 // ReSharper disable AccessToDisposedClosure
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -23,11 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         private static readonly string EOL = Environment.NewLine;
 
+        // ReSharper disable once UnusedParameter.Local
         public AsyncSimpleQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            //#9074
-            Fixture.TestStore.CloseConnection();
             fixture.TestSqlLoggerFactory.Clear();
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
@@ -199,6 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 await context.Customers.ForEachAsync(
+                    // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
                     c => { context.Orders.Where(o => o.CustomerID == c.CustomerID).ToList(); });
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         private bool SupportsOffset => TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;
 
+        // ReSharper disable once UnusedParameter.Local
         public IncludeSqlServerTest(IncludeSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 
+// ReSharper disable UnusedParameter.Local
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {


### PR DESCRIPTION
Issue: Single result async queries create the inner enumerator before the outer enumerator is created. If the outer enumerator isn't created and disposed (e.g. due to an exception) the inner enumerator isn't disposed

Fix: Don't create the inner enumerator until the outer enumerator is created

Fixes #9074
