### PR TITLE
Pin xUnit.net to 2.3.0 Beta 3 for now

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
     <SystemCollectionsImmutableVersion>1.4.0-*</SystemCollectionsImmutableVersion>
     <SystemInteractiveAsyncVersion>3.1.1</SystemInteractiveAsyncVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
-    <XunitVersion>2.3.0-*</XunitVersion>
+    <XunitVersion>2.3.0-beta3-build3705</XunitVersion>
     <XunitVersionInSpecProjects>2.2.0</XunitVersionInSpecProjects>
   </PropertyGroup>
 <!-- Following package versions must match with what is available on NuGet -->


### PR DESCRIPTION
New analyzer warnings were added in Beta 4 which fail with warnings as errors. Filed #9406 for us to do a proper upgrade.