### PR TITLE
Pin xunit to 2.3.0-beta3-build3705

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,8 +15,8 @@
     <StyleCopAnalyzersVersion>1.0.0</StyleCopAnalyzersVersion>
     <SystemCollectionsImmutableVersion>1.4.0-*</SystemCollectionsImmutableVersion>
     <SystemInteractiveAsyncVersion>3.1.1</SystemInteractiveAsyncVersion>
-    <TestSdkVersion>15.3.0-*</TestSdkVersion>
-    <XunitVersion>2.3.0-*</XunitVersion>
+    <TestSdkVersion>15.3.0</TestSdkVersion>
+    <XunitVersion>2.3.0-beta3-build3705</XunitVersion>
     <XunitVersionInSpecProjects>2.2.0</XunitVersionInSpecProjects>
   </PropertyGroup>
 <!-- Following package versions must match with what is available on NuGet -->


### PR DESCRIPTION
A new version of xunit hit nuget.org. The 2.3.0-* float picked it up and caused build failures.

http://aspnetci/viewLog.html?buildId=299594&tab=buildResultsDiv&buildTypeId=UniverseCoherence

Side note: it looks like moving to xunit 2.3.0-beta4 will require at least one source change.